### PR TITLE
reject xmldsig1 references with duplicate IDs (XSW)

### DIFF
--- a/xmldsig1/errors.go
+++ b/xmldsig1/errors.go
@@ -30,6 +30,11 @@ var (
 	// ErrReferenceNotFound is returned when a Reference URI cannot be resolved.
 	ErrReferenceNotFound = errors.New("xmldsig1: reference URI not resolved")
 
+	// ErrDuplicateReferenceID is returned when a Reference URI resolves to more
+	// than one element with the same Id/ID/xml:id value. Such documents are
+	// ambiguous and a known vector for XML Signature Wrapping (XSW) attacks.
+	ErrDuplicateReferenceID = errors.New("xmldsig1: duplicate reference ID")
+
 	// ErrInvalidKeyInfo is returned when KeyInfo content cannot be parsed.
 	ErrInvalidKeyInfo = errors.New("xmldsig1: invalid KeyInfo")
 

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -130,35 +130,44 @@ func collectSubtreeNodes(n helium.Node) []helium.Node {
 // resolveReference resolves a Reference URI to the target node(s).
 // For URI="" (enveloped), returns the document element.
 // For URI="#id", returns the element with that ID.
+//
+// To defend against XML Signature Wrapping (XSW), a document is rejected if
+// the referenced ID resolves to more than one element — including the case
+// where a typed xml:id and a plain Id/ID attribute disagree.
 func resolveReference(doc *helium.Document, uri string) (*helium.Element, error) {
 	if uri == "" {
 		return doc.DocumentElement(), nil
 	}
 	if strings.HasPrefix(uri, "#") {
 		id := uri[1:]
-		// Try the standard GetElementByID first (DTD-declared + xml:id).
-		elem := doc.GetElementByID(id)
-		if elem != nil {
-			return elem, nil
+		typed := doc.GetElementByID(id)
+		attrMatch, attrDup := findElementByIDAttr(doc, id)
+		if attrDup {
+			return nil, fmt.Errorf("%w: %s", ErrDuplicateReferenceID, id)
 		}
-		// Fallback: search for common Id/ID attributes used by XMLDSig/SAML.
-		elem = findElementByIDAttr(doc, id)
-		if elem != nil {
-			return elem, nil
+		if typed != nil && attrMatch != nil && typed != attrMatch {
+			return nil, fmt.Errorf("%w: %s", ErrDuplicateReferenceID, id)
+		}
+		if typed != nil {
+			return typed, nil
+		}
+		if attrMatch != nil {
+			return attrMatch, nil
 		}
 		return nil, fmt.Errorf("%w: %s", ErrReferenceNotFound, uri)
 	}
 	return nil, fmt.Errorf("%w: external references not supported: %s", ErrReferenceNotFound, uri)
 }
 
-// findElementByIDAttr walks the document tree looking for an element with
-// an "Id" or "ID" attribute matching the given value. This handles the common
-// case where documents use Id attributes without DTD declarations (e.g., SAML).
-func findElementByIDAttr(doc *helium.Document, id string) *helium.Element {
-	var found *helium.Element
+// findElementByIDAttr walks the document tree looking for elements with an
+// "Id" or "ID" attribute matching the given value. Returns the single match
+// if exactly one element matches; duplicate is set if more than one matches.
+// This handles documents that use Id attributes without DTD declarations
+// (e.g., SAML).
+func findElementByIDAttr(doc *helium.Document, id string) (match *helium.Element, duplicate bool) {
 	var walk func(helium.Node)
 	walk = func(n helium.Node) {
-		if found != nil {
+		if duplicate {
 			return
 		}
 		elem, ok := helium.AsNode[*helium.Element](n)
@@ -168,8 +177,12 @@ func findElementByIDAttr(doc *helium.Document, id string) *helium.Element {
 		for _, attr := range elem.Attributes() {
 			name := attr.Name()
 			if (name == "Id" || name == "ID") && attr.Value() == id {
-				found = elem
-				return
+				if match != nil && match != elem {
+					duplicate = true
+					return
+				}
+				match = elem
+				break
 			}
 		}
 		for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
@@ -177,5 +190,5 @@ func findElementByIDAttr(doc *helium.Document, id string) *helium.Element {
 		}
 	}
 	walk(doc.DocumentElement())
-	return found
+	return match, duplicate
 }

--- a/xmldsig1/xmldsig1_test.go
+++ b/xmldsig1/xmldsig1_test.go
@@ -301,3 +301,37 @@ func TestSignVerifyWithFragmentReference(t *testing.T) {
 	err = verifier.Verify(t.Context(), doc)
 	require.NoError(t, err)
 }
+
+// XSW defense: a document with two elements sharing the ID referenced by the
+// Signature is ambiguous. The verifier picks one and the consuming application
+// may pick the other, enabling XML Signature Wrapping. Reject duplicates.
+func TestVerify_RejectsDuplicateID(t *testing.T) {
+	xml := `<root><data Id="signed-id">legitimate</data></root>`
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, xml)
+
+	ref := xmldsig1.ReferenceConfig{
+		URI:             "#signed-id",
+		DigestAlgorithm: xmldsig1.DigestSHA256,
+		Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+	}
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(ref)
+
+	sigElem, err := signer.SignDetached(t.Context(), doc, key)
+	require.NoError(t, err)
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	require.NoError(t, verifier.Verify(t.Context(), doc), "sanity: unmodified doc verifies")
+
+	evil := doc.CreateElement("data")
+	require.NoError(t, evil.SetLiteralAttribute("Id", "signed-id"))
+	require.NoError(t, evil.AddChild(doc.CreateText([]byte("malicious"))))
+	require.NoError(t, doc.DocumentElement().AddChild(evil))
+
+	err = verifier.Verify(t.Context(), doc)
+	require.Error(t, err, "verifier must reject documents with duplicate signed-scope IDs")
+	require.ErrorIs(t, err, xmldsig1.ErrDuplicateReferenceID)
+}


### PR DESCRIPTION
- `findElementByIDAttr` is first-match; combined with `verify.go` digesting the matched subtree, attacker-injected sibling with the signed ID resolves first → XSW
- reject documents where the referenced ID resolves to >1 element (incl. typed xml:id vs plain Id/ID mismatch); new sentinel `ErrDuplicateReferenceID`