### PR TITLE
xinclude: address PR #420 review follow-ups

### DIFF
--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -88,11 +88,19 @@ func (p Processor) Resolver(r Resolver) Processor {
 // treated as the permissive default that opens any OS path verbatim.
 //
 // Names handed to fsys.Open use forward slashes and are canonicalized
-// with [path.Clean], so [fs.FS] implementations that enforce
-// [fs.ValidPath] (notably [os.DirFS] and [testing/fstest.MapFS]) see
-// valid names. Relative hrefs that escape the base (e.g. "../foo")
-// leave a leading ".." in the cleaned result and will be rejected by
-// such an FS, giving path-traversal containment for sandboxed input.
+// with [path.Clean]. Relative hrefs that escape the base (e.g. "../foo")
+// leave a leading ".." in the cleaned result and will be rejected by an
+// [fs.ValidPath]-enforcing FS, giving path-traversal containment.
+//
+// Sandboxing note: when paired with [os.DirFS], [testing/fstest.MapFS],
+// or [os.OpenRoot], the document's base URI must be FS-relative — no
+// leading slash and no file:// URL. An absolute base URI (e.g. set via
+// [Processor.BaseURI] with "/abs/path/main.xml" or "file:///abs/main.xml")
+// produces an absolute resolved name that fs.ValidPath rejects with
+// [fs.ErrInvalid], even when the href itself does not escape. This is a
+// deliberate fail-loud contract — silently trimming the leading slash
+// would re-anchor absolute paths under the FS root, masking caller
+// mistakes and risking wrong-file opens.
 func NewFSResolver(fsys fs.FS) Resolver {
 	if fsys == nil {
 		fsys = iofs.PermissiveRoot{}

--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -884,7 +884,7 @@ func resolveURI(href, base string) (string, error) {
 		if basePath == "" {
 			basePath = base
 		}
-		return filepath.Clean(filepath.Join(filepath.Dir(basePath), href)), nil
+		return filepath.Join(filepath.Dir(basePath), href), nil
 	}
 
 	return baseURL.ResolveReference(hrefURL).String(), nil

--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -1197,15 +1197,18 @@ type fsResolver struct {
 }
 
 func (r *fsResolver) Resolve(href, base string) (io.ReadCloser, error) {
-	p := href
+	// Upstream URI resolution (e.g. resolveURI) may produce OS-specific
+	// separators via filepath.Join on Windows. fs.FS requires slash-
+	// separated names, so normalize both inputs before joining.
+	p := filepath.ToSlash(href)
 	if !path.IsAbs(p) && base != "" {
 		baseURL, err := url.Parse(base)
 		if err == nil && (baseURL.Scheme == "" || baseURL.Scheme == "file") {
-			basePath := baseURL.Path
+			basePath := filepath.ToSlash(baseURL.Path)
 			if basePath == "" {
-				basePath = base
+				basePath = filepath.ToSlash(base)
 			}
-			p = path.Join(path.Dir(basePath), href)
+			p = path.Join(path.Dir(basePath), p)
 		}
 	}
 	// fs.FS uses slash-separated paths; using path (not filepath) keeps

--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"net/url"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -83,17 +84,15 @@ func (p Processor) Resolver(r Resolver) Processor {
 // NewFSResolver returns a [Resolver] that opens hrefs through the given
 // [fs.FS]. Relative hrefs are resolved against the document's base URI
 // (only file:// or scheme-less bases are honored) and joined with
-// [filepath.Join] before being passed to fsys.Open. A nil fsys is
+// [path.Join] before being passed to fsys.Open. A nil fsys is
 // treated as the permissive default that opens any OS path verbatim.
 //
-// Note: because the name handed to fsys.Open is the [filepath.Join]
-// result, it may be absolute and may use OS-specific separators on
-// Windows. FS implementations that enforce [fs.ValidPath] (notably
-// [os.DirFS] and [testing/fstest.MapFS]) will reject those names.
-// Sandboxing XInclude behind such an FS requires path normalization
-// that is not yet performed by this package; for now, supply an FS
-// implementation that accepts OS-style names, or use [Processor.Resolver]
-// with a fully custom resolver that controls its own path resolution.
+// Names handed to fsys.Open use forward slashes and are canonicalized
+// with [path.Clean], so [fs.FS] implementations that enforce
+// [fs.ValidPath] (notably [os.DirFS] and [testing/fstest.MapFS]) see
+// valid names. Relative hrefs that escape the base (e.g. "../foo")
+// leave a leading ".." in the cleaned result and will be rejected by
+// such an FS, giving path-traversal containment for sandboxed input.
 func NewFSResolver(fsys fs.FS) Resolver {
 	if fsys == nil {
 		fsys = iofs.PermissiveRoot{}
@@ -1198,20 +1197,21 @@ type fsResolver struct {
 }
 
 func (r *fsResolver) Resolve(href, base string) (io.ReadCloser, error) {
-	path := href
-	if !filepath.IsAbs(path) && base != "" {
+	p := href
+	if !path.IsAbs(p) && base != "" {
 		baseURL, err := url.Parse(base)
 		if err == nil && (baseURL.Scheme == "" || baseURL.Scheme == "file") {
 			basePath := baseURL.Path
 			if basePath == "" {
 				basePath = base
 			}
-			path = filepath.Join(filepath.Dir(basePath), href)
+			p = path.Join(path.Dir(basePath), href)
 		}
 	}
-	// Canonicalize the path so a sandboxing fs.FS (os.DirFS, fstest.MapFS,
-	// os.OpenRoot) sees consistent input. Clean resolves "sub/../target"
-	// down to "target"; any remaining ".." prefix means the join ascended
-	// above the base and will be rejected by an fs.ValidPath-enforcing FS.
-	return r.fsys.Open(filepath.Clean(path)) //nolint:wrapcheck // resolver errors propagate to caller verbatim
+	// fs.FS uses slash-separated paths; using path (not filepath) keeps
+	// names valid on Windows. path.Clean canonicalizes so a sandboxing
+	// fs.FS (os.DirFS, fstest.MapFS, os.OpenRoot) sees consistent input,
+	// and any remaining ".." prefix means the join ascended above the
+	// base and will be rejected by an fs.ValidPath-enforcing FS.
+	return r.fsys.Open(path.Clean(p)) //nolint:wrapcheck // resolver errors propagate to caller verbatim
 }

--- a/xinclude/xinclude_test.go
+++ b/xinclude/xinclude_test.go
@@ -3,6 +3,7 @@ package xinclude_test
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -112,19 +113,20 @@ func TestXIncludeNewFSResolver(t *testing.T) {
 		t.Parallel()
 
 		// xi:include href="../escape.xml" resolves to "../escape.xml" after
-		// cleaning — which fstest.MapFS (fs.ValidPath enforced) rejects.
+		// cleaning. os.DirFS enforces fs.ValidPath and returns fs.ErrInvalid
+		// for names that start with "..", proving path-traversal containment.
+		// (Note: fstest.MapFS also rejects via fs.ValidPath but surfaces
+		// fs.ErrNotExist, so we use os.DirFS to assert the specific reason.)
 		doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
 			<xi:include href="../escape.xml"/>
 		</root>`)
 
-		fsys := fstest.MapFS{
-			"main.xml": &fstest.MapFile{Data: []byte(`<root/>`)},
-		}
+		fsys := os.DirFS(t.TempDir())
 		_, err := xinclude.NewProcessor().
 			Resolver(xinclude.NewFSResolver(fsys)).
 			NoXIncludeMarkers().NoBaseFixup().
 			Process(t.Context(), doc)
-		require.Error(t, err, "expected Process to fail when resolver path escapes FS root")
+		require.ErrorIs(t, err, fs.ErrInvalid, "expected fs.ValidPath rejection when href escapes FS root")
 	})
 }
 

--- a/xinclude/xinclude_test.go
+++ b/xinclude/xinclude_test.go
@@ -109,6 +109,24 @@ func TestXIncludeNewFSResolver(t *testing.T) {
 		require.Equal(t, 1, count)
 	})
 
+	t.Run("OS-native href separators are normalized for fs.FS", func(t *testing.T) {
+		t.Parallel()
+
+		// Upstream resolveURI uses filepath.Join which on Windows produces
+		// backslash-separated paths. The fs.FS contract requires slash-
+		// only names, so the resolver must call filepath.ToSlash before
+		// Open. On Linux filepath.Join already returns slashes, so this
+		// test is a no-op there; it exercises the conversion only on
+		// Windows.
+		href := filepath.Join("dir", "target.xml")
+		fsys := fstest.MapFS{
+			"dir/target.xml": &fstest.MapFile{Data: []byte(`<ok/>`)},
+		}
+		rc, err := xinclude.NewFSResolver(fsys).Resolve(href, "")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = rc.Close() })
+	})
+
 	t.Run("escaping href is rejected by os.DirFS-style FS", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
- drop redundant filepath.Clean around filepath.Join in resolveURI
- switch fsResolver to path (slash) so fs.FS resolves cleanly on Windows
- assert fs.ErrInvalid on the FS-traversal escape test

Follow-ups to #420 (already merged).