### PR TITLE
xinclude: filepath.Clean resolved hrefs before fs.Open

### DIFF
--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -884,7 +884,7 @@ func resolveURI(href, base string) (string, error) {
 		if basePath == "" {
 			basePath = base
 		}
-		return filepath.Join(filepath.Dir(basePath), href), nil
+		return filepath.Clean(filepath.Join(filepath.Dir(basePath), href)), nil
 	}
 
 	return baseURL.ResolveReference(hrefURL).String(), nil
@@ -1209,5 +1209,9 @@ func (r *fsResolver) Resolve(href, base string) (io.ReadCloser, error) {
 			path = filepath.Join(filepath.Dir(basePath), href)
 		}
 	}
-	return r.fsys.Open(path) //nolint:wrapcheck // resolver errors propagate to caller verbatim
+	// Canonicalize the path so a sandboxing fs.FS (os.DirFS, fstest.MapFS,
+	// os.OpenRoot) sees consistent input. Clean resolves "sub/../target"
+	// down to "target"; any remaining ".." prefix means the join ascended
+	// above the base and will be rejected by an fs.ValidPath-enforcing FS.
+	return r.fsys.Open(filepath.Clean(path)) //nolint:wrapcheck // resolver errors propagate to caller verbatim
 }

--- a/xinclude/xinclude_test.go
+++ b/xinclude/xinclude_test.go
@@ -86,6 +86,46 @@ func TestXIncludeNewFSResolver(t *testing.T) {
 		t.Parallel()
 		require.NotNil(t, xinclude.NewFSResolver(nil))
 	})
+
+	t.Run("path is filepath.Clean'd before fs.Open", func(t *testing.T) {
+		t.Parallel()
+
+		// xi:include href="sub/../target.xml" resolves to "target.xml"
+		// after cleaning. Without cleaning, fstest.MapFS would reject
+		// the un-canonicalized name with fs.ErrInvalid.
+		doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
+			<xi:include href="sub/../target.xml"/>
+		</root>`)
+
+		fsys := fstest.MapFS{
+			"target.xml": &fstest.MapFile{Data: []byte(`<ok/>`)},
+		}
+		count, err := xinclude.NewProcessor().
+			Resolver(xinclude.NewFSResolver(fsys)).
+			NoXIncludeMarkers().NoBaseFixup().
+			Process(t.Context(), doc)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+	})
+
+	t.Run("escaping href is rejected by os.DirFS-style FS", func(t *testing.T) {
+		t.Parallel()
+
+		// xi:include href="../escape.xml" resolves to "../escape.xml" after
+		// cleaning — which fstest.MapFS (fs.ValidPath enforced) rejects.
+		doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
+			<xi:include href="../escape.xml"/>
+		</root>`)
+
+		fsys := fstest.MapFS{
+			"main.xml": &fstest.MapFile{Data: []byte(`<root/>`)},
+		}
+		_, err := xinclude.NewProcessor().
+			Resolver(xinclude.NewFSResolver(fsys)).
+			NoXIncludeMarkers().NoBaseFixup().
+			Process(t.Context(), doc)
+		require.Error(t, err, "expected Process to fail when resolver path escapes FS root")
+	})
 }
 
 func TestXIncludeBasicXML(t *testing.T) {


### PR DESCRIPTION
- the fsResolver now Cleans the joined path before handing it to fs.Open so a sandboxing FS (os.DirFS, fstest.MapFS, os.OpenRoot) sees canonical names
- ".."-escaping hrefs are now rejected when the caller wires in an fs.ValidPath-enforcing FS; un-Cleaned "sub/../target" forms now match
- larger fix (default-on ValidPath enforcement, scheme allowlists) deferred to a follow-up