### PR TITLE
html: route silenced SAX callback errors via OnWarning; add Strict

### DIFF
--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -90,6 +90,15 @@ Note: line number appears twice (prefix and message suffix).
 
 Context extraction matches libxml2's `xmlParserInputGetWindow`: skip-eol, walk back 80, forward 80, cap caret.
 
+#### HTML SAX-callback error routing (`html/parser.go`)
+
+When a SAX callback (e.g. `InternalSubset`, `StartElement`, `Characters`) returns a non-nil error other than `ErrHandlerUnspecified`, `handleSAXErr` forwards it through one of two paths:
+
+- Default (`Parser.Strict(false)`): wrapped as a warning and delivered to the SAX `Warning(err)` slot (via `emitWarning`, gated by `cfg.noWarning`). The parser continues — HTML's libxml2-style tolerance.
+- `Parser.Strict(true)`: captured in `parser.fatalSAXErr` and returned from `parse()` after the parser reaches a stable state. `ErrHandlerUnspecified` is filtered in both modes.
+
+This is distinct from `emitError` (parser-detected malformed input → `Error(err)` slot, gated by `cfg.noError`), which has been the existing convention for tokenization/structure errors.
+
 ### XSLT 3.0 (`xslt3/errors.go`)
 
 **`XSLTError`** — structured error with W3C XSLT error code:

--- a/html/html.go
+++ b/html/html.go
@@ -73,6 +73,22 @@ func (p Parser) SuppressWarnings(v bool) Parser {
 	return p
 }
 
+// Strict controls whether non-[ErrHandlerUnspecified] return values from a
+// SAX callback abort the parse. With Strict(false) (the default), such
+// returns are forwarded to the parser's [WarningHandler] (see
+// [SAXCallbacks.SetOnWarning]) and parsing continues — matching libxml2's
+// "tolerate and produce a best-effort DOM" semantics. With Strict(true),
+// the first such return is captured and surfaced as the [Parser.Parse]
+// error after parsing reaches a stable state. [ErrHandlerUnspecified]
+// is always filtered before either path.
+//
+// Default: false.
+func (p Parser) Strict(v bool) Parser {
+	p = p.clone()
+	p.cfg.strict = v
+	return p
+}
+
 func (p Parser) parseConfig() parseConfig {
 	if p.cfg == nil {
 		return parseConfig{}

--- a/html/options.go
+++ b/html/options.go
@@ -6,6 +6,9 @@ type parseConfig struct {
 	noBlanks  bool
 	noError   bool
 	noWarning bool
+	// strict promotes warnings forwarded from silenced SAX callbacks into a
+	// fatal parse error. Default false preserves libxml2-style tolerance.
+	strict bool
 }
 
 // Writer configures HTML serialization. It is a value-style wrapper:

--- a/html/parser.go
+++ b/html/parser.go
@@ -79,7 +79,7 @@ func (p *parser) handleSAXErr(err error) {
 		}
 		return
 	}
-	_ = p.emitWarning("%v", err)
+	_ = p.emitWarning("%w", err)
 }
 
 // emitWarning routes a parser-tolerated condition to the SAX warning slot.

--- a/html/parser.go
+++ b/html/parser.go
@@ -3,6 +3,7 @@ package html
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -55,7 +56,40 @@ type parser struct {
 	// position when the first U+FFFD is encountered in emitCharacters.
 	encodingSanitizer *utf8SanitizeReader
 
+	// fatalSAXErr is set by handleSAXErr when cfg.strict is true and a SAX
+	// callback returns a non-ErrHandlerUnspecified error. parse() surfaces
+	// this value as the parse error. Outside strict mode it stays nil.
+	fatalSAXErr error
+
 	cfg parseConfig
+}
+
+// handleSAXErr filters the by-design ErrHandlerUnspecified signal and routes
+// every other non-nil return from a SAX callback. In the default (non-strict)
+// mode the error is forwarded to the warning channel and parsing continues,
+// preserving HTML's libxml2-compatible tolerance. In strict mode the first
+// such error is captured and surfaced from parse().
+func (p *parser) handleSAXErr(err error) {
+	if err == nil || errors.Is(err, ErrHandlerUnspecified) {
+		return
+	}
+	if p.cfg.strict {
+		if p.fatalSAXErr == nil {
+			p.fatalSAXErr = err
+		}
+		return
+	}
+	_ = p.emitWarning("%v", err)
+}
+
+// emitWarning routes a parser-tolerated condition to the SAX warning slot.
+// Mirrors emitError but fires Warning(...) and is gated by cfg.noWarning so
+// callers can silence these messages alongside emitError's output.
+func (p *parser) emitWarning(msg string, args ...any) error {
+	if p.cfg.noWarning {
+		return nil
+	}
+	return p.sax.Warning(fmt.Errorf(msg, args...))
 }
 
 // parserLocator implements DocumentLocator.
