### PR TITLE
xsd: honor group min/maxoccurs in lookahead

### DIFF
--- a/xsd/validate_elem.go
+++ b/xsd/validate_elem.go
@@ -445,36 +445,94 @@ func (vc *validationContext) tryMatchModelGroup(ctx context.Context, mg *ModelGr
 }
 
 func (vc *validationContext) tryMatchSequence(ctx context.Context, mg *ModelGroup, children []childElem, pos int) (int, error) {
-	cur := pos
-	for _, p := range mg.Particles {
-		consumed, err := vc.tryMatchParticle(ctx, p, children, cur)
-		if err != nil {
-			return 0, err
+	minReps := mg.MinOccurs
+	maxReps := mg.MaxOccurs
+
+	scanOnce := func(p int) (int, error) {
+		cur := p
+		for _, particle := range mg.Particles {
+			consumed, err := vc.tryMatchParticle(ctx, particle, children, cur)
+			if err != nil {
+				return 0, err
+			}
+			cur += consumed
 		}
+		return cur - p, nil
+	}
+
+	cur := pos
+	reps := 0
+	for maxReps == Unbounded || reps < maxReps {
+		consumed, err := scanOnce(cur)
+		if err != nil {
+			break
+		}
+		reps++
 		cur += consumed
+		if consumed == 0 {
+			// Zero-length iteration: further iterations would also be
+			// zero-length, so count remaining required reps at once.
+			if reps < minReps {
+				reps = minReps
+			}
+			break
+		}
+	}
+
+	if reps < minReps {
+		return 0, fmt.Errorf("insufficient sequence repetitions")
 	}
 	return cur - pos, nil
 }
 
 func (vc *validationContext) tryMatchChoice(ctx context.Context, mg *ModelGroup, children []childElem, pos int) (int, error) {
-	// Prefer a branch that consumes at least one child, mirroring matchChoice.
-	// An earlier optional branch can match zero-length, but a later branch may
-	// be the one that actually consumes the current child; returning the
-	// zero-length match first would leave that child stranded.
-	for _, p := range mg.Particles {
-		consumed, err := vc.tryMatchParticle(ctx, p, children, pos)
-		if err == nil && consumed > 0 {
-			return consumed, nil
+	minReps := mg.MinOccurs
+	maxReps := mg.MaxOccurs
+
+	scanOnce := func(p int) (int, bool) {
+		// Prefer a branch that consumes at least one child, mirroring
+		// matchChoice. An earlier optional branch can match zero-length, but a
+		// later branch may be the one that actually consumes the current child;
+		// returning the zero-length match first would leave that child stranded.
+		for _, particle := range mg.Particles {
+			consumed, err := vc.tryMatchParticle(ctx, particle, children, p)
+			if err == nil && consumed > 0 {
+				return consumed, true
+			}
+		}
+		// Fall back to a zero-length (optional) branch.
+		for _, particle := range mg.Particles {
+			consumed, err := vc.tryMatchParticle(ctx, particle, children, p)
+			if err == nil && consumed == 0 {
+				return consumed, true
+			}
+		}
+		return 0, false
+	}
+
+	cur := pos
+	reps := 0
+	for maxReps == Unbounded || reps < maxReps {
+		consumed, ok := scanOnce(cur)
+		if !ok {
+			break
+		}
+		reps++
+		cur += consumed
+		if consumed == 0 {
+			// Zero-length iteration: further iterations would also be
+			// zero-length, so count remaining required reps at once.
+			if reps < minReps {
+				reps = minReps
+			}
+			break
 		}
 	}
-	// Fall back to a zero-length (optional) branch.
-	for _, p := range mg.Particles {
-		consumed, err := vc.tryMatchParticle(ctx, p, children, pos)
-		if err == nil && consumed == 0 {
-			return consumed, nil
-		}
+
+	if reps < minReps {
+		return 0, fmt.Errorf("insufficient choice repetitions")
 	}
-	return 0, fmt.Errorf("no choice matched")
+	return cur - pos, nil
 }
 
 func (vc *validationContext) tryMatchAll(_ context.Context, mg *ModelGroup, children []childElem, pos int) (int, error) {

--- a/xsd/validate_lookahead_repetition_test.go
+++ b/xsd/validate_lookahead_repetition_test.go
@@ -1,0 +1,69 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLookaheadGroupRepetition covers a content model where a repeating nested
+// model group sits as a non-final particle inside an outer repeating sequence:
+//
+//	sequence(minOccurs=0, maxOccurs=2){ sequence(maxOccurs=2){ a }, b }
+//
+// The lookahead used to position the following particle (`b`) must honor the
+// inner group's own minOccurs/maxOccurs. A single-pass scan under-counts the
+// inner group's consumed length and mis-positions `b`, wrongly rejecting valid
+// content. An over-max repetition of the inner group must still be rejected.
+func TestLookaheadGroupRepetition(t *testing.T) {
+	t.Parallel()
+
+	schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence minOccurs="0" maxOccurs="2">
+        <xs:sequence maxOccurs="2">
+          <xs:element name="a" type="xs:string"/>
+        </xs:sequence>
+        <xs:element name="b" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+	schemaDOC, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+	require.NoError(t, err)
+	schema, err := xsd.NewCompiler().Compile(t.Context(), schemaDOC)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		instance string
+		valid    bool
+	}{
+		{"single a then b", `<root><a>1</a><b>1</b></root>`, true},
+		{"repeated inner a then b", `<root><a>1</a><a>2</a><b>1</b></root>`, true},
+		{"two outer reps", `<root><a>1</a><a>2</a><b>1</b><a>3</a><a>4</a><b>2</b></root>`, true},
+		{"empty", `<root/>`, true},
+		// Inner group permits at most two `a`; a third must be rejected.
+		{"inner over max", `<root><a>1</a><a>2</a><a>3</a><b>1</b></root>`, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(tc.instance))
+			require.NoError(t, err)
+
+			var errs string
+			err = validateWithOutput(t, xsd.NewValidator(schema), doc, &errs)
+			if tc.valid {
+				require.NoError(t, err, "expected valid, got errors: %s", errs)
+				return
+			}
+			require.Error(t, err)
+		})
+	}
+}

--- a/xsd/validate_lookahead_repetition_test.go
+++ b/xsd/validate_lookahead_repetition_test.go
@@ -46,7 +46,7 @@ func TestLookaheadGroupRepetition(t *testing.T) {
 		{"single a then b", `<root><a>1</a><b>1</b></root>`, true},
 		{"repeated inner a then b", `<root><a>1</a><a>2</a><b>1</b></root>`, true},
 		{"two outer reps", `<root><a>1</a><a>2</a><b>1</b><a>3</a><a>4</a><b>2</b></root>`, true},
-		{"empty", `<root/>`, true},
+		{"empty", `<root></root>`, true},
 		// Inner group permits at most two `a`; a third must be rejected.
 		{"inner over max", `<root><a>1</a><a>2</a><a>3</a><b>1</b></root>`, false},
 	}


### PR DESCRIPTION
- Fixes a content-model lookahead under-count: `tryMatchSequence`/`tryMatchChoice` scanned a model group's particles once, ignoring the group's own `minOccurs`/`maxOccurs`.
- A repeating nested group as a non-final particle was under-measured, mis-positioning the following particle and wrongly rejecting valid content.
- Wraps the lookahead scan in a reps loop mirroring `matchSequence`/`matchChoice`, with a new regression test.
