### PR TITLE
route external resource loads through fs.FS

### DIFF
--- a/.claude/docs/parser-internals.md
+++ b/.claude/docs/parser-internals.md
@@ -75,7 +75,7 @@ State affects parsing rules: e.g., external entity refs forbidden in `psAttribut
 - `attsDefault map[string][]*Attribute` — default attributes from DTD
 - `inSubset int` — 0=not in subset, 1=internal, 2=external
 - `replaceEntities bool` — expand entity refs (set by SubstituteEntities(true))
-- `fsys fs.FS` — filesystem used to load external DTDs/entities; defaults to `internal/iofs.Root{}` (passthrough to os.Open), overridden via `Parser.FS()`. Used by `TreeBuilder.ExternalSubset` and `TreeBuilder.ResolveEntity`.
+- `fsys fs.FS` — filesystem used to load external DTDs/entities; defaults to `internal/iofs.PermissiveRoot{}` (passthrough to os.Open), overridden via `Parser.FS()`. Used by `TreeBuilder.ExternalSubset` and `TreeBuilder.ResolveEntity`.
 
 ### Entity Amplification Guard
 - `sizeentcopy int64` — cumulative entity expansion bytes

--- a/.claude/docs/parser-internals.md
+++ b/.claude/docs/parser-internals.md
@@ -3,7 +3,7 @@
 ## Entry Points
 
 - **`Parse(ctx, []byte)`** / **`ParseReader(ctx, io.Reader)`** — main entry points
-- **`NewParser()`** — configurable parser; set options, SAX handler, catalog, baseURI, maxDepth
+- **`NewParser()`** — configurable parser; set options, SAX handler, catalog, baseURI, maxDepth, FS
 - **`p := helium.NewParser(); pp := p.NewPushParser(ctx)`** — background push parser (parses incrementally as data arrives)
 - **`ParseInNodeContext(ctx, node, []byte)`** — parse fragment in element context
 
@@ -75,6 +75,7 @@ State affects parsing rules: e.g., external entity refs forbidden in `psAttribut
 - `attsDefault map[string][]*Attribute` — default attributes from DTD
 - `inSubset int` — 0=not in subset, 1=internal, 2=external
 - `replaceEntities bool` — expand entity refs (set by SubstituteEntities(true))
+- `fsys fs.FS` — filesystem used to load external DTDs/entities; defaults to `internal/iofs.Root{}` (passthrough to os.Open), overridden via `Parser.FS()`. Used by `TreeBuilder.ExternalSubset` and `TreeBuilder.ResolveEntity`.
 
 ### Entity Amplification Guard
 - `sizeentcopy int64` — cumulative entity expansion bytes

