### PR TITLE
xsd: deterministic extension-merge order

### DIFF
--- a/xsd/extension_chain_test.go
+++ b/xsd/extension_chain_test.go
@@ -37,7 +37,7 @@ func TestExtensionChainDeterministic(t *testing.T) {
 
 	const docXML = `<?xml version="1.0"?><Doc><Required>x</Required></Doc>`
 
-	for i := 0; i < 200; i++ {
+	for i := range 200 {
 		schemaDOM, err := helium.NewParser().Parse(t.Context(), []byte(schemaXSD))
 		require.NoError(t, err, "iter %d: parse schema", i)
 		schema, err := xsd.NewCompiler().Compile(t.Context(), schemaDOM)

--- a/xsd/extension_chain_test.go
+++ b/xsd/extension_chain_test.go
@@ -1,0 +1,58 @@
+package xsd_test
+
+import (
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExtensionChainDeterministic guards against issue #437: the extension
+// content-model merge in link_refs.go iterated c.typeRefs (a Go map, randomized
+// per call) and captured the base type's ContentModel at merge time. When a
+// derived type was merged before its base, the captured pointer was orphaned by
+// the base's later reassignment, silently dropping transitively-inherited
+// particles. A multi-level A->B->C extension chain therefore validated
+// nondeterministically. Compiling many times exercises different map orders.
+func TestExtensionChainDeterministic(t *testing.T) {
+	const schemaXSD = `<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="A">
+    <xs:sequence><xs:element name="Required" type="xs:string"/></xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="B">
+    <xs:complexContent><xs:extension base="A">
+      <xs:sequence><xs:element name="MidExtra" type="xs:string" minOccurs="0"/></xs:sequence>
+    </xs:extension></xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="C">
+    <xs:complexContent><xs:extension base="B">
+      <xs:sequence><xs:element name="LeafExtra" type="xs:string" minOccurs="0"/></xs:sequence>
+    </xs:extension></xs:complexContent>
+  </xs:complexType>
+  <xs:element name="Doc" type="C"/>
+</xs:schema>`
+
+	const docXML = `<?xml version="1.0"?><Doc><Required>x</Required></Doc>`
+
+	for i := 0; i < 200; i++ {
+		schemaDOM, err := helium.NewParser().Parse(t.Context(), []byte(schemaXSD))
+		require.NoError(t, err, "iter %d: parse schema", i)
+		schema, err := xsd.NewCompiler().Compile(t.Context(), schemaDOM)
+		require.NoError(t, err, "iter %d: compile", i)
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(docXML))
+		require.NoError(t, err, "iter %d: parse doc", i)
+
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		err = xsd.NewValidator(schema).ErrorHandler(collector).Validate(t.Context(), doc)
+		if err != nil {
+			var first string
+			if errs := collector.Errors(); len(errs) > 0 {
+				first = strings.SplitN(errs[0].Error(), "\n", 2)[0]
+			}
+			t.Fatalf("iter %d: expected valid; transitively-inherited particle dropped: %s", i, first)
+		}
+	}
+}

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -165,8 +165,34 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 		}
 	}
 
-	// Merge content models for extension types.
+	// Institute topological ordering of types to ensure child components are processed before they are consumed
+	extensionTypes := make([]*TypeDef, 0, len(c.typeRefs))
 	for td := range c.typeRefs {
+		if td.Derivation != DerivationExtension || td.BaseType == nil {
+			continue
+		}
+		extensionTypes = append(extensionTypes, td)
+	}
+	typeDepth := make(map[*TypeDef]int, len(extensionTypes))
+	var depth func(td *TypeDef) int
+	depth = func(td *TypeDef) int {
+		if td == nil {
+			return 0
+		}
+		if d, ok := typeDepth[td]; ok {
+			return d
+		}
+		typeDepth[td] = 0 // cycle guard; XSD forbids cyclic extension but defend anyway
+		d := 1 + depth(td.BaseType)
+		typeDepth[td] = d
+		return d
+	}
+	sort.Slice(extensionTypes, func(i, j int) bool {
+		return depth(extensionTypes[i]) < depth(extensionTypes[j])
+	})
+
+	// Merge content models for extension types.
+	for _, td := range extensionTypes {
 		if td.Derivation != DerivationExtension || td.BaseType == nil {
 			continue
 		}

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -187,15 +187,25 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 		typeDepth[td] = d
 		return d
 	}
-	// Stable sort with a source-line tie-break so error messages emitted during
-	// the merge (e.g. cos-ct-extends-1-1, duplicate attribute) are deterministic
-	// among equal-depth types, matching the restriction loop below.
+	// Stable sort with source-line then QName tie-breaks so error messages
+	// emitted during the merge (e.g. cos-ct-extends-1-1, duplicate attribute)
+	// are deterministic among equal-depth types, matching the restriction loop
+	// below. Line alone is insufficient — multiple types can share a line (e.g.
+	// minified schemas), so fall back to QName before the randomized map order.
 	sort.SliceStable(extensionTypes, func(i, j int) bool {
-		di, dj := depth(extensionTypes[i]), depth(extensionTypes[j])
+		ti, tj := extensionTypes[i], extensionTypes[j]
+		di, dj := depth(ti), depth(tj)
 		if di != dj {
 			return di < dj
 		}
-		return c.typeDefSources[extensionTypes[i]].line < c.typeDefSources[extensionTypes[j]].line
+		li, lj := c.typeDefSources[ti].line, c.typeDefSources[tj].line
+		if li != lj {
+			return li < lj
+		}
+		if ti.Name.NS != tj.Name.NS {
+			return ti.Name.NS < tj.Name.NS
+		}
+		return ti.Name.Local < tj.Name.Local
 	})
 
 	// Merge content models for extension types. extensionTypes is already

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -187,15 +187,20 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 		typeDepth[td] = d
 		return d
 	}
