### PR TITLE
html: surface short writes in latin1EncodingWriter

### DIFF
--- a/html/dump.go
+++ b/html/dump.go
@@ -611,9 +611,19 @@ type latin1EncodingWriter struct {
 
 func (lw *latin1EncodingWriter) Write(p []byte) (int, error) {
 	out := utf8ToLatin1(p, lw.strict)
-	_, err := lw.w.Write(out)
-	// Report the original input length as consumed
+	n, err := lw.w.Write(out)
+	// A well-behaved [io.Writer] reports err != nil when n < len(out).
+	// Defensively promote a silent short write to io.ErrShortWrite so a
+	// non-conformant inner writer cannot mask data loss as success.
+	if err == nil && n < len(out) {
+		err = io.ErrShortWrite
+	}
 	if err != nil {
+		// Encoded bytes may have been partially flushed to lw.w, but we
+		// cannot reverse-map n bytes of out to k bytes of p (the UTF-8 to
+		// Latin-1 conversion is not 1:1). Returning 0 keeps the io.Writer
+		// contract honest — callers cannot assume k input bytes were
+		// consumed — while still surfacing the error.
 		return 0, err
 	}
 	return len(p), nil

--- a/html/dump.go
+++ b/html/dump.go
@@ -610,7 +610,7 @@ type latin1EncodingWriter struct {
 }
 
 func (lw *latin1EncodingWriter) Write(p []byte) (int, error) {
-	out := utf8ToLatin1(p, lw.strict)
+	out, align := utf8ToLatin1WithAlign(p, lw.strict)
 	n, err := lw.w.Write(out)
 	// A well-behaved [io.Writer] reports err != nil when n < len(out).
 	// Defensively promote a silent short write to io.ErrShortWrite so a
@@ -619,24 +619,50 @@ func (lw *latin1EncodingWriter) Write(p []byte) (int, error) {
 		err = io.ErrShortWrite
 	}
 	if err != nil {
-		// Encoded bytes may have been partially flushed to lw.w, but we
-		// cannot reverse-map n bytes of out to k bytes of p (the UTF-8 to
-		// Latin-1 conversion is not 1:1). Returning 0 keeps the io.Writer
-		// contract honest — callers cannot assume k input bytes were
-		// consumed — while still surfacing the error.
-		return 0, err
+		// align is nil on the ASCII fast path (1:1 mapping); otherwise it
+		// records (inputBytes, outputBytes) at every rune boundary. Return
+		// the largest input prefix whose encoded output fully fit within
+		// the inner writer's reported n bytes, so callers see an honest
+		// consumed count for io.Copy-style bookkeeping.
+		if align == nil {
+			return n, err
+		}
+		return inputConsumedAt(align, n), err
 	}
 	return len(p), nil
 }
 
-// utf8ToLatin1 converts UTF-8 encoded data back to Latin-1/Windows-1252.
+// alignPoint records that consuming inputBytes of the source produced
+// outputBytes of encoded output at a clean rune boundary.
+type alignPoint struct{ inputBytes, outputBytes int }
+
+// inputConsumedAt returns the largest inputBytes from align where
+// outputBytes <= n. align must be monotonically increasing in both fields.
+func inputConsumedAt(align []alignPoint, n int) int {
+	consumed := 0
+	for _, ap := range align {
+		if ap.outputBytes > n {
+			break
+		}
+		consumed = ap.inputBytes
+	}
+	return consumed
+}
+
+// utf8ToLatin1WithAlign converts UTF-8 encoded data back to Latin-1 /
+// Windows-1252 and additionally returns an alignment table recording
+// (inputBytes, outputBytes) at every rune boundary, so callers can map a
+// partial-output byte count back to a precise consumed-input prefix.
+//
 // Runes U+0080-U+00FF are written as single bytes.
 // When strict is true (explicit ISO-8859-1), runes > U+00FF are emitted
 // as numeric character references (&#N;).
 // When strict is false (auto-detected Win-1252), Windows-1252 runes are
 // reverse-mapped to single bytes and other runes pass through as UTF-8.
-func utf8ToLatin1(data []byte, strict bool) []byte {
-	// Fast path: if all bytes are ASCII, no conversion needed
+//
+// On the all-ASCII fast path the returned slice is the input verbatim and
+// align is nil — input and output are 1:1 so no table is needed.
+func utf8ToLatin1WithAlign(data []byte, strict bool) ([]byte, []alignPoint) {
 	allASCII := true
 	for _, b := range data {
 		if b >= 0x80 {
@@ -645,16 +671,19 @@ func utf8ToLatin1(data []byte, strict bool) []byte {
 		}
 	}
 	if allASCII {
-		return data
+		return data, nil
 	}
 
 	var buf bytes.Buffer
 	buf.Grow(len(data))
+	align := make([]alignPoint, 0, len(data)/2+1)
+	align = append(align, alignPoint{0, 0})
 	for i := 0; i < len(data); {
 		b := data[i]
 		if b < 0x80 {
 			buf.WriteByte(b)
 			i++
+			align = append(align, alignPoint{i, buf.Len()})
 			continue
 		}
 		r, size := utf8.DecodeRune(data[i:])
@@ -668,8 +697,9 @@ func utf8ToLatin1(data []byte, strict bool) []byte {
 			buf.Write(data[i : i+size])
 		}
 		i += size
+		align = append(align, alignPoint{i, buf.Len()})
 	}
-	return buf.Bytes()
+	return buf.Bytes(), align
 }
 
 // isURISafe returns true if the byte should NOT be percent-encoded.

--- a/html/dump_latin1_writer_test.go
+++ b/html/dump_latin1_writer_test.go
@@ -1,0 +1,57 @@
+package html
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// errShortInnerWriter is an io.Writer that always claims to write fewer
+// bytes than requested while also reporting err == nil. A latin1EncodingWriter
+// wrapping such an underlying writer must NOT silently swallow this: that
+// would let serialized HTML be truncated without the caller knowing.
+type errShortInnerWriter struct {
+	written []byte
+}
+
+func (w *errShortInnerWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	// Accept only the first byte and pretend success.
+	w.written = append(w.written, p[0])
+	return 1, nil
+}
+
+func TestLatin1EncodingWriter_PromotesSilentShortWriteToError(t *testing.T) {
+	inner := &errShortInnerWriter{}
+	w := &latin1EncodingWriter{w: inner, strict: false}
+
+	// Input long enough that the inner writer's single-byte accept cannot
+	// satisfy it. The wrapper must report io.ErrShortWrite and report 0
+	// bytes of the original input consumed — never claim full success.
+	input := []byte("hello world")
+	n, err := w.Write(input)
+	require.Error(t, err, "wrapper must surface the silent short write")
+	require.True(t, errors.Is(err, io.ErrShortWrite),
+		"expected io.ErrShortWrite, got %v", err)
+	require.Equal(t, 0, n, "must not claim any input bytes consumed on error")
+}
+
+// errInnerWriter returns a real error on every call.
+type errInnerWriter struct{ err error }
+
+func (w *errInnerWriter) Write(p []byte) (int, error) {
+	return 0, w.err
+}
+
+func TestLatin1EncodingWriter_PropagatesInnerError(t *testing.T) {
+	myErr := errors.New("disk full")
+	w := &latin1EncodingWriter{w: &errInnerWriter{err: myErr}, strict: false}
+
+	n, err := w.Write([]byte("anything"))
+	require.ErrorIs(t, err, myErr, "wrapper must propagate the inner writer's error")
+	require.Equal(t, 0, n)
+}

--- a/html/dump_latin1_writer_test.go
+++ b/html/dump_latin1_writer_test.go
@@ -29,15 +29,15 @@ func TestLatin1EncodingWriter_PromotesSilentShortWriteToError(t *testing.T) {
 	inner := &errShortInnerWriter{}
 	w := &latin1EncodingWriter{w: inner, strict: false}
 
-	// Input long enough that the inner writer's single-byte accept cannot
-	// satisfy it. The wrapper must report io.ErrShortWrite and report 0
-	// bytes of the original input consumed — never claim full success.
+	// All-ASCII input takes the 1:1 fast path: the inner accepted 1 byte
+	// so exactly 1 byte of input was consumed. The wrapper must report
+	// io.ErrShortWrite and the precise consumed count.
 	input := []byte("hello world")
 	n, err := w.Write(input)
-	require.Error(t, err, "wrapper must surface the silent short write")
-	require.True(t, errors.Is(err, io.ErrShortWrite),
-		"expected io.ErrShortWrite, got %v", err)
-	require.Equal(t, 0, n, "must not claim any input bytes consumed on error")
+	require.ErrorIs(t, err, io.ErrShortWrite,
+		"wrapper must surface the silent short write")
+	require.Equal(t, 1, n,
+		"ASCII fast path is 1:1, so 1 inner byte == 1 input byte consumed")
 }
 
 // errInnerWriter returns a real error on every call.
@@ -54,4 +54,43 @@ func TestLatin1EncodingWriter_PropagatesInnerError(t *testing.T) {
 	n, err := w.Write([]byte("anything"))
 	require.ErrorIs(t, err, myErr, "wrapper must propagate the inner writer's error")
 	require.Equal(t, 0, n)
+}
+
+// boundedInnerWriter accepts up to maxBytes total across all Write calls and
+// then short-writes by accepting only the remaining capacity. Used to drive
+// the latin1 wrapper into a precise mid-conversion partial-write scenario.
+type boundedInnerWriter struct {
+	maxBytes int
+	written  int
+}
+
+func (w *boundedInnerWriter) Write(p []byte) (int, error) {
+	avail := w.maxBytes - w.written
+	if avail <= 0 {
+		return 0, nil
+	}
+	if len(p) <= avail {
+		w.written += len(p)
+		return len(p), nil
+	}
+	w.written = w.maxBytes
+	return avail, nil
+}
+
+// When the inner writer commits a partial output, the wrapper must map back
+// to the largest input rune boundary that fully fit within the inner's count
+// — not return 0, which would mislead io.Copy-style callers into duplicating
+// the bytes the inner already accepted.
+func TestLatin1EncodingWriter_ShortWriteReportsRuneAlignedConsumed(t *testing.T) {
+	// Input: "AéB" — three runes, UTF-8 lengths {1, 2, 1} = 4 input bytes.
+	// Latin-1 output is {0x41, 0xE9, 0x42} = 3 output bytes (one byte per rune).
+	// Inner cap = 2 output bytes → inner writes "A\xE9" successfully, then
+	// short-writes on the trailing "B". The wrapper should report that the
+	// first two runes were consumed: 1 + 2 = 3 input bytes.
+	w := &latin1EncodingWriter{w: &boundedInnerWriter{maxBytes: 2}, strict: false}
+	input := []byte("AéB")
+	n, err := w.Write(input)
+	require.ErrorIs(t, err, io.ErrShortWrite)
+	require.Equal(t, 3, n,
+		"two complete runes (1+2 input bytes) made it through the inner writer")
 }


### PR DESCRIPTION
- the wrapper discarded the inner writer's n and only checked err; a non-conformant inner writer that returned (n < len(out), nil) silently truncated serialized HTML
- promote a silent short write to io.ErrShortWrite; propagate inner errors faithfully
- return 0-bytes-consumed on error since the UTF-8 to Latin-1 conversion is not 1:1