### PR TITLE
relaxng: backtrack greedy members in naive group

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -93,7 +93,7 @@ Pattern-matching engine with backtracking:
    - **List**: split text, validate items
 3. Element validation: match name, validate attrs, build child list (skip non-content: EntityRef/PI/Comment), validate content, check all attrs+content consumed
 
-### Backtracking Strategy (`backtrackGroupFlexible`)
+### Backtracking Strategy (`backtrackGroupFlexible` / `backtrackGroupNaive`)
 
 When mandatory group child fails:
 1. Check if element was consumed (structural vs content error)
@@ -101,6 +101,12 @@ When mandatory group child fails:
    - Try iteration counts from minimum upward to greedy count
    - Re-validate remaining children at each count
    - Keep highest successful count (maximizes consumption — libxml2 semantics)
+
+Two parallel implementations share this strategy. `validateGroupContent` +
+`backtrackGroupFlexible` runs inside element bodies (threads attrs/attrUsed and
+emits content-failure diagnostics). `validateGroup` + `backtrackGroupNaive` runs
+the bare-`<group>` start path (and any group reached via `validatePattern`),
+operating only on the node sequence with no attribute/element-content context.
 
 ### Error Suppression
 

--- a/relaxng/group_backtrack_test.go
+++ b/relaxng/group_backtrack_test.go
@@ -87,3 +87,45 @@ func TestNaiveGroupBacktrackingInvalid(t *testing.T) {
 	err = relaxng.NewValidator(grammar).Validate(t.Context(), doc)
 	require.Error(t, err, "document with no mandatory trailing element must be rejected")
 }
