### PR TITLE
export xsd.ValidationError; switch relaxng include guard to map

### DIFF
--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -133,6 +133,7 @@ Unwraps to `Cause` via `Unwrap()`.
 All validation errors flow through `ErrorHandler.Handle()`. No `strings.Builder` accumulation.
 
 - `Validate()` returns `ErrValidationFailed` on failure; individual errors go to `ErrorHandler`
+- Errors sent to the handler are `*xsd.ValidationError` (extractable via `errors.As`) wrapped with an `ErrorLeveler` for transport. `ValidationError` fields: `Filename`, `Line`, `Element`, `AttributeName` (empty for element-level errors), `Message`.
 - `reportValidityError` / `reportValidityErrorAttr` on `validationContext` check `suppressDepth > 0` to suppress errors during union member trials
 
 ### RelaxNG

--- a/relaxng/parse.go
+++ b/relaxng/parse.go
@@ -26,7 +26,7 @@ type compiler struct {
 	filename     string
 	errorHandler helium.ErrorHandler
 	errorCount   int
-	includeStack []string // recursion guard for include/externalRef
+	includeStack map[string]struct{} // recursion guard for include/externalRef (lookup in O(1))
 	includeLimit int
 	// grammarStack tracks nested grammars for parentRef resolution.
 	grammarStack []*grammarScope
@@ -367,7 +367,7 @@ func (c *compiler) parseInclude(ctx context.Context, elem *helium.Element) {
 	path := c.resolveHref(ctx, elem, href)
 
 	// Recursion guard
-	if slices.Contains(c.includeStack, path) {
+	if _, recursing := c.includeStack[path]; recursing {
 		msg := fmt.Sprintf("Detected an Include recursion for %s", href)
 		c.errorHandler.Handle(ctx, helium.NewLeveledError(rngParserError(msg), helium.ErrorLevelFatal))
 		c.errorCount++
@@ -379,8 +379,11 @@ func (c *compiler) parseInclude(ctx context.Context, elem *helium.Element) {
 		return
 	}
 
-	c.includeStack = append(c.includeStack, path)
-	defer func() { c.includeStack = c.includeStack[:len(c.includeStack)-1] }()
+	if c.includeStack == nil {
+		c.includeStack = make(map[string]struct{})
+	}
+	c.includeStack[path] = struct{}{}
+	defer delete(c.includeStack, path)
 
 	// Read and parse the included file
 	data, err := fs.ReadFile(c.fsys, path)
@@ -775,7 +778,7 @@ func (c *compiler) parseExternalRef(ctx context.Context, node *helium.Element) *
 	path := c.resolveHref(ctx, node, href)
 
 	// Recursion guard
-	if slices.Contains(c.includeStack, path) {
+	if _, recursing := c.includeStack[path]; recursing {
 		msg := fmt.Sprintf("Detected an externalRef recursion for %s", href)
 		c.errorHandler.Handle(ctx, helium.NewLeveledError(rngParserError(msg), helium.ErrorLevelFatal))
 		c.errorCount++
@@ -787,8 +790,11 @@ func (c *compiler) parseExternalRef(ctx context.Context, node *helium.Element) *
 		return nil
 	}
 
-	c.includeStack = append(c.includeStack, path)
-	defer func() { c.includeStack = c.includeStack[:len(c.includeStack)-1] }()
+	if c.includeStack == nil {
+		c.includeStack = make(map[string]struct{})
+	}
+	c.includeStack[path] = struct{}{}
+	defer delete(c.includeStack, path)
 
 	data, err := fs.ReadFile(c.fsys, path)
 	if err != nil {

--- a/xsd/errors.go
+++ b/xsd/errors.go
@@ -3,8 +3,51 @@ package xsd
 import (
 	"fmt"
 
+	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 )
+
+// ValidationError represents a single XSD validation error with structured
+// fields. It implements the error interface and can be extracted from the
+// values passed to a [helium.ErrorHandler] via [errors.As].
+//
+// AttributeName is empty for element-level errors; non-empty when the error
+// concerns a specific attribute on the element.
+type ValidationError struct {
+	Filename      string // source filename
+	Line          int    // line number in the source document
+	Element       string // element name
+	AttributeName string // attribute name (optional)
+	Message       string // human-readable error description
+}
+
+// Error implements the error interface and produces libxml2-compatible output.
+func (e *ValidationError) Error() string {
+	if e.AttributeName != "" {
+		return validityErrorAttr(e.Filename, e.Line, e.Element, e.AttributeName, e.Message)
+	}
+	return validityError(e.Filename, e.Line, e.Element, e.Message)
+}
+
+// leveledValidationError wraps a *ValidationError with an ErrorLevel so the
+// existing ErrorHandler pipeline can transport typed validation errors while
+// preserving the libxml2-compatible formatted output that callers currently
+// rely on.
+type leveledValidationError struct {
+	*ValidationError
+	level helium.ErrorLevel
+}
+
+func (e *leveledValidationError) ErrorLevel() helium.ErrorLevel { return e.level }
+
+func (e *leveledValidationError) Unwrap() error { return e.ValidationError }
+
+// newLeveledValidationError pairs a *ValidationError with an ErrorLevel for
+// transport through helium.ErrorHandler. The returned error unwraps to the
+// embedded *ValidationError so callers can [errors.As] for it.
+func newLeveledValidationError(ve *ValidationError, level helium.ErrorLevel) error {
+	return &leveledValidationError{ValidationError: ve, level: level}
+}
 
 // validityError formats a validation error in libxml2 format:
 //

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -41,8 +41,13 @@ func (vc *validationContext) reportValidityError(ctx context.Context, file strin
 	if vc.suppressDepth > 0 {
 		return
 	}
-	errStr := validityError(file, line, elemName, msg)
-	vc.errorHandler.Handle(ctx, helium.NewLeveledError(errStr, helium.ErrorLevelError))
+	ve := &ValidationError{
+		Filename: file,
+		Line:     line,
+		Element:  elemName,
+		Message:  msg,
+	}
+	vc.errorHandler.Handle(ctx, newLeveledValidationError(ve, helium.ErrorLevelError))
 }
 
 // reportValidityErrorAttr formats an attribute validation error and sends it to the ErrorHandler.
@@ -50,8 +55,14 @@ func (vc *validationContext) reportValidityErrorAttr(ctx context.Context, file s
 	if vc.suppressDepth > 0 {
 		return
 	}
-	errStr := validityErrorAttr(file, line, elemName, attrName, msg)
-	vc.errorHandler.Handle(ctx, helium.NewLeveledError(errStr, helium.ErrorLevelError))
+	ve := &ValidationError{
+		Filename:      file,
+		Line:          line,
+		Element:       elemName,
+		AttributeName: attrName,
+		Message:       msg,
+	}
+	vc.errorHandler.Handle(ctx, newLeveledValidationError(ve, helium.ErrorLevelError))
 }
 
 // Validate validates a lexical value against this simple type definition.

--- a/xsd/validation_error_test.go
+++ b/xsd/validation_error_test.go
@@ -1,0 +1,52 @@
+package xsd_test
+
+import (
+	"errors"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// xsd validation errors must surface as *xsd.ValidationError via errors.As so
+// callers can read Filename/Line/Element/AttributeName/Message instead of
+// parsing the formatted string. Mirrors the API offered by
+// relaxng.ValidationError and schematron.ValidationError.
+func TestValidationError_AsTyped(t *testing.T) {
+	schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="age" type="xs:int"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+	instanceXML := `<root><age>not-an-int</age></root>`
+
+	schemaDOC, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+	require.NoError(t, err)
+	schema, err := xsd.NewCompiler().Compile(t.Context(), schemaDOC)
+	require.NoError(t, err)
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(instanceXML))
+	require.NoError(t, err)
+
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	_ = xsd.NewValidator(schema).ErrorHandler(collector).Validate(t.Context(), doc)
+
+	require.NotEmpty(t, collector.Errors(), "expected at least one validation error")
+
+	var ve *xsd.ValidationError
+	var found bool
+	for _, e := range collector.Errors() {
+		if errors.As(e, &ve) {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected a *xsd.ValidationError in the collected errors")
+	require.Equal(t, "age", ve.Element)
+	require.NotEmpty(t, ve.Message)
+}


### PR DESCRIPTION
- xsd now sends `*xsd.ValidationError` (extractable via `errors.As`) through ErrorHandler, mirroring relaxng/schematron
- relaxng include/externalRef recursion guard switched from O(n) `slices.Contains` over a `[]string` to O(1) map[string]struct{}