### PR TITLE
relaxng: prefer consuming branch in naive choice

### DIFF
--- a/relaxng/choice_progress_test.go
+++ b/relaxng/choice_progress_test.go
@@ -1,0 +1,52 @@
+package relaxng_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/relaxng"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStartChoiceProgressPreference covers the naive choice matcher reached when
+// grammar.start is a bare <choice>. A zero-length <empty/> branch must not shadow
+// a later consuming branch: choice(empty, element root{empty}) against <root/>
+// should validate.
+func TestStartChoiceProgressPreference(t *testing.T) {
+	t.Parallel()
+
+	const schema = `<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <choice>
+      <empty/>
+      <element name="root"><empty/></element>
+    </choice>
+  </start>
+</grammar>`
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(schema))
+	require.NoError(t, err)
+
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	grammar, err := relaxng.NewCompiler().ErrorHandler(collector).Compile(t.Context(), doc)
+	require.NoError(t, err)
+	_ = collector.Close()
+	_, compileErrors := partitionCompileErrors(collector.Errors())
+	require.Empty(t, compileErrors, "schema should compile without errors")
+
+	t.Run("consuming branch chosen over empty", func(t *testing.T) {
+		xmlDoc, err := helium.NewParser().Parse(t.Context(), []byte(`<root/>`))
+		require.NoError(t, err)
+
+		err = relaxng.NewValidator(grammar).Validate(t.Context(), xmlDoc)
+		require.NoError(t, err, "<root/> should validate against choice(empty, element root)")
+	})
+
+	t.Run("genuinely invalid instance rejected", func(t *testing.T) {
+		xmlDoc, err := helium.NewParser().Parse(t.Context(), []byte(`<wrong/>`))
+		require.NoError(t, err)
+
+		err = relaxng.NewValidator(grammar).Validate(t.Context(), xmlDoc)
+		require.Error(t, err, "<wrong/> should be rejected")
+	})
+}

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1248,22 +1248,34 @@ func (v *validator) validateChoice(pat *pattern, state *validState) int {
 	savedValid := v.valid
 
 	v.suppressDepth++
+	// Prefer a branch that makes progress (consumes input) over a zero-length
+	// match, so an early <empty/>/optional branch can't shadow a later
+	// consuming branch (mirrors the hardened validateContentPat choice case).
+	noProgressMatch := false
 	for _, child := range pat.children {
 		saved := state.clone()
-		if ret := v.validatePattern(child, saved); ret == 0 {
+		if ret := v.validatePattern(child, saved); ret != 0 {
+			continue
+		}
+		if !seqEqual(saved.seq, state.seq) {
+			// Branch made progress — use it.
 			v.suppressDepth--
-			// Restore error state (successful branch discards errors from prior branches)
 			v.pendingErrors = v.pendingErrors[:savedLen]
 			v.valid = savedValid
 			*state = *saved
 			return 0
 		}
+		// Succeeded but consumed nothing — remember and keep trying.
+		noProgressMatch = true
 	}
 	v.suppressDepth--
 
-	// All branches failed — restore error state (no branch errors emitted)
+	// Restore error state (no branch errors emitted).
 	v.pendingErrors = v.pendingErrors[:savedLen]
 	v.valid = savedValid
+	if noProgressMatch {
+		return 0
+	}
 	return -1
 }
 


### PR DESCRIPTION
- Naive `validateChoice` now prefers a branch that consumes input over a zero-length match, so an early `<empty/>`/optional branch no longer shadows a later consuming branch (mirrors the hardened `validateContentPat` choice case).
- Adds a regression test: `start = choice(empty, element root{empty})` now validates `<root/>` while still rejecting `<wrong/>`.
