### PR TITLE
fix(h1): default-deny network and filesystem access in fn:doc and fn:unparsed-text

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -93,7 +93,7 @@ XSLT 3.0 stylesheet compilation + transformation on helium DOM with `xpath3` eva
 - **Compiler.Compile(ctx, *Document) → (*Stylesheet, error)** / **Compiler.MustCompile(ctx, *Document) → *Stylesheet** — terminal compile methods
 - **Transform(ctx, *Document, *Stylesheet) → (*Document, error)** / **TransformToWriter(ctx, *Document, *Stylesheet, io.Writer) → error** / **TransformString(ctx, *Document, *Stylesheet) → (string, error)** — convenience wrappers; nil `*Stylesheet` returns error here
 - **Stylesheet.Transform(*Document) → Invocation** / **Stylesheet.ApplyTemplates(*Document) → Invocation** / **Stylesheet.CallTemplate(string) → Invocation** / **Stylesheet.CallFunction(string, ...Sequence) → Invocation** — invocation entrypoints
-- **Invocation.SourceDocument(*Document) → Invocation** / **Mode(string)** / **Selection(Sequence)** *(ApplyTemplates only)* / **GlobalParameters(*Parameters)** / **TunnelParameters(*Parameters)** / **SetParameter(string, Sequence)** / **SetTunnelParameter(string, Sequence)** / **SetInitialTemplateParameter(string, Sequence)** / **SetInitialModeParameter(string, Sequence)** / **MessageHandler(MessageHandler)** / **ResultDocumentHandler(ResultDocumentHandler)** / **RawResultHandler(RawResultHandler)** / **PrimaryItemsHandler(PrimaryItemsHandler)** / **AnnotationHandler(AnnotationHandler)** / **CollectionResolver(xpath3.CollectionResolver)** / **BaseOutputURI(string)** / **SourceSchemas(...*xsd.Schema)** / **OnMultipleMatch(OnMultipleMatchMode)** / **TraceWriter(io.Writer)** — fluent runtime configuration
+- **Invocation.SourceDocument(*Document) → Invocation** / **Mode(string)** / **Selection(Sequence)** *(ApplyTemplates only)* / **GlobalParameters(*Parameters)** / **TunnelParameters(*Parameters)** / **SetParameter(string, Sequence)** / **SetTunnelParameter(string, Sequence)** / **SetInitialTemplateParameter(string, Sequence)** / **SetInitialModeParameter(string, Sequence)** / **MessageHandler(MessageHandler)** / **ResultDocumentHandler(ResultDocumentHandler)** / **RawResultHandler(RawResultHandler)** / **PrimaryItemsHandler(PrimaryItemsHandler)** / **AnnotationHandler(AnnotationHandler)** / **CollectionResolver(xpath3.CollectionResolver)** / **URIResolver(xpath3.URIResolver)** / **HTTPClient(\*http.Client)** / **BaseOutputURI(string)** / **SourceSchemas(...*xsd.Schema)** / **OnMultipleMatch(OnMultipleMatchMode)** / **TraceWriter(io.Writer)** — fluent runtime configuration. `URIResolver` and `HTTPClient` are the opt-in for runtime `fn:doc`/`fn:unparsed-text` retrieval; without them those functions error per spec.
 - **Invocation.Do(ctx) → (*Document, error)** / **Invocation.Serialize(ctx) → (string, error)** / **Invocation.WriteTo(ctx, io.Writer) → error** / **Invocation.ResolvedOutputDef() → *OutputDef** — terminal execution + resolved primary output metadata
 - **NewParameters() → *Parameters** — mutable XSLT parameter carrier keyed by expanded name
 - Key types: `Stylesheet`, `Compiler`, `Invocation`, `Parameters`, `OutputDef`, `URIResolver`, `PackageResolver`, `MessageHandler`, `ResultDocumentHandler`, `RawResultHandler`, `PrimaryItemsHandler`, `AnnotationHandler`
@@ -387,10 +387,10 @@ String cursor for character-by-character parsing.
 
 ## internal/unparsedtext/
 
-Shared `fn:unparsed-text` / `fn:unparsed-text-lines` resource loading.
+Shared resource loading for `fn:doc`, `fn:doc-available`, `fn:json-doc`, `fn:unparsed-text`, `fn:unparsed-text-available`, `fn:unparsed-text-lines`. Secure by default: with no `URIResolver` and no `HTTPClient`, every retrieval errors out (no implicit `http.DefaultClient`, no implicit `os.ReadFile`). Constructors: `NewHTTPResolver(*http.Client)`, `NewFileResolver(fs.FS)`; `FileURIResolver{BaseDir}` refuses `..` traversal outside `BaseDir`.
 
 - Files: `unparsedtext.go`
-- Imports: none
+- Imports: `internal/encoding`, `internal/lexicon`
 
 ## internal/xpathstream/
 

--- a/.claude/docs/xpath3-api.md
+++ b/.claude/docs/xpath3-api.md
@@ -86,6 +86,11 @@ type CollectionResolver interface {
 }
 ```
 
+**Resource loading is opt-in.** Without an explicit `URIResolver` or `HTTPClient`, `fn:doc`, `fn:doc-available`, `fn:json-doc`, and the `fn:unparsed-text*` family error with `FODC0002` / `FOUT1170` for every URI — there is no implicit `http.DefaultClient` and no implicit `os.ReadFile`. Built-in helpers in `internal/unparsedtext`:
+- `FileURIResolver{BaseDir}` — file resolver confined to `BaseDir` (refuses `..` traversal and absolute paths outside it)
+- `NewFileResolver(fs.FS)` — file resolver backed by `io/fs`
+- `NewHTTPResolver(*http.Client)` — http(s) resolver; caller owns transport, timeouts, redirect policy
+
 User functions registered via `WithFunctionsNS` CANNOT override built-ins in `fn:` namespace.
 
 `Compile()` uses a direct compile fast path where possible, otherwise lowers parsed AST to VM program using an ownership-taking lowering path that can reuse parsed slices. `CompileExpr()` uses a non-mutating lowering path, with raw AST fallback for unsupported custom Expr implementations.

--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -79,7 +79,9 @@ Misc: `adjust-dateTime-to-timezone`, `adjust-date-to-timezone`, `adjust-time-to-
 `parse-json`, `json-doc`, `json-to-xml`, `xml-to-json`, `serialize`
 
 `json-doc` uses same URI resolution/resource-loading stack as `doc` + `unparsed-text`:
-`WithBaseURI` → relative resolution, `WithURIResolver` → first fetch hook, `WithHTTPClient` → HTTP fallback.
+`WithBaseURI` → relative resolution, `WithURIResolver` → resolver for all schemes, `WithHTTPClient` → opt-in HTTP fetch.
+
+**Secure by default.** With no `URIResolver` and no `HTTPClient`, `fn:doc`, `fn:doc-available`, `fn:json-doc`, `fn:unparsed-text`, `fn:unparsed-text-available`, and `fn:unparsed-text-lines` cannot reach the filesystem or network — they error with `FODC0002` / `FOUT1170`. To allow access, supply a `URIResolver` (e.g. `unparsedtext.FileURIResolver{BaseDir:...}`, `unparsedtext.NewFileResolver(fs.FS)`, or `unparsedtext.NewHTTPResolver(*http.Client)`), or set an explicit `HTTPClient` whose transport/timeouts/redirect policy you control. `fn:doc` parses retrieved bytes with `BlockXXE(true).AllowNetwork(false)` so the returned document cannot pull additional externals.
 
 ### `functions_qname.go`
 `QName`, `resolve-QName`, `prefix-from-QName`, `local-name-from-QName`, `namespace-uri-from-QName`, `namespace-uri-for-prefix`, `in-scope-prefixes`

