### PR TITLE
xmldsig1: harden against XML Signature Wrapping (XSW) attacks

### DIFF
--- a/examples/xmldsig1_sign_verify_example_test.go
+++ b/examples/xmldsig1_sign_verify_example_test.go
@@ -56,7 +56,7 @@ func Example_xmldsig1_sign_verify() {
 	// Verify checks the first ds:Signature element in the document.
 	// It validates both the SignatureValue (cryptographic signature over
 	// the canonical SignedInfo) and each Reference digest.
-	err = xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).
+	_, err = xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).
 		Verify(context.Background(), doc)
 	if err != nil {
 		fmt.Printf("verification failed: %s\n", err)

--- a/examples/xmldsig1_sign_verify_example_test.go
+++ b/examples/xmldsig1_sign_verify_example_test.go
@@ -53,9 +53,11 @@ func Example_xmldsig1_sign_verify() {
 	// public key. StaticKey always returns the same key; for SAML you
 	// would typically use X509CertKeySource with the IdP's certificate.
 	//
-	// Verify checks the first ds:Signature element in the document.
-	// It validates both the SignatureValue (cryptographic signature over
-	// the canonical SignedInfo) and each Reference digest.
+	// Verify requires the document to contain exactly one ds:Signature
+	// element; it returns ErrAmbiguousSignature when more than one is
+	// present (use VerifyElement to disambiguate in that case). It
+	// validates both the SignatureValue (cryptographic signature over the
+	// canonical SignedInfo) and each Reference digest.
 	_, err = xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).
 		Verify(context.Background(), doc)
 	if err != nil {

--- a/examples/xmldsig1_x509_keyinfo_example_test.go
+++ b/examples/xmldsig1_x509_keyinfo_example_test.go
@@ -64,7 +64,7 @@ func Example_xmldsig1_x509_keyinfo() {
 	fmt.Println(strings.Contains(out, "ds:X509Certificate"))
 
 	// Verify using the trusted certificate.
-	err = xmldsig1.NewVerifier(xmldsig1.X509CertKeySource(cert)).
+	_, err = xmldsig1.NewVerifier(xmldsig1.X509CertKeySource(cert)).
 		Verify(context.Background(), doc)
 	if err != nil {
 		fmt.Printf("verify error: %s\n", err)

--- a/xmldsig1/README.md
+++ b/xmldsig1/README.md
@@ -66,7 +66,7 @@ func Example_xmldsig1_sign_verify() {
   // Verify checks the first ds:Signature element in the document.
   // It validates both the SignatureValue (cryptographic signature over
   // the canonical SignedInfo) and each Reference digest.
-  err = xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).
+  _, err = xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).
     Verify(context.Background(), doc)
   if err != nil {
     fmt.Printf("verification failed: %s\n", err)

--- a/xmldsig1/README.md
+++ b/xmldsig1/README.md
@@ -63,9 +63,11 @@ func Example_xmldsig1_sign_verify() {
   // public key. StaticKey always returns the same key; for SAML you
   // would typically use X509CertKeySource with the IdP's certificate.
   //
-  // Verify checks the first ds:Signature element in the document.
-  // It validates both the SignatureValue (cryptographic signature over
-  // the canonical SignedInfo) and each Reference digest.
+  // Verify requires the document to contain exactly one ds:Signature
+  // element; it returns ErrAmbiguousSignature when more than one is
+  // present (use VerifyElement to disambiguate in that case). It
+  // validates both the SignatureValue (cryptographic signature over the
+  // canonical SignedInfo) and each Reference digest.
   _, err = xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).
     Verify(context.Background(), doc)
   if err != nil {

--- a/xmldsig1/dom_helpers.go
+++ b/xmldsig1/dom_helpers.go
@@ -10,15 +10,21 @@ import (
 // detach/AddChild reattachment moves the Signature to the end of its
 // parent's child list and silently restructures the document — a quiet
 // corruption that confuses downstream consumers and can mask XSW shapes.
+//
+// parent is stored as MutableNode (rather than *Element) so that we can
+// also anchor a Signature whose parent is the Document itself — i.e., a
+// document whose root element is <ds:Signature>. If parent were typed as
+// *Element, that case would silently drop the anchor and the detached
+// Signature would never be reattached.
 type sigAnchor struct {
-	parent      *helium.Element
+	parent      helium.MutableNode
 	nextSibling helium.Node // nil if Signature was the last child
 }
 
 // captureAnchor records the current location of sigElem.
 func captureAnchor(sigElem *helium.Element) sigAnchor {
 	a := sigAnchor{}
-	if p, ok := helium.AsNode[*helium.Element](sigElem.Parent()); ok {
+	if p, ok := sigElem.Parent().(helium.MutableNode); ok {
 		a.parent = p
 	}
 	a.nextSibling = sigElem.NextSibling()
@@ -43,7 +49,7 @@ func (a sigAnchor) restore(sigElem *helium.Element) error {
 // ref. ref must be a current child of parent and newChild must currently
 // be detached. Implemented via MutableNode.Replace so we don't depend on
 // helium's unexported docnode internals.
-func insertBefore(parent *helium.Element, newChild *helium.Element, ref helium.Node) error {
+func insertBefore(parent helium.MutableNode, newChild *helium.Element, ref helium.Node) error {
 	refMut, ok := ref.(helium.MutableNode)
 	if !ok {
 		// Fall back to AddChild (appends) so we don't lose the node.

--- a/xmldsig1/dom_helpers.go
+++ b/xmldsig1/dom_helpers.go
@@ -1,0 +1,56 @@
+package xmldsig1
+
+import (
+	helium "github.com/lestrrat-go/helium"
+)
+
+// sigAnchor remembers a Signature element's exact location in its sibling
+// chain so it can be reinserted in the same spot after a temporary detach
+// during enveloped-signature processing. Without this, naive
+// detach/AddChild reattachment moves the Signature to the end of its
+// parent's child list and silently restructures the document — a quiet
+// corruption that confuses downstream consumers and can mask XSW shapes.
+type sigAnchor struct {
+	parent      *helium.Element
+	nextSibling helium.Node // nil if Signature was the last child
+}
+
+// captureAnchor records the current location of sigElem.
+func captureAnchor(sigElem *helium.Element) sigAnchor {
+	a := sigAnchor{}
+	if p, ok := helium.AsNode[*helium.Element](sigElem.Parent()); ok {
+		a.parent = p
+	}
+	a.nextSibling = sigElem.NextSibling()
+	return a
+}
+
+// restore reattaches sigElem at the anchored position. If nextSibling is
+// nil, the node is appended at the end (equivalent to AddChild). Otherwise
+// the node is spliced in before nextSibling, preserving the original
+// document layout.
+func (a sigAnchor) restore(sigElem *helium.Element) error {
+	if a.parent == nil {
+		return nil
+	}
+	if a.nextSibling == nil {
+		return a.parent.AddChild(sigElem)
+	}
+	return insertBefore(a.parent, sigElem, a.nextSibling)
+}
+
+// insertBefore inserts newChild into parent's child list immediately before
+// ref. ref must be a current child of parent and newChild must currently
+// be detached. Implemented via MutableNode.Replace so we don't depend on
+// helium's unexported docnode internals.
+func insertBefore(parent *helium.Element, newChild *helium.Element, ref helium.Node) error {
+	refMut, ok := ref.(helium.MutableNode)
+	if !ok {
+		// Fall back to AddChild (appends) so we don't lose the node.
+		return parent.AddChild(newChild)
+	}
+	// Replace ref with [newChild, ref] — Replace patches parent's
+	// firstChild/lastChild pointers and rewrites the sibling chain
+	// correctly even when ref is the first child of parent.
+	return refMut.Replace(newChild, ref)
+}

--- a/xmldsig1/dom_helpers_test.go
+++ b/xmldsig1/dom_helpers_test.go
@@ -1,0 +1,28 @@
+package xmldsig1
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSigAnchor_DocumentParent exercises the case where the Signature element
+// is the document's root element. captureAnchor must record the Document as
+// the parent (not nil) so that restore can reattach the node after a
+// temporary detach during enveloped-signature processing.
+func TestSigAnchor_DocumentParent(t *testing.T) {
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"/>`))
+	require.NoError(t, err)
+	root := doc.DocumentElement()
+	require.NotNil(t, root)
+
+	anchor := captureAnchor(root)
+	require.NotNil(t, anchor.parent, "anchor must record the Document parent")
+
+	helium.UnlinkNode(root)
+	require.Nil(t, doc.DocumentElement(), "root should be detached")
+
+	require.NoError(t, anchor.restore(root))
+	require.Same(t, root, doc.DocumentElement(), "restore must reattach the Signature as document element")
+}

--- a/xmldsig1/errors.go
+++ b/xmldsig1/errors.go
@@ -30,6 +30,17 @@ var (
 	// ErrReferenceNotFound is returned when a Reference URI cannot be resolved.
 	ErrReferenceNotFound = errors.New("xmldsig1: reference URI not resolved")
 
+	// ErrAmbiguousReference is returned when a Reference URI resolves to more
+	// than one element. This is the primary defense against XML Signature
+	// Wrapping (XSW) attacks where an attacker injects a duplicate-ID element
+	// containing malicious content alongside the legitimately signed element.
+	ErrAmbiguousReference = errors.New("xmldsig1: reference URI matches multiple elements")
+
+	// ErrAmbiguousSignature is returned when the document contains more than
+	// one Signature element and Verify cannot decide which one to verify.
+	// Callers must use VerifyElement to disambiguate.
+	ErrAmbiguousSignature = errors.New("xmldsig1: document contains multiple Signature elements")
+
 	// ErrInvalidKeyInfo is returned when KeyInfo content cannot be parsed.
 	ErrInvalidKeyInfo = errors.New("xmldsig1: invalid KeyInfo")
 

--- a/xmldsig1/result.go
+++ b/xmldsig1/result.go
@@ -1,0 +1,68 @@
+package xmldsig1
+
+import (
+	helium "github.com/lestrrat-go/helium"
+)
+
+// VerifiedReference describes a single Reference that was successfully
+// verified. Callers should use this to confirm the *Element they are about
+// to consume from the document is actually covered by the signature —
+// guarding against XML Signature Wrapping (XSW) attacks.
+type VerifiedReference struct {
+	// URI is the value of the Reference URI attribute as it appeared in the
+	// signed document.
+	URI string
+
+	// Element is the element that the URI resolved to at verification time.
+	// For the enveloped pattern (URI=""), this is the document element.
+	// For fragment references (URI="#id"), this is the unique element with
+	// that Id/ID attribute. If duplicate matches existed, verification fails
+	// with ErrAmbiguousReference before this field is populated.
+	Element *helium.Element
+
+	// DigestAlgorithm is the algorithm URI declared in the DigestMethod
+	// element (e.g. DigestSHA256).
+	DigestAlgorithm string
+}
+
+// VerifyResult is returned by Verifier.Verify and Verifier.VerifyElement on
+// success. It exposes the set of elements that were actually covered by the
+// signature so callers can correlate signed content with the element they
+// intend to consume.
+type VerifyResult struct {
+	// Signature is the Signature element that was verified.
+	Signature *helium.Element
+
+	// References lists every Reference inside SignedInfo that was
+	// successfully verified, in document order.
+	References []VerifiedReference
+}
+
+// SignedElement returns the resolved element for the Reference with the
+// given URI, or nil if no such Reference was verified. This is the
+// preferred way to confirm an element was covered by the signature before
+// consuming it.
+func (r *VerifyResult) SignedElement(uri string) *helium.Element {
+	if r == nil {
+		return nil
+	}
+	for _, ref := range r.References {
+		if ref.URI == uri {
+			return ref.Element
+		}
+	}
+	return nil
+}
+
+// Covers reports whether elem was covered by any verified Reference.
+func (r *VerifyResult) Covers(elem *helium.Element) bool {
+	if r == nil || elem == nil {
+		return false
+	}
+	for _, ref := range r.References {
+		if ref.Element == elem {
+			return true
+		}
+	}
+	return false
+}

--- a/xmldsig1/sign.go
+++ b/xmldsig1/sign.go
@@ -224,8 +224,12 @@ func processReference(_ context.Context, doc *helium.Document, sigElem, signedIn
 		}
 	}
 
-	// For enveloped signature, temporarily detach the Signature element.
+	// For enveloped signature, temporarily detach the Signature element,
+	// remembering its exact position so we can restore it after
+	// canonicalization.
+	var anchor sigAnchor
 	if hasEnveloped {
+		anchor = captureAnchor(sigElem)
 		helium.UnlinkNode(sigElem)
 	}
 
@@ -250,11 +254,10 @@ func processReference(_ context.Context, doc *helium.Document, sigElem, signedIn
 		canonical, err = canonicalizeSubtree(c14nMethod, target, prefixes)
 	}
 
-	// Reattach the Signature element.
+	// Reattach the Signature element at its original sibling position.
 	if hasEnveloped {
-		parent := target
-		if err2 := parent.AddChild(sigElem); err2 != nil {
-			return err2
+		if rerr := anchor.restore(sigElem); rerr != nil {
+			return rerr
 		}
 	}
 

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -127,40 +127,50 @@ func collectSubtreeNodes(n helium.Node) []helium.Node {
 	return nodes
 }
 
-// resolveReference resolves a Reference URI to the target node(s).
+// resolveReference resolves a Reference URI to the target node.
 // For URI="" (enveloped), returns the document element.
-// For URI="#id", returns the element with that ID.
+// For URI="#id", returns the unique element with that ID. If more than one
+// element matches the ID, returns ErrAmbiguousReference — this is the
+// primary defense against XML Signature Wrapping (XSW) attacks where an
+// attacker injects a duplicate-ID element containing malicious content.
 func resolveReference(doc *helium.Document, uri string) (*helium.Element, error) {
 	if uri == "" {
 		return doc.DocumentElement(), nil
 	}
 	if strings.HasPrefix(uri, "#") {
 		id := uri[1:]
-		// Try the standard GetElementByID first (DTD-declared + xml:id).
-		elem := doc.GetElementByID(id)
-		if elem != nil {
-			return elem, nil
+		// Walk the tree once and collect every candidate. We accept matches
+		// from any of: DTD-declared ID, xml:id, or the common "Id"/"ID"
+		// attribute conventions used by XMLDSig/SAML. We refuse to resolve
+		// the reference if more than one element matches.
+		matches := findElementsByID(doc, id)
+		switch len(matches) {
+		case 0:
+			return nil, fmt.Errorf("%w: %s", ErrReferenceNotFound, uri)
+		case 1:
+			return matches[0], nil
+		default:
+			return nil, fmt.Errorf("%w: %s (matched %d elements)", ErrAmbiguousReference, uri, len(matches))
 		}
-		// Fallback: search for common Id/ID attributes used by XMLDSig/SAML.
-		elem = findElementByIDAttr(doc, id)
-		if elem != nil {
-			return elem, nil
-		}
-		return nil, fmt.Errorf("%w: %s", ErrReferenceNotFound, uri)
 	}
 	return nil, fmt.Errorf("%w: external references not supported: %s", ErrReferenceNotFound, uri)
 }
 
-// findElementByIDAttr walks the document tree looking for an element with
-// an "Id" or "ID" attribute matching the given value. This handles the common
-// case where documents use Id attributes without DTD declarations (e.g., SAML).
-func findElementByIDAttr(doc *helium.Document, id string) *helium.Element {
-	var found *helium.Element
+// findElementsByID walks the entire document tree and returns every element
+// whose ID (DTD-declared, xml:id, or an "Id"/"ID" attribute) matches the
+// given value. The walk is exhaustive — it never short-circuits — so that
+// duplicate IDs are surfaced to the caller rather than silently masked.
+func findElementsByID(doc *helium.Document, id string) []*helium.Element {
+	var matches []*helium.Element
+	// First, consult the document's GetElementByID — this covers DTD-declared
+	// IDs and xml:id. The result is added unconditionally; the attribute walk
+	// below de-duplicates pointers.
+	if elem := doc.GetElementByID(id); elem != nil {
+		matches = append(matches, elem)
+	}
+
 	var walk func(helium.Node)
 	walk = func(n helium.Node) {
-		if found != nil {
-			return
-		}
 		elem, ok := helium.AsNode[*helium.Element](n)
 		if !ok {
 			return
@@ -168,8 +178,10 @@ func findElementByIDAttr(doc *helium.Document, id string) *helium.Element {
 		for _, attr := range elem.Attributes() {
 			name := attr.Name()
 			if (name == "Id" || name == "ID") && attr.Value() == id {
-				found = elem
-				return
+				if !containsElem(matches, elem) {
+					matches = append(matches, elem)
+				}
+				break
 			}
 		}
 		for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
@@ -177,5 +189,14 @@ func findElementByIDAttr(doc *helium.Document, id string) *helium.Element {
 		}
 	}
 	walk(doc.DocumentElement())
-	return found
+	return matches
+}
+
+func containsElem(s []*helium.Element, e *helium.Element) bool {
+	for _, x := range s {
+		if x == e {
+			return true
+		}
+	}
+	return false
 }

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -2,10 +2,10 @@ package xmldsig1
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/lestrrat-go/helium/c14n"
+	"github.com/lestrrat-go/helium/enum"
 
 	helium "github.com/lestrrat-go/helium"
 )
@@ -158,18 +158,15 @@ func resolveReference(doc *helium.Document, uri string) (*helium.Element, error)
 }
 
 // findElementsByID walks the entire document tree and returns every element
-// whose ID (DTD-declared, xml:id, or an "Id"/"ID" attribute) matches the
-// given value. The walk is exhaustive — it never short-circuits — so that
-// duplicate IDs are surfaced to the caller rather than silently masked.
+// whose ID (xml:id, an "Id"/"ID" attribute, or a DTD-declared ID-typed
+// attribute) matches the given value. The walk is exhaustive — it never
+// short-circuits — so that duplicate IDs are surfaced to the caller rather
+// than silently masked. We do NOT consult Document.GetElementByID: its
+// underlying ID table is keyed by ID value and Document.RegisterID
+// overwrites on collision, which would hide the duplicate-xml:id case that
+// XSW hardening relies on.
 func findElementsByID(doc *helium.Document, id string) []*helium.Element {
 	var matches []*helium.Element
-	// First, consult the document's GetElementByID — this covers DTD-declared
-	// IDs and xml:id. The result is added unconditionally; the attribute walk
-	// below de-duplicates pointers.
-	if elem := doc.GetElementByID(id); elem != nil {
-		matches = append(matches, elem)
-	}
-
 	var walk func(helium.Node)
 	walk = func(n helium.Node) {
 		elem, ok := helium.AsNode[*helium.Element](n)
@@ -178,10 +175,14 @@ func findElementsByID(doc *helium.Document, id string) []*helium.Element {
 		}
 		for _, attr := range elem.Attributes() {
 			name := attr.Name()
-			if (name == "Id" || name == "ID") && attr.Value() == id {
-				if !slices.Contains(matches, elem) {
-					matches = append(matches, elem)
-				}
+			isIDAttr := name == "Id" || name == "ID" || name == "xml:id" || attr.AType() == enum.AttrID
+			if !isIDAttr {
+				continue
+			}
+			// xs:ID derives from xs:NCName, which collapses whitespace;
+			// match libxml2/helium normalization for xml:id.
+			if strings.TrimSpace(attr.Value()) == id {
+				matches = append(matches, elem)
 				break
 			}
 		}

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -2,6 +2,7 @@ package xmldsig1
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/lestrrat-go/helium/c14n"
@@ -178,7 +179,7 @@ func findElementsByID(doc *helium.Document, id string) []*helium.Element {
 		for _, attr := range elem.Attributes() {
 			name := attr.Name()
 			if (name == "Id" || name == "ID") && attr.Value() == id {
-				if !containsElem(matches, elem) {
+				if !slices.Contains(matches, elem) {
 					matches = append(matches, elem)
 				}
 				break
@@ -190,13 +191,4 @@ func findElementsByID(doc *helium.Document, id string) []*helium.Element {
 	}
 	walk(doc.DocumentElement())
 	return matches
-}
-
-func containsElem(s []*helium.Element, e *helium.Element) bool {
-	for _, x := range s {
-		if x == e {
-			return true
-		}
-	}
-	return false
 }

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -31,10 +31,10 @@ type parsedTransform struct {
 	prefixes  []string // for Exclusive C14N InclusiveNamespaces
 }
 
-func verifySignature(ctx context.Context, cfg *verifierConfig, doc *helium.Document, sigElem *helium.Element) error {
+func verifySignature(ctx context.Context, cfg *verifierConfig, doc *helium.Document, sigElem *helium.Element) (*VerifyResult, error) {
 	parsed, err := parseSignatureElement(sigElem)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Resolve key.
@@ -42,40 +42,48 @@ func verifySignature(ctx context.Context, cfg *verifierConfig, doc *helium.Docum
 	if parsed.keyInfoElem != nil {
 		keyInfoData, err = parseKeyInfo(parsed.keyInfoElem)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	key, err := cfg.keySource.ResolveKey(ctx, keyInfoData, parsed.signatureAlg)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Canonicalize SignedInfo.
 	canonical, err := canonicalizeSubtree(parsed.c14nMethod, parsed.signedInfoElem, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Verify signature value.
 	if err := verifyBytes(parsed.signatureAlg, key, canonical, parsed.signatureValue); err != nil {
-		return &VerificationError{Reference: -1, Err: err}
+		return nil, &VerificationError{Reference: -1, Err: err}
 	}
 
-	// Verify each reference.
+	// Verify each reference and record the resolved element so callers can
+	// confirm that the element they intend to consume is actually covered.
+	result := &VerifyResult{Signature: sigElem}
 	for i, ref := range parsed.references {
-		if err := verifyReference(doc, sigElem, ref); err != nil {
-			return &VerificationError{Reference: i, URI: ref.uri, Err: err}
+		target, err := verifyReference(doc, sigElem, ref)
+		if err != nil {
+			return nil, &VerificationError{Reference: i, URI: ref.uri, Err: err}
 		}
+		result.References = append(result.References, VerifiedReference{
+			URI:             ref.uri,
+			Element:         target,
+			DigestAlgorithm: ref.digestAlgorithm,
+		})
 	}
 
-	return nil
+	return result, nil
 }
 
-func verifyReference(doc *helium.Document, sigElem *helium.Element, ref parsedReference) error {
+func verifyReference(doc *helium.Document, sigElem *helium.Element, ref parsedReference) (*helium.Element, error) {
 	target, err := resolveReference(doc, ref.uri)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Check for enveloped-signature transform.
@@ -87,12 +95,13 @@ func verifyReference(doc *helium.Document, sigElem *helium.Element, ref parsedRe
 		}
 	}
 
-	// Temporarily detach the Signature element for enveloped signatures.
-	var sigParent *helium.Element
+	// Temporarily detach the Signature element for enveloped signatures,
+	// remembering its exact position so we can restore it after
+	// canonicalization. Naive reattach-via-AddChild would move the
+	// Signature to the end of its parent and silently restructure the doc.
+	var anchor sigAnchor
 	if hasEnveloped {
-		if p, ok := helium.AsNode[*helium.Element](sigElem.Parent()); ok {
-			sigParent = p
-		}
+		anchor = captureAnchor(sigElem)
 		helium.UnlinkNode(sigElem)
 	}
 
@@ -114,26 +123,28 @@ func verifyReference(doc *helium.Document, sigElem *helium.Element, ref parsedRe
 		canonical, err = canonicalizeSubtree(c14nMethod, target, prefixes)
 	}
 
-	// Reattach the Signature element.
-	if hasEnveloped && sigParent != nil {
-		_ = sigParent.AddChild(sigElem)
+	// Reattach the Signature element at its original sibling position.
+	if hasEnveloped {
+		if rerr := anchor.restore(sigElem); rerr != nil && err == nil {
+			err = rerr
+		}
 	}
 
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Compute and compare digest.
 	computed, err := computeDigest(ref.digestAlgorithm, canonical)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !digestEqual(computed, ref.digestValue) {
-		return ErrDigestMismatch
+		return nil, ErrDigestMismatch
 	}
 
-	return nil
+	return target, nil
 }
 
 func digestEqual(a, b []byte) bool {

--- a/xmldsig1/xmldsig1.go
+++ b/xmldsig1/xmldsig1.go
@@ -127,35 +127,59 @@ func NewVerifier(ks KeySource) Verifier {
 	return Verifier{cfg: &verifierConfig{keySource: ks}}
 }
 
-// Verify verifies the first Signature element found in the document.
-func (v Verifier) Verify(ctx context.Context, doc *helium.Document) error {
-	sig := findSignatureElement(doc.DocumentElement())
-	if sig == nil {
-		return ErrSignatureNotFound
+// Verify verifies the Signature element in the document. The document must
+// contain exactly one ds:Signature element; if it contains more than one
+// the function returns ErrAmbiguousSignature and the caller must use
+// VerifyElement to disambiguate.
+//
+// On success the returned VerifyResult exposes the set of elements actually
+// covered by the signature so callers can confirm — by pointer identity —
+// that the element they intend to consume was signed. This is the primary
+// defense against XML Signature Wrapping (XSW) attacks at the application
+// layer.
+func (v Verifier) Verify(ctx context.Context, doc *helium.Document) (*VerifyResult, error) {
+	sigs := findSignatureElements(doc.DocumentElement())
+	switch len(sigs) {
+	case 0:
+		return nil, ErrSignatureNotFound
+	case 1:
+		return verifySignature(ctx, v.cfg, doc, sigs[0])
+	default:
+		return nil, ErrAmbiguousSignature
 	}
+}
+
+// VerifyElement verifies a specific Signature element. Use this when the
+// document contains more than one Signature, or when the caller wants
+// explicit control over which Signature is targeted.
+func (v Verifier) VerifyElement(ctx context.Context, doc *helium.Document, sig *helium.Element) (*VerifyResult, error) {
 	return verifySignature(ctx, v.cfg, doc, sig)
 }
 
-// VerifyElement verifies a specific Signature element.
-func (v Verifier) VerifyElement(ctx context.Context, doc *helium.Document, sig *helium.Element) error {
-	return verifySignature(ctx, v.cfg, doc, sig)
-}
-
-// findSignatureElement searches for the first ds:Signature element in the tree.
-func findSignatureElement(n helium.Node) *helium.Element {
-	elem, ok := helium.AsNode[*helium.Element](n)
-	if !ok {
-		return nil
-	}
-	if localName(elem) == "Signature" && isDSigNS(elem) {
-		return elem
-	}
-	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
-		if found := findSignatureElement(child); found != nil {
-			return found
+// findSignatureElements walks the tree and returns every ds:Signature
+// element. The walk is exhaustive so that multiple-Signature documents are
+// detected rather than silently resolved to the first match.
+func findSignatureElements(n helium.Node) []*helium.Element {
+	var out []*helium.Element
+	var walk func(helium.Node)
+	walk = func(node helium.Node) {
+		elem, ok := helium.AsNode[*helium.Element](node)
+		if !ok {
+			return
+		}
+		if localName(elem) == "Signature" && isDSigNS(elem) {
+			out = append(out, elem)
+			// Do not descend into a Signature — a Signature inside
+			// another Signature (e.g. inside KeyInfo) is not itself a
+			// signature to be verified at the document level.
+			return
+		}
+		for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
+			walk(child)
 		}
 	}
-	return nil
+	walk(n)
+	return out
 }
 
 func isDSigNS(e *helium.Element) bool {

--- a/xmldsig1/xmldsig1_test.go
+++ b/xmldsig1/xmldsig1_test.go
@@ -76,7 +76,7 @@ func TestSignVerifyRoundTripRSASHA256(t *testing.T) {
 	require.NoError(t, err)
 
 	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
-	err = verifier.Verify(t.Context(), doc)
+	_, err = verifier.Verify(t.Context(), doc)
 	require.NoError(t, err)
 }
 
@@ -96,7 +96,7 @@ func TestSignVerifyRoundTripRSASHA1(t *testing.T) {
 	require.NoError(t, err)
 
 	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
-	err = verifier.Verify(t.Context(), doc)
+	_, err = verifier.Verify(t.Context(), doc)
 	require.NoError(t, err)
 }
 
@@ -112,7 +112,7 @@ func TestSignVerifyRoundTripECDSASHA256(t *testing.T) {
 	require.NoError(t, err)
 
 	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
-	err = verifier.Verify(t.Context(), doc)
+	_, err = verifier.Verify(t.Context(), doc)
 	require.NoError(t, err)
 }
 
@@ -132,7 +132,7 @@ func TestSignVerifyRoundTripECDSASHA384(t *testing.T) {
 	require.NoError(t, err)
 
 	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
-	err = verifier.Verify(t.Context(), doc)
+	_, err = verifier.Verify(t.Context(), doc)
 	require.NoError(t, err)
 }
 
@@ -151,7 +151,7 @@ func TestSignVerifyRoundTripHMACSHA256(t *testing.T) {
 	require.NoError(t, err)
 
 	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(secret))
-	err = verifier.Verify(t.Context(), doc)
+	_, err = verifier.Verify(t.Context(), doc)
 	require.NoError(t, err)
 }
 
@@ -167,7 +167,7 @@ func TestSignVerifyRoundTripEd25519(t *testing.T) {
 	require.NoError(t, err)
 
 	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(key.Public()))
-	err = verifier.Verify(t.Context(), doc)
+	_, err = verifier.Verify(t.Context(), doc)
 	require.NoError(t, err)
 }
 
@@ -185,7 +185,7 @@ func TestSignVerifyWithX509CertKeySource(t *testing.T) {
 	require.NoError(t, err)
 
 	verifier := xmldsig1.NewVerifier(xmldsig1.X509CertKeySource(cert))
-	err = verifier.Verify(t.Context(), doc)
+	_, err = verifier.Verify(t.Context(), doc)
 	require.NoError(t, err)
 }
 
@@ -207,7 +207,7 @@ func TestVerifyTamperedDocument(t *testing.T) {
 	doc2 := mustParseXML(t, tampered)
 
 	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
-	err = verifier.Verify(t.Context(), doc2)
+	_, err = verifier.Verify(t.Context(), doc2)
 	require.Error(t, err)
 }
 
@@ -224,7 +224,7 @@ func TestVerifyWrongKey(t *testing.T) {
 	require.NoError(t, err)
 
 	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key2.PublicKey))
-	err = verifier.Verify(t.Context(), doc)
+	_, err = verifier.Verify(t.Context(), doc)
 	require.Error(t, err)
 }
 
@@ -233,7 +233,7 @@ func TestVerifyNoSignature(t *testing.T) {
 	key := generateRSAKey(t)
 
 	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
-	err := verifier.Verify(t.Context(), doc)
+	_, err := verifier.Verify(t.Context(), doc)
 	require.ErrorIs(t, err, xmldsig1.ErrSignatureNotFound)
 }
 
@@ -298,6 +298,6 @@ func TestSignVerifyWithFragmentReference(t *testing.T) {
 	require.NoError(t, err)
 
 	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
-	err = verifier.Verify(t.Context(), doc)
+	_, err = verifier.Verify(t.Context(), doc)
 	require.NoError(t, err)
 }

--- a/xmldsig1/xsw_test.go
+++ b/xmldsig1/xsw_test.go
@@ -1,0 +1,282 @@
+package xmldsig1_test
+
+import (
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xmldsig1"
+	"github.com/stretchr/testify/require"
+)
+
+// duplicateIDElementName walks the doc element subtree, finds an element
+// whose name local part matches elementLocalName carrying an Id/ID attribute
+// equal to id, and returns the *first* such element. Test helper only.
+func findByLocalNameAndID(doc *helium.Document, localName, id string) *helium.Element {
+	var found *helium.Element
+	var walk func(n helium.Node)
+	walk = func(n helium.Node) {
+		if found != nil {
+			return
+		}
+		elem, ok := helium.AsNode[*helium.Element](n)
+		if !ok {
+			return
+		}
+		name := elem.Name()
+		l := name
+		if i := strings.IndexByte(name, ':'); i >= 0 {
+			l = name[i+1:]
+		}
+		if l == localName {
+			for _, a := range elem.Attributes() {
+				if (a.Name() == "Id" || a.Name() == "ID") && a.Value() == id {
+					found = elem
+					return
+				}
+			}
+		}
+		for c := elem.FirstChild(); c != nil; c = c.NextSibling() {
+			walk(c)
+		}
+	}
+	walk(doc.DocumentElement())
+	return found
+}
+
+// TestXSW_DuplicateIDFailsVerify reproduces the classic XML Signature
+// Wrapping shape: the document contains two elements with the same Id and
+// the Reference URI matches both. Verify MUST refuse to resolve the
+// reference rather than silently pick one.
+func TestXSW_DuplicateIDFailsVerify(t *testing.T) {
+	xml := `<root><payload Id="target"><val>good</val></payload></root>`
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, xml)
+
+	ref := xmldsig1.ReferenceConfig{
+		URI:             "#target",
+		DigestAlgorithm: xmldsig1.DigestSHA256,
+		Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+	}
+
+	sigElem, err := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(ref).
+		SignDetached(t.Context(), doc, key)
+	require.NoError(t, err)
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	// Now mount the attack: serialize, inject a duplicate-ID payload, re-parse.
+	signed, err := helium.WriteString(doc)
+	require.NoError(t, err)
+
+	// Inject an evil twin BEFORE the legitimate payload.
+	evil := `<payload Id="target"><val>evil</val></payload>`
+	tampered := strings.Replace(signed, `<payload Id="target">`, evil+`<payload Id="target">`, 1)
+	require.NotEqual(t, signed, tampered)
+
+	doc2 := mustParseXML(t, tampered)
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(t.Context(), doc2)
+	require.ErrorIs(t, err, xmldsig1.ErrAmbiguousReference)
+}
+
+// TestVerifyResult_ExposesSignedElement asserts that Verify returns the
+// resolved element pointer for each Reference, so the caller can compare
+// pointer equality against the element they are about to consume.
+func TestVerifyResult_ExposesSignedElement(t *testing.T) {
+	xml := `<root><data Id="payload">secret</data></root>`
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, xml)
+
+	target := findByLocalNameAndID(doc, "data", "payload")
+	require.NotNil(t, target)
+
+	ref := xmldsig1.ReferenceConfig{
+		URI:             "#payload",
+		DigestAlgorithm: xmldsig1.DigestSHA256,
+		Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+	}
+
+	sigElem, err := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(ref).
+		SignDetached(t.Context(), doc, key)
+	require.NoError(t, err)
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	res, err := verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Len(t, res.References, 1)
+	require.Equal(t, "#payload", res.References[0].URI)
+	require.Same(t, target, res.References[0].Element)
+	require.Same(t, target, res.SignedElement("#payload"))
+	require.True(t, res.Covers(target))
+}
+
+// TestVerifyPreservesSiblingPosition signs an enveloped signature, then
+// inserts a sibling AFTER the Signature element and asserts that, after
+// Verify, the canonical bytes of the whole document are unchanged.
+func TestVerifyPreservesSiblingPosition(t *testing.T) {
+	// Use a doc with multiple children; SignEnveloped appends the Signature
+	// at the end. After signing we insert a benign trailing comment by
+	// re-parsing — what we really care about is invariance across Verify.
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.NewEnvelopedReference())
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+	before, err := helium.WriteString(doc)
+	require.NoError(t, err)
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+
+	after, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Equal(t, before, after, "Verify must not restructure the document")
+}
+
+// TestVerifyPreservesSiblingPosition_NonTrailing places the Signature at a
+// non-trailing sibling position and asserts the same invariance. This
+// catches the "AddChild reattaches to end" bug specifically.
+func TestVerifyPreservesSiblingPosition_NonTrailing(t *testing.T) {
+	// Build doc with Issuer, then Signature, then Subject siblings.
+	src := `<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_abc123" IssueInstant="2024-01-01T00:00:00Z" Version="2.0"><saml:Issuer>https://idp.example.com</saml:Issuer><saml:Subject><saml:NameID>user@example.com</saml:NameID></saml:Subject></saml:Assertion>`
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, src)
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.NewEnvelopedReference())
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+	// Serialize+reparse so we can manipulate the Signature node position.
+	signed, err := helium.WriteString(doc)
+	require.NoError(t, err)
+
+	// Manually relocate the Signature to between Issuer and Subject by
+	// splicing the serialized form. Order in signed doc currently has
+	// Signature at the end; move it.
+	sigStart := strings.Index(signed, "<ds:Signature")
+	require.GreaterOrEqual(t, sigStart, 0)
+	sigEnd := strings.Index(signed, "</ds:Signature>") + len("</ds:Signature>")
+	require.Greater(t, sigEnd, sigStart)
+	sigBlock := signed[sigStart:sigEnd]
+	// Remove the trailing Signature.
+	without := signed[:sigStart] + signed[sigEnd:]
+	// Insert between Issuer and Subject.
+	insertAt := strings.Index(without, "<saml:Subject")
+	require.GreaterOrEqual(t, insertAt, 0)
+	relocated := without[:insertAt] + sigBlock + without[insertAt:]
+
+	doc2 := mustParseXML(t, relocated)
+	before, err := helium.WriteString(doc2)
+	require.NoError(t, err)
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(t.Context(), doc2)
+	require.NoError(t, err)
+
+	after, err := helium.WriteString(doc2)
+	require.NoError(t, err)
+	require.Equal(t, before, after, "Verify must preserve Signature sibling position")
+}
+
+// TestVerifyMultipleSignatures rejects ambiguous documents containing
+// more than one Signature. The caller must use VerifyElement to choose.
+// We use detached signatures so we can guarantee that adding a duplicate
+// Signature element does not perturb the canonical bytes of the signed
+// fragment.
+func TestVerifyMultipleSignatures(t *testing.T) {
+	xml := `<root><data Id="payload">secret</data></root>`
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, xml)
+
+	ref := xmldsig1.ReferenceConfig{
+		URI:             "#payload",
+		DigestAlgorithm: xmldsig1.DigestSHA256,
+		Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+	}
+	sigElem, err := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(ref).
+		SignDetached(t.Context(), doc, key)
+	require.NoError(t, err)
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	signed, err := helium.WriteString(doc)
+	require.NoError(t, err)
+
+	// Inject a second copy of the (legitimate) Signature element. From
+	// Verify's perspective the document is now ambiguous.
+	sigStart := strings.Index(signed, "<ds:Signature")
+	sigEnd := strings.Index(signed, "</ds:Signature>") + len("</ds:Signature>")
+	sigBlock := signed[sigStart:sigEnd]
+	doubled := signed[:sigEnd] + sigBlock + signed[sigEnd:]
+
+	doc2 := mustParseXML(t, doubled)
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(t.Context(), doc2)
+	require.ErrorIs(t, err, xmldsig1.ErrAmbiguousSignature)
+
+	// But VerifyElement on a specific Signature element succeeds — detached
+	// signatures don't depend on document-level structure beyond the
+	// referenced fragment.
+	var sig1 *helium.Element
+	var walk func(n helium.Node)
+	walk = func(n helium.Node) {
+		if sig1 != nil {
+			return
+		}
+		elem, ok := helium.AsNode[*helium.Element](n)
+		if !ok {
+			return
+		}
+		nm := elem.Name()
+		if nm == "Signature" || strings.HasSuffix(nm, ":Signature") {
+			sig1 = elem
+			return
+		}
+		for c := elem.FirstChild(); c != nil; c = c.NextSibling() {
+			walk(c)
+		}
+	}
+	walk(doc2.DocumentElement())
+	require.NotNil(t, sig1)
+	_, err = verifier.VerifyElement(t.Context(), doc2, sig1)
+	require.NoError(t, err)
+}
+
+// TestSignEnvelopedSiblingPositionStable locks in the current behavior
+// (Signature appended at end of parent) and ensures any future change is
+// deliberate. The signed document's canonical form is byte-stable across
+// Verify.
+func TestSignEnvelopedSiblingPositionStable(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.NewEnvelopedReference())
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+	// Verify twice — should be idempotent.
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err := verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+	out1, err := helium.WriteString(doc)
+	require.NoError(t, err)
+
+	_, err = verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+	out2, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Equal(t, out1, out2)
+}

--- a/xmldsig1/xsw_test.go
+++ b/xmldsig1/xsw_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// duplicateIDElementName walks the doc element subtree, finds an element
-// whose name local part matches elementLocalName carrying an Id/ID attribute
+// findByLocalNameAndID walks the doc element subtree, finds an element
+// whose name local part matches localName carrying an Id/ID attribute
 // equal to id, and returns the *first* such element. Test helper only.
 func findByLocalNameAndID(doc *helium.Document, localName, id string) *helium.Element {
 	var found *helium.Element

--- a/xmldsig1/xsw_test.go
+++ b/xmldsig1/xsw_test.go
@@ -116,13 +116,13 @@ func TestVerifyResult_ExposesSignedElement(t *testing.T) {
 	require.True(t, res.Covers(target))
 }
 
-// TestVerifyPreservesSiblingPosition signs an enveloped signature, then
-// inserts a sibling AFTER the Signature element and asserts that, after
-// Verify, the canonical bytes of the whole document are unchanged.
+// TestVerifyPreservesSiblingPosition signs an enveloped signature and
+// asserts that Verify is non-mutating — the serialized bytes of the
+// document must be identical before and after Verify, even though Verify
+// internally detaches the Signature element to canonicalize the enveloped
+// content. The non-trailing variant below covers the case where naive
+// AddChild reattachment would visibly relocate the Signature.
 func TestVerifyPreservesSiblingPosition(t *testing.T) {
-	// Use a doc with multiple children; SignEnveloped appends the Signature
-	// at the end. After signing we insert a benign trailing comment by
-	// re-parsing — what we really care about is invariance across Verify.
 	key := generateRSAKey(t)
 	doc := mustParseXML(t, samlAssertion)
 

--- a/xmldsig1/xsw_test.go
+++ b/xmldsig1/xsw_test.go
@@ -25,8 +25,8 @@ func findByLocalNameAndID(doc *helium.Document, localName, id string) *helium.El
 		}
 		name := elem.Name()
 		l := name
-		if i := strings.IndexByte(name, ':'); i >= 0 {
-			l = name[i+1:]
+		if _, after, ok := strings.Cut(name, ":"); ok {
+			l = after
 		}
 		if l == localName {
 			for _, a := range elem.Attributes() {

--- a/xmldsig1/xsw_test.go
+++ b/xmldsig1/xsw_test.go
@@ -217,7 +217,10 @@ func TestVerifyMultipleSignatures(t *testing.T) {
 	// Inject a second copy of the (legitimate) Signature element. From
 	// Verify's perspective the document is now ambiguous.
 	sigStart := strings.Index(signed, "<ds:Signature")
-	sigEnd := strings.Index(signed, "</ds:Signature>") + len("</ds:Signature>")
+	require.GreaterOrEqual(t, sigStart, 0, "signed output must contain a ds:Signature open tag")
+	sigEnd := strings.Index(signed, "</ds:Signature>")
+	require.Greater(t, sigEnd, sigStart, "signed output must contain a matching ds:Signature close tag")
+	sigEnd += len("</ds:Signature>")
 	sigBlock := signed[sigStart:sigEnd]
 	doubled := signed[:sigEnd] + sigBlock + signed[sigEnd:]
 

--- a/xmldsig1/xsw_test.go
+++ b/xmldsig1/xsw_test.go
@@ -81,6 +81,42 @@ func TestXSW_DuplicateIDFailsVerify(t *testing.T) {
 	require.ErrorIs(t, err, xmldsig1.ErrAmbiguousReference)
 }
 
+// TestXSW_DuplicateXMLIDFailsVerify is the xml:id variant of the
+// duplicate-ID XSW shape. It guards against the failure mode where the
+// document-level ID table (populated via xml:id during parse) silently
+// overwrites duplicates and hands a single hit back to the reference
+// resolver. The resolver MUST walk the tree and surface both matches.
+func TestXSW_DuplicateXMLIDFailsVerify(t *testing.T) {
+	xml := `<root xmlns:xml="http://www.w3.org/XML/1998/namespace"><payload xml:id="target"><val>good</val></payload></root>`
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, xml)
+
+	ref := xmldsig1.ReferenceConfig{
+		URI:             "#target",
+		DigestAlgorithm: xmldsig1.DigestSHA256,
+		Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+	}
+
+	sigElem, err := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(ref).
+		SignDetached(t.Context(), doc, key)
+	require.NoError(t, err)
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	signed, err := helium.WriteString(doc)
+	require.NoError(t, err)
+
+	evil := `<payload xml:id="target"><val>evil</val></payload>`
+	tampered := strings.Replace(signed, `<payload xml:id="target">`, evil+`<payload xml:id="target">`, 1)
+	require.NotEqual(t, signed, tampered)
+
+	doc2 := mustParseXML(t, tampered)
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(t.Context(), doc2)
+	require.ErrorIs(t, err, xmldsig1.ErrAmbiguousReference)
+}
+
 // TestVerifyResult_ExposesSignedElement asserts that Verify returns the
 // resolved element pointer for each Reference, so the caller can compare
 // pointer equality against the element they are about to consume.


### PR DESCRIPTION
Refuses ambiguous Id and Signature resolution, returns a VerifyResult exposing the signed elements, and preserves the Signature's original sibling position across enveloped-transform detach/reattach. Fixes finding H3.