### PR TITLE
xpath3: bound regexp2 fallback with DefaultRegexMatchTimeout

### DIFF
--- a/xpath3/functions_string.go
+++ b/xpath3/functions_string.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 	"unicode"
 	"unicode/utf8"
 
@@ -1063,6 +1064,19 @@ type xpathRegexCacheKey struct {
 
 var compiledXPathRegexCache sync.Map
 
+// DefaultRegexMatchTimeout bounds how long the backtracking regex engine
+// will spend on a single match before returning a timeout error. Patterns
+// using features outside RE2 (backreferences, character-class subtraction,
+// large quantifiers) are compiled with [regexp2], a backtracking engine
+// that is vulnerable to catastrophic-backtracking ReDoS on adversary-
+// supplied inputs. The default of 1 second is a defense-in-depth ceiling
+// for those patterns; pure RE2-compatible patterns are unaffected.
+//
+// Set to 0 to disable the timeout entirely. Mutating this value affects
+// only subsequently-compiled regexes; already-cached compilations keep
+// the timeout in effect at the time they were compiled.
+var DefaultRegexMatchTimeout = 1 * time.Second
+
 func (r *compiledXPathRegex) MatchString(s string) (bool, error) {
 	if r.backtrack != nil {
 		return r.backtrack.MatchString(s)
@@ -1285,6 +1299,9 @@ func compileXPathRegex(pattern, flags string) (*compiledXPathRegex, error) {
 		re, err := regexp2.Compile(pattern, re2Opts)
 		if err != nil {
 			return nil, &XPathError{Code: errCodeFORX0002, Message: fmt.Sprintf("invalid regular expression: %s", err)}
+		}
+		if t := DefaultRegexMatchTimeout; t > 0 {
+			re.MatchTimeout = t
 		}
 		compiled := &compiledXPathRegex{
 			backtrack:    re,

--- a/xpath3/regex_timeout_test.go
+++ b/xpath3/regex_timeout_test.go
@@ -1,0 +1,43 @@
+package xpath3_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// Patterns containing features Go's RE2 cannot handle (backreferences,
+// character-class subtraction, large quantifiers) fall through to a
+// backtracking regex engine that is vulnerable to catastrophic backtracking
+// on adversary-supplied inputs. xpath3 sets a default match timeout on
+// every such compilation so a pathological pattern + input does not pin
+// a goroutine.
+func TestRegexMatchTimeout_BoundsCatastrophicBacktracking(t *testing.T) {
+	// Tighten the timeout for the test so we don't have to wait a full
+	// second to confirm bounding.
+	orig := xpath3.DefaultRegexMatchTimeout
+	xpath3.DefaultRegexMatchTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { xpath3.DefaultRegexMatchTimeout = orig })
+
+	// Backreference forces the regexp2 path. (a+)\1+ over a long run of 'a'
+	// followed by a non-matching tail explores an exponential split space.
+	input := strings.Repeat("a", 30) + "!"
+	expr := `matches("` + input + `", "^(a+)\1+$")`
+
+	compiled, err := xpath3.NewCompiler().Compile(expr)
+	require.NoError(t, err)
+
+	start := time.Now()
+	_, evalErr := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Evaluate(t.Context(), compiled, nil)
+	elapsed := time.Since(start)
+
+	// Either the engine returns a timeout error, or it returns a non-timeout
+	// result/error quickly. The forbidden outcome is "runs much longer than
+	// the timeout without erroring". Allow a generous margin for scheduling.
+	require.Less(t, elapsed, 2*time.Second,
+		"regex match exceeded budget; elapsed=%v err=%v", elapsed, evalErr)
+}

--- a/xpath3/regex_timeout_test.go
+++ b/xpath3/regex_timeout_test.go
@@ -16,16 +16,24 @@ import (
 // every such compilation so a pathological pattern + input does not pin
 // a goroutine.
 func TestRegexMatchTimeout_BoundsCatastrophicBacktracking(t *testing.T) {
-	// Tighten the timeout for the test so we don't have to wait a full
-	// second to confirm bounding.
+	// regexp2's fastclock has ~100ms granularity, so a 150ms budget
+	// realizes as ~150-300ms wall time. The elapsed bound is well below
+	// the 1s default DefaultRegexMatchTimeout — a passing assertion
+	// here proves the lowered budget actually took effect.
+	const matchBudget = 150 * time.Millisecond
+	const elapsedBound = 750 * time.Millisecond
+
 	orig := xpath3.DefaultRegexMatchTimeout
-	xpath3.DefaultRegexMatchTimeout = 100 * time.Millisecond
+	xpath3.DefaultRegexMatchTimeout = matchBudget
 	t.Cleanup(func() { xpath3.DefaultRegexMatchTimeout = orig })
 
-	// Backreference forces the regexp2 path. (a+)\1+ over a long run of 'a'
-	// followed by a non-matching tail explores an exponential split space.
-	input := strings.Repeat("a", 30) + "!"
-	expr := `matches("` + input + `", "^(a+)\1+$")`
+	// (.+)+\1 forces the regexp2 path (backreference) and exhibits
+	// catastrophic backtracking: with 30 'a's plus a non-matching 'b'
+	// the engine explores ~2^n splits. Empirically this runs many
+	// seconds without a timeout; with matchBudget it must fail quickly
+	// with regexp2's "match timeout after ..." error.
+	input := strings.Repeat("a", 30) + "b"
+	expr := `matches("` + input + `", "^(.+)+\1$")`
 
 	compiled, err := xpath3.NewCompiler().Compile(expr)
 	require.NoError(t, err)
@@ -35,9 +43,11 @@ func TestRegexMatchTimeout_BoundsCatastrophicBacktracking(t *testing.T) {
 		Evaluate(t.Context(), compiled, nil)
 	elapsed := time.Since(start)
 
-	// Either the engine returns a timeout error, or it returns a non-timeout
-	// result/error quickly. The forbidden outcome is "runs much longer than
-	// the timeout without erroring". Allow a generous margin for scheduling.
-	require.Less(t, elapsed, 2*time.Second,
-		"regex match exceeded budget; elapsed=%v err=%v", elapsed, evalErr)
+	require.Error(t, evalErr,
+		"expected regexp2 match timeout, got nil error; elapsed=%v", elapsed)
+	require.Contains(t, evalErr.Error(), "match timeout",
+		"expected regexp2 timeout error, got %v; elapsed=%v", evalErr, elapsed)
+	require.Less(t, elapsed, elapsedBound,
+		"timeout did not fire near %v budget; elapsed=%v err=%v",
+		matchBudget, elapsed, evalErr)
 }


### PR DESCRIPTION
- patterns with backreferences / char-class subtraction / large quantifiers fall through to the regexp2 backtracking engine; it had no MatchTimeout, so a pathological pattern could pin a goroutine
- DefaultRegexMatchTimeout (1s) is applied to every regexp2 compile; 0 disables it
- pure RE2-compatible patterns are unaffected