--- a/internal/unparsedtext/unparsedtext.go
+++ b/internal/unparsedtext/unparsedtext.go
@@ -5,15 +5,17 @@
 // Resource loading is opt-in. With no URIResolver and no HTTPClient supplied,
 // every retrieval attempt fails with ErrCodeRetrieval — there is no implicit
 // network access and no implicit filesystem access. Callers who want network
-// access must pass an explicit *http.Client (via Config.HTTPClient) — the
-// caller owns the transport, timeouts, and redirect policy. Callers who want
-// filesystem access must supply a URIResolver such as FileURIResolver or one
-// returned from NewFileResolver(fs.FS).
+// access must either pass an explicit *http.Client via Config.HTTPClient
+// (caller owns the transport, timeouts, and redirect policy) or supply a
+// URIResolver that accepts http(s) schemes. Callers who want filesystem
+// access must supply a URIResolver such as FileURIResolver or one returned
+// from NewFileResolver(fs.FS).
 package unparsedtext
 
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -236,7 +238,14 @@ func extractHTTPCharset(contentType string) string {
 // See the package-level documentation.
 func ReadURI(ctx context.Context, cfg *Config, uri string) ([]byte, error) {
 	data, _, err := readURIWithEncoding(ctx, cfg, uri)
-	return data, err
+	if err != nil {
+		var e *Error
+		if errors.As(err, &e) {
+			return nil, err
+		}
+		return nil, &Error{Code: ErrCodeRetrieval, Message: fmt.Sprintf("cannot retrieve resource: %v", err)}
+	}
+	return data, nil
 }
 
 // DecodeText decodes raw bytes to a string, handling BOM detection,

--- a/internal/unparsedtext/unparsedtext.go
+++ b/internal/unparsedtext/unparsedtext.go
@@ -543,7 +543,11 @@ func (r *httpResolver) ResolveURI(uri string) (io.ReadCloser, error) {
 	if parsed.Scheme != lexicon.SchemeHTTP && parsed.Scheme != lexicon.SchemeHTTPS {
 		return nil, fmt.Errorf("unsupported URI scheme for HTTP resolver: %s", parsed.Scheme)
 	}
-	req, err := http.NewRequest(http.MethodGet, uri, nil) //nolint:noctx // request-scoped contexts are passed by the ReadURI/ReadURIWithEncoding caller via cancellation of the underlying transport; this resolver has no ctx
+	// The URIResolver interface intentionally has no context parameter, so
+	// callers cannot cancel an in-flight request via ctx. Cancellation and
+	// deadlines must be enforced through the supplied http.Client's Timeout
+	// and Transport settings.
+	req, err := http.NewRequest(http.MethodGet, uri, nil) //nolint:noctx // URIResolver has no ctx; rely on client Timeout/Transport for cancellation
 	if err != nil {
 		return nil, err
 	}

--- a/internal/unparsedtext/unparsedtext.go
+++ b/internal/unparsedtext/unparsedtext.go
@@ -564,9 +564,9 @@ func (r *httpResolver) ResolveURI(uri string) (io.ReadCloser, error) {
 
 // NewFileResolver returns a URIResolver backed by an io/fs.FS. URIs are
 // interpreted as fs paths (slash-separated, relative to the FS root).
-// file:// URIs are accepted but only their cleaned, non-absolute path
-// component is used to look up against fsys; absolute paths and "../"
-// traversal are refused.
+// Bare relative paths and file: URIs without an authority are accepted;
+// absolute paths (anything beginning with "/", including file:// URIs
+// such as file:///etc/passwd) and "../" traversal are refused.
 func NewFileResolver(fsys fs.FS) URIResolver {
 	return &fsResolver{fsys: fsys}
 }
@@ -594,12 +594,14 @@ func (r *fsResolver) ResolveURI(uri string) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("unsupported URI scheme: %s", parsed.Scheme)
 	}
 
-	name = strings.TrimPrefix(name, "/")
 	if name == "" {
 		return nil, fmt.Errorf("empty path")
 	}
+	if strings.HasPrefix(name, "/") {
+		return nil, fmt.Errorf("absolute path %q is not allowed", name)
+	}
 	cleaned := path.Clean(name)
-	if cleaned == ".." || strings.HasPrefix(cleaned, "../") || path.IsAbs(cleaned) {
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
 		return nil, fmt.Errorf("path %q escapes the FS root", name)
 	}
 	return r.fsys.Open(cleaned)

--- a/internal/unparsedtext/unparsedtext.go
+++ b/internal/unparsedtext/unparsedtext.go
@@ -532,10 +532,13 @@ func ensureWithin(baseDir, target string) error {
 
 // NewHTTPResolver returns a URIResolver that fetches http/https URIs using
 // the supplied client. The caller owns the client's transport, timeouts,
-// and redirect policy. Non-http(s) schemes are refused.
+// and redirect policy. Non-http(s) schemes are refused. The client must be
+// non-nil; passing nil panics. There is intentionally no fallback to
+// http.DefaultClient — that would reintroduce the unbounded-timeout
+// behavior this package is designed to keep out of XPath evaluation.
 func NewHTTPResolver(client *http.Client) URIResolver {
 	if client == nil {
-		client = http.DefaultClient
+		panic("unparsedtext.NewHTTPResolver: client must not be nil")
 	}
 	return &httpResolver{client: client}
 }

--- a/internal/unparsedtext/unparsedtext.go
+++ b/internal/unparsedtext/unparsedtext.go
@@ -1,8 +1,14 @@
 // Package unparsedtext implements the text resource loading pipeline for
-// XPath 3.1 fn:unparsed-text, fn:unparsed-text-available, and
-// fn:unparsed-text-lines. It handles URI resolution, content retrieval,
-// BOM detection, encoding conversion, XML character validation, and
-// line splitting.
+// XPath 3.1 fn:unparsed-text, fn:unparsed-text-available, fn:unparsed-text-lines,
+// and the document retrieval that backs fn:doc / fn:json-doc.
+//
+// Resource loading is opt-in. With no URIResolver and no HTTPClient supplied,
+// every retrieval attempt fails with ErrCodeRetrieval — there is no implicit
+// network access and no implicit filesystem access. Callers who want network
+// access must pass an explicit *http.Client (via Config.HTTPClient) — the
+// caller owns the transport, timeouts, and redirect policy. Callers who want
+// filesystem access must supply a URIResolver such as FileURIResolver or one
+// returned from NewFileResolver(fs.FS).
 package unparsedtext
 
 import (
@@ -10,9 +16,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"unicode/utf8"
@@ -141,58 +149,68 @@ func ResolveURI(_ context.Context, cfg *Config, href string) (string, error) {
 
 // readURIWithEncoding reads the content at the resolved URI and returns
 // an optional encoding hint from HTTP Content-Type headers.
+//
+// Retrieval is opt-in: file/path URIs require an explicit URIResolver;
+// http/https URIs require either an explicit HTTPClient or a URIResolver
+// that accepts those schemes. There is no implicit os.ReadFile and no
+// implicit http.DefaultClient — see the package-level documentation.
+//
+// When both HTTPClient and URIResolver are configured, HTTPClient wins
+// for http/https so the Content-Type charset hint is preserved.
 func readURIWithEncoding(ctx context.Context, cfg *Config, uri string) ([]byte, string, error) {
-	if cfg != nil && cfg.URIResolver != nil {
-		rc, err := cfg.URIResolver.ResolveURI(uri)
-		if err != nil {
-			return nil, "", err
-		}
-		defer func() { _ = rc.Close() }()
-		data, err := io.ReadAll(rc)
-		return data, "", err
-	}
-
 	parsed, err := url.Parse(uri)
 	if err != nil {
 		return nil, "", err
 	}
 
 	if parsed.Scheme == lexicon.SchemeHTTP || parsed.Scheme == lexicon.SchemeHTTPS {
-		client := http.DefaultClient
 		if cfg != nil && cfg.HTTPClient != nil {
-			client = cfg.HTTPClient
+			return doHTTPGet(ctx, cfg.HTTPClient, uri)
 		}
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
-		if err != nil {
-			return nil, "", err
+		if cfg != nil && cfg.URIResolver != nil {
+			return readViaResolver(cfg.URIResolver, uri)
 		}
-		resp, err := client.Do(req)
-		if err != nil {
-			return nil, "", err
-		}
-		defer func() { _ = resp.Body.Close() }()
-		if resp.StatusCode != http.StatusOK {
-			return nil, "", fmt.Errorf("HTTP %d for %s", resp.StatusCode, uri)
-		}
-		data, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, "", err
-		}
-		// Extract charset from Content-Type header.
-		enc := extractHTTPCharset(resp.Header.Get("Content-Type"))
-		return data, enc, nil
+		return nil, "", fmt.Errorf("network retrieval requires an explicit HTTPClient or URIResolver: %s", uri)
 	}
 
-	switch parsed.Scheme {
-	case lexicon.SchemeFile:
-		data, err := os.ReadFile(parsed.Path)
-		return data, "", err
-	case "":
-		data, err := os.ReadFile(uri)
-		return data, "", err
-	default:
-		return nil, "", fmt.Errorf("unsupported URI scheme: %s", parsed.Scheme)
+	if cfg != nil && cfg.URIResolver != nil {
+		return readViaResolver(cfg.URIResolver, uri)
 	}
+
+	// file:// and bare paths require an explicit URIResolver.
+	return nil, "", fmt.Errorf("retrieval of %q requires a URIResolver", uri)
+}
+
+func readViaResolver(r URIResolver, uri string) ([]byte, string, error) {
+	rc, err := r.ResolveURI(uri)
+	if err != nil {
+		return nil, "", err
+	}
+	defer func() { _ = rc.Close() }()
+	data, err := io.ReadAll(rc)
+	return data, "", err
+}
+
+// doHTTPGet performs an HTTP GET using the caller-supplied client.
+func doHTTPGet(ctx context.Context, client *http.Client, uri string) ([]byte, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("HTTP %d for %s", resp.StatusCode, uri)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", err
+	}
+	enc := extractHTTPCharset(resp.Header.Get("Content-Type"))
+	return data, enc, nil
 }
 
 // extractHTTPCharset parses the charset parameter from a Content-Type header value.
@@ -212,49 +230,13 @@ func extractHTTPCharset(contentType string) string {
 }
 
 // ReadURI reads the content at the resolved URI.
+//
+// Retrieval is opt-in: file/path URIs require an explicit URIResolver;
+// http/https URIs require either an explicit HTTPClient or a URIResolver.
+// See the package-level documentation.
 func ReadURI(ctx context.Context, cfg *Config, uri string) ([]byte, error) {
-	if cfg != nil && cfg.URIResolver != nil {
-		rc, err := cfg.URIResolver.ResolveURI(uri)
-		if err != nil {
-			return nil, err
-		}
-		defer func() { _ = rc.Close() }()
-		return io.ReadAll(rc)
-	}
-
-	parsed, err := url.Parse(uri)
-	if err != nil {
-		return nil, err
-	}
-
-	if parsed.Scheme == "http" || parsed.Scheme == "https" {
-		client := http.DefaultClient
-		if cfg != nil && cfg.HTTPClient != nil {
-			client = cfg.HTTPClient
-		}
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
-		if err != nil {
-			return nil, err
-		}
-		resp, err := client.Do(req)
-		if err != nil {
-			return nil, err
-		}
-		defer func() { _ = resp.Body.Close() }()
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("HTTP %d for %s", resp.StatusCode, uri)
-		}
-		return io.ReadAll(resp.Body)
-	}
-
-	switch parsed.Scheme {
-	case lexicon.SchemeFile:
-		return os.ReadFile(parsed.Path)
-	case "":
-		return os.ReadFile(uri)
-	default:
-		return nil, fmt.Errorf("unsupported URI scheme: %s", parsed.Scheme)
-	}
+	data, _, err := readURIWithEncoding(ctx, cfg, uri)
+	return data, err
 }
 
 // DecodeText decodes raw bytes to a string, handling BOM detection,
@@ -473,7 +455,9 @@ func EncodingsCompatible(specified, detected string) bool {
 }
 
 // FileURIResolver resolves file:// URIs and relative file paths against a
-// base directory.
+// base directory. Resolution is confined to BaseDir: paths outside (via
+// "../" traversal or absolute paths that don't share the BaseDir prefix)
+// are refused.
 type FileURIResolver struct {
 	BaseDir string
 }
@@ -485,25 +469,136 @@ func (r *FileURIResolver) ResolveURI(uri string) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	var path string
+	var target string
 	switch parsed.Scheme {
-	case "file":
-		path = parsed.Path
+	case lexicon.SchemeFile:
+		target = parsed.Path
 	case "":
 		if filepath.IsAbs(uri) {
-			path = uri
+			target = uri
 		} else {
-			path = filepath.Join(r.BaseDir, uri)
+			target = filepath.Join(r.BaseDir, uri)
 		}
 	default:
 		return nil, fmt.Errorf("unsupported URI scheme: %s", parsed.Scheme)
 	}
 
-	f, err := os.Open(path)
+	if err := ensureWithin(r.BaseDir, target); err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(target)
 	if err != nil {
 		return nil, err
 	}
 	return f, nil
+}
+
+// ensureWithin verifies that target is inside baseDir after symlink-free
+// path cleaning. Both arguments are resolved to absolute, cleaned forms.
+// Note that this is a path-level check; callers that must defend against
+// symlink races should supply a URIResolver that uses io/fs primitives
+// (see NewFileResolver).
+func ensureWithin(baseDir, target string) error {
+	if baseDir == "" {
+		return fmt.Errorf("FileURIResolver: BaseDir is empty")
+	}
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return err
+	}
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(absBase, absTarget)
+	if err != nil {
+		return fmt.Errorf("path %q is outside base %q", target, baseDir)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path %q is outside base %q", target, baseDir)
+	}
+	return nil
+}
+
+// NewHTTPResolver returns a URIResolver that fetches http/https URIs using
+// the supplied client. The caller owns the client's transport, timeouts,
+// and redirect policy. Non-http(s) schemes are refused.
+func NewHTTPResolver(client *http.Client) URIResolver {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &httpResolver{client: client}
+}
+
+type httpResolver struct {
+	client *http.Client
+}
+
+func (r *httpResolver) ResolveURI(uri string) (io.ReadCloser, error) {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+	if parsed.Scheme != lexicon.SchemeHTTP && parsed.Scheme != lexicon.SchemeHTTPS {
+		return nil, fmt.Errorf("unsupported URI scheme for HTTP resolver: %s", parsed.Scheme)
+	}
+	req, err := http.NewRequest(http.MethodGet, uri, nil) //nolint:noctx // request-scoped contexts are passed by the ReadURI/ReadURIWithEncoding caller via cancellation of the underlying transport; this resolver has no ctx
+	if err != nil {
+		return nil, err
+	}
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("HTTP %d for %s", resp.StatusCode, uri)
+	}
+	return resp.Body, nil
+}
+
+// NewFileResolver returns a URIResolver backed by an io/fs.FS. URIs are
+// interpreted as fs paths (slash-separated, relative to the FS root).
+// file:// URIs are accepted but only their cleaned, non-absolute path
+// component is used to look up against fsys; absolute paths and "../"
+// traversal are refused.
+func NewFileResolver(fsys fs.FS) URIResolver {
+	return &fsResolver{fsys: fsys}
+}
+
+type fsResolver struct {
+	fsys fs.FS
+}
+
+func (r *fsResolver) ResolveURI(uri string) (io.ReadCloser, error) {
+	if r.fsys == nil {
+		return nil, fmt.Errorf("fsResolver: nil FS")
+	}
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	var name string
+	switch parsed.Scheme {
+	case lexicon.SchemeFile:
+		name = parsed.Path
+	case "":
+		name = uri
+	default:
+		return nil, fmt.Errorf("unsupported URI scheme: %s", parsed.Scheme)
+	}
+
+	name = strings.TrimPrefix(name, "/")
+	if name == "" {
+		return nil, fmt.Errorf("empty path")
+	}
+	cleaned := path.Clean(name)
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") || path.IsAbs(cleaned) {
+		return nil, fmt.Errorf("path %q escapes the FS root", name)
+	}
+	return r.fsys.Open(cleaned)
 }
 
 func normalizeEncodingName(s string) string {

--- a/internal/unparsedtext/unparsedtext_test.go
+++ b/internal/unparsedtext/unparsedtext_test.go
@@ -520,6 +520,11 @@ func TestNewHTTPResolver(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	require.PanicsWithValue(t,
+		"unparsedtext.NewHTTPResolver: client must not be nil",
+		func() { unparsedtext.NewHTTPResolver(nil) },
+	)
+
 	r := unparsedtext.NewHTTPResolver(srv.Client())
 	require.NotNil(t, r)
 

--- a/internal/unparsedtext/unparsedtext_test.go
+++ b/internal/unparsedtext/unparsedtext_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"unicode/utf16"
 
@@ -272,22 +273,23 @@ func TestResolveURI(t *testing.T) {
 }
 
 func TestReadURI(t *testing.T) {
-	t.Run("file path", func(t *testing.T) {
+	t.Run("file path via resolver", func(t *testing.T) {
 		dir := t.TempDir()
-		path := filepath.Join(dir, "test.txt")
-		require.NoError(t, os.WriteFile(path, []byte("content"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "test.txt"), []byte("content"), 0644))
 
-		data, err := unparsedtext.ReadURI(t.Context(), nil, path)
+		cfg := &unparsedtext.Config{URIResolver: unparsedtext.NewFileResolver(os.DirFS(dir))}
+		data, err := unparsedtext.ReadURI(t.Context(), cfg, "test.txt")
 		require.NoError(t, err)
 		require.Equal(t, "content", string(data))
 	})
 
-	t.Run("file URI", func(t *testing.T) {
+	t.Run("file URI via resolver", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "test.txt")
 		require.NoError(t, os.WriteFile(path, []byte("file-uri"), 0644))
 
-		data, err := unparsedtext.ReadURI(t.Context(), nil, "file://"+path)
+		cfg := &unparsedtext.Config{URIResolver: &unparsedtext.FileURIResolver{BaseDir: dir}}
+		data, err := unparsedtext.ReadURI(t.Context(), cfg, "file://"+path)
 		require.NoError(t, err)
 		require.Equal(t, "file-uri", string(data))
 	})
@@ -333,12 +335,14 @@ func TestReadURI(t *testing.T) {
 }
 
 func TestLoadText(t *testing.T) {
-	t.Run("basic file load", func(t *testing.T) {
+	t.Run("basic file load via resolver", func(t *testing.T) {
 		dir := t.TempDir()
-		path := filepath.Join(dir, "test.txt")
-		require.NoError(t, os.WriteFile(path, []byte("hello world"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "test.txt"), []byte("hello world"), 0644))
 
-		cfg := &unparsedtext.Config{BaseURI: "file://" + dir + "/"}
+		cfg := &unparsedtext.Config{
+			BaseURI:     "file://" + dir + "/",
+			URIResolver: &unparsedtext.FileURIResolver{BaseDir: dir},
+		}
 		text, err := unparsedtext.LoadText(t.Context(), cfg, "test.txt", "")
 		require.NoError(t, err)
 		require.Equal(t, "hello world", text)
@@ -349,7 +353,8 @@ func TestLoadText(t *testing.T) {
 		path := filepath.Join(dir, "bad.txt")
 		require.NoError(t, os.WriteFile(path, []byte("hello\x00world"), 0644))
 
-		text, err := unparsedtext.LoadText(t.Context(), nil, "file://"+path, "")
+		cfg := &unparsedtext.Config{URIResolver: &unparsedtext.FileURIResolver{BaseDir: dir}}
+		text, err := unparsedtext.LoadText(t.Context(), cfg, "file://"+path, "")
 		require.Error(t, err)
 		require.Empty(t, text)
 		var ue *unparsedtext.Error
@@ -357,8 +362,10 @@ func TestLoadText(t *testing.T) {
 		require.Equal(t, unparsedtext.ErrCodeEncoding, ue.Code)
 	})
 
-	t.Run("nonexistent file", func(t *testing.T) {
-		_, err := unparsedtext.LoadText(t.Context(), nil, "file:///nonexistent/file.txt", "")
+	t.Run("nonexistent file via resolver", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := &unparsedtext.Config{URIResolver: &unparsedtext.FileURIResolver{BaseDir: dir}}
+		_, err := unparsedtext.LoadText(t.Context(), cfg, "nope.txt", "")
 		require.Error(t, err)
 		var ue *unparsedtext.Error
 		require.ErrorAs(t, err, &ue)
@@ -371,7 +378,8 @@ func TestLoadTextLines(t *testing.T) {
 	path := filepath.Join(dir, "lines.txt")
 	require.NoError(t, os.WriteFile(path, []byte("line1\r\nline2\nline3"), 0644))
 
-	lines, err := unparsedtext.LoadTextLines(t.Context(), nil, "file://"+path, "")
+	cfg := &unparsedtext.Config{URIResolver: &unparsedtext.FileURIResolver{BaseDir: dir}}
+	lines, err := unparsedtext.LoadTextLines(t.Context(), cfg, "file://"+path, "")
 	require.NoError(t, err)
 	require.Equal(t, []string{"line1", "line2", "line3"}, lines)
 }
@@ -381,8 +389,9 @@ func TestIsAvailable(t *testing.T) {
 	path := filepath.Join(dir, "exists.txt")
 	require.NoError(t, os.WriteFile(path, []byte("ok"), 0644))
 
-	require.True(t, unparsedtext.IsAvailable(t.Context(), nil, "file://"+path, ""))
-	require.False(t, unparsedtext.IsAvailable(t.Context(), nil, "file://"+filepath.Join(dir, "nope.txt"), ""))
+	cfg := &unparsedtext.Config{URIResolver: &unparsedtext.FileURIResolver{BaseDir: dir}}
+	require.True(t, unparsedtext.IsAvailable(t.Context(), cfg, "file://"+path, ""))
+	require.False(t, unparsedtext.IsAvailable(t.Context(), cfg, "file://"+filepath.Join(dir, "nope.txt"), ""))
 }
 
 func TestFileURIResolver(t *testing.T) {
@@ -414,6 +423,122 @@ func TestFileURIResolver(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unsupported URI scheme")
 	})
+}
+
+func TestReadURINoNetworkByDefault(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = w.Write([]byte("nope"))
+	}))
+	defer srv.Close()
+
+	// nil config and config without HTTPClient/URIResolver must refuse.
+	_, err := unparsedtext.ReadURI(t.Context(), nil, srv.URL+"/x")
+	require.Error(t, err)
+	require.Zero(t, atomic.LoadInt32(&hits))
+
+	_, err = unparsedtext.ReadURI(t.Context(), &unparsedtext.Config{}, srv.URL+"/x")
+	require.Error(t, err)
+	require.Zero(t, atomic.LoadInt32(&hits))
+}
+
+func TestReadURINoFileReadByDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+	require.NoError(t, os.WriteFile(path, []byte("secret"), 0644))
+
+	// nil config — raw path
+	_, err := unparsedtext.ReadURI(t.Context(), nil, path)
+	require.Error(t, err)
+
+	// nil config — file:// URI
+	_, err = unparsedtext.ReadURI(t.Context(), nil, "file://"+path)
+	require.Error(t, err)
+}
+
+func TestLoadTextNoNetworkByDefault(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = w.Write([]byte("nope"))
+	}))
+	defer srv.Close()
+
+	_, err := unparsedtext.LoadText(t.Context(), nil, srv.URL+"/x", "")
+	require.Error(t, err)
+	var ue *unparsedtext.Error
+	require.ErrorAs(t, err, &ue)
+	require.Equal(t, unparsedtext.ErrCodeRetrieval, ue.Code)
+	require.Zero(t, atomic.LoadInt32(&hits))
+}
+
+func TestLoadTextNoFileReadByDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+	require.NoError(t, os.WriteFile(path, []byte("secret"), 0644))
+
+	_, err := unparsedtext.LoadText(t.Context(), nil, "file://"+path, "")
+	require.Error(t, err)
+	var ue *unparsedtext.Error
+	require.ErrorAs(t, err, &ue)
+	require.Equal(t, unparsedtext.ErrCodeRetrieval, ue.Code)
+}
+
+func TestFileURIResolverRejectsTraversal(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(filepath.Dir(dir), "outside.txt")
+	require.NoError(t, os.WriteFile(outside, []byte("escape"), 0644))
+	t.Cleanup(func() { _ = os.Remove(outside) })
+
+	r := &unparsedtext.FileURIResolver{BaseDir: dir}
+
+	t.Run("dotdot relative path refused", func(t *testing.T) {
+		_, err := r.ResolveURI("../outside.txt")
+		require.Error(t, err)
+	})
+
+	t.Run("absolute path refused", func(t *testing.T) {
+		_, err := r.ResolveURI(outside)
+		require.Error(t, err)
+	})
+
+	t.Run("file URI with absolute path refused", func(t *testing.T) {
+		_, err := r.ResolveURI("file://" + outside)
+		require.Error(t, err)
+	})
+}
+
+func TestNewHTTPResolver(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("via-http-resolver"))
+	}))
+	defer srv.Close()
+
+	r := unparsedtext.NewHTTPResolver(srv.Client())
+	require.NotNil(t, r)
+
+	cfg := &unparsedtext.Config{URIResolver: r}
+	data, err := unparsedtext.ReadURI(t.Context(), cfg, srv.URL+"/x")
+	require.NoError(t, err)
+	require.Equal(t, "via-http-resolver", string(data))
+}
+
+func TestNewFileResolver(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ok.txt"), []byte("via-fs"), 0644))
+
+	r := unparsedtext.NewFileResolver(os.DirFS(dir))
+	require.NotNil(t, r)
+
+	cfg := &unparsedtext.Config{URIResolver: r}
+	data, err := unparsedtext.ReadURI(t.Context(), cfg, "ok.txt")
+	require.NoError(t, err)
+	require.Equal(t, "via-fs", string(data))
+
+	// Traversal must be refused.
+	_, err = unparsedtext.ReadURI(t.Context(), cfg, "../etc/passwd")
+	require.Error(t, err)
 }
 
 func TestErrorType(t *testing.T) {

--- a/internal/unparsedtext/unparsedtext_test.go
+++ b/internal/unparsedtext/unparsedtext_test.go
@@ -539,6 +539,11 @@ func TestNewFileResolver(t *testing.T) {
 	// Traversal must be refused.
 	_, err = unparsedtext.ReadURI(t.Context(), cfg, "../etc/passwd")
 	require.Error(t, err)
+
+	// Absolute file URIs must be refused, not silently rewritten to relative.
+	_, err = unparsedtext.ReadURI(t.Context(), cfg, "file:///etc/passwd")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "absolute path")
 }
 
 func TestErrorType(t *testing.T) {

--- a/internal/unparsedtext/unparsedtext_test.go
+++ b/internal/unparsedtext/unparsedtext_test.go
@@ -426,9 +426,9 @@ func TestFileURIResolver(t *testing.T) {
 }
 
 func TestReadURINoNetworkByDefault(t *testing.T) {
-	var hits int32
+	var hits atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt32(&hits, 1)
+		hits.Add(1)
 		_, _ = w.Write([]byte("nope"))
 	}))
 	defer srv.Close()
