### PR TITLE
xpath3: expose DefaultMaxRecursionDepth as tunable var

### DIFF
--- a/xpath3/eval.go
+++ b/xpath3/eval.go
@@ -27,7 +27,7 @@ const maxNodeSetLength = ixpath.DefaultMaxNodeSetLength
 // no data race between an evaluating goroutine and a goroutine that
 // updates the default. Concurrent mutation by multiple writers still
 // requires external synchronization.
-// 0 disables the limit (NOT recommended for untrusted input).
+// Any value <= 0 disables the limit (NOT recommended for untrusted input).
 var DefaultMaxRecursionDepth = ixpath.DefaultMaxRecursionDepth
 
 // evalContext holds the evaluation state for an XPath 3.1 expression.

--- a/xpath3/eval.go
+++ b/xpath3/eval.go
@@ -13,10 +13,17 @@ import (
 	ixpath "github.com/lestrrat-go/helium/internal/xpath"
 )
 
-const (
-	maxRecursionDepth = ixpath.DefaultMaxRecursionDepth
-	maxNodeSetLength  = ixpath.DefaultMaxNodeSetLength
-)
+const maxNodeSetLength = ixpath.DefaultMaxNodeSetLength
+
+// DefaultMaxRecursionDepth bounds the maximum nested-expression depth the
+// evaluator will explore before returning [ErrRecursionLimit]. The default
+// matches libxml2's XPATH_MAX_RECURSION_DEPTH and is large enough for any
+// realistic XPath. Lower it when accepting untrusted expressions to fail
+// fast on adversarial input that tries to consume the goroutine stack.
+//
+// Mutating this value affects only evaluations started after the change.
+// 0 disables the limit (NOT recommended for untrusted input).
+var DefaultMaxRecursionDepth = ixpath.DefaultMaxRecursionDepth
 
 // evalContext holds the evaluation state for an XPath 3.1 expression.
 type evalContext struct {
@@ -251,7 +258,7 @@ type exprEvaluator func(context.Context, *evalContext, Expr) (Sequence, error)
 
 func evalWith(evalFn exprEvaluator, ctx context.Context, ec *evalContext, expr Expr) (Sequence, error) {
 	ec.depth++
-	if ec.depth > maxRecursionDepth {
+	if limit := DefaultMaxRecursionDepth; limit > 0 && ec.depth > limit {
 		return nil, ErrRecursionLimit
 	}
 	defer func() { ec.depth-- }()

--- a/xpath3/eval.go
+++ b/xpath3/eval.go
@@ -21,7 +21,12 @@ const maxNodeSetLength = ixpath.DefaultMaxNodeSetLength
 // realistic XPath. Lower it when accepting untrusted expressions to fail
 // fast on adversarial input that tries to consume the goroutine stack.
 //
-// Mutating this value affects only evaluations started after the change.
+// Each [Evaluator.Evaluate] call snapshots this value once at the start
+// of evaluation and reads from the snapshot during recursion, so an
+// in-flight evaluation never observes a mid-flight mutation and there is
+// no data race between an evaluating goroutine and a goroutine that
+// updates the default. Concurrent mutation by multiple writers still
+// requires external synchronization.
 // 0 disables the limit (NOT recommended for untrusted input).
 var DefaultMaxRecursionDepth = ixpath.DefaultMaxRecursionDepth
 
@@ -36,6 +41,7 @@ type evalContext struct {
 	functions            map[string]Function
 	fnsNS                map[QualifiedName]Function
 	depth                int
+	maxRecursionDepth    int  // snapshot of DefaultMaxRecursionDepth at newEvalCtx
 	opCount              *int // shared via pointer across copies; safe because eval is single-goroutine
 	opLimit              int
 	docOrder             *ixpath.DocOrderCache
@@ -258,7 +264,7 @@ type exprEvaluator func(context.Context, *evalContext, Expr) (Sequence, error)
 
 func evalWith(evalFn exprEvaluator, ctx context.Context, ec *evalContext, expr Expr) (Sequence, error) {
 	ec.depth++
-	if limit := DefaultMaxRecursionDepth; limit > 0 && ec.depth > limit {
+	if ec.maxRecursionDepth > 0 && ec.depth > ec.maxRecursionDepth {
 		return nil, ErrRecursionLimit
 	}
 	defer func() { ec.depth-- }()

--- a/xpath3/evaluator.go
+++ b/xpath3/evaluator.go
@@ -362,6 +362,7 @@ func (e Evaluator) newEvalCtx(node helium.Node) *evalContext {
 
 	// limits
 	ec.opLimit = cfg.opLimit
+	ec.maxRecursionDepth = DefaultMaxRecursionDepth
 
 	// time
 	if cfg.currentTime != nil {

--- a/xpath3/recursion_depth_test.go
+++ b/xpath3/recursion_depth_test.go
@@ -1,0 +1,35 @@
+package xpath3_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// Lowering DefaultMaxRecursionDepth must cause deeply-nested expressions
+// to terminate quickly with ErrRecursionLimit rather than continuing to
+// consume goroutine stack.
+func TestDefaultMaxRecursionDepth_Tunable(t *testing.T) {
+	orig := xpath3.DefaultMaxRecursionDepth
+	xpath3.DefaultMaxRecursionDepth = 8
+	t.Cleanup(func() { xpath3.DefaultMaxRecursionDepth = orig })
+
+	// A long chain of left-associative binary expressions
+	//   ((((1+1)+1)+1)…+1)
+	// forces the evaluator to recurse N-1 times to reach the leaf.
+	// 50 operands → ~49 levels, comfortably above the limit of 8.
+	const n = 50
+	expr := "1" + strings.Repeat("+1", n-1)
+
+	compiled, err := xpath3.NewCompiler().Compile(expr)
+	require.NoError(t, err)
+
+	_, evalErr := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Evaluate(t.Context(), compiled, nil)
+	require.Error(t, evalErr, "deeply-nested expression must trip the lowered recursion limit")
+	require.True(t, errors.Is(evalErr, xpath3.ErrRecursionLimit),
+		"expected ErrRecursionLimit, got %v", evalErr)
+}


### PR DESCRIPTION
- prior limit was a package-level const (5000); now a mutable `DefaultMaxRecursionDepth` so callers accepting untrusted XPath can lower it
- 0 disables (not recommended for untrusted input)
- recursion check itself was already wired through evalWith; this PR makes the threshold configurable