### PR TITLE
xsd: compare enumeration in value space

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -46,8 +46,10 @@ decimal `5.0`≡`5`, boolean `1`≡`true`, float `1.50`≡`1.5`, equal dateTimes
 different timezones). For float/double, NaN equals NaN for enumeration (but
 remains incomparable for min/max ordering). QName/NOTATION enumeration resolves
 both instance and facet lexical QNames against their respective in-scope
-namespaces. String-family types where `value.Compare` cannot compare fall back
-to the lexical-equality test.
+namespaces. Value-space comparison is restricted to an allowlist of numeric,
+boolean, and date/time builtins (`enumValueSpaceTypes`); string-family, binary,
+and anyURI types are lexical-only, so a numeric-looking string enum `"5"` does
+not accept `"5.0"`.
 
 **Pass 2 — Identity Constraints** (`validateIDConstraints` via second `helium.Walk()`):
 - For elements with IDCs (xs:unique, xs:key, xs:keyref):

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -40,10 +40,14 @@ Files: `xsd/xsd.go` (API), `compile*.go` + `read_*.go` + `link_refs.go` + `check
      - Simple: no child elements, validate text vs type facets
      - Element-only/Mixed: match children against ModelGroup (`matchSequence()`/`matchChoice()`)
 
-QName/NOTATION simple-value validation compares enumeration facets in value
-space, not raw prefix text. Instance lexical QNames are resolved against the
-instance node's in-scope namespaces; facet lexical QNames are resolved against
-the schema facet's in-scope namespaces.
+Enumeration facets are compared in value space, not raw lexical text. A value is
+a member if it lexically equals a member OR value-compares equal to one (e.g.
+decimal `5.0`≡`5`, boolean `1`≡`true`, float `1.50`≡`1.5`, equal dateTimes in
+different timezones). For float/double, NaN equals NaN for enumeration (but
+remains incomparable for min/max ordering). QName/NOTATION enumeration resolves
+both instance and facet lexical QNames against their respective in-scope
+namespaces. String-family types where `value.Compare` cannot compare fall back
+to the lexical-equality test.
 
 **Pass 2 — Identity Constraints** (`validateIDConstraints` via second `helium.Walk()`):
 - For elements with IDCs (xs:unique, xs:key, xs:keyref):

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -47,9 +47,11 @@ different timezones). For float/double, NaN equals NaN for enumeration (but
 remains incomparable for min/max ordering). QName/NOTATION enumeration resolves
 both instance and facet lexical QNames against their respective in-scope
 namespaces. Value-space comparison is restricted to an allowlist of numeric,
-boolean, and date/time builtins (`enumValueSpaceTypes`); string-family, binary,
-and anyURI types are lexical-only, so a numeric-looking string enum `"5"` does
-not accept `"5.0"`.
+boolean, date/time, and binary builtins (`enumValueSpaceTypes`); hexBinary and
+base64Binary compare by decoded octets (so `"0A"`≡`"0a"`). String-family and
+anyURI types stay lexical-only (their value space equals their whitespace-
+processed lexical space), so a numeric-looking string enum `"5"` does not accept
+`"5.0"`.
 
 **Pass 2 — Identity Constraints** (`validateIDConstraints` via second `helium.Walk()`):
 - For elements with IDCs (xs:unique, xs:key, xs:keyref):

--- a/internal/xsd/value/compare.go
+++ b/internal/xsd/value/compare.go
@@ -128,11 +128,17 @@ func decodeBase64Binary(s string) ([]byte, bool) {
 		}
 		return r
 	}, s)
-	decoded, err := base64.StdEncoding.DecodeString(stripped)
-	if err != nil {
-		return nil, false
+	if decoded, err := base64.StdEncoding.DecodeString(stripped); err == nil {
+		return decoded, true
 	}
-	return decoded, true
+	// validateBase64Binary is regex-only, so it admits unpadded (and partially
+	// padded) forms that StdEncoding rejects. Fall back to RawStdEncoding after
+	// dropping any partial padding, so a value-space comparison still succeeds
+	// for a value the lexical validator accepted (e.g. "TQ" == "TQ==").
+	if decoded, err := base64.RawStdEncoding.DecodeString(strings.TrimRight(stripped, "=")); err == nil {
+		return decoded, true
+	}
+	return nil, false
 }
 
 func parseXSDFloat(s string) (float64, bool) {

--- a/internal/xsd/value/compare.go
+++ b/internal/xsd/value/compare.go
@@ -1,6 +1,9 @@
 package value
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
 	"math"
 	"math/big"
 	"strconv"
@@ -34,6 +37,10 @@ func Compare(a, b, builtinLocal string) (int, bool) {
 		return compareGMonthDay(a, b)
 	case "duration":
 		return compareDuration(a, b)
+	case "hexBinary":
+		return compareHexBinary(a, b)
+	case "base64Binary":
+		return compareBase64Binary(a, b)
 	default:
 		cmp := CompareDecimal(a, b)
 		if cmp == -2 {
@@ -66,9 +73,10 @@ func parseXSDBoolean(s string) (bool, bool) {
 	return false, false
 }
 
-// compareBoolean compares two xs:boolean values in value space. Booleans have
-// no ordering, so only equality is meaningful: equal values return 0, distinct
-// values return a nonzero result whose sign is arbitrary but stable.
+// compareBoolean compares two xs:boolean values in value space. xs:boolean has
+// no order relation in XSD, so callers should rely only on equality (cmp == 0).
+// For a total, deterministic result this orders false < true; equal values
+// return 0.
 func compareBoolean(a, b string) (int, bool) {
 	ba, ok1 := parseXSDBoolean(a)
 	bb, ok2 := parseXSDBoolean(b)
@@ -84,13 +92,62 @@ func compareBoolean(a, b string) (int, bool) {
 	return 1, true
 }
 
+// compareHexBinary compares two xs:hexBinary values in value space (the decoded
+// octet sequence), so lexically distinct forms that decode to the same bytes are
+// equal (e.g. "0A" == "0a"). hexBinary has no order relation; only equality is
+// meaningful. Returns ok=false if either operand is not valid hexBinary.
+func compareHexBinary(a, b string) (int, bool) {
+	da, err1 := hex.DecodeString(a)
+	db, err2 := hex.DecodeString(b)
+	if err1 != nil || err2 != nil {
+		return 0, false
+	}
+	if bytes.Equal(da, db) {
+		return 0, true
+	}
+	return 1, true
+}
+
+// compareBase64Binary compares two xs:base64Binary values in value space (the
+// decoded octet sequence), ignoring the whitespace permitted in the lexical
+// form. base64Binary has no order relation; only equality is meaningful. Returns
+// ok=false if either operand is not valid base64Binary.
+func compareBase64Binary(a, b string) (int, bool) {
+	da, ok1 := decodeBase64Binary(a)
+	db, ok2 := decodeBase64Binary(b)
+	if !ok1 || !ok2 {
+		return 0, false
+	}
+	if bytes.Equal(da, db) {
+		return 0, true
+	}
+	return 1, true
+}
+
+func decodeBase64Binary(s string) ([]byte, bool) {
+	stripped := strings.Map(func(r rune) rune {
+		if r == ' ' || r == '\n' || r == '\r' || r == '\t' {
+			return -1
+		}
+		return r
+	}, s)
+	decoded, err := base64.StdEncoding.DecodeString(stripped)
+	if err != nil {
+		return nil, false
+	}
+	return decoded, true
+}
+
 func parseXSDFloat(s string) (float64, bool) {
 	switch s {
 	case "INF", "+INF":
 		return math.Inf(1), true
 	case "-INF":
 		return math.Inf(-1), true
-	case "NaN":
+	// The float lexical validator (floatRegex) accepts an optional leading sign
+	// on NaN, so accept the signed forms here too for consistency. The sign is
+	// meaningless for NaN.
+	case "NaN", "+NaN", "-NaN":
 		return math.NaN(), true
 	}
 	f, err := strconv.ParseFloat(s, 64)
@@ -98,6 +155,13 @@ func parseXSDFloat(s string) (float64, bool) {
 		return 0, false
 	}
 	return f, true
+}
+
+// IsFloatNaN reports whether s is a valid xs:float/xs:double lexical form that
+// denotes NaN (including the sign-prefixed forms the lexical validator accepts).
+func IsFloatNaN(s string) bool {
+	f, ok := parseXSDFloat(s)
+	return ok && math.IsNaN(f)
 }
 
 func compareFloat(a, b string) (int, bool) {

--- a/internal/xsd/value/compare.go
+++ b/internal/xsd/value/compare.go
@@ -12,6 +12,8 @@ import (
 // is undefined (NaN, incomparable durations, parse failures).
 func Compare(a, b, builtinLocal string) (int, bool) {
 	switch builtinLocal {
+	case "boolean":
+		return compareBoolean(a, b)
 	case "float", "double":
 		return compareFloat(a, b)
 	case "dateTime":
@@ -50,6 +52,36 @@ func CompareDecimal(a, b string) int {
 		return -2
 	}
 	return ra.Cmp(rb)
+}
+
+// parseXSDBoolean canonicalizes an xs:boolean lexical form. "true"/"1" map to
+// true and "false"/"0" map to false. Any other input is not a valid boolean.
+func parseXSDBoolean(s string) (bool, bool) {
+	switch s {
+	case "true", "1":
+		return true, true
+	case "false", "0":
+		return false, true
+	}
+	return false, false
+}
+
+// compareBoolean compares two xs:boolean values in value space. Booleans have
+// no ordering, so only equality is meaningful: equal values return 0, distinct
+// values return a nonzero result whose sign is arbitrary but stable.
+func compareBoolean(a, b string) (int, bool) {
+	ba, ok1 := parseXSDBoolean(a)
+	bb, ok2 := parseXSDBoolean(b)
+	if !ok1 || !ok2 {
+		return 0, false
+	}
+	if ba == bb {
+		return 0, true
+	}
+	if !ba {
+		return -1, true
+	}
+	return 1, true
 }
 
 func parseXSDFloat(s string) (float64, bool) {

--- a/internal/xsd/value/compare.go
+++ b/internal/xsd/value/compare.go
@@ -94,34 +94,31 @@ func compareBoolean(a, b string) (int, bool) {
 
 // compareHexBinary compares two xs:hexBinary values in value space (the decoded
 // octet sequence), so lexically distinct forms that decode to the same bytes are
-// equal (e.g. "0A" == "0a"). hexBinary has no order relation; only equality is
-// meaningful. Returns ok=false if either operand is not valid hexBinary.
+// equal (e.g. "0A" == "0a"). XSD does not order hexBinary, but a deterministic,
+// antisymmetric total order (bytes.Compare of the decoded octets) is returned so
+// the result is a well-behaved comparator; enumeration only relies on cmp == 0.
+// Returns ok=false if either operand is not valid hexBinary.
 func compareHexBinary(a, b string) (int, bool) {
 	da, err1 := hex.DecodeString(a)
 	db, err2 := hex.DecodeString(b)
 	if err1 != nil || err2 != nil {
 		return 0, false
 	}
-	if bytes.Equal(da, db) {
-		return 0, true
-	}
-	return 1, true
+	return bytes.Compare(da, db), true
 }
 
 // compareBase64Binary compares two xs:base64Binary values in value space (the
 // decoded octet sequence), ignoring the whitespace permitted in the lexical
-// form. base64Binary has no order relation; only equality is meaningful. Returns
-// ok=false if either operand is not valid base64Binary.
+// form. As with hexBinary, a deterministic bytes.Compare total order is returned
+// rather than a bare equality flag. Returns ok=false if either operand is not
+// valid base64Binary.
 func compareBase64Binary(a, b string) (int, bool) {
 	da, ok1 := decodeBase64Binary(a)
 	db, ok2 := decodeBase64Binary(b)
 	if !ok1 || !ok2 {
 		return 0, false
 	}
-	if bytes.Equal(da, db) {
-		return 0, true
-	}
-	return 1, true
+	return bytes.Compare(da, db), true
 }
 
 func decodeBase64Binary(s string) ([]byte, bool) {

--- a/internal/xsd/value/validate_test.go
+++ b/internal/xsd/value/validate_test.go
@@ -233,6 +233,14 @@ func TestCompareValues(t *testing.T) {
 		{"integer", "100", "100", 0, true},
 		{"integer", "-5", "5", -1, true},
 
+		// boolean — "true"/"1" and "false"/"0" are value-equal; invalid lexicals
+		// are indeterminate.
+		{lexicon.TypeBoolean, "true", "1", 0, true},
+		{lexicon.TypeBoolean, "false", "0", 0, true},
+		{lexicon.TypeBoolean, "true", "false", 1, true},
+		{lexicon.TypeBoolean, "false", "true", -1, true},
+		{lexicon.TypeBoolean, "maybe", "true", 0, false},
+
 		// float
 		{lexicon.TypeFloat, lexicon.XSLTVersion10, "2.0", -1, true},
 		{lexicon.TypeFloat, "2.0", lexicon.XSLTVersion10, 1, true},

--- a/internal/xsd/value/validate_test.go
+++ b/internal/xsd/value/validate_test.go
@@ -241,6 +241,17 @@ func TestCompareValues(t *testing.T) {
 		{lexicon.TypeBoolean, "false", "true", -1, true},
 		{lexicon.TypeBoolean, "maybe", "true", 0, false},
 
+		// hexBinary — compared by decoded octets, so case is not significant.
+		{"hexBinary", "0A", "0a", 0, true},
+		{"hexBinary", "DEADbeef", "deadBEEF", 0, true},
+		{"hexBinary", "0A", "0B", 1, true},
+		{"hexBinary", "0G", "0A", 0, false}, // invalid hex -> indeterminate
+
+		// base64Binary — compared by decoded octets, whitespace insignificant.
+		{"base64Binary", "YWJj", "YW Jj", 0, true},
+		{"base64Binary", "YWJj", "YWJk", 1, true},
+		{"base64Binary", "@@@@", "YWJj", 0, false}, // invalid -> indeterminate
+
 		// float
 		{lexicon.TypeFloat, lexicon.XSLTVersion10, "2.0", -1, true},
 		{lexicon.TypeFloat, "2.0", lexicon.XSLTVersion10, 1, true},

--- a/internal/xsd/value/validate_test.go
+++ b/internal/xsd/value/validate_test.go
@@ -241,15 +241,16 @@ func TestCompareValues(t *testing.T) {
 		{lexicon.TypeBoolean, "false", "true", -1, true},
 		{lexicon.TypeBoolean, "maybe", "true", 0, false},
 
-		// hexBinary — compared by decoded octets, so case is not significant.
+		// hexBinary — compared by decoded octets (bytes.Compare order), so case
+		// is not significant and 0x0A < 0x0B.
 		{"hexBinary", "0A", "0a", 0, true},
 		{"hexBinary", "DEADbeef", "deadBEEF", 0, true},
-		{"hexBinary", "0A", "0B", 1, true},
+		{"hexBinary", "0A", "0B", -1, true},
 		{"hexBinary", "0G", "0A", 0, false}, // invalid hex -> indeterminate
 
 		// base64Binary — compared by decoded octets, whitespace insignificant.
 		{"base64Binary", "YWJj", "YW Jj", 0, true},
-		{"base64Binary", "YWJj", "YWJk", 1, true},
+		{"base64Binary", "YWJj", "YWJk", -1, true}, // "abc" < "abd"
 		{"base64Binary", "@@@@", "YWJj", 0, false}, // invalid -> indeterminate
 
 		// float

--- a/xsd/simplevalue_facets.go
+++ b/xsd/simplevalue_facets.go
@@ -55,10 +55,11 @@ func checkMaxExclusive(v, bound, builtinLocal string) bool {
 // enumValueSpaceTypes is the set of builtin base types for which value.Compare
 // implements correct value-space equality, so the enumeration facet may accept a
 // member that is value-equal but lexically distinct. It deliberately excludes
-// string-family, binary, and anyURI types: value.Compare falls back to decimal
-// comparison for any unrecognized builtin, which would wrongly treat numeric-
-// looking lexicals as equal (e.g. xs:string enumeration "5" accepting "5.0").
-// Those types stay lexical-only.
+// string-family and anyURI types: value.Compare falls back to decimal comparison
+// for any unrecognized builtin, which would wrongly treat numeric-looking
+// lexicals as equal (e.g. xs:string enumeration "5" accepting "5.0"). Those
+// types stay lexical-only, which is correct because their value space equals
+// their (whitespace-processed) lexical space.
 var enumValueSpaceTypes = map[string]struct{}{
 	// Numeric (decimal-derived).
 	"decimal": {}, "integer": {}, "nonPositiveInteger": {}, "negativeInteger": {},
@@ -72,6 +73,8 @@ var enumValueSpaceTypes = map[string]struct{}{
 	// Date/time/duration.
 	"dateTime": {}, "date": {}, "time": {}, "duration": {},
 	"gYear": {}, "gYearMonth": {}, "gMonth": {}, "gDay": {}, "gMonthDay": {},
+	// Binary (compared by decoded octets, not lexical text).
+	"hexBinary": {}, "base64Binary": {},
 }
 
 // enumerationValueEqual reports whether v is value-equal to a member ev for the
@@ -85,7 +88,7 @@ func enumerationValueEqual(v, ev, builtinLocal string) bool {
 		return false
 	}
 	if builtinLocal == "float" || builtinLocal == "double" {
-		if v == "NaN" && ev == "NaN" {
+		if value.IsFloatNaN(v) && value.IsFloatNaN(ev) {
 			return true
 		}
 	}

--- a/xsd/simplevalue_facets.go
+++ b/xsd/simplevalue_facets.go
@@ -52,6 +52,20 @@ func checkMaxExclusive(v, bound, builtinLocal string) bool {
 	return cmp < 0
 }
 
+// enumerationValueEqual reports whether v is value-equal to a member ev for the
+// purpose of the enumeration facet. For float/double, XSD treats NaN as equal to
+// NaN for enumeration (unlike ordering, where NaN is incomparable), so that case
+// is handled explicitly before delegating to value.Compare.
+func enumerationValueEqual(v, ev, builtinLocal string) bool {
+	if builtinLocal == "float" || builtinLocal == "double" {
+		if v == "NaN" && ev == "NaN" {
+			return true
+		}
+	}
+	cmp, ok := value.Compare(v, ev, builtinLocal)
+	return ok && cmp == 0
+}
+
 func checkFacets(ctx context.Context, value string, valueNS map[string]string, fs *FacetSet, builtinLocal, elemName, filename string, line int, vc *validationContext) error {
 	var anyErr error
 
@@ -74,7 +88,19 @@ func checkFacets(ctx context.Context, value string, valueNS map[string]string, f
 				}
 			}
 		} else {
+			// Enumeration is defined on the value space. A lexical match is
+			// sufficient (and is the only correct test for string-family types
+			// where value.Compare cannot compare), but lexically distinct values
+			// that are value-equal to a member must also be accepted.
 			found = slices.Contains(fs.Enumeration, value)
+			if !found {
+				for _, ev := range fs.Enumeration {
+					if enumerationValueEqual(value, ev, builtinLocal) {
+						found = true
+						break
+					}
+				}
+			}
 		}
 		if !found {
 			set := "'" + strings.Join(fs.Enumeration, "', '") + "'"

--- a/xsd/simplevalue_facets.go
+++ b/xsd/simplevalue_facets.go
@@ -52,11 +52,38 @@ func checkMaxExclusive(v, bound, builtinLocal string) bool {
 	return cmp < 0
 }
 
+// enumValueSpaceTypes is the set of builtin base types for which value.Compare
+// implements correct value-space equality, so the enumeration facet may accept a
+// member that is value-equal but lexically distinct. It deliberately excludes
+// string-family, binary, and anyURI types: value.Compare falls back to decimal
+// comparison for any unrecognized builtin, which would wrongly treat numeric-
+// looking lexicals as equal (e.g. xs:string enumeration "5" accepting "5.0").
+// Those types stay lexical-only.
+var enumValueSpaceTypes = map[string]struct{}{
+	// Numeric (decimal-derived).
+	"decimal": {}, "integer": {}, "nonPositiveInteger": {}, "negativeInteger": {},
+	"long": {}, "int": {}, "short": {}, "byte": {},
+	"nonNegativeInteger": {}, "unsignedLong": {}, "unsignedInt": {},
+	"unsignedShort": {}, "unsignedByte": {}, "positiveInteger": {},
+	// Floating point.
+	"float": {}, "double": {},
+	// Boolean.
+	"boolean": {},
+	// Date/time/duration.
+	"dateTime": {}, "date": {}, "time": {}, "duration": {},
+	"gYear": {}, "gYearMonth": {}, "gMonth": {}, "gDay": {}, "gMonthDay": {},
+}
+
 // enumerationValueEqual reports whether v is value-equal to a member ev for the
-// purpose of the enumeration facet. For float/double, XSD treats NaN as equal to
-// NaN for enumeration (unlike ordering, where NaN is incomparable), so that case
-// is handled explicitly before delegating to value.Compare.
+// purpose of the enumeration facet. It only performs value-space comparison for
+// types in enumValueSpaceTypes; for all others (string-family, binary, anyURI,
+// and the empty/untyped case) enumeration stays lexical-only and this returns
+// false. For float/double, XSD treats NaN as equal to NaN for enumeration
+// (unlike ordering, where NaN is incomparable), handled explicitly here.
 func enumerationValueEqual(v, ev, builtinLocal string) bool {
+	if _, ok := enumValueSpaceTypes[builtinLocal]; !ok {
+		return false
+	}
 	if builtinLocal == "float" || builtinLocal == "double" {
 		if v == "NaN" && ev == "NaN" {
 			return true
@@ -89,9 +116,10 @@ func checkFacets(ctx context.Context, value string, valueNS map[string]string, f
 			}
 		} else {
 			// Enumeration is defined on the value space. A lexical match is
-			// sufficient (and is the only correct test for string-family types
-			// where value.Compare cannot compare), but lexically distinct values
-			// that are value-equal to a member must also be accepted.
+			// always sufficient; additionally, for value-space-comparable types
+			// (see enumValueSpaceTypes) a lexically distinct value that is
+			// value-equal to a member must also be accepted. String-family and
+			// other non-comparable types stay lexical-only.
 			found = slices.Contains(fs.Enumeration, value)
 			if !found {
 				for _, ev := range fs.Enumeration {

--- a/xsd/simplevalue_facets.go
+++ b/xsd/simplevalue_facets.go
@@ -79,10 +79,11 @@ var enumValueSpaceTypes = map[string]struct{}{
 
 // enumerationValueEqual reports whether v is value-equal to a member ev for the
 // purpose of the enumeration facet. It only performs value-space comparison for
-// types in enumValueSpaceTypes; for all others (string-family, binary, anyURI,
-// and the empty/untyped case) enumeration stays lexical-only and this returns
-// false. For float/double, XSD treats NaN as equal to NaN for enumeration
-// (unlike ordering, where NaN is incomparable), handled explicitly here.
+// types in enumValueSpaceTypes (numeric, boolean, date/time, and binary); for
+// all others (string-family, anyURI, and the empty/untyped case) enumeration
+// stays lexical-only and this returns false. For float/double, XSD treats NaN as
+// equal to NaN for enumeration (unlike ordering, where NaN is incomparable),
+// handled explicitly here.
 func enumerationValueEqual(v, ev, builtinLocal string) bool {
 	if _, ok := enumValueSpaceTypes[builtinLocal]; !ok {
 		return false

--- a/xsd/validate_enumeration_value_space_test.go
+++ b/xsd/validate_enumeration_value_space_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const xsDecimalType = "xs:decimal"
+const (
+	xsDecimalType = "xs:decimal"
+	nanLexical    = "NaN"
+)
 
 // TestEnumerationValueSpace verifies that the enumeration facet is compared in
 // value space, not raw lexical space. A value that is lexically distinct from
@@ -45,10 +48,10 @@ func TestEnumerationValueSpace(t *testing.T) {
 
 		// float NaN — per XSD, NaN equals NaN for enumeration purposes; signed
 		// lexical forms (accepted by the float validator) must match too.
-		{name: "float NaN matches NaN", baseType: "xs:float", enum: []string{"NaN"}, instance: "NaN"},
-		{name: "double NaN matches NaN", baseType: "xs:double", enum: []string{"NaN"}, instance: "NaN"},
-		{name: "float signed NaN matches NaN", baseType: "xs:float", enum: []string{"NaN"}, instance: "+NaN"},
-		{name: "double signed NaN matches NaN", baseType: "xs:double", enum: []string{"NaN"}, instance: "-NaN"},
+		{name: "float NaN matches NaN", baseType: "xs:float", enum: []string{nanLexical}, instance: nanLexical},
+		{name: "double NaN matches NaN", baseType: "xs:double", enum: []string{nanLexical}, instance: nanLexical},
+		{name: "float signed NaN matches NaN", baseType: "xs:float", enum: []string{nanLexical}, instance: "+NaN"},
+		{name: "double signed NaN matches NaN", baseType: "xs:double", enum: []string{nanLexical}, instance: "-NaN"},
 
 		// hexBinary — value space is the decoded octets, so case differences are
 		// not significant ("0A" == "0a"); a different byte must be rejected.

--- a/xsd/validate_enumeration_value_space_test.go
+++ b/xsd/validate_enumeration_value_space_test.go
@@ -43,9 +43,23 @@ func TestEnumerationValueSpace(t *testing.T) {
 		{name: "double exponent form", baseType: "xs:double", enum: []string{"1.5"}, instance: "1.5E0"},
 		{name: "double non-member", baseType: "xs:double", enum: []string{"1.5"}, instance: "2.5", wantReject: true},
 
-		// float NaN — per XSD, NaN equals NaN for enumeration purposes.
+		// float NaN — per XSD, NaN equals NaN for enumeration purposes; signed
+		// lexical forms (accepted by the float validator) must match too.
 		{name: "float NaN matches NaN", baseType: "xs:float", enum: []string{"NaN"}, instance: "NaN"},
 		{name: "double NaN matches NaN", baseType: "xs:double", enum: []string{"NaN"}, instance: "NaN"},
+		{name: "float signed NaN matches NaN", baseType: "xs:float", enum: []string{"NaN"}, instance: "+NaN"},
+		{name: "double signed NaN matches NaN", baseType: "xs:double", enum: []string{"NaN"}, instance: "-NaN"},
+
+		// hexBinary — value space is the decoded octets, so case differences are
+		// not significant ("0A" == "0a"); a different byte must be rejected.
+		{name: "hexBinary case-insensitive", baseType: "xs:hexBinary", enum: []string{"0A"}, instance: "0a"},
+		{name: "hexBinary mixed case member", baseType: "xs:hexBinary", enum: []string{"deadBEEF"}, instance: "DEADbeef"},
+		{name: "hexBinary non-member", baseType: "xs:hexBinary", enum: []string{"0A"}, instance: "0b", wantReject: true},
+
+		// base64Binary — value space is the decoded octets; whitespace in the
+		// lexical form is not significant.
+		{name: "base64Binary whitespace insignificant", baseType: "xs:base64Binary", enum: []string{"YWJj"}, instance: "YW Jj"},
+		{name: "base64Binary non-member", baseType: "xs:base64Binary", enum: []string{"YWJj"}, instance: "YWJk", wantReject: true},
 
 		// dateTime — same instant written with a different timezone form.
 		{name: "dateTime equal across timezone", baseType: "xs:dateTime",

--- a/xsd/validate_enumeration_value_space_test.go
+++ b/xsd/validate_enumeration_value_space_test.go
@@ -58,6 +58,17 @@ func TestEnumerationValueSpace(t *testing.T) {
 		// string — lexical members must still be matched lexically.
 		{name: "string member", baseType: "xs:string", enum: []string{"alpha", "beta"}, instance: "beta"},
 		{name: "string non-member", baseType: "xs:string", enum: []string{"alpha"}, instance: "gamma", wantReject: true},
+
+		// string-family types must stay lexical-only: a numeric-looking instance
+		// must NOT be accepted via numeric value-space comparison against a
+		// numeric-looking member ("5" must not accept "5.0").
+		{name: "string numeric lexical not value-equal", baseType: "xs:string",
+			enum: []string{"5"}, instance: "5.0", wantReject: true},
+		{name: "token numeric lexical not value-equal", baseType: "xs:token",
+			enum: []string{"10"}, instance: "1e1", wantReject: true},
+		{name: "anyURI numeric lexical not value-equal", baseType: "xs:anyURI",
+			enum: []string{"5"}, instance: "5.00", wantReject: true},
+		{name: "string numeric member exact", baseType: "xs:string", enum: []string{"5"}, instance: "5"},
 	}
 
 	for _, tc := range cases {

--- a/xsd/validate_enumeration_value_space_test.go
+++ b/xsd/validate_enumeration_value_space_test.go
@@ -63,6 +63,9 @@ func TestEnumerationValueSpace(t *testing.T) {
 		// lexical form is not significant.
 		{name: "base64Binary whitespace insignificant", baseType: "xs:base64Binary", enum: []string{"YWJj"}, instance: "YW Jj"},
 		{name: "base64Binary non-member", baseType: "xs:base64Binary", enum: []string{"YWJj"}, instance: "YWJk", wantReject: true},
+		// The lexical validator (regex-only) admits unpadded forms; an unpadded
+		// instance must still value-match its padded, byte-equal member.
+		{name: "base64Binary unpadded matches padded", baseType: "xs:base64Binary", enum: []string{"TQ=="}, instance: "TQ"},
 
 		// dateTime — same instant written with a different timezone form.
 		{name: "dateTime equal across timezone", baseType: "xs:dateTime",

--- a/xsd/validate_enumeration_value_space_test.go
+++ b/xsd/validate_enumeration_value_space_test.go
@@ -1,0 +1,100 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnumerationValueSpace verifies that the enumeration facet is compared in
+// value space, not raw lexical space. A value that is lexically distinct from
+// every enumeration member but value-equal to one of them must be accepted; a
+// value that is value-distinct from all members must be rejected.
+func TestEnumerationValueSpace(t *testing.T) {
+	type testCase struct {
+		name       string
+		baseType   string
+		enum       []string
+		instance   string
+		wantReject bool
+	}
+
+	cases := []testCase{
+		// decimal — lexical variants that are value-equal to "5".
+		{name: "decimal trailing zero", baseType: "xs:decimal", enum: []string{"5"}, instance: "5.0"},
+		{name: "decimal more trailing zeros", baseType: "xs:decimal", enum: []string{"5"}, instance: "5.00"},
+		{name: "decimal leading zero", baseType: "xs:decimal", enum: []string{"5"}, instance: "05"},
+		{name: "decimal plus sign", baseType: "xs:decimal", enum: []string{"5"}, instance: "+5"},
+		{name: "decimal non-member", baseType: "xs:decimal", enum: []string{"5"}, instance: "6", wantReject: true},
+
+		// boolean — "true"/"1" and "false"/"0" are value-equal pairs.
+		{name: "boolean true vs 1", baseType: "xs:boolean", enum: []string{"true"}, instance: "1"},
+		{name: "boolean false vs 0", baseType: "xs:boolean", enum: []string{"false"}, instance: "0"},
+		{name: "boolean non-member", baseType: "xs:boolean", enum: []string{"true"}, instance: "0", wantReject: true},
+
+		// float / double — trailing zero and exponent forms.
+		{name: "float trailing zero", baseType: "xs:float", enum: []string{"1.5"}, instance: "1.50"},
+		{name: "float exponent form", baseType: "xs:float", enum: []string{"1.5"}, instance: "1.5E0"},
+		{name: "double exponent form", baseType: "xs:double", enum: []string{"1.5"}, instance: "1.5E0"},
+		{name: "double non-member", baseType: "xs:double", enum: []string{"1.5"}, instance: "2.5", wantReject: true},
+
+		// float NaN — per XSD, NaN equals NaN for enumeration purposes.
+		{name: "float NaN matches NaN", baseType: "xs:float", enum: []string{"NaN"}, instance: "NaN"},
+		{name: "double NaN matches NaN", baseType: "xs:double", enum: []string{"NaN"}, instance: "NaN"},
+
+		// dateTime — same instant written with a different timezone form.
+		{name: "dateTime equal across timezone", baseType: "xs:dateTime",
+			enum: []string{"2000-01-01T12:00:00Z"}, instance: "2000-01-01T13:00:00+01:00"},
+		{name: "dateTime trailing-zero seconds", baseType: "xs:dateTime",
+			enum: []string{"2000-01-01T12:00:00Z"}, instance: "2000-01-01T12:00:00.0Z"},
+		{name: "dateTime non-member", baseType: "xs:dateTime",
+			enum: []string{"2000-01-01T12:00:00Z"}, instance: "2000-01-01T12:00:01Z", wantReject: true},
+
+		// string — lexical members must still be matched lexically.
+		{name: "string member", baseType: "xs:string", enum: []string{"alpha", "beta"}, instance: "beta"},
+		{name: "string non-member", baseType: "xs:string", enum: []string{"alpha"}, instance: "gamma", wantReject: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var enumXML string
+			for _, e := range tc.enum {
+				enumXML += `      <xs:enumeration value="` + e + `"/>` + "\n"
+			}
+
+			schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:simpleType>
+      <xs:restriction base="` + tc.baseType + `">
+` + enumXML + `      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>`
+
+			instanceXML := `<root>` + tc.instance + `</root>`
+
+			schemaDOC, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+			require.NoError(t, err)
+
+			schema, err := xsd.NewCompiler().Compile(t.Context(), schemaDOC)
+			require.NoError(t, err)
+
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(instanceXML))
+			require.NoError(t, err)
+
+			var errs string
+			err = validateWithOutput(t, xsd.NewValidator(schema), doc, &errs)
+
+			if tc.wantReject {
+				require.Error(t, err)
+				require.Contains(t, errs, "[facet 'enumeration']")
+				return
+			}
+			require.NoError(t, err, "validation errors: %s", errs)
+		})
+	}
+}