@@ -436,11 +436,11 @@ func TestReadURINoNetworkByDefault(t *testing.T) {
 	// nil config and config without HTTPClient/URIResolver must refuse.
 	_, err := unparsedtext.ReadURI(t.Context(), nil, srv.URL+"/x")
 	require.Error(t, err)
-	require.Zero(t, atomic.LoadInt32(&hits))
+	require.Zero(t, hits.Load())
 
 	_, err = unparsedtext.ReadURI(t.Context(), &unparsedtext.Config{}, srv.URL+"/x")
 	require.Error(t, err)
-	require.Zero(t, atomic.LoadInt32(&hits))
+	require.Zero(t, hits.Load())
 }
 
 func TestReadURINoFileReadByDefault(t *testing.T) {
@@ -458,9 +458,9 @@ func TestReadURINoFileReadByDefault(t *testing.T) {
 }
 
 func TestLoadTextNoNetworkByDefault(t *testing.T) {
-	var hits int32
+	var hits atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt32(&hits, 1)
+		hits.Add(1)
 		_, _ = w.Write([]byte("nope"))
 	}))
 	defer srv.Close()
@@ -470,7 +470,7 @@ func TestLoadTextNoNetworkByDefault(t *testing.T) {
 	var ue *unparsedtext.Error
 	require.ErrorAs(t, err, &ue)
 	require.Equal(t, unparsedtext.ErrCodeRetrieval, ue.Code)
-	require.Zero(t, atomic.LoadInt32(&hits))
+	require.Zero(t, hits.Load())
 }
 
 func TestLoadTextNoFileReadByDefault(t *testing.T) {

--- a/internal/unparsedtext/unparsedtext_test.go
+++ b/internal/unparsedtext/unparsedtext_test.go
@@ -451,10 +451,15 @@ func TestReadURINoFileReadByDefault(t *testing.T) {
 	// nil config — raw path
 	_, err := unparsedtext.ReadURI(t.Context(), nil, path)
 	require.Error(t, err)
+	var ue *unparsedtext.Error
+	require.ErrorAs(t, err, &ue)
+	require.Equal(t, unparsedtext.ErrCodeRetrieval, ue.Code)
 
 	// nil config — file:// URI
 	_, err = unparsedtext.ReadURI(t.Context(), nil, "file://"+path)
 	require.Error(t, err)
+	require.ErrorAs(t, err, &ue)
+	require.Equal(t, unparsedtext.ErrCodeRetrieval, ue.Code)
 }
 
 func TestLoadTextNoNetworkByDefault(t *testing.T) {

--- a/xpath3/functions_node.go
+++ b/xpath3/functions_node.go
@@ -961,7 +961,10 @@ func loadDoc(ctx context.Context, uri string) (helium.Node, error) {
 		return nil, &XPathError{Code: errCodeFODC0002, Message: fmt.Sprintf("fn:doc: cannot retrieve resource: %v", err)}
 	}
 
-	doc, err := helium.NewParser().Parse(ctx, data)
+	// Block external entity expansion and network access in the retrieved
+	// document. Without this, an attacker who controls the resource body
+	// could chain XXE/SSRF on top of the doc() retrieval.
+	doc, err := helium.NewParser().BlockXXE(true).AllowNetwork(false).Parse(ctx, data)
 	if err != nil {
 		return nil, &XPathError{Code: errCodeFODC0002, Message: fmt.Sprintf("fn:doc: cannot parse document: %v", err)}
 	}

--- a/xpath3/qt3_helpers_test.go
+++ b/xpath3/qt3_helpers_test.go
@@ -3,11 +3,13 @@ package xpath3_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"math"
 	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -19,9 +21,33 @@ import (
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/heliumtest"
+	"github.com/lestrrat-go/helium/internal/unparsedtext"
 	"github.com/lestrrat-go/helium/xpath3"
 	"github.com/stretchr/testify/require"
 )
+
+// qt3Resolver returns a URIResolver that lets QT3 tests reach both the
+// shared HTTP fixture server and the local testdata tree. It's the QT3
+// harness's explicit opt-in to network + filesystem access.
+func qt3Resolver(client *http.Client) xpath3.URIResolver {
+	return &qt3CombinedResolver{
+		httpR: unparsedtext.NewHTTPResolver(client),
+		fileR: &unparsedtext.FileURIResolver{BaseDir: string(filepath.Separator)},
+	}
+}
+
+type qt3CombinedResolver struct {
+	httpR xpath3.URIResolver
+	fileR xpath3.URIResolver
+}
+
+func (r *qt3CombinedResolver) ResolveURI(uri string) (io.ReadCloser, error) {
+	parsed, err := url.Parse(uri)
+	if err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https") {
+		return r.httpR.ResolveURI(uri)
+	}
+	return r.fileR.ResolveURI(uri)
+}
 
 // qt3Assertion checks a result sequence, calling t.Fatal on failure.
 type qt3Assertion func(t *testing.T, seq xpath3.Sequence)
@@ -184,6 +210,7 @@ func qt3RunTests(t *testing.T, tests []qt3Test) {
 			opts := []qt3EvalMutator{
 				func(e xpath3.Evaluator) xpath3.Evaluator { return e.ImplicitTimezone(qt3ImplicitTZ) },
 				func(e xpath3.Evaluator) xpath3.Evaluator { return e.HTTPClient(httpClient) },
+				func(e xpath3.Evaluator) xpath3.Evaluator { return e.URIResolver(qt3Resolver(httpClient)) },
 			}
 			if tc.DefaultDecimal != nil {
 				df := tc.DefaultDecimal.toXPath3()

--- a/xpath3/security_test.go
+++ b/xpath3/security_test.go
@@ -19,9 +19,9 @@ import (
 func TestFnDocNoNetworkByDefault(t *testing.T) {
 	t.Parallel()
 	// If any request reaches the server, the test fails.
-	var hits int32
+	var hits atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt32(&hits, 1)
+		hits.Add(1)
 		_, _ = w.Write([]byte("<root/>"))
 	}))
 	defer srv.Close()
@@ -36,7 +36,7 @@ func TestFnDocNoNetworkByDefault(t *testing.T) {
 	var xpErr *xpath3.XPathError
 	require.ErrorAs(t, err, &xpErr)
 	require.Equal(t, "FODC0002", xpErr.Code)
-	require.Zero(t, atomic.LoadInt32(&hits), "no HTTP request should be issued by default")
+	require.Zero(t, hits.Load(), "no HTTP request should be issued by default")
 }
 
 func TestFnDocNoFileReadByDefault(t *testing.T) {
@@ -77,9 +77,9 @@ func TestFnDocNoFileURIReadByDefault(t *testing.T) {
 
 func TestFnUnparsedTextNoNetworkByDefault(t *testing.T) {
 	t.Parallel()
-	var hits int32
+	var hits atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt32(&hits, 1)
+		hits.Add(1)
 		_, _ = w.Write([]byte("hello"))
 	}))
 	defer srv.Close()
@@ -94,7 +94,7 @@ func TestFnUnparsedTextNoNetworkByDefault(t *testing.T) {
 	var xpErr *xpath3.XPathError
 	require.ErrorAs(t, err, &xpErr)
 	require.Equal(t, "FOUT1170", xpErr.Code)
-	require.Zero(t, atomic.LoadInt32(&hits), "no HTTP request should be issued by default")
+	require.Zero(t, hits.Load(), "no HTTP request should be issued by default")
 }
 
 func TestFnUnparsedTextNoFileReadByDefault(t *testing.T) {

--- a/xpath3/security_test.go
+++ b/xpath3/security_test.go
@@ -1,0 +1,172 @@
+package xpath3_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// H1: fn:doc / fn:unparsed-text must be secure-by-default — no implicit
+// HTTP fetches, no implicit os.ReadFile reads, no XXE in fetched docs.
+
+func TestFnDocNoNetworkByDefault(t *testing.T) {
+	t.Parallel()
+	// If any request reaches the server, the test fails.
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = w.Write([]byte("<root/>"))
+	}))
+	defer srv.Close()
+
+	compiled, err := xpath3.NewCompiler().Compile(`doc("` + srv.URL + `/x")`)
+	require.NoError(t, err)
+
+	_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Evaluate(t.Context(), compiled, nil)
+	require.Error(t, err)
+
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, "FODC0002", xpErr.Code)
+	require.Zero(t, atomic.LoadInt32(&hits), "no HTTP request should be issued by default")
+}
+
+func TestFnDocNoFileReadByDefault(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.xml")
+	require.NoError(t, os.WriteFile(path, []byte("<root>secret</root>"), 0644))
+
+	compiled, err := xpath3.NewCompiler().Compile(`doc("` + path + `")`)
+	require.NoError(t, err)
+
+	_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Evaluate(t.Context(), compiled, nil)
+	require.Error(t, err)
+
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, "FODC0002", xpErr.Code)
+}
+
+func TestFnDocNoFileURIReadByDefault(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.xml")
+	require.NoError(t, os.WriteFile(path, []byte("<root>secret</root>"), 0644))
+
+	compiled, err := xpath3.NewCompiler().Compile(`doc("file://` + path + `")`)
+	require.NoError(t, err)
+
+	_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Evaluate(t.Context(), compiled, nil)
+	require.Error(t, err)
+
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, "FODC0002", xpErr.Code)
+}
+
+func TestFnUnparsedTextNoNetworkByDefault(t *testing.T) {
+	t.Parallel()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer srv.Close()
+
+	compiled, err := xpath3.NewCompiler().Compile(`unparsed-text("` + srv.URL + `/x")`)
+	require.NoError(t, err)
+
+	_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Evaluate(t.Context(), compiled, nil)
+	require.Error(t, err)
+
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, "FOUT1170", xpErr.Code)
+	require.Zero(t, atomic.LoadInt32(&hits), "no HTTP request should be issued by default")
+}
+
+func TestFnUnparsedTextNoFileReadByDefault(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+	require.NoError(t, os.WriteFile(path, []byte("secret"), 0644))
+
+	compiled, err := xpath3.NewCompiler().Compile(`unparsed-text("file://` + path + `")`)
+	require.NoError(t, err)
+
+	_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Evaluate(t.Context(), compiled, nil)
+	require.Error(t, err)
+
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, "FOUT1170", xpErr.Code)
+}
+
+func TestFnDocWithExplicitHTTPClientSucceeds(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`<root><name>helium</name></root>`))
+	}))
+	defer srv.Close()
+
+	compiled, err := xpath3.NewCompiler().Compile(`string(doc("` + srv.URL + `/x")/root/name)`)
+	require.NoError(t, err)
+
+	result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		HTTPClient(srv.Client()).
+		Evaluate(t.Context(), compiled, nil)
+	require.NoError(t, err)
+	s, ok := result.IsString()
+	require.True(t, ok)
+	require.Equal(t, "helium", s)
+}
+
+// When fn:doc retrieves an XML doc that declares an external entity,
+// the parser used by loadDoc must NOT load the external entity.
+func TestFnDocBlocksXXEInRetrievedDoc(t *testing.T) {
+	t.Parallel()
+	// Create a secret file the external entity would try to read.
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "secret.txt")
+	require.NoError(t, os.WriteFile(secretPath, []byte("PWNED"), 0644))
+
+	// Resource doc declares an external entity pointing at the secret.
+	resourceBody := `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ENTITY xxe SYSTEM "file://` + secretPath + `">
+]>
+<root>&xxe;</root>`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(resourceBody))
+	}))
+	defer srv.Close()
+
+	compiled, err := xpath3.NewCompiler().Compile(`string(doc("` + srv.URL + `/x")/root)`)
+	require.NoError(t, err)
+
+	result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		HTTPClient(srv.Client()).
+		Evaluate(t.Context(), compiled, nil)
+	// Either the parse errors out (acceptable) or it succeeds with the
+	// entity *not* expanded. Either way, "PWNED" must not appear.
+	if err == nil {
+		s, ok := result.IsString()
+		require.True(t, ok)
+		require.False(t, strings.Contains(s, "PWNED"),
+			"BlockXXE must prevent external entity expansion, got: %q", s)
+	}
+}

