### PR TITLE
Add topological ordering to link_refs

### DIFF
--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -165,8 +165,34 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 		}
 	}
 
-	// Merge content models for extension types.
+	// Institute topological ordering of types to ensure child components are processed before they are consumed
+	extensionTypes := make([]*TypeDef, 0, len(c.typeRefs))
 	for td := range c.typeRefs {
+		if td.Derivation != DerivationExtension || td.BaseType == nil {
+			continue
+		}
+		extensionTypes = append(extensionTypes, td)
+	}
+	typeDepth := make(map[*TypeDef]int, len(extensionTypes))
+	var depth func(td *TypeDef) int
+	depth = func(td *TypeDef) int {
+		if td == nil {
+			return 0
+		}
+		if d, ok := typeDepth[td]; ok {
+			return d
+		}
+		typeDepth[td] = 0 // cycle guard; XSD forbids cyclic extension but defend anyway
+		d := 1 + depth(td.BaseType)
+		typeDepth[td] = d
+		return d
+	}
+	sort.Slice(extensionTypes, func(i, j int) bool {
+		return depth(extensionTypes[i]) < depth(extensionTypes[j])
+	})
+
+	// Merge content models for extension types.
+	for _, td := range extensionTypes {
 		if td.Derivation != DerivationExtension || td.BaseType == nil {
 			continue
 		}


### PR DESCRIPTION
**Describe the bug**
`xsd.Compiler.Compile` is nondeterministic for schemas containing multi-level `xs:complexContent/xs:extension` chains. The merge loop iterates `c.typeRefs` (a Go map, randomized per process) and captures a pointer to the base's `ContentModel` at the moment of merge. If iteration visits a derived type before its base has been merged, the captured pointer is orphaned by the base's later reassignment, and the derived type's merged content model silently omits transitively inherited particles.

go version: `go version go1.26.3 darwin/arm64`

**To Reproduce / Expected behavior**
Standalone test (drop in a fresh module with go get github.com/lestrrat-go/helium@v0.0.1):

```
package main

import (
    "context"
    "strings"
    "testing"

    helium "github.com/lestrrat-go/helium"
    "github.com/lestrrat-go/helium/xsd"
)

func TestExtensionChain(t *testing.T) {
    ctx := context.Background()

    const schemaXSD = `<?xml version="1.0" encoding="UTF-8"?>
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
  <xs:complexType name="A">
    <xs:sequence><xs:element name="Required" type="xs:string"/></xs:sequence>
  </xs:complexType>
  <xs:complexType name="B">
    <xs:complexContent><xs:extension base="A">
      <xs:sequence><xs:element name="MidExtra" type="xs:string" minOccurs="0"/></xs:sequence>
    </xs:extension></xs:complexContent>
  </xs:complexType>
  <xs:complexType name="C">
    <xs:complexContent><xs:extension base="B">
      <xs:sequence><xs:element name="LeafExtra" type="xs:string" minOccurs="0"/></xs:sequence>
    </xs:extension></xs:complexContent>
  </xs:complexType>
  <xs:element name="Doc" type="C"/>
</xs:schema>`

    const docXML = `<?xml version="1.0"?><Doc><Required>x</Required></Doc>`

    pass, fail := 0, 0
    var firstErr string
    for i := 0; i < 100; i++ {
        schemaDom, err := helium.NewParser().Parse(ctx, []byte(schemaXSD))
        if err != nil { t.Fatalf("iter %d: parse schema: %v", i, err) }
        schema, err := xsd.NewCompiler().Compile(ctx, schemaDom)
        if err != nil { t.Fatalf("iter %d: compile: %v", i, err) }
        doc, err := helium.NewParser().Parse(ctx, []byte(docXML))
        if err != nil { t.Fatalf("iter %d: parse doc: %v", i, err) }

        collector := helium.NewErrorCollector(ctx, 0)
        if err := xsd.NewValidator(schema).ErrorHandler(collector).Validate(ctx, doc); err != nil {
            fail++
            if firstErr == "" {
                if c := collector.Errors(); len(c) > 0 {
                    firstErr = c[0].Error()
                }
            }
        } else {
            pass++
        }
    }
    t.Logf("PASS: %d / 100, FAIL: %d / 100", pass, fail)
    if fail > 0 {
        t.Logf("first failure: %s", strings.SplitN(firstErr, "\n", 2)[0])
        t.Errorf("expected zero failures across 100 iterations; got %d", fail)
    }
}
```
Expected: every iteration validates successfully; Required is a member of A and Doc/C transitively inherits it.

Actual (observed locally, helium@v0.0.1, go1.26.3 darwin/arm64):


PASS: 85 / 100, FAIL: 15 / 100
first failure: `(string):1: Schemas validity error : Element 'Required: This element is not expected.`
The pass/fail ratio varies between test runs because each iteration draws independently from c.typeRefs's randomized map iteration. Schemas with longer extension chains push the failure rate toward 50%.

**Additional context**
Suspected source: [xsd/link_refs.go](https://github.com/lestrrat-go/helium/blob/main/xsd/link_refs.go), the extension-merge loop:

```
for td := range c.typeRefs {
    if td.Derivation != DerivationExtension || td.BaseType == nil { continue }
    ...
    merged := &ModelGroup{
        Particles: []*Particle{
            {... Term: baseMG},     // captured pointer
            {... Term: derivedMG},
        },
    }
    td.ContentModel = merged        // fresh allocation; doesn't mutate old
}
```
For chain A → B → C visited in order (B, A, C): B captures A's pre-merge pointer; A's later merge reassigns A.ContentModel to a new *ModelGroup; C then captures B.ContentModel, whose Term still points at A's old (now orphaned) model. The Required particle becomes unreachable from C.

Precedent: [xsd/compile.go](https://github.com/lestrrat-go/helium/blob/main/xsd/compile.go) sorts substitution-group members with // Sort substitution group members for deterministic error messages

A fix that resolves the issue locally is to sort extension types by base-chain depth (ascending) before running the merge body, so every derived type sees a fully-merged base. Happy to send this as a PR if useful.