### PR TITLE
xsd: fractionDigits counts significant fraction digits, not lexical

### DIFF
--- a/xsd/simplevalue_facets.go
+++ b/xsd/simplevalue_facets.go
@@ -227,9 +227,10 @@ func countTotalDigits(value string) int {
 	return total
 }
 
-// countFractionDigits counts the number of digits after the decimal point.
-// If there is no decimal point, returns 0.
-// Trailing zeros are significant: "1.20" → 2, "1.0" → 1.
+// countFractionDigits counts the number of significant digits after the
+// decimal point. The fractionDigits facet constrains the value, not the
+// lexical form, so trailing zeros are not significant: "1.20" → 1, "2.00" → 0,
+// "1.0" → 0. If there is no decimal point, returns 0.
 func countFractionDigits(value string) int {
 	s := value
 	if len(s) > 0 && (s[0] == '+' || s[0] == '-') {
@@ -239,7 +240,7 @@ func countFractionDigits(value string) int {
 	if dotIdx < 0 {
 		return 0
 	}
-	return len(s) - dotIdx - 1
+	return len(strings.TrimRight(s[dotIdx+1:], "0"))
 }
 
 // facetLength returns the effective length of a value for facet checking.

--- a/xsd/simplevalue_facets.go
+++ b/xsd/simplevalue_facets.go
@@ -236,11 +236,11 @@ func countFractionDigits(value string) int {
 	if len(s) > 0 && (s[0] == '+' || s[0] == '-') {
 		s = s[1:]
 	}
-	dotIdx := strings.Index(s, ".")
-	if dotIdx < 0 {
+	_, frac, found := strings.Cut(s, ".")
+	if !found {
 		return 0
 	}
-	return len(strings.TrimRight(s[dotIdx+1:], "0"))
+	return len(strings.TrimRight(frac, "0"))
 }
 
 // facetLength returns the effective length of a value for facet checking.

--- a/xsd/validate_fractiondigits_test.go
+++ b/xsd/validate_fractiondigits_test.go
@@ -1,0 +1,62 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFractionDigitsTrailingZeros checks that the fractionDigits facet counts
+// significant fraction digits of the value, not lexical characters. Trailing
+// zeros are not significant: "2.00" has the same value as "2", so it satisfies
+// fractionDigits="1".
+func TestFractionDigitsTrailingZeros(t *testing.T) {
+	t.Parallel()
+
+	schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" type="oneFracDigit"/>
+  <xs:simpleType name="oneFracDigit">
+    <xs:restriction base="xs:decimal">
+      <xs:fractionDigits value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`
+
+	schemaDOC, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+	require.NoError(t, err)
+	schema, err := xsd.NewCompiler().Compile(t.Context(), schemaDOC)
+	require.NoError(t, err)
+
+	cases := []struct {
+		value string
+		valid bool
+	}{
+		{"2.0", true},
+		{"2.00", true},  // trailing zero — value has 0 fraction digits
+		{"2.000", true}, // more trailing zeros
+		{"2", true},
+		{"2.5", true},
+		{"-3.00", true},
+		{"2.50", true},  // one significant fraction digit, then a trailing zero
+		{"2.05", false}, // two significant fraction digits
+		{"2.55", false}, // two significant fraction digits
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.value, func(t *testing.T) {
+			t.Parallel()
+			doc, err := helium.NewParser().Parse(t.Context(), []byte("<root>"+tc.value+"</root>"))
+			require.NoError(t, err)
+
+			var errs string
+			err = validateWithOutput(t, xsd.NewValidator(schema), doc, &errs)
+			if tc.valid {
+				require.NoError(t, err, "expected valid, got: %s", errs)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #444.

`countFractionDigits` counted every character after the decimal point, so a decimal like `2.00` was treated as having 2 fraction digits and rejected against `fractionDigits="1"`. The `fractionDigits` facet constrains the value, not the lexical form: trailing zeros are not significant, and `2.00` has the same value as `2` (0 fraction digits). libxml2 accepts it.

The fix strips trailing zeros before counting, mirroring `countTotalDigits`, which already does this (the two were inconsistent). Adds `TestFractionDigitsTrailingZeros`. Full `xsd` suite passes.

---

I'm currently working on making helium work with the EPRX API which has relatively complex validation requirements. Link is here: https://www.occto.or.jp/iken/2025_250731_jyukyubpkiyakuan.html