--- a/xslt3/execute.go
+++ b/xslt3/execute.go
@@ -989,6 +989,14 @@ func (ec *execContext) buildBaseXPathEvaluator(baseURI string) xpath3.Evaluator 
 	if resolver := ec.collectionResolver(); resolver != nil {
 		eval = eval.CollectionResolver(resolver)
 	}
+	if ec.transformConfig != nil {
+		if r := ec.transformConfig.uriResolver; r != nil {
+			eval = eval.URIResolver(r)
+		}
+		if c := ec.transformConfig.httpClient; c != nil {
+			eval = eval.HTTPClient(c)
+		}
+	}
 	return eval
 }
 

--- a/xslt3/fn_transform_test.go
+++ b/xslt3/fn_transform_test.go
@@ -310,3 +310,63 @@ func TestFnTransformCustomURIScheme(t *testing.T) {
 	require.Contains(t, resolver.calledWith, "mem://pkg/inner.xsl",
 		"resolver should receive properly resolved URI, got: %v", resolver.calledWith)
 }
+
+// httpResolverFunc adapts a function to the xpath3.URIResolver interface.
+type httpResolverFunc func(uri string) (io.ReadCloser, error)
+
+func (f httpResolverFunc) ResolveURI(uri string) (io.ReadCloser, error) { return f(uri) }
+
+// TestFnTransformInheritsRuntimeResolver verifies that fn:unparsed-text
+// called from inside an inner stylesheet invoked via fn:transform()
+// inherits the outer Invocation's URIResolver, instead of being refused
+// by secure-by-default retrieval.
+func TestFnTransformInheritsRuntimeResolver(t *testing.T) {
+	const dataURI = "http://example.invalid/data/hello.txt"
+
+	var calledWith []string
+	runtimeResolver := httpResolverFunc(func(uri string) (io.ReadCloser, error) {
+		calledWith = append(calledWith, uri)
+		if uri != dataURI {
+			return nil, &xpath3.XPathError{Code: "FOUT1170", Message: "not found: " + uri}
+		}
+		return io.NopCloser(strings.NewReader("hello-from-resolver")), nil
+	})
+
+	innerXSLT := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <inner><xsl:value-of select="unparsed-text('` + dataURI + `')"/></inner>
+  </xsl:template>
+</xsl:stylesheet>`
+	outerXSLT := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:map="http://www.w3.org/2005/xpath-functions/map">
+  <xsl:template match="/">
+    <xsl:variable name="result" select="transform(map{
+      'stylesheet-location': 'mem://stylesheets/inner.xsl',
+      'delivery-format': 'serialized'
+    })"/>
+    <result><xsl:value-of select="$result('output')"/></result>
+  </xsl:template>
+</xsl:stylesheet>`
+
+	compileResolver := &memResolver{
+		files: map[string]string{
+			"mem://stylesheets/inner.xsl": innerXSLT,
+		},
+	}
+
+	ctx := t.Context()
+	doc, err := helium.NewParser().Parse(ctx, []byte(outerXSLT))
+	require.NoError(t, err)
+	ss, err := xslt3.NewCompiler().URIResolver(compileResolver).Compile(ctx, doc)
+	require.NoError(t, err)
+
+	src, _ := helium.NewParser().Parse(ctx, []byte(`<dummy/>`))
+	out, err := ss.Transform(src).URIResolver(runtimeResolver).Serialize(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "hello-from-resolver",
+		"inner fn:unparsed-text should resolve via outer Invocation's URIResolver")
+	require.Contains(t, calledWith, dataURI)
+}

