### PR TITLE
xsd: consume non-first choice branch after an omitted optional element

### DIFF
--- a/xsd/validate_elem.go
+++ b/xsd/validate_elem.go
@@ -457,9 +457,20 @@ func (vc *validationContext) tryMatchSequence(ctx context.Context, mg *ModelGrou
 }
 
 func (vc *validationContext) tryMatchChoice(ctx context.Context, mg *ModelGroup, children []childElem, pos int) (int, error) {
+	// Prefer a branch that consumes at least one child, mirroring matchChoice.
+	// An earlier optional branch can match zero-length, but a later branch may
+	// be the one that actually consumes the current child; returning the
+	// zero-length match first would leave that child stranded.
 	for _, p := range mg.Particles {
 		consumed, err := vc.tryMatchParticle(ctx, p, children, pos)
-		if err == nil {
+		if err == nil && consumed > 0 {
+			return consumed, nil
+		}
+	}
+	// Fall back to a zero-length (optional) branch.
+	for _, p := range mg.Particles {
+		consumed, err := vc.tryMatchParticle(ctx, p, children, pos)
+		if err == nil && consumed == 0 {
 			return consumed, nil
 		}
 	}

--- a/xsd/validate_optional_choice_test.go
+++ b/xsd/validate_optional_choice_test.go
@@ -1,0 +1,67 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOptionalElementBeforeChoice covers a content model where an optional
+// element precedes a choice of optional branches:
+//
+//	sequence{ Lead?, choice{ P?, Q? } }
+//
+// When the optional Lead element is omitted and the instance selects a choice
+// branch other than the first, the lookahead must still consume the chosen
+// branch instead of stopping at the first zero-length-matching branch.
+func TestOptionalElementBeforeChoice(t *testing.T) {
+	t.Parallel()
+
+	schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Lead" type="xs:string" minOccurs="0"/>
+        <xs:choice>
+          <xs:element name="P" type="xs:string" minOccurs="0"/>
+          <xs:element name="Q" type="xs:string" minOccurs="0"/>
+        </xs:choice>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+	schemaDOC, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+	require.NoError(t, err)
+	schema, err := xsd.NewCompiler().Compile(t.Context(), schemaDOC)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		instance string
+		valid    bool
+	}{
+		{"omit Lead, pick first branch", `<root><P>x</P></root>`, true},
+		{"omit Lead, pick second branch", `<root><Q>x</Q></root>`, true},
+		{"include Lead, pick second branch", `<root><Lead>l</Lead><Q>x</Q></root>`, true},
+		{"omit Lead, empty choice", `<root/>`, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(tc.instance))
+			require.NoError(t, err)
+
+			var errs string
+			err = validateWithOutput(t, xsd.NewValidator(schema), doc, &errs)
+			if tc.valid {
+				require.NoError(t, err, "expected valid, got errors: %s", errs)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #441.

`tryMatchChoice` returned the first branch that matched, including a zero-length match on an optional branch. For a content model like `sequence{ Lead?, choice{ P?, Q? } }`, when `Lead` is omitted and the instance picks a branch other than the first (`<root><Q/></root>`), the lookahead stopped at the first zero-length-matching branch (`P?`) and left `Q` unconsumed, reported as `Element 'Q': This element is not expected`.

The fix makes `tryMatchChoice` prefer a branch that consumes at least one child before falling back to a zero-length branch, mirroring the two-pass logic `matchChoice` already uses. Added `TestOptionalElementBeforeChoice` covering both branches, with and without the optional lead element, and the empty case. Full `xsd` suite passes; the only failing test in the repo (`xpath3/TestQT3_fn_timezone_from_date`) is unrelated and pre-existing on main.