--- a/xsd/validate_enumeration_value_space_test.go
+++ b/xsd/validate_enumeration_value_space_test.go
@@ -1,12 +1,15 @@
 package xsd_test
 
 import (
+	"strings"
 	"testing"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/xsd"
 	"github.com/stretchr/testify/require"
 )
+
+const xsDecimalType = "xs:decimal"
 
 // TestEnumerationValueSpace verifies that the enumeration facet is compared in
 // value space, not raw lexical space. A value that is lexically distinct from
@@ -23,11 +26,11 @@ func TestEnumerationValueSpace(t *testing.T) {
 
 	cases := []testCase{
 		// decimal — lexical variants that are value-equal to "5".
-		{name: "decimal trailing zero", baseType: "xs:decimal", enum: []string{"5"}, instance: "5.0"},
-		{name: "decimal more trailing zeros", baseType: "xs:decimal", enum: []string{"5"}, instance: "5.00"},
-		{name: "decimal leading zero", baseType: "xs:decimal", enum: []string{"5"}, instance: "05"},
-		{name: "decimal plus sign", baseType: "xs:decimal", enum: []string{"5"}, instance: "+5"},
-		{name: "decimal non-member", baseType: "xs:decimal", enum: []string{"5"}, instance: "6", wantReject: true},
+		{name: "decimal trailing zero", baseType: xsDecimalType, enum: []string{"5"}, instance: "5.0"},
+		{name: "decimal more trailing zeros", baseType: xsDecimalType, enum: []string{"5"}, instance: "5.00"},
+		{name: "decimal leading zero", baseType: xsDecimalType, enum: []string{"5"}, instance: "05"},
+		{name: "decimal plus sign", baseType: xsDecimalType, enum: []string{"5"}, instance: "+5"},
+		{name: "decimal non-member", baseType: xsDecimalType, enum: []string{"5"}, instance: "6", wantReject: true},
 
 		// boolean — "true"/"1" and "false"/"0" are value-equal pairs.
 		{name: "boolean true vs 1", baseType: "xs:boolean", enum: []string{"true"}, instance: "1"},
@@ -61,10 +64,11 @@ func TestEnumerationValueSpace(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			var enumXML string
+			var enumBuilder strings.Builder
 			for _, e := range tc.enum {
-				enumXML += `      <xs:enumeration value="` + e + `"/>` + "\n"
+				enumBuilder.WriteString(`      <xs:enumeration value="` + e + `"/>` + "\n")
 			}
+			enumXML := enumBuilder.String()
 
 			schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="root">


### PR DESCRIPTION
- Compare the `enumeration` facet in value space for all simple types, not just QName/NOTATION: a value matches if it lexically equals or value-compares equal to a member (e.g. decimal `5.0`≡`5`, boolean `1`≡`true`, float `1.50`≡`1.5`, equal dateTimes across timezones).
- Add a boolean case to `internal/xsd/value.Compare`, and treat float/double NaN as equal to NaN for enumeration only.