--- a/xslt3/functions_transform.go
+++ b/xslt3/functions_transform.go
@@ -549,6 +549,11 @@ func (ec *execContext) fnTransform(ctx context.Context, args []xpath3.Sequence) 
 	}
 
 	// Build a fresh transform config for the inner fn:transform call.
+	// Inherit the outer Invocation's URIResolver and HTTPClient so that
+	// fn:doc / fn:unparsed-text inside the inner transform see the same
+	// opt-in resource access as the caller. Without this, secure-by-default
+	// retrieval would refuse network/filesystem access even when the outer
+	// Invocation enabled it.
 	secondaryResults := make(map[string]*helium.Document)
 	secondaryOutputDefs := make(map[string]*OutputDef)
 	fnTransformCfg := &transformConfig{
@@ -557,6 +562,10 @@ func (ec *execContext) fnTransform(ctx context.Context, args []xpath3.Sequence) 
 		initialFunction:  initialFunction,
 		baseOutputURI:    baseOutputURI,
 		resultDocHandler: resultDocCollector{results: secondaryResults, outputDefs: secondaryOutputDefs},
+	}
+	if ec.transformConfig != nil {
+		fnTransformCfg.uriResolver = ec.transformConfig.uriResolver
+		fnTransformCfg.httpClient = ec.transformConfig.httpClient
 	}
 
 	// Apply map-valued options from the fn:transform options map.