@@ -343,7 +377,7 @@ func getEndPriority(name string) int {
 func (p *parser) htmlAutoClose(newTag string) {
 	for p.currentName() != "" && shouldAutoClose(p.currentName(), newTag) {
 		name := p.popName()
-		_ = p.sax.EndElement(name)
+		p.handleSAXErr(p.sax.EndElement(name))
 	}
 }
 
@@ -375,7 +409,7 @@ func (p *parser) htmlAutoCloseOnClose(endTag string) {
 			_ = p.emitError("Opening and ending tag mismatch: %s and %s", endTag, cur)
 		}
 		p.popName()
-		_ = p.sax.EndElement(cur)
+		p.handleSAXErr(p.sax.EndElement(cur))
 	}
 }
 
@@ -383,7 +417,7 @@ func (p *parser) htmlAutoCloseOnClose(endTag string) {
 func (p *parser) htmlAutoCloseOnEnd() {
 	for len(p.nameStack) > 0 {
 		name := p.popName()
-		_ = p.sax.EndElement(name)
+		p.handleSAXErr(p.sax.EndElement(name))
 	}
 }
 
@@ -399,7 +433,7 @@ func (p *parser) htmlCheckImplied(newTag string) {
 	// Ensure <html> exists
 	if len(p.nameStack) == 0 {
 		p.pushName(elemHTML)
-		_ = p.sax.StartElement(elemHTML, nil)
+		p.handleSAXErr(p.sax.StartElement(elemHTML, nil))
 	}
 
 	if newTag == elemBody || newTag == elemHead {
@@ -412,7 +446,7 @@ func (p *parser) htmlCheckImplied(newTag string) {
 			return
 		}
 		p.pushName(elemHead)
-		_ = p.sax.StartElement(elemHead, nil)
+		p.handleSAXErr(p.sax.StartElement(elemHead, nil))
 		return
 	}
 
@@ -428,14 +462,14 @@ func (p *parser) htmlCheckImplied(newTag string) {
 			}
 		}
 		p.pushName(elemBody)
-		_ = p.sax.StartElement(elemBody, nil)
+		p.handleSAXErr(p.sax.StartElement(elemBody, nil))
 	}
 }
 
 // parse runs the main parsing loop.
 func (p *parser) parse(ctx context.Context) error {
-	_ = p.sax.SetDocumentLocator(p.locator)
-	_ = p.sax.StartDocument()
+	p.handleSAXErr(p.sax.SetDocumentLocator(p.locator))
+	p.handleSAXErr(p.sax.StartDocument())
 
 	for !p.cur.Done() {
 		if err := ctx.Err(); err != nil {
@@ -469,8 +503,8 @@ func (p *parser) parse(ctx context.Context) error {
 	}
 
 	p.htmlAutoCloseOnEnd()
-	_ = p.sax.EndDocument()
-	return nil
+	p.handleSAXErr(p.sax.EndDocument())
+	return p.fatalSAXErr
 }
 
 // parseStartTag parses an HTML start tag: <tagname attrs...>
@@ -510,13 +544,13 @@ func (p *parser) parseStartTag() {
 
 	// Fire SAX event
 	p.pushName(name)
-	_ = p.sax.StartElement(name, attrs)
+	p.handleSAXErr(p.sax.StartElement(name, attrs))
 
 	// Handle void elements — immediately close
 	desc := lookupElement(name)
 	if desc != nil && desc.empty {
 		p.popName()
-		_ = p.sax.EndElement(name)
+		p.handleSAXErr(p.sax.EndElement(name))
 		return
 	}
 
@@ -592,7 +626,7 @@ func (p *parser) parseEndTag() {
 	// If the current open element matches, close it
 	if p.currentName() == name {
 		p.popName()
-		_ = p.sax.EndElement(name)
+		p.handleSAXErr(p.sax.EndElement(name))
 	}
 }
 
@@ -604,13 +638,13 @@ func (p *parser) parseComment() {
 	if p.cur.Peek() == '>' {
 		// <!-->  — empty comment
 		_ = p.cur.Advance(1)
-		_ = p.sax.Comment(nil)
+		p.handleSAXErr(p.sax.Comment(nil))
 		return
 	}
 	if p.cur.Peek() == '-' && p.cur.PeekAt(1) == '>' {
 		// <!---> — empty comment
 		_ = p.cur.Advance(2)
-		_ = p.sax.Comment(nil)
+		p.handleSAXErr(p.sax.Comment(nil))
 		return
 	}
 
@@ -624,14 +658,14 @@ func (p *parser) parseComment() {
 		if b == '-' && p.cur.PeekAt(n+1) == '-' && p.cur.PeekAt(n+2) == '>' {
 			data := p.cur.PeekString(n)
 			_ = p.cur.Advance(n + 3) // skip data + '-->'
-			_ = p.sax.Comment([]byte(data))
+			p.handleSAXErr(p.sax.Comment([]byte(data)))
 			return
 		}
 		// Also handle incorrectly closed comment: --!>
 		if b == '-' && p.cur.PeekAt(n+1) == '-' && p.cur.PeekAt(n+2) == '!' && p.cur.PeekAt(n+3) == '>' {
 			data := p.cur.PeekString(n)
 			_ = p.cur.Advance(n + 4) // skip data + '--!>'
-			_ = p.sax.Comment([]byte(data))
+			p.handleSAXErr(p.sax.Comment([]byte(data)))
 			return
 		}
 		n++
@@ -640,7 +674,7 @@ func (p *parser) parseComment() {
 	// Unterminated comment — emit everything as comment
 	data := p.cur.PeekString(n)
 	_ = p.cur.Advance(n)
-	_ = p.sax.Comment([]byte(data))
+	p.handleSAXErr(p.sax.Comment([]byte(data)))
 }
 
 // parseBogusComment parses a bogus comment: <! ... >
@@ -659,7 +693,7 @@ func (p *parser) parseBogusComment() {
 	if p.cur.Peek() == '>' {
 		_ = p.cur.Advance(1)
 	}
-	_ = p.sax.Comment([]byte(data))
+	p.handleSAXErr(p.sax.Comment([]byte(data)))
 }
 
 // parsePI parses a processing instruction in HTML mode.
@@ -677,14 +711,14 @@ func (p *parser) parsePI() {
 		if b == '>' {
 			data := p.cur.PeekString(n)
 			_ = p.cur.Advance(n + 1) // skip data + '>'
-			_ = p.sax.Comment([]byte(data))
+			p.handleSAXErr(p.sax.Comment([]byte(data)))
 			return
 		}
 		n++
 	}
 	data := p.cur.PeekString(n)
 	_ = p.cur.Advance(n)
-	_ = p.sax.Comment([]byte(data))
+	p.handleSAXErr(p.sax.Comment([]byte(data)))
 }
 
 // parseDoctype parses a DOCTYPE declaration.
@@ -721,7 +755,7 @@ func (p *parser) parseDoctype() {
 		_ = p.cur.Advance(1)
 	}
 
-	_ = p.sax.InternalSubset(name, externalID, systemID)
+	p.handleSAXErr(p.sax.InternalSubset(name, externalID, systemID))
 }
 
 // parseCharacters parses character data (text content).
@@ -1016,7 +1050,7 @@ func (p *parser) parseRawContent(tagName string) {
 					}
 					// In normal or escaped state, </script> closes the element
 					if content.Len() > 0 {
-						_ = p.sax.CDataBlock(content.Bytes())
+						p.handleSAXErr(p.sax.CDataBlock(content.Bytes()))
 					}
 					return // Let the main loop handle the end tag
 				}
@@ -1028,7 +1062,7 @@ func (p *parser) parseRawContent(tagName string) {
 
 	// Unterminated — emit everything as cdata
 	if content.Len() > 0 {
-		_ = p.sax.CDataBlock(content.Bytes())
+		p.handleSAXErr(p.sax.CDataBlock(content.Bytes()))
 	}
 }
 
@@ -1088,7 +1122,7 @@ func (p *parser) parsePlaintext() {
 	if n > 0 {
 		text := p.cur.PeekString(n)
 		_ = p.cur.Advance(n)
-		_ = p.sax.Characters([]byte(text))
+		p.handleSAXErr(p.sax.Characters([]byte(text)))
 	}
 }
 

--- a/html/sax_warning_test.go
+++ b/html/sax_warning_test.go
@@ -1,0 +1,62 @@
+package html_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lestrrat-go/helium/html"
+	"github.com/stretchr/testify/require"
+)
+
+// In the default (non-strict) Parse path, a tree-builder objection to a
+// duplicate DOCTYPE must NOT abort parsing — HTML's libxml2-compatible
+// tolerance is preserved. Regression for the doc3.htm-style fixture.
+func TestSAXErrors_DuplicateDoctype_DefaultParseStillSucceeds(t *testing.T) {
+	input := `<!DOCTYPE a><!DOCTYPE b><html><body>hi</body></html>`
+	doc, err := html.NewParser().Parse(t.Context(), []byte(input))
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+}
+
+// A caller-supplied handler whose callback returns a non-ErrHandlerUnspecified
+// error must have that error routed through OnWarning, not silently dropped.
+func TestSAXErrors_NonUnspecifiedRoutedToOnWarning(t *testing.T) {
+	customErr := errors.New("caller-supplied: cannot accept this event")
+
+	var warnings []string
+	sax := &html.SAXCallbacks{}
+	sax.SetOnWarning(html.WarningFunc(func(err error) error {
+		warnings = append(warnings, err.Error())
+		return nil
+	}))
+	sax.SetOnInternalSubset(html.InternalSubsetFunc(func(_, _, _ string) error {
+		return customErr
+	}))
+
+	input := `<!DOCTYPE html><html><body/></html>`
+	err := html.NewParser().ParseWithSAX(t.Context(), []byte(input), sax)
+	require.NoError(t, err, "non-strict parse must keep going past handler errors")
+	require.NotEmpty(t, warnings, "OnWarning must observe the handler's error")
+	require.Contains(t, warnings[0], "cannot accept this event")
+}
+
+// With Strict(true), a tree-builder objection from the default Parse path
+// MUST surface as a fatal parse error. Mirror-image of the regression test
+// above: the same input that succeeds non-strict must fail strict.
+func TestSAXErrors_StrictPromotesTreeBuilderObjectionToFatal(t *testing.T) {
+	input := `<!DOCTYPE a><!DOCTYPE b><html><body>hi</body></html>`
+	_, err := html.NewParser().Strict(true).Parse(t.Context(), []byte(input))
+	require.Error(t, err, "Strict(true) must surface tree-builder objections")
+	require.Contains(t, err.Error(), "internal subset",
+		"fatal error message should reference the offending invariant")
+}
+
+// Strict(true) must NOT trip on ErrHandlerUnspecified — that sentinel is
+// always the "no handler is registered for this event" plumbing signal,
+// not a real error. Well-formed HTML parsed in strict mode succeeds.
+func TestSAXErrors_StrictIgnoresErrHandlerUnspecified(t *testing.T) {
+	input := `<html><body><p>well-formed</p></body></html>`
+	doc, err := html.NewParser().Strict(true).Parse(t.Context(), []byte(input))
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+}

--- a/html/sax_warning_test.go
+++ b/html/sax_warning_test.go
@@ -20,13 +20,15 @@ func TestSAXErrors_DuplicateDoctype_DefaultParseStillSucceeds(t *testing.T) {
 
 // A caller-supplied handler whose callback returns a non-ErrHandlerUnspecified
 // error must have that error routed through OnWarning, not silently dropped.
+// The forwarded warning must wrap (not stringify) the original error so
+// callers can recover it via errors.Is / errors.As.
 func TestSAXErrors_NonUnspecifiedRoutedToOnWarning(t *testing.T) {
 	customErr := errors.New("caller-supplied: cannot accept this event")
 
-	var warnings []string
+	var warnings []error
 	sax := &html.SAXCallbacks{}
 	sax.SetOnWarning(html.WarningFunc(func(err error) error {
-		warnings = append(warnings, err.Error())
+		warnings = append(warnings, err)
 		return nil
 	}))
 	sax.SetOnInternalSubset(html.InternalSubsetFunc(func(_, _, _ string) error {
@@ -37,7 +39,8 @@ func TestSAXErrors_NonUnspecifiedRoutedToOnWarning(t *testing.T) {
 	err := html.NewParser().ParseWithSAX(t.Context(), []byte(input), sax)
 	require.NoError(t, err, "non-strict parse must keep going past handler errors")
 	require.NotEmpty(t, warnings, "OnWarning must observe the handler's error")
-	require.Contains(t, warnings[0], "cannot accept this event")
+	require.ErrorIs(t, warnings[0], customErr,
+		"forwarded warning must preserve the original error chain")
 }
 
 // With Strict(true), a tree-builder objection from the default Parse path


### PR DESCRIPTION
- 24 callsites that did `_ = p.sax.X(...)` now route non-`ErrHandlerUnspecified` returns through a new `handleSAXErr` helper
- non-strict (default): forwards through new `emitWarning` → `OnWarning` slot, gated by existing `cfg.noWarning`; parser continues, libxml2 tolerance preserved
- `Parser.Strict(true)`: captures the first such error and returns it from Parse, for callers that want fatal behavior on tolerated oddities
- `ErrHandlerUnspecified` always filtered in both modes