### PR TITLE
xsd: cap xs:import recursion depth

### DIFF
--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -54,7 +54,10 @@ type compiler struct {
 }
 
 // defaultMaxImportDepth is the limit applied when no caller-specified
-// limit is provided. Mirrors relaxng/parse.go's includeLimit.
+// limit is provided. This bounds xs:import recursion depth (not a flat
+// import count), so a modest value is enough to terminate adversarial
+// namespace-cycling chains while leaving generous headroom for real
+// schema hierarchies, which rarely nest more than a few levels deep.
 const defaultMaxImportDepth = 40
 
 // elemRefSource tracks source location for error reporting.

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -43,7 +43,19 @@ type compiler struct {
 	includeFile  string // currently-included file path (for duplicate element errors)
 	// importedNS tracks which namespaces have been imported and their schema locations.
 	importedNS map[string]string // namespace → schema location
+	// importDepth and maxImportDepth bound xs:import recursion. Each sub-compiler
+	// created by loadImport inherits maxImportDepth and stores its own
+	// importDepth = parent.importDepth + 1. A sub-compiler whose depth would
+	// exceed the limit is rejected. This blocks namespace-cycling import
+	// chains (A → B → C → A …) where each schema declares a distinct namespace
+	// so the per-compiler importedNS map does not detect the cycle.
+	importDepth    int
+	maxImportDepth int
 }