--- a/xslt3/invocation.go
+++ b/xslt3/invocation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"net/http"
 	"strings"
 
 	"github.com/lestrrat-go/helium"
@@ -84,6 +85,8 @@ type invocationConfig struct {
 	primaryItemsHandler PrimaryItemsHandler
 	annotationHandler   AnnotationHandler
 	collectionResolver  xpath3.CollectionResolver
+	uriResolver         xpath3.URIResolver
+	httpClient          *http.Client
 	baseOutputURI       string
 	sourceSchemas       []*xsd.Schema
 	onMultipleMatch     OnMultipleMatchMode
@@ -245,6 +248,27 @@ func (inv Invocation) CollectionResolver(r xpath3.CollectionResolver) Invocation
 	return inv
 }
 
+// URIResolver sets a custom URI resolver used by fn:doc, fn:unparsed-text,
+// fn:unparsed-text-lines, fn:unparsed-text-available, fn:doc-available,
+// and fn:json-doc during the transformation. Without this (and without an
+// HTTPClient) those functions cannot reach the filesystem or network and
+// return their spec-mandated retrieval errors.
+func (inv Invocation) URIResolver(r xpath3.URIResolver) Invocation {
+	inv = inv.clone()
+	inv.cfg.uriResolver = r
+	return inv
+}
+
+// HTTPClient sets the HTTP client used to fetch http/https URIs for
+// fn:doc / fn:unparsed-text / fn:json-doc when no URIResolver is supplied.
+// The caller owns the client's transport, timeouts, and redirect policy.
+// Without this (and without a URIResolver), network retrieval is refused.
+func (inv Invocation) HTTPClient(client *http.Client) Invocation {
+	inv = inv.clone()
+	inv.cfg.httpClient = client
+	return inv
+}
+
 // BaseOutputURI sets the base output URI for current-output-uri().
 func (inv Invocation) BaseOutputURI(uri string) Invocation {
 	inv = inv.clone()
@@ -401,6 +425,8 @@ func (inv Invocation) toTransformConfig() *transformConfig {
 	c := inv.cfg
 	tcfg := &transformConfig{
 		collectionResolver: c.collectionResolver,
+		uriResolver:        c.uriResolver,
+		httpClient:         c.httpClient,
 		baseOutputURI:      c.baseOutputURI,
 		sourceSchemas:      c.sourceSchemas,
 		onMultipleMatch:    c.onMultipleMatch.String(),

--- a/xslt3/options.go
+++ b/xslt3/options.go
@@ -2,6 +2,7 @@ package xslt3
 
 import (
 	"io"
+	"net/http"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/xpath3"
@@ -46,7 +47,9 @@ type transformConfig struct {
 	initialFunctionParams []xpath3.Sequence // positional params for initial function
 	resultDocHandler      ResultDocumentHandler
 	collectionResolver    xpath3.CollectionResolver
-	onMultipleMatch       string // "use-last" or "fail" — overrides default mode's on-multiple-match
+	uriResolver           xpath3.URIResolver // resolver for fn:doc, fn:unparsed-text, fn:json-doc
+	httpClient            *http.Client       // explicit HTTP client for fn:doc/fn:unparsed-text — opt-in network
+	onMultipleMatch       string             // "use-last" or "fail" — overrides default mode's on-multiple-match
 	rawResultHandler      RawResultHandler
 	baseOutputURI         string // base output URI for current-output-uri()
 	annotationHandler     AnnotationHandler

--- a/xslt3/w3c_helpers_test.go
+++ b/xslt3/w3c_helpers_test.go
@@ -146,6 +146,11 @@ var (
 	// so absolute file:// URIs from the catalog resolve. Production callers
 	// must NOT do this; supply a tightly scoped resolver instead.
 	w3cTestFileResolver = &unparsedtext.FileURIResolver{BaseDir: string(filepath.Separator)}
+
+	// w3cTestHTTPClient is used for the handful of W3C tests that fetch
+	// real http(s) URLs (e.g. www.w3.org). A bounded Timeout keeps the
+	// suite from hanging when the remote host is slow or unreachable.
+	w3cTestHTTPClient = &http.Client{Timeout: 30 * time.Second}
 )
 
 // w3cPackageDep describes a secondary package dependency for a W3C test.
@@ -1253,7 +1258,7 @@ func w3cRunOne(t *testing.T, tc w3cTest) {
 	// also fetch real http(s) URLs from www.w3.org. The harness opts in
 	// to both — production callers must NOT replicate this; supply a
 	// tightly scoped URIResolver / scoped HTTPClient instead.
-	inv = inv.URIResolver(w3cTestFileResolver).HTTPClient(http.DefaultClient)
+	inv = inv.URIResolver(w3cTestFileResolver).HTTPClient(w3cTestHTTPClient)
 
 	// Set base output URI for current-output-uri(). Use explicit value if
 	// provided, otherwise auto-compute for tests in the known list.

--- a/xslt3/w3c_helpers_test.go
+++ b/xslt3/w3c_helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -19,6 +20,7 @@ import (
 	htmlparser "github.com/lestrrat-go/helium/html"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/sequence"
+	"github.com/lestrrat-go/helium/internal/unparsedtext"
 	"github.com/lestrrat-go/helium/xpath3"
 	"github.com/lestrrat-go/helium/xsd"
 	"github.com/lestrrat-go/helium/xslt3"
@@ -138,6 +140,12 @@ var (
 	// result documents, keyed by "testName\x00href". Populated by the test
 	// runner and read by w3cAssertResultDocument for proper serialization.
 	w3cResultDocOutputDefs sync.Map // "testName\x00href" → *xslt3.OutputDef
+
+	// w3cTestFileResolver is the explicit opt-in file URI resolver used by
+	// the W3C XSLT test harness. The base directory is the filesystem root
+	// so absolute file:// URIs from the catalog resolve. Production callers
+	// must NOT do this; supply a tightly scoped resolver instead.
+	w3cTestFileResolver = &unparsedtext.FileURIResolver{BaseDir: string(filepath.Separator)}
 )
 
 // w3cPackageDep describes a secondary package dependency for a W3C test.
@@ -1239,6 +1247,13 @@ func w3cRunOne(t *testing.T, tc w3cTest) {
 		resolver := w3cBuildCollectionResolver(t, collections)
 		inv = inv.CollectionResolver(resolver)
 	}
+
+	// The W3C XSLT 3.0 test suite fixtures live on the local filesystem
+	// and are referenced via absolute file:// URIs. A handful of tests
+	// also fetch real http(s) URLs from www.w3.org. The harness opts in
+	// to both — production callers must NOT replicate this; supply a
+	// tightly scoped URIResolver / scoped HTTPClient instead.
+	inv = inv.URIResolver(w3cTestFileResolver).HTTPClient(http.DefaultClient)
 
 	// Set base output URI for current-output-uri(). Use explicit value if
 	// provided, otherwise auto-compute for tests in the known list.


### PR DESCRIPTION
H1 SSRF/LFI: `fn:doc` and `fn:unparsed-text` no longer fall back to `http.DefaultClient` or `os.ReadFile`; retrieval requires an explicit `URIResolver` or `HTTPClient`, and `fn:doc` parses with `BlockXXE(true).AllowNetwork(false)` to block chained XXE.