### PR TITLE
schemas: reject schema location/href escaping baseDir

### DIFF
--- a/relaxng/parse.go
+++ b/relaxng/parse.go
@@ -341,31 +341,31 @@ func combinePatterns(existing, incoming *pattern, mode string) *pattern {
 // fixup for <include> and <externalRef> hrefs.
 //
 // When the result is computed by joining baseDir+href, any ".." segments
-// that would ascend above baseDir return an empty string — the caller
-// reports an Include load failure with a clear error message rather than
-// silently reading from an unintended directory. Mirrors xsd's
-// validateSchemaPath; defense-in-depth alongside whatever path
-// constraints the configured fs.FS enforces.
-func (c *compiler) resolveHref(_ context.Context, elem *helium.Element, href string) string {
+// that would ascend above baseDir produce a non-nil error — the caller
+// reports an Include load failure with a clear "escapes base directory"
+// message rather than silently reading from an unintended directory.
+// Mirrors xsd's validateSchemaPath; defense-in-depth alongside whatever
+// path constraints the configured fs.FS enforces.
+func (c *compiler) resolveHref(_ context.Context, elem *helium.Element, href string) (string, error) {
 	if filepath.IsAbs(href) {
-		return href
+		return href, nil
 	}
 	if doc := elem.OwnerDocument(); doc != nil {
 		base := helium.NodeGetBase(doc, elem)
 		if base != "" {
-			return helium.BuildURI(href, base)
+			return helium.BuildURI(href, base), nil
 		}
 	}
 	if c.baseDir != "" {
 		joined := filepath.Join(c.baseDir, href)
 		if rel, err := filepath.Rel(c.baseDir, joined); err == nil {
 			if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-				return ""
+				return "", fmt.Errorf("href %q escapes base directory", href)
 			}
 		}
-		return joined
+		return joined, nil
 	}
-	return href
+	return href, nil
 }
 
 // parseInclude parses an <include> element.
@@ -377,7 +377,13 @@ func (c *compiler) parseInclude(ctx context.Context, elem *helium.Element) {
 		return
 	}
 
-	path := c.resolveHref(ctx, elem, href)
+	path, err := c.resolveHref(ctx, elem, href)
+	if err != nil {
+		msg := fmt.Sprintf("xmlRelaxNGParse: could not load %s: %s", href, err)
+		c.errorHandler.Handle(ctx, helium.NewLeveledError(rngParserError(msg), helium.ErrorLevelFatal))
+		c.errorCount++
+		return
+	}
 
 	// Recursion guard
 	if _, recursing := c.includeStack[path]; recursing {
@@ -788,7 +794,13 @@ func (c *compiler) parseExternalRef(ctx context.Context, node *helium.Element) *
 		return nil
 	}
 
-	path := c.resolveHref(ctx, node, href)
+	path, err := c.resolveHref(ctx, node, href)
+	if err != nil {
+		msg := fmt.Sprintf("xmlRelaxNGParse: could not load %s: %s", href, err)
+		c.errorHandler.Handle(ctx, helium.NewLeveledError(rngParserError(msg), helium.ErrorLevelFatal))
+		c.errorCount++
+		return nil
+	}
 
 	// Recursion guard
 	if _, recursing := c.includeStack[path]; recursing {

--- a/relaxng/parse.go
+++ b/relaxng/parse.go
@@ -339,6 +339,13 @@ func combinePatterns(existing, incoming *pattern, mode string) *pattern {
 // resolveHref resolves a relative href against xml:base ancestors and the
 // compiler's baseDir. This mirrors libxml2's xmlRelaxNGCleanupTree xml:base
 // fixup for <include> and <externalRef> hrefs.
+//
+// When the result is computed by joining baseDir+href, any ".." segments
+// that would ascend above baseDir return an empty string — the caller
+// reports an Include load failure with a clear error message rather than
+// silently reading from an unintended directory. Mirrors xsd's
+// validateSchemaPath; defense-in-depth alongside whatever path
+// constraints the configured fs.FS enforces.
 func (c *compiler) resolveHref(_ context.Context, elem *helium.Element, href string) string {
 	if filepath.IsAbs(href) {
 		return href
@@ -350,7 +357,13 @@ func (c *compiler) resolveHref(_ context.Context, elem *helium.Element, href str
 		}
 	}
 	if c.baseDir != "" {
-		return filepath.Join(c.baseDir, href)
+		joined := filepath.Join(c.baseDir, href)
+		if rel, err := filepath.Rel(c.baseDir, joined); err == nil {
+			if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				return ""
+			}
+		}
+		return joined
 	}
 	return href
 }

--- a/relaxng/path_escape_test.go
+++ b/relaxng/path_escape_test.go
@@ -1,0 +1,73 @@
+package relaxng_test
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/relaxng"
+	"github.com/stretchr/testify/require"
+)
+
+// <include href="../..."> / <externalRef href="../..."> paths that
+// "../"-escape the compiler's baseDir must be rejected with a clear
+// "escapes base directory" error. Defense-in-depth for callers wiring in
+// permissive fs.FS implementations; os.DirFS would already refuse via
+// fs.ValidPath, but the check here gives consistent behavior independent
+// of the FS choice. Mirrors xsd/path_escape_test.go.
+func TestCompile_RejectsParentEscapeInHref(t *testing.T) {
+	t.Parallel()
+
+	const includer = `<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <include href="../escape.rng"/>
+  <start><ref name="root"/></start>
+</grammar>`
+
+	const externalRefer = `<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start><externalRef href="../escape.rng"/></start>
+</grammar>`
+
+	const escapeRNG = `<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <define name="root"><element name="root"><text/></element></define>
+  <start><ref name="root"/></start>
+</grammar>`
+
+	fsys := fstest.MapFS{
+		"schemas/main.rng":   &fstest.MapFile{Data: []byte(includer)},
+		"schemas/extref.rng": &fstest.MapFile{Data: []byte(externalRefer)},
+		"escape.rng":         &fstest.MapFile{Data: []byte(escapeRNG)},
+	}
+
+	compile := func(t *testing.T, file string) string {
+		t.Helper()
+		data, err := fsys.ReadFile(file)
+		require.NoError(t, err)
+		doc, err := helium.NewParser().Parse(t.Context(), data)
+		require.NoError(t, err)
+
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, err = relaxng.NewCompiler().FS(fsys).BaseDir("schemas").ErrorHandler(collector).Compile(t.Context(), doc)
+		require.NoError(t, err)
+		_ = collector.Close()
+		_, compileErrors := partitionCompileErrors(collector.Errors())
+		return compileErrors
+	}
+
+	t.Run("include", func(t *testing.T) {
+		t.Parallel()
+		got := compile(t, "schemas/main.rng")
+		require.True(t, strings.Contains(got, "escapes base directory"),
+			"error should mention escape; got: %s", got)
+	})
+
+	t.Run("externalRef", func(t *testing.T) {
+		t.Parallel()
+		got := compile(t, "schemas/extref.rng")
+		require.True(t, strings.Contains(got, "escapes base directory"),
+			"error should mention escape; got: %s", got)
+	})
+}

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -17,6 +17,12 @@ import (
 // treating it as a warning the way it treats ordinary I/O failures.
 var errImportDepthExceeded = errors.New("xsd: max import depth exceeded")
 
+// errSchemaPathEscape signals that a schemaLocation joined onto baseDir
+// would escape upward via ".." segments. processIncludes surfaces this
+// as a fatal error rather than swallowing it as a generic I/O warning,
+// so the containment violation is visible to callers.
+var errSchemaPathEscape = errors.New("xsd: schema location escapes base directory")
+
 // validateSchemaPath joins location onto baseDir and refuses paths that
 // escape upward via ".." segments. The escape check compares the joined
 // path back to baseDir via [filepath.Rel] — a relative result that begins
@@ -27,6 +33,13 @@ var errImportDepthExceeded = errors.New("xsd: max import depth exceeded")
 // will reject absolute paths and ValidPath violations on its own), but
 // catching the escape here gives consistent behavior with permissive FS
 // implementations.
+//
+// Note: [filepath.Join] does not preserve an absolute prefix on the second
+// argument — Join("schemas", "/etc/passwd") returns "schemas/etc/passwd",
+// which lives inside baseDir and is not an escape. Absolute schemaLocation
+// values therefore do not bypass this check; they land inside baseDir.
+// (When baseDir is empty there is nothing to escape from, and the
+// configured fs.FS decides what to accept.)
 func validateSchemaPath(baseDir, location string) (string, error) {
 	if baseDir == "" {
 		return filepath.Clean(location), nil
@@ -39,7 +52,7 @@ func validateSchemaPath(baseDir, location string) (string, error) {
 		return path, nil //nolint:nilerr
 	}
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("schema location %q escapes base directory", location)
+		return "", fmt.Errorf("%w: %q", errSchemaPathEscape, location)
 	}
 	return path, nil
 }
@@ -81,9 +94,10 @@ func (c *compiler) processIncludes(ctx context.Context, root *helium.Element) er
 			}
 
 			if err := c.loadImport(ctx, loc, ns); err != nil {
-				// Depth-exceeded is a security limit, not an I/O hiccup;
-				// surface it as a fatal compilation error.
-				if errors.Is(err, errImportDepthExceeded) {
+				// Depth-exceeded and baseDir-escape are security limits,
+				// not I/O hiccups; surface them as fatal compilation
+				// errors rather than demoting to an I/O warning.
+				if errors.Is(err, errImportDepthExceeded) || errors.Is(err, errSchemaPathEscape) {
 					return err
 				}
 				// Import failure — report warning if we have a filename.

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"maps"
 	"path/filepath"
+	"strings"
 
 	helium "github.com/lestrrat-go/helium"
 )
@@ -15,6 +16,33 @@ import (
 // configured limit. processIncludes propagates this error rather than
 // treating it as a warning the way it treats ordinary I/O failures.
 var errImportDepthExceeded = errors.New("xsd: max import depth exceeded")
+
+// validateSchemaPath joins location onto baseDir and refuses paths that
+// escape upward via ".." segments. The escape check compares the joined
+// path back to baseDir via [filepath.Rel] — a relative result that begins
+// with ".." means location ascended above baseDir (independently of
+// whether baseDir itself contains ".." segments, which is common in test
+// fixtures). Mirrors the defense-in-depth path normalization in xinclude
+// (#420/#425) — the configured fs.FS may further constrain (and os.DirFS
+// will reject absolute paths and ValidPath violations on its own), but
+// catching the escape here gives consistent behavior with permissive FS
+// implementations.
+func validateSchemaPath(baseDir, location string) (string, error) {
+	if baseDir == "" {
+		return filepath.Clean(location), nil
+	}
+	path := filepath.Join(baseDir, location)
+	rel, err := filepath.Rel(baseDir, path)
+	if err != nil {
+		// Rel only fails when one is absolute and the other isn't;
+		// nothing actionable here — accept and let fs.FS decide.
+		return path, nil //nolint:nilerr
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("schema location %q escapes base directory", location)
+	}
+	return path, nil
+}
 
 // processIncludes handles xs:include and xs:import elements.
 func (c *compiler) processIncludes(ctx context.Context, root *helium.Element) error {
@@ -86,9 +114,9 @@ func (c *compiler) processIncludes(ctx context.Context, root *helium.Element) er
 
 // loadInclude loads and merges an included schema file.
 func (c *compiler) loadInclude(ctx context.Context, location string, includeElem *helium.Element) error {
-	path := location
-	if c.baseDir != "" {
-		path = filepath.Join(c.baseDir, location)
+	path, err := validateSchemaPath(c.baseDir, location)
+	if err != nil {
+		return fmt.Errorf("xsd: failed to load include %q: %w", location, err)
 	}
 
 	data, err := fs.ReadFile(c.fsys, path)
@@ -167,9 +195,9 @@ func (c *compiler) loadInclude(ctx context.Context, location string, includeElem
 // redefinitions for complexType, simpleType, group, and attributeGroup children.
 func (c *compiler) loadRedefine(ctx context.Context, location string, redefineElem *helium.Element) error {
 	// Phase A: Load the redefined schema (same as include).
-	path := location
-	if c.baseDir != "" {
-		path = filepath.Join(c.baseDir, location)
+	path, err := validateSchemaPath(c.baseDir, location)
+	if err != nil {
+		return fmt.Errorf("xsd: failed to load redefine %q: %w", location, err)
 	}
 
 	data, err := fs.ReadFile(c.fsys, path)
@@ -383,9 +411,9 @@ func (c *compiler) loadImport(ctx context.Context, location, _ string) error {
 		return fmt.Errorf("%w (limit=%d, location=%q)", errImportDepthExceeded, c.maxImportDepth, location)
 	}
 
-	path := location
-	if c.baseDir != "" {
-		path = filepath.Join(c.baseDir, location)
+	path, err := validateSchemaPath(c.baseDir, location)
+	if err != nil {
+		return fmt.Errorf("xsd: failed to load import %q: %w", location, err)
 	}
 
 	data, err := fs.ReadFile(c.fsys, path)

--- a/xsd/path_escape_test.go
+++ b/xsd/path_escape_test.go
@@ -18,23 +18,52 @@ import (
 func TestCompile_RejectsParentEscapeInSchemaLocation(t *testing.T) {
 	t.Parallel()
 
-	includer := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:include schemaLocation="../escape.xsd"/>
+	const escapeXSD = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"/>`
+	const importerEscape = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import namespace="urn:escape" schemaLocation="../escape.xsd"/>
 </xs:schema>`
 
-	fsys := fstest.MapFS{
-		"schemas/main.xsd": &fstest.MapFile{Data: []byte(includer)},
-		// A file at the parent level the attacker might want to read.
-		"escape.xsd": &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"/>`)},
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "include",
+			body: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../escape.xsd"/>
+</xs:schema>`,
+		},
+		{
+			name: "import",
+			body: importerEscape,
+		},
+		{
+			name: "redefine",
+			body: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="../escape.xsd"/>
+</xs:schema>`,
+		},
 	}
 
-	data, err := fsys.ReadFile("schemas/main.xsd")
-	require.NoError(t, err)
-	doc, err := helium.NewParser().Parse(t.Context(), data)
-	require.NoError(t, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, err = xsd.NewCompiler().FS(fsys).BaseDir("schemas").Label("schemas/main.xsd").Compile(t.Context(), doc)
-	require.Error(t, err, "compile must reject schemaLocation that escapes baseDir")
-	require.True(t, strings.Contains(err.Error(), "escapes base directory"),
-		"error should mention escape; got: %v", err)
+			fsys := fstest.MapFS{
+				"schemas/main.xsd": &fstest.MapFile{Data: []byte(tc.body)},
+				// A file at the parent level the attacker might want to read.
+				"escape.xsd": &fstest.MapFile{Data: []byte(escapeXSD)},
+			}
+
+			data, err := fsys.ReadFile("schemas/main.xsd")
+			require.NoError(t, err)
+			doc, err := helium.NewParser().Parse(t.Context(), data)
+			require.NoError(t, err)
+
+			_, err = xsd.NewCompiler().FS(fsys).BaseDir("schemas").Label("schemas/main.xsd").Compile(t.Context(), doc)
+			require.Error(t, err, "compile must reject schemaLocation that escapes baseDir")
+			require.True(t, strings.Contains(err.Error(), "escapes base directory"),
+				"error should mention escape; got: %v", err)
+		})
+	}
 }

--- a/xsd/path_escape_test.go
+++ b/xsd/path_escape_test.go
@@ -1,0 +1,40 @@
+package xsd_test
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// xs:include / xs:import / xs:redefine paths that "../"-escape the
+// compiler's baseDir must be rejected with a clear error. Defense-in-depth
+// for callers wiring in permissive fs.FS implementations; os.DirFS would
+// already refuse via fs.ValidPath, but the check here ensures consistent
+// behavior independent of the FS choice.
+func TestCompile_RejectsParentEscapeInSchemaLocation(t *testing.T) {
+	t.Parallel()
+
+	includer := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="../escape.xsd"/>
+</xs:schema>`
+
+	fsys := fstest.MapFS{
+		"schemas/main.xsd": &fstest.MapFile{Data: []byte(includer)},
+		// A file at the parent level the attacker might want to read.
+		"escape.xsd": &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"/>`)},
+	}
+
+	data, err := fsys.ReadFile("schemas/main.xsd")
+	require.NoError(t, err)
+	doc, err := helium.NewParser().Parse(t.Context(), data)
+	require.NoError(t, err)
+
+	_, err = xsd.NewCompiler().FS(fsys).BaseDir("schemas").Label("schemas/main.xsd").Compile(t.Context(), doc)
+	require.Error(t, err, "compile must reject schemaLocation that escapes baseDir")
+	require.True(t, strings.Contains(err.Error(), "escapes base directory"),
+		"error should mention escape; got: %v", err)
+}


### PR DESCRIPTION
- xsd loadInclude/loadRedefine/loadImport and relaxng resolveHref now compute filepath.Rel(baseDir, joined) and refuse paths whose result begins with ".."
- defense-in-depth alongside whatever the configured fs.FS enforces — os.DirFS rejects via ValidPath already, but permissive fs.FS implementations now see consistent containment
- baseDir containing ".." segments (common in test fixtures) is unaffected because filepath.Rel is comparing back to the same anchor