+
+// TestNaiveGroupBacktrackingFlexKinds covers the optional and oneOrMore branches
+// of backtrackGroupNaive (the originally-added test only exercised zeroOrMore).
+// The naive group path matches the single top-level document element, so each
+// flexible member competes for that one element.
+func TestNaiveGroupBacktrackingFlexKinds(t *testing.T) {
+	t.Parallel()
+
+	mk := func(members string) string {
+		return `<grammar xmlns="http://relaxng.org/ns/structure/1.0"><start><group>` +
+			members + `</group></start></grammar>`
+	}
+	root := `<element name="root"><empty/></element>`
+
+	cases := []struct {
+		name   string
+		schema string
+		valid  bool
+	}{
+		// optional greedily takes the root, the mandatory member then fails, and
+		// backtracking yields the optional to zero so the mandatory matches.
+		{"optional yields for mandatory", mk(`<optional>` + root + `</optional>` + root), true},
+		// oneOrMore takes the only root (it cannot go below one), leaving nothing
+		// for the mandatory member: correctly rejected.
+		{"oneOrMore cannot yield below one", mk(`<oneOrMore>` + root + `</oneOrMore>` + root), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			grammar := compileGrammar(t, tc.schema)
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root/>`))
+			require.NoError(t, err)
+			verr := relaxng.NewValidator(grammar).Validate(t.Context(), doc)
+			if tc.valid {
+				require.NoError(t, verr)
+				return
+			}
+			require.Error(t, verr)
+		})
+	}
+}

--- a/relaxng/group_backtrack_test.go
+++ b/relaxng/group_backtrack_test.go
@@ -1,0 +1,89 @@
+package relaxng_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/relaxng"
+	"github.com/stretchr/testify/require"
+)
+
+// compileGrammar compiles a RELAX NG grammar from a string, failing the test on
+// any compile error.
+func compileGrammar(t *testing.T, schema string) *relaxng.Grammar {
+	t.Helper()
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(schema))
+	require.NoError(t, err)
+
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	grammar, err := relaxng.NewCompiler().ErrorHandler(collector).Compile(t.Context(), doc)
+	require.NoError(t, err)
+	_ = collector.Close()
+	_, compileErrors := partitionCompileErrors(collector.Errors())
+	require.Empty(t, compileErrors, "grammar should compile without errors")
+
+	return grammar
+}
+
+// TestNaiveGroupBacktracking exercises the bare-<group> start path, which uses
+// validateGroup (no element-content context). A greedy zeroOrMore member must
+// not strand a later mandatory member: zeroOrMore should yield items back so the
+// mandatory member can still match.
+func TestNaiveGroupBacktracking(t *testing.T) {
+	t.Parallel()
+
+	// start is a bare <group> whose first member greedily matches zero-or-more
+	// "root" elements and whose second member requires exactly one "root".
+	const schema = `<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <group>
+      <zeroOrMore>
+        <element name="root"><empty/></element>
+      </zeroOrMore>
+      <element name="root"><empty/></element>
+    </group>
+  </start>
+</grammar>`
+
+	grammar := compileGrammar(t, schema)
+
+	// zeroOrMore matches 0, the mandatory element matches the single root.
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root/>`))
+	require.NoError(t, err)
+
+	err = relaxng.NewValidator(grammar).Validate(t.Context(), doc)
+	require.NoError(t, err, "single root should validate against group(zeroOrMore(root), root)")
+}
+
+// TestNaiveGroupBacktrackingInvalid ensures the backtracking fix does not make
+// the naive group accept content it should reject. With a fixed trailing
+// member after a greedy zeroOrMore, an instance that supplies only the
+// optional kind and never the mandatory one must still fail.
+func TestNaiveGroupBacktrackingInvalid(t *testing.T) {
+	t.Parallel()
+
+	// start is a bare <group> of zeroOrMore "a" followed by a mandatory "b".
+	const schema = `<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <group>
+      <zeroOrMore>
+        <element name="a"><empty/></element>
+      </zeroOrMore>
+      <element name="b"><empty/></element>
+    </group>
+  </start>
+</grammar>`
+
+	grammar := compileGrammar(t, schema)
+
+	// Only "a" elements, never the mandatory "b": must be rejected even after
+	// the greedy zeroOrMore yields items back.
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<a/>`))
+	require.NoError(t, err)
+
+	err = relaxng.NewValidator(grammar).Validate(t.Context(), doc)
+	require.Error(t, err, "document with no mandatory trailing element must be rejected")
+}

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1234,12 +1234,114 @@ func (v *validator) matchAttrTokens(pat *pattern, tokens []string) (int, bool) {
 }
 
 func (v *validator) validateGroup(pat *pattern, state *validState) int {
-	for _, child := range pat.children {
+	children := pat.children
+	if len(children) == 0 {
+		return 0
+	}
+
+	// Record state at each child boundary so a later mandatory member that
+	// fails can ask a previous flexible member (zeroOrMore/oneOrMore/optional)
+	// to yield items back. This mirrors validateGroupContent's backtracking,
+	// minus the attribute/element-content bookkeeping that path threads.
+	bounds := make([]groupBound, 1, len(children)+1)
+	bounds[0] = saveGroupBound(state, nil, len(v.pendingErrors), v.valid)
+
+	for gi, child := range children {
 		if ret := v.validatePattern(child, state); ret != 0 {
+			if gi > 0 && v.backtrackGroupNaive(children, gi, state, bounds) {
+				bounds = append(bounds, saveGroupBound(state, nil, len(v.pendingErrors), v.valid))
+				continue
+			}
 			return -1
 		}
+		bounds = append(bounds, saveGroupBound(state, nil, len(v.pendingErrors), v.valid))
 	}
 	return 0
+}
+
+// backtrackGroupNaive fixes a naive-group failure at failIdx by reducing the
+// consumption of a previous flexible child (zeroOrMore/oneOrMore/optional). It
+// tries each flexible child from nearest to furthest, and for each tries
+// iteration counts from the minimum upward, preferring the highest count that
+// lets the remaining children match (maximizing content consumption). It is the
+// validatePattern-based counterpart to backtrackGroupFlexible.
+func (v *validator) backtrackGroupNaive(children []*pattern, failIdx int,
+	state *validState, bounds []groupBound) bool {
+	for j := failIdx - 1; j >= 0; j-- {
+		child := children[j]
+		isZeroFlex := child.kind == patternZeroOrMore || child.kind == patternOptional
+		isOneMore := child.kind == patternOneOrMore
+		if !isZeroFlex && !isOneMore {
+			continue
+		}
+		// Skip flexible children that consumed nothing — nothing to yield back.
+		if seqEqual(bounds[j].state.seq, bounds[j+1].state.seq) {
+			continue
+		}
+
+		minIter := 0
+		if isOneMore {
+			minIter = 1
+		}
+
+		content := wrapChildren(child.children)
+
+		var bestState *validState
+		var bestErrLen int
+		var bestValid bool
+
+		for iter := minIter; ; iter++ {
+			bounds[j].restore(state, nil, v)
+
+			iterOK := true
+			for range iter {
+				savedSt := state.clone()
+				v.suppressDepth++
+				ret := v.validatePattern(content, state)
+				v.suppressDepth--
+				if ret != 0 || seqEqual(state.seq, savedSt.seq) {
+					iterOK = false
+					break
+				}
+			}
+			if !iterOK {
+				break
+			}
+
+			// Stop once we reach the greedy consumption level — that is the
+			// state that already failed.
+			if seqEqual(state.seq, bounds[j+1].state.seq) {
+				break
+			}
+
+			retryLen := len(v.pendingErrors)
+			retryValid := v.valid
+			allOK := true
+			for k := j + 1; k <= failIdx; k++ {
+				if v.validatePattern(children[k], state) != 0 {
+					allOK = false
+					break
+				}
+			}
+			if allOK {
+				bestState = state.clone()
+				bestErrLen = len(v.pendingErrors)
+				bestValid = v.valid
+			}
+			v.pendingErrors = v.pendingErrors[:retryLen]
+			v.valid = retryValid
+		}
+
+		if bestState != nil {
+			*state = *bestState
+			v.pendingErrors = v.pendingErrors[:bestErrLen]
+			v.valid = bestValid
+			return true
+		}
+
+		bounds[j].restore(state, nil, v)
+	}
+	return false
 }
 
 func (v *validator) validateChoice(pat *pattern, state *validState) int {

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1265,6 +1265,19 @@ func (v *validator) validateGroup(pat *pattern, state *validState) int {
 // iteration counts from the minimum upward, preferring the highest count that
 // lets the remaining children match (maximizing content consumption). It is the
 // validatePattern-based counterpart to backtrackGroupFlexible.
+//
+// Two scope notes:
+//   - The naive group path runs only for the top-level document sequence (a
+//     single root element); multi-node sequences are element content, handled by
+//     validateGroupContent. So `bounds[failIdx]` is always the freshly-appended
+//     boundary and there is no multi-node cascade across separate backtrack calls
+//     that could observe a stale intermediate `bounds` entry.
+//   - Recovery reduces exactly one flexible child and greedily re-validates the
+//     rest; it does not cascade yields across several competing flexible members.
+//     A group with two or more flexible members that must each yield (e.g.
+//     group(zeroOrMore(x), zeroOrMore(x), x)) is therefore not fully recovered.
+//     This is a deliberate, pre-existing limitation shared with the element-
+//     content path (backtrackGroupFlexible), not specific to this function.
 func (v *validator) backtrackGroupNaive(children []*pattern, failIdx int,
 	state *validState, bounds []groupBound) bool {
 	for j := failIdx - 1; j >= 0; j-- {


### PR DESCRIPTION
- Add backtracking to the naive `validateGroup` path (bare-`<group>` start) so a greedy `zeroOrMore`/`oneOrMore`/`optional` member yields items back when a later mandatory member would otherwise be stranded.
- New `backtrackGroupNaive` mirrors the element-content `backtrackGroupFlexible` but operates on the node sequence only.
