### PR TITLE
complete refactor of parser using strcursor

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1,6 +1,8 @@
 package helium
 
 import (
+	"bytes"
+
 	"github.com/lestrrat/helium/internal/debug"
 	"github.com/lestrrat/helium/sax"
 )
@@ -19,11 +21,11 @@ func NewParser() *Parser {
 func (p *Parser) Parse(b []byte) (*Document, error) {
 	if debug.Enabled {
 		g := debug.IPrintf("=== START Parser.Parse ===")
-		defer g.IRelease("=== END   Parser.Parse ===")
+		defer g.IRelease("=== END Parser.Parse ===")
 	}
 
 	ctx := &parserCtx{}
-	ctx.init(p, b)
+	ctx.init(p, bytes.NewReader(b))
 	defer ctx.release()
 
 	if err := ctx.parseDocument(); err != nil {

--- a/parser_interface.go
+++ b/parser_interface.go
@@ -2,6 +2,7 @@ package helium
 
 import (
 	"errors"
+	"io"
 
 	"github.com/lestrrat/go-strcursor"
 	"github.com/lestrrat/helium/sax"
@@ -29,6 +30,7 @@ var (
 	ErrAttrListNotFinished          = errors.New("attrlist must finish with a ')'")
 	ErrAttrListNotStarted           = errors.New("attrlist must start with a '('")
 	ErrAttributeNameRequired        = errors.New("attribute namewas required here (ATTLIST)")
+	ErrByteCursorRequired           = errors.New("inconsistent state: required ByteCursor")
 	ErrDocTypeNameRequired          = errors.New("doctype name required")
 	ErrDocTypeNotFinished           = errors.New("doctype not finished")
 	ErrDocumentEnd                  = errors.New("extra content at document end")
@@ -105,7 +107,9 @@ type parserCtx struct {
 	// <?xml version="1.0"?> vs <?xml version="1.0" encoding="utf-8"?>
 	encoding          string
 	detectedEncoding  string
-	cursor            *strcursor.Cursor
+	in                io.Reader
+	bytecursor        *strcursor.ByteCursor // Used for parsing up to XML declaration
+	cursor            *strcursor.RuneCursor // Used for XML content
 	nbread            int
 	instate           parserState
 	keepBlanks        bool

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,6 +1,7 @@
 package helium
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/lestrrat/helium/internal/debug"
@@ -24,7 +25,7 @@ func TestDetectBOM(t *testing.T) {
 	for expected, inputs := range data {
 		for i, input := range inputs {
 			ctx := &parserCtx{}
-			ctx.init(p, input)
+			ctx.init(p, bytes.NewReader(input))
 			enc, err := ctx.detectEncoding()
 			if expected == "" {
 				t.Logf("checking [invalid] (%d)", i)
@@ -98,10 +99,6 @@ func TestParseMisc(t *testing.T) {
 		doc, err := p.Parse([]byte(input))
 		if !assert.NoError(t, err, "Parse should succeed for '%s'", input) {
 			return
-		}
-
-		if debug.Enabled {
-			debug.Dump(doc)
 		}
 
 		// XXX Not sure if this is right, but I'm going to assume it's ok


### PR DESCRIPTION
Now we actually respect the XML decl's encoding attribute and
do the magic of converting the input stream inline into a
UTF-8 input, using go-strcursor and golang.org/x/text/encoding