+
+// defaultMaxImportDepth is the limit applied when no caller-specified
+// limit is provided. Mirrors relaxng/parse.go's includeLimit.
+const defaultMaxImportDepth = 40
 
 // elemRefSource tracks source location for error reporting.
 type elemRefSource struct {
@@ -98,6 +110,7 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 		itemTypeRefs:      make(map[*TypeDef]QName),
 		attrRefs:          make(map[*AttrUse]QName),
 		importedNS:        make(map[string]string),
+		maxImportDepth:    defaultMaxImportDepth,
 	}
 	c.errorHandler = helium.NilErrorHandler{}
 	if cfg != nil {

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -53,11 +53,13 @@ type compiler struct {
 	maxImportDepth int
 }
 
-// defaultMaxImportDepth is the limit applied when no caller-specified
-// limit is provided. This bounds xs:import recursion depth (not a flat
+// defaultMaxImportDepth bounds xs:import recursion depth (not a flat
 // import count), so a modest value is enough to terminate adversarial
 // namespace-cycling chains while leaving generous headroom for real
 // schema hierarchies, which rarely nest more than a few levels deep.
+// The limit is not currently exposed as a Compiler option; matches the
+// hardcoded defensive caps used by relaxng (include limit), catalog
+// (resolution depth), and xpath/xslt (recursion depth).
 const defaultMaxImportDepth = 40
 
 // elemRefSource tracks source location for error reporting.

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -16,7 +16,7 @@ import (
 // treating it as a warning the way it treats ordinary I/O failures.
 var errImportDepthExceeded = errors.New("xsd: max import depth exceeded")
 
-// processIncludesAndImports handles xs:include and xs:import elements.
+// processIncludes handles xs:include and xs:import elements.
 func (c *compiler) processIncludes(ctx context.Context, root *helium.Element) error {
 	for child := range helium.Children(root) {
 		if child.Type() != helium.ElementNode {

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -2,6 +2,7 @@ package xsd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"maps"
@@ -9,6 +10,11 @@ import (
 
 	helium "github.com/lestrrat-go/helium"
 )
+
+// errImportDepthExceeded signals that xs:import recursion reached the
+// configured limit. processIncludes propagates this error rather than
+// treating it as a warning the way it treats ordinary I/O failures.
+var errImportDepthExceeded = errors.New("xsd: max import depth exceeded")
 
 // processIncludesAndImports handles xs:include and xs:import elements.
 func (c *compiler) processIncludes(ctx context.Context, root *helium.Element) error {
@@ -47,6 +53,11 @@ func (c *compiler) processIncludes(ctx context.Context, root *helium.Element) er
 			}
 
 			if err := c.loadImport(ctx, loc, ns); err != nil {
+				// Depth-exceeded is a security limit, not an I/O hiccup;
+				// surface it as a fatal compilation error.
+				if errors.Is(err, errImportDepthExceeded) {
+					return err
+				}
 				// Import failure — report warning if we have a filename.
 				if c.filename != "" {
 					displayLoc := filepath.Join(filepath.Dir(c.filename), loc)
@@ -364,6 +375,14 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 
 // loadImport loads an imported schema and merges its declarations.
 func (c *compiler) loadImport(ctx context.Context, location, _ string) error {
+	// Bound the import recursion. Each sub-compiler inherits this limit
+	// and tracks its own depth so namespace-cycling chains (A → B → C → A …)
+	// cannot exhaust memory / stack even when every link uses a distinct
+	// namespace URI.
+	if c.importDepth+1 > c.maxImportDepth {
+		return fmt.Errorf("%w (limit=%d, location=%q)", errImportDepthExceeded, c.maxImportDepth, location)
+	}
+
 	path := location
 	if c.baseDir != "" {
 		path = filepath.Join(c.baseDir, location)
@@ -413,6 +432,8 @@ func (c *compiler) loadImport(ctx context.Context, location, _ string) error {
 		attrRefs:          make(map[*AttrUse]QName),
 		filename:          impFilename,
 		importedNS:        make(map[string]string),
+		importDepth:       c.importDepth + 1,
+		maxImportDepth:    c.maxImportDepth,
 	}
 
 	// Sub-compiler collects errors into its own collector so we can
@@ -439,7 +460,13 @@ func (c *compiler) loadImport(ctx context.Context, location, _ string) error {
 
 	// Process includes/imports in the imported schema (but skip back-references).
 	if err := impC.processIncludes(ctx, impRoot); err != nil {
-		// Non-fatal for imported schemas.
+		// Depth-exceeded errors propagate so a hostile import cycle
+		// is reported to the caller rather than being silently truncated.
+		if errors.Is(err, errImportDepthExceeded) {
+			return err
+		}
+		// Other errors in nested processing are non-fatal — the import
+		// loader treats failure to load referenced schemas as warnings.
 		_ = err
 	}
 

--- a/xsd/import_depth_test.go
+++ b/xsd/import_depth_test.go
@@ -37,7 +37,7 @@ func TestCompile_ImportCycle_BoundedByDepth(t *testing.T) {
 		"c.xsd": &fstest.MapFile{Data: []byte(mkSchema(nsC, nsA, "a.xsd"))},
 	}
 
-	data, err := fstest.MapFS(fsys).ReadFile("a.xsd")
+	data, err := fsys.ReadFile("a.xsd")
 	require.NoError(t, err)
 	doc, err := helium.NewParser().Parse(t.Context(), data)
 	require.NoError(t, err)

--- a/xsd/import_depth_test.go
+++ b/xsd/import_depth_test.go
@@ -1,0 +1,49 @@
+package xsd_test
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// xsd:import cycles between distinct namespaces must not recurse without
+// bound. The per-compiler `importedNS` map only catches reimports of the
+// same namespace; a chain like A(urn:a) → B(urn:b) → C(urn:c) → A(urn:a)
+// is invisible to that map because each step is a fresh namespace at the
+// site of the import. A depth ceiling closes the loop.
+func TestCompile_ImportCycle_BoundedByDepth(t *testing.T) {
+	const (
+		nsA = "urn:a"
+		nsB = "urn:b"
+		nsC = "urn:c"
+	)
+
+	mkSchema := func(targetNS, importNS, importLoc string) string {
+		return `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="` + targetNS + `">
+  <xs:import namespace="` + importNS + `" schemaLocation="` + importLoc + `"/>
+</xs:schema>`
+	}
+
+	// A → B → C → A (and back). With max import depth enforced, compilation
+	// must terminate with an error rather than spinning indefinitely.
+	fsys := fstest.MapFS{
+		"a.xsd": &fstest.MapFile{Data: []byte(mkSchema(nsA, nsB, "b.xsd"))},
+		"b.xsd": &fstest.MapFile{Data: []byte(mkSchema(nsB, nsC, "c.xsd"))},
+		"c.xsd": &fstest.MapFile{Data: []byte(mkSchema(nsC, nsA, "a.xsd"))},
+	}
+
+	data, err := fstest.MapFS(fsys).ReadFile("a.xsd")
+	require.NoError(t, err)
+	doc, err := helium.NewParser().Parse(t.Context(), data)
+	require.NoError(t, err)
+
+	_, err = xsd.NewCompiler().FS(fsys).Compile(t.Context(), doc)
+	require.Error(t, err, "compilation must reject unbounded import cycle across distinct namespaces")
+	require.True(t, strings.Contains(err.Error(), "max import depth"),
+		"error must mention the depth limit; got: %v", err)
+}


### PR DESCRIPTION
- importedNS map is per sub-compiler, so namespace-cycling chains (A urn:a → B urn:b → C urn:c → A urn:a …) recursed without bound
- new importDepth/maxImportDepth (default 40, mirroring relaxng includeLimit) inherited into sub-compilers; depth-exceeded surfaces as a fatal error, not the swallowed I/O-warning that ordinary load failures take