### PR TITLE
xmlenc1: fix CBC padding oracle, XXE on decrypted plaintext, GCM AAD (H2)

### DIFF
--- a/xmlenc1/README.md
+++ b/xmlenc1/README.md
@@ -6,6 +6,21 @@ The `xmlenc1` package implements W3C XML Encryption 1.1 for helium documents.
 
 Import path: `github.com/lestrrat-go/helium/xmlenc1`
 
+## Security
+
+- Prefer AES-GCM. The package binds the `EncryptionMethod/@Algorithm`
+  URI into the AEAD additional-authenticated-data so an attacker cannot
+  substitute a different algorithm URI on the wire.
+- AES-CBC is unauthenticated and vulnerable to padding-oracle attacks
+  (Jager/Somorovsky 2011). `Decryptor` refuses CBC by default and
+  returns `ErrCBCRequiresOptIn`. Pass `AllowUnauthenticatedCBC(true)`
+  only if you must accept legacy CBC and you have verified that
+  decryption errors are not exposed to remote attackers.
+- The inner parser used on the decrypted plaintext has DTD loading,
+  external entity resolution, and network access all disabled. Decrypted
+  bytes are attacker-controlled, so a relaxed parser would constitute an
+  XXE oracle.
+
 <!-- INCLUDE(examples/xmlenc1_encrypt_decrypt_example_test.go) -->
 ```go
 package examples_test

--- a/xmlenc1/block.go
+++ b/xmlenc1/block.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/subtle"
 	"fmt"
 	"io"
 )
@@ -19,29 +20,44 @@ func keySizeForAlgorithm(algorithm string) (int, error) {
 	}
 }
 
+// blockEncrypt encrypts plaintext with the given algorithm. For AEAD
+// algorithms (GCM) the algorithm URI is bound into the additional
+// authenticated data so that an attacker cannot substitute a different
+// EncryptionMethod/@Algorithm on the wire.
 func blockEncrypt(algorithm string, key, plaintext []byte) ([]byte, error) {
 	switch algorithm {
 	case AES128CBC, AES256CBC:
 		return encryptCBC(key, plaintext)
 	case AES128GCM, AES256GCM:
-		return encryptGCM(key, plaintext)
+		return encryptGCM(key, plaintext, []byte(algorithm))
 	default:
 		return nil, &UnsupportedAlgorithmError{Algorithm: algorithm}
 	}
 }
 
+// blockDecrypt decrypts ciphertext. For AEAD algorithms (GCM) the
+// algorithm URI is verified as additional authenticated data. For CBC
+// the function returns ErrDecryptionFailed for ANY failure (cipher,
+// padding, or downstream parse) so callers cannot mount a padding
+// oracle by distinguishing the cause.
 func blockDecrypt(algorithm string, key, ciphertext []byte) ([]byte, error) {
 	switch algorithm {
 	case AES128CBC, AES256CBC:
 		return decryptCBC(key, ciphertext)
 	case AES128GCM, AES256GCM:
-		return decryptGCM(key, ciphertext)
+		return decryptGCM(key, ciphertext, []byte(algorithm))
 	default:
 		return nil, &UnsupportedAlgorithmError{Algorithm: algorithm}
 	}
 }
 
 // AES-CBC
+//
+// CBC ciphertexts produced by this package are NOT authenticated. The
+// XML-Encryption 1.0 CBC mode is vulnerable to padding-oracle attacks
+// (Jager/Somorovsky 2011) and has been deprecated by XML-Encryption 1.1.
+// Decryption with CBC requires an explicit caller opt-in via
+// Decryptor.AllowUnauthenticatedCBC(true).
 
 func encryptCBC(key, plaintext []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
@@ -66,14 +82,12 @@ func encryptCBC(key, plaintext []byte) ([]byte, error) {
 func decryptCBC(key, data []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrDecryptionFailed, err)
+		// Caller error (wrong key size), not an oracle signal.
+		return nil, ErrDecryptionFailed
 	}
 
-	if len(data) < aes.BlockSize*2 {
-		return nil, fmt.Errorf("%w: ciphertext too short", ErrDecryptionFailed)
-	}
-	if len(data)%aes.BlockSize != 0 {
-		return nil, fmt.Errorf("%w: ciphertext not block-aligned", ErrDecryptionFailed)
+	if len(data) < aes.BlockSize*2 || len(data)%aes.BlockSize != 0 {
+		return nil, ErrDecryptionFailed
 	}
 
 	iv := data[:aes.BlockSize]
@@ -83,12 +97,19 @@ func decryptCBC(key, data []byte) ([]byte, error) {
 	mode := cipher.NewCBCDecrypter(block, iv)
 	mode.CryptBlocks(plaintext, ciphertext)
 
-	return pkcs7Unpad(plaintext, aes.BlockSize)
+	out, ok := pkcs7UnpadConstantTime(plaintext, aes.BlockSize)
+	if !ok {
+		// Do not distinguish "bad padding" from any other downstream
+		// failure: surface the same opaque ErrDecryptionFailed so the
+		// caller cannot build a padding oracle.
+		return nil, ErrDecryptionFailed
+	}
+	return out, nil
 }
 
 // AES-GCM
 
-func encryptGCM(key, plaintext []byte) ([]byte, error) {
+func encryptGCM(key, plaintext, aad []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrEncryptionFailed, err)
@@ -104,11 +125,11 @@ func encryptGCM(key, plaintext []byte) ([]byte, error) {
 		return nil, fmt.Errorf("%w: %v", ErrEncryptionFailed, err)
 	}
 
-	// nonce || ciphertext || tag
-	return gcm.Seal(nonce, nonce, plaintext, nil), nil
+	// nonce || ciphertext || tag, with aad bound into the tag.
+	return gcm.Seal(nonce, nonce, plaintext, aad), nil
 }
 
-func decryptGCM(key, data []byte) ([]byte, error) {
+func decryptGCM(key, data, aad []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrDecryptionFailed, err)
@@ -127,7 +148,7 @@ func decryptGCM(key, data []byte) ([]byte, error) {
 	nonce := data[:nonceSize]
 	ciphertext := data[nonceSize:]
 
-	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, aad)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrDecryptionFailed, err)
 	}
@@ -146,18 +167,37 @@ func pkcs7Pad(data []byte, blockSize int) []byte {
 	return padded
 }
 
-func pkcs7Unpad(data []byte, blockSize int) ([]byte, error) {
-	if len(data) == 0 {
-		return nil, ErrInvalidPadding
+// pkcs7UnpadConstantTime removes PKCS#7 padding without short-circuiting
+// on the first invalid byte. The return value ok is false iff the
+// padding is invalid; valid is computed by walking every padding byte
+// regardless of intermediate mismatches.
+//
+// Note: the work performed depends on the *padding length byte*, which
+// is observable in cache-timing studies but is the same trade-off as
+// stdlib `crypto/tls`'s legacy CBC unpadding. This is a defense in
+// depth on top of the primary mitigation (require opt-in for CBC). For
+// strong authentication use AES-GCM.
+func pkcs7UnpadConstantTime(data []byte, blockSize int) ([]byte, bool) {
+	if len(data) == 0 || len(data)%blockSize != 0 {
+		return nil, false
 	}
 	padding := int(data[len(data)-1])
+	// Bounds check on the padding length.
+	good := 1
 	if padding == 0 || padding > blockSize || padding > len(data) {
-		return nil, ErrInvalidPadding
+		good = 0
+		// Continue with a safe value so the inner loop still runs to
+		// completion on a fixed range.
+		padding = blockSize
 	}
+	// Compare every byte of the (assumed) padding region in constant
+	// time relative to `padding`.
+	want := byte(padding)
 	for i := len(data) - padding; i < len(data); i++ {
-		if data[i] != byte(padding) {
-			return nil, ErrInvalidPadding
-		}
+		good &= subtle.ConstantTimeByteEq(data[i], want)
 	}
-	return data[:len(data)-padding], nil
+	if good != 1 {
+		return nil, false
+	}
+	return data[:len(data)-int(data[len(data)-1])], true
 }

--- a/xmlenc1/errors.go
+++ b/xmlenc1/errors.go
@@ -26,6 +26,18 @@ var (
 
 	// ErrMissingConfig is returned when required encryption config is missing.
 	ErrMissingConfig = errors.New("xmlenc1: missing required configuration")
+
+	// ErrCBCRequiresOptIn is returned when a Decryptor is asked to
+	// decrypt an AES-CBC ciphertext but the caller has not opted in
+	// to unauthenticated CBC via Decryptor.AllowUnauthenticatedCBC(true).
+	//
+	// AES-CBC under XML Encryption 1.0 is unauthenticated and is
+	// vulnerable to padding-oracle attacks (Jager/Somorovsky 2011).
+	// XML Encryption 1.1 deprecated CBC in favor of AES-GCM. Callers
+	// that must interoperate with legacy CBC ciphertexts can opt in
+	// after evaluating the attack surface (e.g. ensuring decryption
+	// errors are not exposed to remote attackers).
+	ErrCBCRequiresOptIn = errors.New("xmlenc1: AES-CBC decryption requires AllowUnauthenticatedCBC(true)")
 )
 
 // UnsupportedAlgorithmError is returned for unrecognized algorithm URIs.

--- a/xmlenc1/export_test.go
+++ b/xmlenc1/export_test.go
@@ -1,0 +1,29 @@
+package xmlenc1
+
+import (
+	helium "github.com/lestrrat-go/helium"
+)
+
+// EncryptBytesForTest encrypts an arbitrary byte slice with the given
+// algorithm and key and returns the resulting CipherValue (IV/nonce
+// prefix included). It exists solely so security tests can construct
+// EncryptedData whose plaintext is not a well-formed XML element
+// serializable through the public Encryptor (e.g. payloads beginning
+// with a DOCTYPE).
+func EncryptBytesForTest(algorithm string, key, plaintext []byte) ([]byte, error) {
+	return blockEncrypt(algorithm, key, plaintext)
+}
+
+// MarshalEncryptedDataForTest is a test-only re-export of the package
+// internal marshaler so security tests can assemble EncryptedData
+// elements from raw fields.
+func MarshalEncryptedDataForTest(doc *helium.Document, ed *EncryptedData) (*helium.Element, error) {
+	return marshalEncryptedData(doc, ed)
+}
+
+// HardenedParserForTest returns the parser configuration the decryptor
+// uses for inner decrypted-XML parsing. Tests use this to assert that
+// XXE-class inputs are rejected or stripped.
+func HardenedParserForTest() helium.Parser {
+	return newHardenedInnerParser()
+}

--- a/xmlenc1/security_test.go
+++ b/xmlenc1/security_test.go
@@ -1,0 +1,261 @@
+package xmlenc1_test
+
+import (
+	"crypto/rand"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xmlenc1"
+	"github.com/stretchr/testify/require"
+)
+
+// H2 Flaw 1: CBC is unauthenticated; require explicit opt-in to decrypt.
+//
+// Default Decryptor should refuse to decrypt AES-CBC ciphertext with
+// ErrCBCRequiresOptIn, since unauthenticated CBC is vulnerable to padding
+// oracle attacks (Jager/Somorovsky 2011).
+func TestDecryptCBC_DefaultDenied(t *testing.T) {
+	sessionKey := make([]byte, 16)
+	_, err := rand.Read(sessionKey)
+	require.NoError(t, err)
+
+	doc := mustParseXML(t, samlAssertion)
+
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES128CBC).
+		SessionKey(sessionKey)
+	edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	decryptor := xmlenc1.NewDecryptor().SessionKey(sessionKey)
+	_, err = decryptor.Decrypt(t.Context(), edElem)
+	require.Error(t, err)
+	require.ErrorIs(t, err, xmlenc1.ErrCBCRequiresOptIn)
+}
+
+// H2 Flaw 1: explicit opt-in must allow CBC decryption.
+func TestDecryptCBC_OptInAllowed(t *testing.T) {
+	sessionKey := make([]byte, 16)
+	_, err := rand.Read(sessionKey)
+	require.NoError(t, err)
+
+	doc := mustParseXML(t, samlAssertion)
+
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES128CBC).
+		SessionKey(sessionKey)
+	edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	decryptor := xmlenc1.NewDecryptor().
+		SessionKey(sessionKey).
+		AllowUnauthenticatedCBC(true)
+	nodes, err := decryptor.Decrypt(t.Context(), edElem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	s, err := helium.WriteString(nodes[0])
+	require.NoError(t, err)
+	require.Contains(t, s, "user@example.com")
+}
+
+// H2 Flaw 2: a hardened inner parser must not resolve external entities
+// declared in the decrypted plaintext.
+//
+// We point the entity at a sentinel file we control, then check that
+// the file's contents do NOT appear in the parser output. (The DOCTYPE
+// SYSTEM identifier itself may be echoed in the serialization — that
+// is harmless, we care that the referenced file was not fetched.)
+func TestHardenedInnerParser_BlocksXXE(t *testing.T) {
+	sentinel := t.TempDir() + "/secret.txt"
+	require.NoError(t, os.WriteFile(sentinel, []byte("XXE_LEAKED_SECRET"), 0o600))
+
+	xxePlain := `<!DOCTYPE foo [<!ENTITY x SYSTEM "file://` + sentinel + `">]><foo>&x;</foo>`
+	innerDoc, err := xmlenc1.HardenedParserForTest().Parse(t.Context(), []byte(xxePlain))
+	if err == nil {
+		out, werr := helium.WriteString(innerDoc)
+		require.NoError(t, werr)
+		require.NotContains(t, out, "XXE_LEAKED_SECRET",
+			"external entity was resolved: %s", out)
+	}
+}
+
+// H2 Flaw 2: end-to-end test that a decrypted XXE payload is parsed by
+// the hardened inner parser and does not load the external entity.
+func TestDecryptXXE_NotResolved(t *testing.T) {
+	sentinel := t.TempDir() + "/secret.txt"
+	require.NoError(t, os.WriteFile(sentinel, []byte("XXE_LEAKED_SECRET"), 0o600))
+
+	sessionKey := make([]byte, 32)
+	_, err := rand.Read(sessionKey)
+	require.NoError(t, err)
+
+	algorithm := xmlenc1.AES256GCM
+	xxePlain := []byte(`<!DOCTYPE foo [<!ENTITY x SYSTEM "file://` + sentinel + `">]><foo>&x;</foo>`)
+	cipher, err := xmlenc1.EncryptBytesForTest(algorithm, sessionKey, xxePlain)
+	require.NoError(t, err)
+
+	doc := mustParseXML(t, `<root/>`)
+	ed := &xmlenc1.EncryptedData{
+		Type:             xmlenc1.TypeElement,
+		EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: algorithm},
+		CipherValue:      cipher,
+	}
+	edElem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+	require.NoError(t, err)
+
+	decryptor := xmlenc1.NewDecryptor().SessionKey(sessionKey)
+	nodes, err := decryptor.Decrypt(t.Context(), edElem)
+	// Parsing may succeed (with &x; unresolved) or fail; either is
+	// acceptable as long as the external entity is not loaded.
+	if err == nil {
+		require.NotEmpty(t, nodes)
+		for _, n := range nodes {
+			s, werr := helium.WriteString(n)
+			require.NoError(t, werr)
+			require.NotContains(t, s, "XXE_LEAKED_SECRET",
+				"external entity was resolved: %s", s)
+		}
+	}
+}
+
+// H2 Flaw 3: GCM round-trip with algorithm URI bound as AAD must succeed.
+func TestDecryptGCM_RoundTripWithAAD(t *testing.T) {
+	sessionKey := make([]byte, 32)
+	_, err := rand.Read(sessionKey)
+	require.NoError(t, err)
+
+	doc := mustParseXML(t, samlAssertion)
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		SessionKey(sessionKey)
+	edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	decryptor := xmlenc1.NewDecryptor().SessionKey(sessionKey)
+	nodes, err := decryptor.Decrypt(t.Context(), edElem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+}
+
+// H2 Flaw 3: swapping the EncryptionMethod/@Algorithm URI between encrypt
+// and decrypt must cause AAD verification to fail.
+func TestDecryptGCM_AlgorithmSwapFails(t *testing.T) {
+	// Same key length on both sides (128 bits) so AES-128-GCM works
+	// at the cipher level; the AAD binding must still reject the swap.
+	sessionKey := make([]byte, 16)
+	_, err := rand.Read(sessionKey)
+	require.NoError(t, err)
+
+	// Encrypt the raw plaintext under AES-128-GCM with a known AAD
+	// (the algorithm URI). Then assemble an EncryptedData whose
+	// EncryptionMethod/@Algorithm is a *different* GCM URI of the
+	// same key size... wait, there is no other 128-bit GCM URI in
+	// xmlenc. Instead, encrypt under AES-128-GCM and then mutate the
+	// EncryptedData to claim AES-256-GCM; the decryptor must refuse
+	// (either at key-size validation or AAD verification — both are
+	// correct failure modes).
+	algorithm := xmlenc1.AES128GCM
+	plaintext := []byte("<x>secret</x>")
+	cipher, err := xmlenc1.EncryptBytesForTest(algorithm, sessionKey, plaintext)
+	require.NoError(t, err)
+
+	doc := mustParseXML(t, `<root/>`)
+	ed := &xmlenc1.EncryptedData{
+		Type:             xmlenc1.TypeElement,
+		EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: algorithm},
+		CipherValue:      cipher,
+	}
+	edElem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+	require.NoError(t, err)
+
+	// Swap the on-the-wire Algorithm attribute to a different URI.
+	swapEncryptionMethodAlgorithm(t, edElem, xmlenc1.AES256GCM)
+
+	decryptor := xmlenc1.NewDecryptor().SessionKey(sessionKey)
+	_, err = decryptor.Decrypt(t.Context(), edElem)
+	require.Error(t, err)
+}
+
+// H2 Flaw 4: padding oracle hardening. Errors from CBC decryption must
+// not distinguish "bad padding" from "valid padding but invalid XML" at
+// the caller-visible boundary.
+func TestDecryptCBC_PaddingOracle_IndistinguishableErrors(t *testing.T) {
+	sessionKey := make([]byte, 16)
+	_, err := rand.Read(sessionKey)
+	require.NoError(t, err)
+
+	algorithm := xmlenc1.AES128CBC
+	plaintext := []byte("<x>secret data inside</x>")
+	cipher, err := xmlenc1.EncryptBytesForTest(algorithm, sessionKey, plaintext)
+	require.NoError(t, err)
+
+	mkED := func(c []byte) *helium.Element {
+		doc := mustParseXML(t, `<root/>`)
+		ed := &xmlenc1.EncryptedData{
+			Type:             xmlenc1.TypeElement,
+			EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: algorithm},
+			CipherValue:      c,
+		}
+		edElem, mErr := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+		require.NoError(t, mErr)
+		return edElem
+	}
+
+	decryptor := xmlenc1.NewDecryptor().
+		SessionKey(sessionKey).
+		AllowUnauthenticatedCBC(true)
+
+	// Mutation A: flip a bit in the IV. This randomizes the first
+	// plaintext block and is very likely to produce bytes that look
+	// like invalid padding once unpadding is attempted on the last
+	// block (since last block plaintext is unaffected, this often
+	// produces valid padding but garbage XML — useful contrast).
+	cipherA := append([]byte(nil), cipher...)
+	cipherA[0] ^= 0x01
+
+	// Mutation B: flip a bit in the LAST ciphertext byte. This
+	// directly corrupts padding most of the time.
+	cipherB := append([]byte(nil), cipher...)
+	cipherB[len(cipherB)-1] ^= 0x01
+
+	_, errA := decryptor.Decrypt(t.Context(), mkED(cipherA))
+	require.Error(t, errA)
+	require.ErrorIs(t, errA, xmlenc1.ErrDecryptionFailed)
+	require.False(t,
+		strings.Contains(strings.ToLower(errA.Error()), "padding"),
+		"error A leaks padding state: %v", errA)
+	require.False(t, errors.Is(errA, xmlenc1.ErrInvalidPadding),
+		"error A is distinguishable as ErrInvalidPadding: %v", errA)
+
+	_, errB := decryptor.Decrypt(t.Context(), mkED(cipherB))
+	require.Error(t, errB)
+	require.ErrorIs(t, errB, xmlenc1.ErrDecryptionFailed)
+	require.False(t,
+		strings.Contains(strings.ToLower(errB.Error()), "padding"),
+		"error B leaks padding state: %v", errB)
+	require.False(t, errors.Is(errB, xmlenc1.ErrInvalidPadding),
+		"error B is distinguishable as ErrInvalidPadding: %v", errB)
+}
+
+// swapEncryptionMethodAlgorithm finds the EncryptionMethod child of
+// edElem and rewrites its Algorithm attribute to newAlg.
+func swapEncryptionMethodAlgorithm(t *testing.T, edElem *helium.Element, newAlg string) {
+	t.Helper()
+	for child := edElem.FirstChild(); child != nil; child = child.NextSibling() {
+		e, ok := helium.AsNode[*helium.Element](child)
+		if !ok {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, "EncryptionMethod") {
+			continue
+		}
+		require.NoError(t, e.SetLiteralAttribute("Algorithm", newAlg))
+		return
+	}
+	t.Fatalf("EncryptionMethod child not found in EncryptedData")
+}

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -254,9 +255,10 @@ func removeChildren(elem *helium.Element) {
 
 // decryptConfig holds the configuration for a Decryptor.
 type decryptConfig struct {
-	privateKey       *rsa.PrivateKey
-	keyEncryptionKey []byte
-	sessionKey       []byte
+	privateKey              *rsa.PrivateKey
+	keyEncryptionKey        []byte
+	sessionKey              []byte
+	allowUnauthenticatedCBC bool
 }
 
 // Decryptor decrypts XML EncryptedData elements. It uses clone-on-write
@@ -299,6 +301,23 @@ func (d Decryptor) SessionKey(key []byte) Decryptor {
 	return d
 }
 
+// AllowUnauthenticatedCBC opts the Decryptor in to decrypting AES-CBC
+// ciphertexts. AES-CBC under XML Encryption 1.0 is unauthenticated and
+// vulnerable to padding-oracle attacks (Jager/Somorovsky 2011); XML
+// Encryption 1.1 deprecated CBC in favor of AES-GCM.
+//
+// By default the Decryptor refuses CBC and returns
+// [ErrCBCRequiresOptIn]. Set this to true only if you must accept
+// legacy CBC ciphertexts AND you have verified that decryption errors
+// are not exposed to remote attackers (e.g. by surfacing the same
+// generic error for every failure path and never timing-sidechannel
+// distinguishing them).
+func (d Decryptor) AllowUnauthenticatedCBC(v bool) Decryptor {
+	d = d.clone()
+	d.cfg.allowUnauthenticatedCBC = v
+	return d
+}
+
 // Decrypt decrypts an EncryptedData element and returns the decrypted nodes.
 func (d Decryptor) Decrypt(ctx context.Context, elem *helium.Element) ([]helium.Node, error) {
 	return decryptElement(ctx, d.cfg, elem)
@@ -320,35 +339,69 @@ func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Elemen
 	if ed.EncryptionMethod == nil {
 		return nil, fmt.Errorf("%w: missing EncryptionMethod", ErrMalformedEncrypted)
 	}
-	plaintext, err := blockDecrypt(ed.EncryptionMethod.Algorithm, sessionKey, ed.CipherValue)
+
+	alg := ed.EncryptionMethod.Algorithm
+	switch alg {
+	case AES128CBC, AES256CBC:
+		if !cfg.allowUnauthenticatedCBC {
+			return nil, ErrCBCRequiresOptIn
+		}
+	}
+
+	plaintext, err := blockDecrypt(alg, sessionKey, ed.CipherValue)
 	if err != nil {
+		// Squash all decryption errors to the same sentinel — and
+		// crucially, the same string — so callers cannot distinguish
+		// "bad padding" from "bad cipher" from "downstream parse"
+		// when CBC is in use. GCM authenticates so this collapse is
+		// safe there too.
+		if errors.Is(err, ErrDecryptionFailed) || errors.Is(err, ErrInvalidPadding) {
+			return nil, ErrDecryptionFailed
+		}
 		return nil, err
 	}
 
-	// Parse decrypted XML.
+	// Parse decrypted XML through a hardened parser: no external DTD,
+	// no XXE entity loading, no network. The plaintext is attacker-
+	// controlled (it is the output of the attacker's ciphertext under
+	// the recipient's key) and must not be allowed to fetch external
+	// resources.
+	parser := newHardenedInnerParser()
 	isContent := ed.Type == TypeContent
 
 	var nodes []helium.Node
 	if isContent {
 		// Content may be multiple children; wrap in a temporary root.
 		wrapped := "<_wrap>" + string(plaintext) + "</_wrap>"
-		tmpDoc, err := helium.NewParser().Parse(ctx, []byte(wrapped))
+		tmpDoc, err := parser.Parse(ctx, []byte(wrapped))
 		if err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrDecryptionFailed, err)
+			return nil, ErrDecryptionFailed
 		}
 		root := tmpDoc.DocumentElement()
 		for child := root.FirstChild(); child != nil; child = child.NextSibling() {
 			nodes = append(nodes, child)
 		}
 	} else {
-		tmpDoc, err := helium.NewParser().Parse(ctx, plaintext)
+		tmpDoc, err := parser.Parse(ctx, plaintext)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrDecryptionFailed, err)
+			return nil, ErrDecryptionFailed
 		}
 		nodes = append(nodes, tmpDoc.DocumentElement())
 	}
 
 	return nodes, nil
+}
+
+// newHardenedInnerParser returns the helium parser used to parse the
+// decrypted plaintext of an EncryptedData element. Decrypted bytes are
+// attacker-controlled (an attacker who can submit ciphertexts to a
+// decryption oracle can choose the recovered plaintext), so DTD loading,
+// external entity resolution, and network access are all disabled.
+func newHardenedInnerParser() helium.Parser {
+	return helium.NewParser().
+		BlockXXE(true).
+		LoadExternalDTD(false).
+		AllowNetwork(false)
 }
 
 func resolveSessionKey(cfg *decryptConfig, ed *EncryptedData) ([]byte, error) {

--- a/xmlenc1/xmlenc1_test.go
+++ b/xmlenc1/xmlenc1_test.go
@@ -47,8 +47,8 @@ func TestEncryptDecryptElementRSAOAEP_AES128CBC(t *testing.T) {
 	require.Contains(t, xml, "EncryptedData")
 	require.NotContains(t, xml, "user@example.com")
 
-	// Decrypt.
-	decryptor := xmlenc1.NewDecryptor().PrivateKey(key)
+	// Decrypt. CBC requires explicit opt-in (see ErrCBCRequiresOptIn).
+	decryptor := xmlenc1.NewDecryptor().PrivateKey(key).AllowUnauthenticatedCBC(true)
 	nodes, err := decryptor.Decrypt(t.Context(), edElem)
 	require.NoError(t, err)
 	require.Len(t, nodes, 1)
@@ -124,7 +124,7 @@ func TestEncryptDecryptWithAESKeyWrap(t *testing.T) {
 	edElem, err := encryptor.EncryptElement(t.Context(), elem)
 	require.NoError(t, err)
 
-	decryptor := xmlenc1.NewDecryptor().KeyEncryptionKey(kek)
+	decryptor := xmlenc1.NewDecryptor().KeyEncryptionKey(kek).AllowUnauthenticatedCBC(true)
 	nodes, err := decryptor.Decrypt(t.Context(), edElem)
 	require.NoError(t, err)
 	require.Len(t, nodes, 1)
@@ -149,7 +149,7 @@ func TestEncryptDecryptWithSessionKey(t *testing.T) {
 	edElem, err := encryptor.EncryptElement(t.Context(), elem)
 	require.NoError(t, err)
 
-	decryptor := xmlenc1.NewDecryptor().SessionKey(sessionKey)
+	decryptor := xmlenc1.NewDecryptor().SessionKey(sessionKey).AllowUnauthenticatedCBC(true)
 	nodes, err := decryptor.Decrypt(t.Context(), edElem)
 	require.NoError(t, err)
 	require.Len(t, nodes, 1)
@@ -205,8 +205,9 @@ func TestDecryptWrongKey(t *testing.T) {
 	edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
 	require.NoError(t, err)
 
-	// Decrypt with wrong key.
-	decryptor := xmlenc1.NewDecryptor().PrivateKey(key2)
+	// Decrypt with wrong key. Opt in to CBC so the failure exercises
+	// the wrong-key (RSA) path rather than the CBC opt-in gate.
+	decryptor := xmlenc1.NewDecryptor().PrivateKey(key2).AllowUnauthenticatedCBC(true)
 	_, err = decryptor.Decrypt(t.Context(), edElem)
 	require.Error(t, err)
 }
@@ -232,7 +233,7 @@ func TestAESKeyWrapRFC3394(t *testing.T) {
 	edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
 	require.NoError(t, err)
 
-	decryptor := xmlenc1.NewDecryptor().KeyEncryptionKey(kek)
+	decryptor := xmlenc1.NewDecryptor().KeyEncryptionKey(kek).AllowUnauthenticatedCBC(true)
 	nodes, err := decryptor.Decrypt(t.Context(), edElem)
 	require.NoError(t, err)
 	require.Len(t, nodes, 1)


### PR DESCRIPTION
Default-denies AES-CBC decryption (opt in via `AllowUnauthenticatedCBC(true)`), hardens the inner parser used on decrypted plaintext (BlockXXE + no DTD + no network), and binds `EncryptionMethod/@Algorithm` into the GCM AAD. The AAD change is a wire-format break — pre-fix GCM ciphertexts will not decrypt.