--- a/internal/iofs/iofs.go
+++ b/internal/iofs/iofs.go
@@ -15,9 +15,16 @@ import (
 //
 // It exists to preserve helium's historical behavior of opening any
 // path supplied to the parser, schema compilers, and XInclude processor.
-// Callers handling untrusted input should substitute a stricter fs.FS
-// on the relevant builder, for example one produced by [os.DirFS] or
-// [os.OpenRoot].
+//
+// Note: the helium packages that consume this FS build the names they
+// pass to Open via [filepath.Join] against the document's base URI /
+// base dir, so those names may be absolute and may use OS-specific
+// separators on Windows. A caller-supplied FS that enforces
+// [fs.ValidPath] (such as [os.DirFS] or [os.OpenRoot]) will reject
+// those names. Sandboxing the loader behind such an FS requires path
+// normalization that is not yet performed by helium; until then,
+// PermissiveRoot is the only configuration that accepts OS-style
+// names end-to-end.
 type PermissiveRoot struct{}
 
 // Open implements [fs.FS].

--- a/internal/iofs/iofs.go
+++ b/internal/iofs/iofs.go
@@ -7,17 +7,20 @@ import (
 	"os"
 )
 
-// Root is an [fs.FS] backed by direct calls to [os.Open]. Unlike most
-// fs.FS implementations it does not enforce [fs.ValidPath]; names are
-// passed straight through to the OS. This preserves helium's historical
-// behavior of opening any path (absolute, traversal-containing, etc.)
-// supplied to the parser, schema compilers, and XInclude processor.
+// PermissiveRoot is an [fs.FS] backed by direct calls to [os.Open]. It
+// is the explicit opposite of [os.Root]: rather than sandboxing access
+// to a directory, it accepts any path the caller hands it — absolute,
+// containing "..", anywhere on the filesystem — and forwards verbatim
+// to os.Open without enforcing [fs.ValidPath].
 //
+// It exists to preserve helium's historical behavior of opening any
+// path supplied to the parser, schema compilers, and XInclude processor.
 // Callers handling untrusted input should substitute a stricter fs.FS
-// on the relevant builder (e.g. one produced by [os.DirFS]).
-type Root struct{}
+// on the relevant builder, for example one produced by [os.DirFS] or
+// [os.OpenRoot].
+type PermissiveRoot struct{}
 
 // Open implements [fs.FS].
-func (Root) Open(name string) (fs.File, error) {
+func (PermissiveRoot) Open(name string) (fs.File, error) {
 	return os.Open(name) //nolint:gosec,wrapcheck // intentional passthrough; see type doc
 }

--- a/internal/iofs/iofs.go
+++ b/internal/iofs/iofs.go
@@ -1,0 +1,23 @@
+// Package iofs provides the default [fs.FS] used by helium for opening
+// external resources (DTDs, entities, schemas, XInclude targets).
+package iofs
+
+import (
+	"io/fs"
+	"os"
+)
+
+// Root is an [fs.FS] backed by direct calls to [os.Open]. Unlike most
+// fs.FS implementations it does not enforce [fs.ValidPath]; names are
+// passed straight through to the OS. This preserves helium's historical
+// behavior of opening any path (absolute, traversal-containing, etc.)
+// supplied to the parser, schema compilers, and XInclude processor.
+//
+// Callers handling untrusted input should substitute a stricter fs.FS
+// on the relevant builder (e.g. one produced by [os.DirFS]).
+type Root struct{}
+
+// Open implements [fs.FS].
+func (Root) Open(name string) (fs.File, error) {
+	return os.Open(name) //nolint:gosec,wrapcheck // intentional passthrough; see type doc
+}

--- a/parser.go
+++ b/parser.go
@@ -456,8 +456,14 @@ func (p Parser) Catalog(c CatalogResolver) Parser {
 // document — external DTDs ([LoadExternalDTD]) and external entities
 // resolved through [TreeBuilder.ResolveEntity]. A nil value restores the
 // default, which opens any path supplied to the parser via [os.Open].
-// Callers handling untrusted input should supply a stricter FS — for
-// example one rooted at the document's directory via [os.DirFS].
+//
+// Note: the names handed to the FS are built with [filepath.Join] against
+// the document's base URI, so they may be absolute and may use
+// OS-specific separators on Windows. FS implementations that enforce
+// [fs.ValidPath] (notably [os.DirFS] and [testing/fstest.MapFS]) will
+// reject those names. Sandboxing the loader behind such an FS requires
+// path normalization that is not yet performed by this package; for now,
+// supply an FS implementation that accepts OS-style names.
 func (p Parser) FS(fsys fs.FS) Parser {
 	p = p.clone()
 	if fsys == nil {

--- a/parser.go
+++ b/parser.go
@@ -57,7 +57,7 @@ type Parser struct {
 func NewParser() Parser {
 	return Parser{cfg: &parserConfig{
 		sax:  NewTreeBuilder(),
-		fsys: iofs.Root{},
+		fsys: iofs.PermissiveRoot{},
 	}}
 }
 
@@ -461,7 +461,7 @@ func (p Parser) Catalog(c CatalogResolver) Parser {
 func (p Parser) FS(fsys fs.FS) Parser {
 	p = p.clone()
 	if fsys == nil {
-		fsys = iofs.Root{}
+		fsys = iofs.PermissiveRoot{}
 	}
 	p.cfg.fsys = fsys
 	return p

--- a/parser.go
+++ b/parser.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 
+	"github.com/lestrrat-go/helium/internal/iofs"
 	"github.com/lestrrat-go/helium/push"
 	"github.com/lestrrat-go/helium/sax"
 	"github.com/lestrrat-go/pdebug"
@@ -39,6 +41,7 @@ type parserConfig struct {
 	options        parseOption
 	baseURI        string
 	catalog        CatalogResolver
+	fsys           fs.FS
 	maxDepth       int
 	errorHandler   ErrorHandler
 }
@@ -53,7 +56,8 @@ type Parser struct {
 // NewParser creates a new Parser with default settings.
 func NewParser() Parser {
 	return Parser{cfg: &parserConfig{
-		sax: NewTreeBuilder(),
+		sax:  NewTreeBuilder(),
+		fsys: iofs.Root{},
 	}}
 }
 
@@ -445,6 +449,21 @@ func (p Parser) MaxDepth(depth int) Parser {
 func (p Parser) Catalog(c CatalogResolver) Parser {
 	p = p.clone()
 	p.cfg.catalog = c
+	return p
+}
+
+// FS sets the [fs.FS] used to load external resources referenced by the
+// document — external DTDs ([LoadExternalDTD]) and external entities
+// resolved through [TreeBuilder.ResolveEntity]. A nil value restores the
+// default, which opens any path supplied to the parser via [os.Open].
+// Callers handling untrusted input should supply a stricter FS — for
+// example one rooted at the document's directory via [os.DirFS].
+func (p Parser) FS(fsys fs.FS) Parser {
+	p = p.clone()
+	if fsys == nil {
+		fsys = iofs.Root{}
+	}
+	p.cfg.fsys = fsys
 	return p
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/enum"
@@ -929,6 +931,53 @@ func TestBlockXXE(t *testing.T) {
 		_ = err
 		require.False(t, resolved, "external DTD should not be loaded with BlockXXE")
 	})
+}
+
+func TestParserFS(t *testing.T) {
+	t.Parallel()
+
+	t.Run("external DTD loaded from custom FS", func(t *testing.T) {
+		t.Parallel()
+
+		const input = `<?xml version="1.0"?>
+<!DOCTYPE doc SYSTEM "ext.dtd">
+<doc/>`
+
+		fsys := fstest.MapFS{
+			"ext.dtd": &fstest.MapFile{Data: []byte("<!ELEMENT doc EMPTY>\n")},
+		}
+
+		p := helium.NewParser().LoadExternalDTD(true).FS(fsys)
+		_, err := p.Parse(t.Context(), []byte(input))
+		require.NoError(t, err)
+	})
+
+	t.Run("FS error surfaces as missing resource (silent)", func(t *testing.T) {
+		t.Parallel()
+
+		const input = `<?xml version="1.0"?>
+<!DOCTYPE doc SYSTEM "nope.dtd">
+<doc/>`
+
+		p := helium.NewParser().LoadExternalDTD(true).FS(fstest.MapFS{})
+		_, err := p.Parse(t.Context(), []byte(input))
+		require.NoError(t, err, "missing external DTD is silently ignored, same as before")
+	})
+
+	t.Run("nil FS restores default", func(t *testing.T) {
+		t.Parallel()
+
+		const input = `<?xml version="1.0"?><doc/>`
+
+		// Set a custom FS then clear it; parsing a doc that needs no external
+		// resources must still work.
+		p := helium.NewParser().FS(fstest.MapFS{}).FS(nil)
+		_, err := p.Parse(t.Context(), []byte(input))
+		require.NoError(t, err)
+	})
+
+	// Compile-time check that fs.FS is the parameter type.
+	var _ = helium.NewParser().FS(fs.FS(fstest.MapFS{}))
 }
 
 func TestSkipIDs(t *testing.T) {

--- a/parserctx.go
+++ b/parserctx.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"unicode/utf8"
 
 	"github.com/lestrrat-go/helium/enum"
+	"github.com/lestrrat-go/helium/internal/iofs"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/pool"
 	"github.com/lestrrat-go/helium/internal/strcursor"
@@ -95,6 +97,7 @@ type parserCtx struct {
 	charBufferSize    int
 	baseURI           string          // document base URI for resolving external references
 	catalog           CatalogResolver // XML catalog for entity resolution
+	fsys              fs.FS           // filesystem for loading external DTDs and entities
 	elem              *Element        // current context element
 
 	nsTab       nsStack
@@ -396,6 +399,7 @@ func (ctx *parserCtx) init(p *parserConfig, in io.Reader) error {
 		ctx.charBufferSize = p.charBufferSize
 		ctx.options = p.options
 		ctx.catalog = p.catalog
+		ctx.fsys = p.fsys
 		if ctx.options.IsSet(parseNoBlanks) {
 			ctx.keepBlanks = false
 		}
@@ -418,6 +422,9 @@ func (ctx *parserCtx) init(p *parserConfig, in io.Reader) error {
 			ctx.loadsubset.Set(SkipIDs)
 		}
 		ctx.maxElemDepth = p.maxDepth
+	}
+	if ctx.fsys == nil {
+		ctx.fsys = iofs.Root{}
 	}
 	return nil
 }

--- a/parserctx.go
+++ b/parserctx.go
@@ -424,7 +424,7 @@ func (ctx *parserCtx) init(p *parserConfig, in io.Reader) error {
 		ctx.maxElemDepth = p.maxDepth
 	}
 	if ctx.fsys == nil {
-		ctx.fsys = iofs.Root{}
+		ctx.fsys = iofs.PermissiveRoot{}
 	}
 	return nil
 }

--- a/relaxng/parse.go
+++ b/relaxng/parse.go
@@ -58,7 +58,7 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 		label = "(string)"
 	}
 
-	fsys := fs.FS(iofs.Root{})
+	fsys := fs.FS(iofs.PermissiveRoot{})
 	if cfg.fsys != nil {
 		fsys = cfg.fsys
 	}

--- a/relaxng/parse.go
+++ b/relaxng/parse.go
@@ -3,12 +3,13 @@ package relaxng
 import (
 	"context"
 	"fmt"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"slices"
 	"strings"
 
 	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/iofs"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 )
 
@@ -21,6 +22,7 @@ const (
 type compiler struct {
 	grammar      *Grammar
 	baseDir      string
+	fsys         fs.FS // filesystem for loading include/externalRef targets
 	filename     string
 	errorHandler helium.ErrorHandler
 	errorCount   int
@@ -56,11 +58,16 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 		label = "(string)"
 	}
 
+	fsys := fs.FS(iofs.Root{})
+	if cfg.fsys != nil {
+		fsys = cfg.fsys
+	}
 	c := &compiler{
 		grammar: &Grammar{
 			defines: make(map[string]*pattern),
 		},
 		baseDir:      baseDir,
+		fsys:         fsys,
 		filename:     label,
 		errorHandler: eh,
 		includeLimit: 1000,
@@ -376,7 +383,7 @@ func (c *compiler) parseInclude(ctx context.Context, elem *helium.Element) {
 	defer func() { c.includeStack = c.includeStack[:len(c.includeStack)-1] }()
 
 	// Read and parse the included file
-	data, err := os.ReadFile(path)
+	data, err := fs.ReadFile(c.fsys, path)
 	if err != nil {
 		msg := fmt.Sprintf("xmlRelaxNGParse: could not load %s", href)
 		c.errorHandler.Handle(ctx, helium.NewLeveledError(rngParserError(msg), helium.ErrorLevelFatal))
@@ -783,7 +790,7 @@ func (c *compiler) parseExternalRef(ctx context.Context, node *helium.Element) *
 	c.includeStack = append(c.includeStack, path)
 	defer func() { c.includeStack = c.includeStack[:len(c.includeStack)-1] }()
 
-	data, err := os.ReadFile(path)
+	data, err := fs.ReadFile(c.fsys, path)
 	if err != nil {
 		msg := fmt.Sprintf("xmlRelaxNGParse: could not load %s", href)
 		c.errorHandler.Handle(ctx, helium.NewLeveledError(rngParserError(msg), helium.ErrorLevelFatal))

--- a/relaxng/relaxng.go
+++ b/relaxng/relaxng.go
@@ -72,7 +72,7 @@ func (c Compiler) BaseDir(dir string) Compiler {
 func (c Compiler) FS(fsys fs.FS) Compiler {
 	c = c.clone()
 	if fsys == nil {
-		fsys = iofs.Root{}
+		fsys = iofs.PermissiveRoot{}
 	}
 	c.cfg.fsys = fsys
 	return c

--- a/relaxng/relaxng.go
+++ b/relaxng/relaxng.go
@@ -4,15 +4,18 @@ import (
 	"context"
 	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 
 	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/iofs"
 )
 
 type compileConfig struct {
 	label        string // label for error messages (e.g. source filename)
 	baseDir      string
+	fsys         fs.FS // filesystem for loading include/externalRef targets
 	errorHandler helium.ErrorHandler
 }
 
@@ -58,6 +61,20 @@ func (c Compiler) Label(name string) Compiler {
 func (c Compiler) BaseDir(dir string) Compiler {
 	c = c.clone()
 	c.cfg.baseDir = dir
+	return c
+}
+
+// FS sets the [fs.FS] used to load schemas referenced by include and
+// externalRef during compilation. A nil value restores the default,
+// which opens any path supplied to the compiler via [os.Open]. Callers
+// handling untrusted schemas should supply a stricter FS (for example
+// one produced by [os.DirFS]).
+func (c Compiler) FS(fsys fs.FS) Compiler {
+	c = c.clone()
+	if fsys == nil {
+		fsys = iofs.Root{}
+	}
+	c.cfg.fsys = fsys
 	return c
 }
 

--- a/relaxng/relaxng.go
+++ b/relaxng/relaxng.go
@@ -66,9 +66,16 @@ func (c Compiler) BaseDir(dir string) Compiler {
 
 // FS sets the [fs.FS] used to load schemas referenced by include and
 // externalRef during compilation. A nil value restores the default,
-// which opens any path supplied to the compiler via [os.Open]. Callers
-// handling untrusted schemas should supply a stricter FS (for example
-// one produced by [os.DirFS]).
+// which opens any path supplied to the compiler via [os.Open].
+//
+// Note: the names handed to the FS are built with [filepath.Join] from
+// [Compiler.BaseDir] and the include href, so they may be absolute and
+// may use OS-specific separators on Windows. FS implementations that
+// enforce [fs.ValidPath] (notably [os.DirFS] and
+// [testing/fstest.MapFS]) will reject those names. Sandboxing schema
+// loading behind such an FS requires path normalization that is not yet
+// performed by this package; for now, supply an FS implementation that
+// accepts OS-style names.
 func (c Compiler) FS(fsys fs.FS) Compiler {
 	c = c.clone()
 	if fsys == nil {

--- a/relaxng/relaxng_test.go
+++ b/relaxng/relaxng_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/fstest"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/relaxng"
@@ -542,6 +543,44 @@ func TestCheckRules(t *testing.T) {
   <define name="foo"><value>x</value></define>
 </grammar>`)
 		require.Contains(t, errs, "Found forbidden pattern data/except//ref")
+	})
+}
+
+func TestCompilerFS(t *testing.T) {
+	t.Parallel()
+
+	const baseRNG = `<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <include href="part.rng"/>
+  <start><ref name="root"/></start>
+</grammar>`
+
+	const partRNG = `<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <define name="root">
+    <element name="root"><text/></element>
+  </define>
+</grammar>`
+
+	t.Run("include resolved through injected FS", func(t *testing.T) {
+		t.Parallel()
+
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(baseRNG))
+		require.NoError(t, err)
+
+		fsys := fstest.MapFS{
+			"part.rng": &fstest.MapFile{Data: []byte(partRNG)},
+		}
+		_, err = relaxng.NewCompiler().FS(fsys).Compile(t.Context(), doc)
+		require.NoError(t, err)
+	})
+
+	t.Run("nil FS restores default", func(t *testing.T) {
+		t.Parallel()
+		var c relaxng.Compiler
+		require.NotPanics(t, func() {
+			_ = c.FS(fstest.MapFS{}).FS(nil)
+		})
 	})
 }
 

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"strings"
 
@@ -400,7 +400,7 @@ func (t *TreeBuilder) ExternalSubset(ctxif context.Context, name, eid, uri strin
 		resolved = filepath.Join(filepath.Dir(ctx.baseURI), uri)
 	}
 
-	data, err := os.ReadFile(resolved)
+	data, err := fs.ReadFile(ctx.fsys, resolved)
 	if err != nil {
 		// Silently ignore missing external DTDs
 		return nil
@@ -704,7 +704,7 @@ func (t *TreeBuilder) ResolveEntity(ctxif context.Context, publicID string, syst
 	ctx := t.pctx(ctxif)
 	if ctx.catalog != nil {
 		if resolved := ctx.catalog.Resolve(ctxif, publicID, systemID); resolved != "" {
-			f, err := os.Open(resolved)
+			f, err := ctx.fsys.Open(resolved)
 			if err == nil {
 				return &fileParseInput{ReadCloser: f, uri: resolved}, nil
 			}
@@ -715,7 +715,7 @@ func (t *TreeBuilder) ResolveEntity(ctxif context.Context, publicID string, syst
 	// is the entity's resolved URI (built from system ID + base URI in
 	// EntityDecl). Try opening it as a file path.
 	if systemID != "" {
-		f, err := os.Open(systemID)
+		f, err := ctx.fsys.Open(systemID)
 		if err == nil {
 			return &fileParseInput{ReadCloser: f, uri: systemID}, nil
 		}

--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -91,7 +91,7 @@ func (p Processor) Resolver(r Resolver) Processor {
 func (p Processor) FS(fsys fs.FS) Processor {
 	p = p.clone()
 	if fsys == nil {
-		fsys = iofs.Root{}
+		fsys = iofs.PermissiveRoot{}
 	}
 	p.cfg.fsys = fsys
 	return p
@@ -173,7 +173,7 @@ func (proc Processor) ProcessTree(ctx context.Context, node helium.Node) (int, e
 	if p.resolver == nil {
 		fsys := cfg.fsys
 		if fsys == nil {
-			fsys = iofs.Root{}
+			fsys = iofs.PermissiveRoot{}
 		}
 		p.resolver = &fileResolver{fsys: fsys}
 	}
@@ -1190,7 +1190,7 @@ func (p *processor) computeFixupBases(inc *helium.Element, sourceURI string) (st
 }
 
 // fileResolver resolves URIs by reading from an [fs.FS]. The default FS
-// (an internal/iofs.Root{}) opens any OS path. Substitute a stricter
+// (an internal/iofs.PermissiveRoot{}) opens any OS path. Substitute a stricter
 // fs.FS through [Processor.FS] for untrusted input.
 type fileResolver struct {
 	fsys fs.FS

--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/url"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -13,6 +13,7 @@ import (
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/encoding"
+	"github.com/lestrrat-go/helium/internal/iofs"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/xpointer"
 )
@@ -32,6 +33,7 @@ type processorCfg struct {
 	noMarkers    bool
 	noBaseFixup  bool
 	resolver     Resolver
+	fsys         fs.FS
 	baseURI      string
 	errorHandler helium.ErrorHandler
 }
@@ -69,10 +71,29 @@ func (p Processor) NoBaseFixup() Processor {
 	return p
 }
 
-// Resolver sets a custom resource resolver.
+// Resolver sets a custom resource resolver. A non-nil Resolver takes
+// precedence over [Processor.FS]: the FS-backed default is only used
+// when no explicit Resolver is configured.
 func (p Processor) Resolver(r Resolver) Processor {
 	p = p.clone()
 	p.cfg.resolver = r
+	return p
+}
+
+// FS sets the [fs.FS] used by the default file-based resolver to load
+// XInclude targets (both parse="xml" and parse="text"). A nil value
+// restores the default, which opens any path supplied via [os.Open] —
+// preserving historical behavior. Callers handling untrusted documents
+// should supply a stricter FS (for example one produced by [os.DirFS]).
+//
+// If a Resolver is also configured via [Processor.Resolver], it takes
+// precedence and this FS is ignored.
+func (p Processor) FS(fsys fs.FS) Processor {
+	p = p.clone()
+	if fsys == nil {
+		fsys = iofs.Root{}
+	}
+	p.cfg.fsys = fsys
 	return p
 }
 
@@ -150,7 +171,11 @@ func (proc Processor) ProcessTree(ctx context.Context, node helium.Node) (int, e
 		txtCache:     make(map[string]txtCacheEntry),
 	}
 	if p.resolver == nil {
-		p.resolver = &fileResolver{}
+		fsys := cfg.fsys
+		if fsys == nil {
+			fsys = iofs.Root{}
+		}
+		p.resolver = &fileResolver{fsys: fsys}
 	}
 
 	if err := p.processNode(ctx, node); err != nil {
@@ -1164,8 +1189,12 @@ func (p *processor) computeFixupBases(inc *helium.Element, sourceURI string) (st
 	return relSource, effectiveBaseURI(inc, relTarget)
 }
 
-// fileResolver resolves URIs by reading from the filesystem.
-type fileResolver struct{}
+// fileResolver resolves URIs by reading from an [fs.FS]. The default FS
+// (an internal/iofs.Root{}) opens any OS path. Substitute a stricter
+// fs.FS through [Processor.FS] for untrusted input.
+type fileResolver struct {
+	fsys fs.FS
+}
 
 func (r *fileResolver) Resolve(href, base string) (io.ReadCloser, error) {
 	path := href
@@ -1179,5 +1208,5 @@ func (r *fileResolver) Resolve(href, base string) (io.ReadCloser, error) {
 			path = filepath.Join(filepath.Dir(basePath), href)
 		}
 	}
-	return os.Open(path) //nolint:gosec,wrapcheck // path is constructed from caller-supplied href/base; file access is the intended behavior
+	return r.fsys.Open(path) //nolint:wrapcheck // resolver errors propagate to caller verbatim
 }

--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -33,7 +33,6 @@ type processorCfg struct {
 	noMarkers    bool
 	noBaseFixup  bool
 	resolver     Resolver
-	fsys         fs.FS
 	baseURI      string
 	errorHandler helium.ErrorHandler
 }
@@ -71,30 +70,32 @@ func (p Processor) NoBaseFixup() Processor {
 	return p
 }
 
-// Resolver sets a custom resource resolver. A non-nil Resolver takes
-// precedence over [Processor.FS]: the FS-backed default is only used
-// when no explicit Resolver is configured.
+// Resolver sets a custom resource resolver. When unset, an FS-backed
+// resolver opens any OS path verbatim via [os.Open], preserving
+// historical behavior. Callers handling untrusted documents should
+// supply a Resolver backed by a stricter [fs.FS] — see [NewFSResolver].
 func (p Processor) Resolver(r Resolver) Processor {
 	p = p.clone()
 	p.cfg.resolver = r
 	return p
 }
 
-// FS sets the [fs.FS] used by the default file-based resolver to load
-// XInclude targets (both parse="xml" and parse="text"). A nil value
-// restores the default, which opens any path supplied via [os.Open] —
-// preserving historical behavior. Callers handling untrusted documents
-// should supply a stricter FS (for example one produced by [os.DirFS]).
+// NewFSResolver returns a [Resolver] that opens hrefs through the given
+// [fs.FS]. Relative hrefs are resolved against the document's base URI
+// (only file:// or scheme-less bases are honored) and joined with
+// filepath.Join before being passed to fsys.Open. A nil fsys is treated
+// as the permissive default that opens any OS path verbatim.
 //
-// If a Resolver is also configured via [Processor.Resolver], it takes
-// precedence and this FS is ignored.
-func (p Processor) FS(fsys fs.FS) Processor {
-	p = p.clone()
+// Pair this with [Processor.Resolver] to sandbox XInclude — for example
+//
+//	xinclude.NewProcessor().
+//	    Resolver(xinclude.NewFSResolver(os.DirFS("/var/data"))).
+//	    Process(ctx, doc)
+func NewFSResolver(fsys fs.FS) Resolver {
 	if fsys == nil {
 		fsys = iofs.PermissiveRoot{}
 	}
-	p.cfg.fsys = fsys
-	return p
+	return &fsResolver{fsys: fsys}
 }
 
 // BaseURI sets the base URI for resolving relative hrefs.
@@ -171,11 +172,7 @@ func (proc Processor) ProcessTree(ctx context.Context, node helium.Node) (int, e
 		txtCache:     make(map[string]txtCacheEntry),
 	}
 	if p.resolver == nil {
-		fsys := cfg.fsys
-		if fsys == nil {
-			fsys = iofs.PermissiveRoot{}
-		}
-		p.resolver = &fileResolver{fsys: fsys}
+		p.resolver = NewFSResolver(nil)
 	}
 
 	if err := p.processNode(ctx, node); err != nil {
@@ -1189,14 +1186,15 @@ func (p *processor) computeFixupBases(inc *helium.Element, sourceURI string) (st
 	return relSource, effectiveBaseURI(inc, relTarget)
 }
 
-// fileResolver resolves URIs by reading from an [fs.FS]. The default FS
-// (an internal/iofs.PermissiveRoot{}) opens any OS path. Substitute a stricter
-// fs.FS through [Processor.FS] for untrusted input.
-type fileResolver struct {
+// fsResolver resolves URIs by reading from an [fs.FS]. The default FS
+// is [iofs.PermissiveRoot] which opens any OS path verbatim; callers
+// handling untrusted input should construct one with a stricter fs.FS
+// via [NewFSResolver].
+type fsResolver struct {
 	fsys fs.FS
 }
 
-func (r *fileResolver) Resolve(href, base string) (io.ReadCloser, error) {
+func (r *fsResolver) Resolve(href, base string) (io.ReadCloser, error) {
 	path := href
 	if !filepath.IsAbs(path) && base != "" {
 		baseURL, err := url.Parse(base)

--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -83,14 +83,17 @@ func (p Processor) Resolver(r Resolver) Processor {
 // NewFSResolver returns a [Resolver] that opens hrefs through the given
 // [fs.FS]. Relative hrefs are resolved against the document's base URI
 // (only file:// or scheme-less bases are honored) and joined with
-// filepath.Join before being passed to fsys.Open. A nil fsys is treated
-// as the permissive default that opens any OS path verbatim.
+// [filepath.Join] before being passed to fsys.Open. A nil fsys is
+// treated as the permissive default that opens any OS path verbatim.
 //
-// Pair this with [Processor.Resolver] to sandbox XInclude — for example
-//
-//	xinclude.NewProcessor().
-//	    Resolver(xinclude.NewFSResolver(os.DirFS("/var/data"))).
-//	    Process(ctx, doc)
+// Note: because the name handed to fsys.Open is the [filepath.Join]
+// result, it may be absolute and may use OS-specific separators on
+// Windows. FS implementations that enforce [fs.ValidPath] (notably
+// [os.DirFS] and [testing/fstest.MapFS]) will reject those names.
+// Sandboxing XInclude behind such an FS requires path normalization
+// that is not yet performed by this package; for now, supply an FS
+// implementation that accepts OS-style names, or use [Processor.Resolver]
+// with a fully custom resolver that controls its own path resolution.
 func NewFSResolver(fsys fs.FS) Resolver {
 	if fsys == nil {
 		fsys = iofs.PermissiveRoot{}

--- a/xinclude/xinclude_test.go
+++ b/xinclude/xinclude_test.go
@@ -51,19 +51,21 @@ func (e *resolveError) Error() string {
 	return "not found: " + e.href
 }
 
-func TestXIncludeFS(t *testing.T) {
+func TestXIncludeNewFSResolver(t *testing.T) {
 	t.Parallel()
 
-	t.Run("default resolver reads from injected FS", func(t *testing.T) {
+	t.Run("reads through injected FS", func(t *testing.T) {
 		t.Parallel()
 		doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
-			<xi:include href="included.xml"/>
+			<xi:include href="fs-target.xml"/>
 		</root>`)
 
 		fsys := fstest.MapFS{
-			"included.xml": &fstest.MapFile{Data: []byte(`<chapter>FromFS</chapter>`)},
+			"fs-target.xml": &fstest.MapFile{Data: []byte(`<loaded>FromFS</loaded>`)},
 		}
-		count, err := xinclude.NewProcessor().FS(fsys).NoXIncludeMarkers().NoBaseFixup().
+		count, err := xinclude.NewProcessor().
+			Resolver(xinclude.NewFSResolver(fsys)).
+			NoXIncludeMarkers().NoBaseFixup().
 			Process(t.Context(), doc)
 		require.NoError(t, err)
 		require.Equal(t, 1, count)
@@ -72,49 +74,17 @@ func TestXIncludeFS(t *testing.T) {
 		require.NotNil(t, root)
 		var found bool
 		for c := root.FirstChild(); c != nil; c = c.NextSibling() {
-			if c.Type() == helium.ElementNode && c.(*helium.Element).LocalName() == "chapter" {
+			if c.Type() == helium.ElementNode && c.(*helium.Element).LocalName() == "loaded" {
 				found = true
 				require.Equal(t, "FromFS", string(c.Content()))
 			}
 		}
-		require.True(t, found, "<chapter> from FS not found")
+		require.True(t, found, "loaded element from FS not found")
 	})
 
-	t.Run("Resolver takes precedence over FS", func(t *testing.T) {
+	t.Run("nil FS yields a permissive default", func(t *testing.T) {
 		t.Parallel()
-		doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
-			<xi:include href="included.xml"/>
-		</root>`)
-
-		// FS would return "<from-fs/>" but Resolver returns "<from-resolver/>";
-		// Resolver wins.
-		fsys := fstest.MapFS{
-			"included.xml": &fstest.MapFile{Data: []byte(`<from-fs/>`)},
-		}
-		res := &stringResolver{files: map[string]string{"included.xml": `<from-resolver/>`}}
-		count, err := xinclude.NewProcessor().FS(fsys).Resolver(res).NoXIncludeMarkers().NoBaseFixup().
-			Process(t.Context(), doc)
-		require.NoError(t, err)
-		require.Equal(t, 1, count)
-
-		root := docElement(doc)
-		require.NotNil(t, root)
-		var localName string
-		for c := root.FirstChild(); c != nil; c = c.NextSibling() {
-			if c.Type() == helium.ElementNode {
-				localName = c.(*helium.Element).LocalName()
-				break
-			}
-		}
-		require.Equal(t, "from-resolver", localName)
-	})
-
-	t.Run("nil FS restores default", func(t *testing.T) {
-		t.Parallel()
-		var p xinclude.Processor
-		require.NotPanics(t, func() {
-			_ = p.FS(fstest.MapFS{}).FS(nil)
-		})
+		require.NotNil(t, xinclude.NewFSResolver(nil))
 	})
 }
 

--- a/xinclude/xinclude_test.go
+++ b/xinclude/xinclude_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/xinclude"
@@ -48,6 +49,73 @@ type resolveError struct {
 
 func (e *resolveError) Error() string {
 	return "not found: " + e.href
+}
+
+func TestXIncludeFS(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default resolver reads from injected FS", func(t *testing.T) {
+		t.Parallel()
+		doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
+			<xi:include href="included.xml"/>
+		</root>`)
+
+		fsys := fstest.MapFS{
+			"included.xml": &fstest.MapFile{Data: []byte(`<chapter>FromFS</chapter>`)},
+		}
+		count, err := xinclude.NewProcessor().FS(fsys).NoXIncludeMarkers().NoBaseFixup().
+			Process(t.Context(), doc)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+
+		root := docElement(doc)
+		require.NotNil(t, root)
+		var found bool
+		for c := root.FirstChild(); c != nil; c = c.NextSibling() {
+			if c.Type() == helium.ElementNode && c.(*helium.Element).LocalName() == "chapter" {
+				found = true
+				require.Equal(t, "FromFS", string(c.Content()))
+			}
+		}
+		require.True(t, found, "<chapter> from FS not found")
+	})
+
+	t.Run("Resolver takes precedence over FS", func(t *testing.T) {
+		t.Parallel()
+		doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
+			<xi:include href="included.xml"/>
+		</root>`)
+
+		// FS would return "<from-fs/>" but Resolver returns "<from-resolver/>";
+		// Resolver wins.
+		fsys := fstest.MapFS{
+			"included.xml": &fstest.MapFile{Data: []byte(`<from-fs/>`)},
+		}
+		res := &stringResolver{files: map[string]string{"included.xml": `<from-resolver/>`}}
+		count, err := xinclude.NewProcessor().FS(fsys).Resolver(res).NoXIncludeMarkers().NoBaseFixup().
+			Process(t.Context(), doc)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+
+		root := docElement(doc)
+		require.NotNil(t, root)
+		var localName string
+		for c := root.FirstChild(); c != nil; c = c.NextSibling() {
+			if c.Type() == helium.ElementNode {
+				localName = c.(*helium.Element).LocalName()
+				break
+			}
+		}
+		require.Equal(t, "from-resolver", localName)
+	})
+
+	t.Run("nil FS restores default", func(t *testing.T) {
+		t.Parallel()
+		var p xinclude.Processor
+		require.NotPanics(t, func() {
+			_ = p.FS(fstest.MapFS{}).FS(nil)
+		})
+	})
 }
 
 func TestXIncludeBasicXML(t *testing.T) {

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -73,7 +73,7 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 		return nil, fmt.Errorf("xsd: root element is not xs:schema")
 	}
 
-	fsys := fs.FS(iofs.Root{})
+	fsys := fs.FS(iofs.PermissiveRoot{})
 	if cfg != nil && cfg.fsys != nil {
 		fsys = cfg.fsys
 	}

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -3,10 +3,12 @@ package xsd
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"sort"
 	"strconv"
 
 	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/iofs"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 )
 
@@ -14,6 +16,7 @@ import (
 type compiler struct {
 	schema  *Schema
 	baseDir string // directory of the schema file, for resolving relative paths
+	fsys    fs.FS  // filesystem for loading xs:include/xs:import/xs:redefine targets
 	// unresolved type references: maps from element/type QName to the type ref string
 	typeRefs map[*TypeDef]QName
 	elemRefs map[*ElementDecl]QName
@@ -70,6 +73,10 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 		return nil, fmt.Errorf("xsd: root element is not xs:schema")
 	}
 
+	fsys := fs.FS(iofs.Root{})
+	if cfg != nil && cfg.fsys != nil {
+		fsys = cfg.fsys
+	}
 	c := &compiler{
 		schema: &Schema{
 			elements:    make(map[QName]*ElementDecl),
@@ -80,6 +87,7 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 			substGroups: make(map[QName][]*ElementDecl),
 		},
 		baseDir:           baseDir,
+		fsys:              fsys,
 		typeRefs:          make(map[*TypeDef]QName),
 		elemRefs:          make(map[*ElementDecl]QName),
 		elemRefSources:    make(map[*ElementDecl]elemRefSource),

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -3,8 +3,8 @@ package xsd
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"maps"
-	"os"
 	"path/filepath"
 
 	helium "github.com/lestrrat-go/helium"
@@ -80,7 +80,7 @@ func (c *compiler) loadInclude(ctx context.Context, location string, includeElem
 		path = filepath.Join(c.baseDir, location)
 	}
 
-	data, err := os.ReadFile(path) //nolint:gosec // path is constructed from schema baseDir + user-supplied location
+	data, err := fs.ReadFile(c.fsys, path)
 	if err != nil {
 		return fmt.Errorf("xsd: failed to load include %q: %w", location, err)
 	}
@@ -161,7 +161,7 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 		path = filepath.Join(c.baseDir, location)
 	}
 
-	data, err := os.ReadFile(path) //nolint:gosec // path is constructed from schema baseDir + user-supplied location
+	data, err := fs.ReadFile(c.fsys, path)
 	if err != nil {
 		return fmt.Errorf("xsd: failed to load redefine %q: %w", location, err)
 	}
@@ -369,7 +369,7 @@ func (c *compiler) loadImport(ctx context.Context, location, _ string) error {
 		path = filepath.Join(c.baseDir, location)
 	}
 
-	data, err := os.ReadFile(path) //nolint:gosec // path is constructed from schema baseDir + import location
+	data, err := fs.ReadFile(c.fsys, path)
 	if err != nil {
 		return fmt.Errorf("xsd: failed to load import %q: %w", location, err)
 	}
@@ -401,6 +401,7 @@ func (c *compiler) loadImport(ctx context.Context, location, _ string) error {
 			substGroups: make(map[QName][]*ElementDecl),
 		},
 		baseDir:           filepath.Dir(path),
+		fsys:              c.fsys,
 		typeRefs:          make(map[*TypeDef]QName),
 		elemRefs:          make(map[*ElementDecl]QName),
 		elemRefSources:    make(map[*ElementDecl]elemRefSource),

--- a/xsd/xsd.go
+++ b/xsd/xsd.go
@@ -86,7 +86,7 @@ func (c Compiler) BaseDir(dir string) Compiler {
 func (c Compiler) FS(fsys fs.FS) Compiler {
 	c = c.clone()
 	if fsys == nil {
-		fsys = iofs.Root{}
+		fsys = iofs.PermissiveRoot{}
 	}
 	c.cfg.fsys = fsys
 	return c

--- a/xsd/xsd.go
+++ b/xsd/xsd.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 
 	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/iofs"
 )
 
 // ErrValidationFailed is returned by Validate when the document does not
@@ -19,6 +21,7 @@ var ErrValidationFailed = errors.New("xsd: validation failed")
 type compileConfig struct {
 	label        string // label for error messages (e.g. source filename)
 	baseDir      string // base directory for resolving relative includes
+	fsys         fs.FS  // filesystem for loading xs:include/xs:import/xs:redefine targets
 	errorHandler helium.ErrorHandler
 }
 
@@ -72,6 +75,20 @@ func (c Compiler) Label(name string) Compiler {
 func (c Compiler) BaseDir(dir string) Compiler {
 	c = c.clone()
 	c.cfg.baseDir = dir
+	return c
+}
+
+// FS sets the [fs.FS] used to load schemas referenced by xs:include,
+// xs:import, and xs:redefine during compilation. A nil value restores
+// the default, which opens any path supplied to the compiler via
+// [os.Open]. Callers handling untrusted schemas should supply a
+// stricter FS (for example one produced by [os.DirFS]).
+func (c Compiler) FS(fsys fs.FS) Compiler {
+	c = c.clone()
+	if fsys == nil {
+		fsys = iofs.Root{}
+	}
+	c.cfg.fsys = fsys
 	return c
 }
 

--- a/xsd/xsd.go
+++ b/xsd/xsd.go
@@ -81,8 +81,16 @@ func (c Compiler) BaseDir(dir string) Compiler {
 // FS sets the [fs.FS] used to load schemas referenced by xs:include,
 // xs:import, and xs:redefine during compilation. A nil value restores
 // the default, which opens any path supplied to the compiler via
-// [os.Open]. Callers handling untrusted schemas should supply a
-// stricter FS (for example one produced by [os.DirFS]).
+// [os.Open].
+//
+// Note: the names handed to the FS are built with [filepath.Join] from
+// [Compiler.BaseDir] and the include location, so they may be absolute
+// and may use OS-specific separators on Windows. FS implementations
+// that enforce [fs.ValidPath] (notably [os.DirFS] and
+// [testing/fstest.MapFS]) will reject those names. Sandboxing schema
+// loading behind such an FS requires path normalization that is not yet
+// performed by this package; for now, supply an FS implementation that
+// accepts OS-style names.
 func (c Compiler) FS(fsys fs.FS) Compiler {
 	c = c.clone()
 	if fsys == nil {

--- a/xsd/xsd_test.go
+++ b/xsd/xsd_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/fstest"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/xsd"
@@ -993,6 +994,44 @@ func TestWithAnnotations(t *testing.T) {
 	require.Equal(t, "xs:string", byName["elem:name"])
 	require.Equal(t, "xs:integer", byName["elem:age"])
 	require.Equal(t, "xs:ID", byName["attr:id"])
+}
+
+func TestCompilerFS(t *testing.T) {
+	t.Parallel()
+
+	const baseXSD = `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="part.xsd"/>
+  <xs:element name="root" type="xs:string"/>
+</xs:schema>`
+
+	const partXSD = `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="part-t">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+</xs:schema>`
+
+	t.Run("include resolved through injected FS", func(t *testing.T) {
+		t.Parallel()
+
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(baseXSD))
+		require.NoError(t, err)
+
+		fsys := fstest.MapFS{
+			"part.xsd": &fstest.MapFile{Data: []byte(partXSD)},
+		}
+		_, err = xsd.NewCompiler().FS(fsys).Compile(t.Context(), doc)
+		require.NoError(t, err)
+	})
+
+	t.Run("nil FS restores default", func(t *testing.T) {
+		t.Parallel()
+		var c xsd.Compiler
+		require.NotPanics(t, func() {
+			_ = c.FS(fstest.MapFS{}).FS(nil)
+		})
+	})
 }
 
 func TestZeroCompilerFluent(t *testing.T) {


### PR DESCRIPTION
Routes external XML resource loads (DTDs, entities, schema includes, XInclude targets) through a configurable fs.FS — adds Parser.FS, xsd.Compiler.FS, relaxng.Compiler.FS, and xinclude.NewFSResolver. Defaults preserve current behavior verbatim; tightening defaults is a separate follow-up.