-	sort.Slice(extensionTypes, func(i, j int) bool {
-		return depth(extensionTypes[i]) < depth(extensionTypes[j])
+	// Stable sort with a source-line tie-break so error messages emitted during
+	// the merge (e.g. cos-ct-extends-1-1, duplicate attribute) are deterministic
+	// among equal-depth types, matching the restriction loop below.
+	sort.SliceStable(extensionTypes, func(i, j int) bool {
+		di, dj := depth(extensionTypes[i]), depth(extensionTypes[j])
+		if di != dj {
+			return di < dj
+		}
+		return c.typeDefSources[extensionTypes[i]].line < c.typeDefSources[extensionTypes[j]].line
 	})
 
-	// Merge content models for extension types.
+	// Merge content models for extension types. extensionTypes is already
+	// filtered to extension types with a base, so no per-item guard is needed.
 	for _, td := range extensionTypes {
-		if td.Derivation != DerivationExtension || td.BaseType == nil {
-			continue
-		}
 		if td.ContentType == ContentTypeSimple {
 			// simpleContent extension — inherit attributes and wildcard from base.
 			if td.BaseType.Attributes != nil {

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -165,7 +165,9 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 		}
 	}
 
-	// Institute topological ordering of types to ensure child components are processed before they are consumed
+	// Topologically order extension types so each base type is merged before
+	// the types that derive from it (the merge reads the base's finalized
+	// content model and attributes).
 	extensionTypes := make([]*TypeDef, 0, len(c.typeRefs))
 	for td := range c.typeRefs {
 		if td.Derivation != DerivationExtension || td.BaseType == nil {


### PR DESCRIPTION
- Cherry-picks #437 (topological ordering of extension types) — fixes nondeterministic dropped particles in multi-level `xs:complexContent` extension chains, which could false-accept documents missing transitively-inherited required content
- Stable sort + source-line tie-break so compile errors among equal-depth types are deterministic
- Adds 200-iteration regression test
