### PR TITLE
parser: absolute entity-expansion ceiling survives RelaxLimits

### DIFF
--- a/parser_entity_ref.go
+++ b/parser_entity_ref.go
@@ -684,7 +684,12 @@ func (ctx *parserCtx) entityCheck(ent sax.Entity, size int) error {
 	// is asserting that legitimate large entities are OK, not that
 	// unbounded billion-laughs expansion is OK.
 	if ctx.sizeentcopy > entityHardCeiling {
-		return errors.New("maximum entity expansion size exceeded")
+		// The "maximum entity expansion size" prefix matches the historical
+		// error text; substring callers (tests) keep matching. The
+		// (current, limit) suffix surfaces the actual numbers so a
+		// production diagnosis doesn't require code spelunking.
+		return fmt.Errorf("maximum entity expansion size exceeded (%d > %d)",
+			ctx.sizeentcopy, entityHardCeiling)
 	}
 
 	if ctx.maxAmpl == 0 {

--- a/parser_entity_ref.go
+++ b/parser_entity_ref.go
@@ -668,16 +668,27 @@ func saturatedAdd(a, b int64) int64 {
 }
 
 func (ctx *parserCtx) entityCheck(ent sax.Entity, size int) error {
-	if ctx.maxAmpl == 0 {
-		return nil
-	}
-
+	// Account expanded bytes even when the ratio check is disabled
+	// (maxAmpl=0 via RelaxLimits) so the absolute ceiling below can
+	// catch unbounded growth.
 	if e, ok := ent.(*Entity); ok && e != nil && e.Checked() {
 		ctx.sizeentcopy = saturatedAdd(ctx.sizeentcopy, e.expandedSize)
 		ctx.sizeentcopy = saturatedAdd(ctx.sizeentcopy, entityFixedCost)
 	} else {
 		ctx.sizeentcopy = saturatedAdd(ctx.sizeentcopy, int64(size))
 		ctx.sizeentcopy = saturatedAdd(ctx.sizeentcopy, entityFixedCost)
+	}
+
+	// Absolute ceiling: enforced even when RelaxLimits disables the
+	// amplification-ratio check. A document opting into "relaxed limits"
+	// is asserting that legitimate large entities are OK, not that
+	// unbounded billion-laughs expansion is OK.
+	if ctx.sizeentcopy > entityHardCeiling {
+		return errors.New("maximum entity expansion size exceeded")
+	}
+
+	if ctx.maxAmpl == 0 {
+		return nil
 	}
 
 	if ctx.sizeentcopy > entityAllowedExpansion {

--- a/parser_entity_test.go
+++ b/parser_entity_test.go
@@ -92,7 +92,11 @@ func TestEntityAmplification(t *testing.T) {
 	})
 
 	t.Run("RelaxLimits still capped by absolute ceiling", func(t *testing.T) {
-		t.Parallel()
+		// Intentionally NOT t.Parallel: this subtest drives expansion up
+		// to entityHardCeiling (1 GiB). Running it alongside the parallel
+		// subtests above amplified peak memory under loaded CI runners.
+		// The ceiling does eventually trip, but the parser still
+		// materializes nontrivial intermediate state, so we serialize it.
 		// A bigger billion-laughs that would expand to many GB even with
 		// the ratio check disabled. The absolute ceiling (entityHardCeiling
 		// in parserctx.go) must still trip and abort the parse.

--- a/parser_entity_test.go
+++ b/parser_entity_test.go
@@ -115,6 +115,8 @@ func TestEntityAmplification(t *testing.T) {
 		require.Error(t, err, "absolute ceiling must trip even with RelaxLimits")
 		require.Contains(t, err.Error(), "maximum entity expansion size",
 			"error must explain the ceiling, got: %v", err)
+		require.Regexp(t, `\(\d+ > \d+\)`, err.Error(),
+			"error must include observed and configured sizes for diagnosis, got: %v", err)
 	})
 }
 

--- a/parser_entity_test.go
+++ b/parser_entity_test.go
@@ -90,6 +90,32 @@ func TestEntityAmplification(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, doc)
 	})
+
+	t.Run("RelaxLimits still capped by absolute ceiling", func(t *testing.T) {
+		t.Parallel()
+		// A bigger billion-laughs that would expand to many GB even with
+		// the ratio check disabled. The absolute ceiling (entityHardCeiling
+		// in parserctx.go) must still trip and abort the parse.
+		xml := `<?xml version="1.0"?>
+<!DOCTYPE lolz [
+  <!ENTITY lol "lol">
+  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+  <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+  <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+  <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+  <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+  <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+  <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
+]>
+<root>&lol9;</root>`
+
+		p := helium.NewParser().SubstituteEntities(true).RelaxLimits(true)
+		_, err := p.Parse(t.Context(), []byte(xml))
+		require.Error(t, err, "absolute ceiling must trip even with RelaxLimits")
+		require.Contains(t, err.Error(), "maximum entity expansion size",
+			"error must explain the ceiling, got: %v", err)
+	})
 }
 
 func TestPredefinedEntities(t *testing.T) {

--- a/parserctx.go
+++ b/parserctx.go
@@ -51,6 +51,13 @@ const (
 	entityAllowedExpansion int64 = 1_000_000 // 1 MB baseline before ratio check
 	entityFixedCost        int64 = 20        // fixed byte cost per entity reference
 	entityMaxAmplDefault         = 5         // default max amplification factor
+	// entityHardCeiling caps total entity expansion even when the ratio
+	// check is disabled (maxAmpl=0 via [Parser.RelaxLimits]). Without it,
+	// RelaxLimits permits unbounded amplification — a single document
+	// could expand to many GB of resident memory. 1 GB is permissive enough
+	// for any realistic XML workload but blocks the unbounded billion-laughs
+	// path that a hostile document could otherwise exploit.
+	entityHardCeiling int64 = 1_000_000_000 // 1 GB absolute cap, survives RelaxLimits
 )
 
 const (


### PR DESCRIPTION
- RelaxLimits(true) set maxAmpl=0 which made entityCheck return without accounting; a hostile doc could expand entities unboundedly even with relaxed limits opted-in
- new entityHardCeiling (1 GB) enforced regardless of maxAmpl; ratio check still gated by maxAmpl as before
- ceiling chosen permissive enough for any realistic XML; intent of RelaxLimits is "tolerate big legitimate inputs", not "accept unbounded billion-laughs"