### PR TITLE
xsd: 14h rule for mixed-tz datetime compare

### DIFF
--- a/internal/xsd/value/compare.go
+++ b/internal/xsd/value/compare.go
@@ -497,13 +497,15 @@ func compareDateTimeParsed(a, b xsdDateTime) (int, bool) {
 func compareDateTimeMixedTZ(a, b xsdDateTime) (int, bool) {
 	// The determinate rule normalizes a synthetic ±14:00 offset across day
 	// boundaries, which requires a full calendar date (year, month, day). The
-	// partial date/time types leave some of those components zero — gYear,
-	// gYearMonth (day=0), gMonth/gDay (year=0, and one of month/day=0), time
-	// (all zero), and gMonthDay (year=0). Applying the offset to a zero field
-	// makes normalizeToUTC borrow into a neighbouring period and yield a
-	// determinately wrong result (e.g. gYear "2020" rolling back to 2019), so
-	// those types stay indeterminate, as they were before this rule existed.
-	// (The only loss is a literal year-0000 dateTime, an XSD 1.1 edge case, which
+	// partial gregorian types leave some of those components zero — gYear
+	// (month=0, day=0), gYearMonth (day=0), gMonth (year=0, day=0), gDay (year=0,
+	// month=0), and gMonthDay (year=0). Applying the offset to a zero field makes
+	// normalizeToUTC borrow into a neighbouring period and yield a determinately
+	// wrong result (e.g. gYear "2020" rolling back to 2019), so those types stay
+	// indeterminate, as they were before this rule existed. (xs:time is not in
+	// this set: compareTime assigns a reference date before comparing, so it has
+	// a full calendar date and flows through the determinate path correctly. The
+	// only loss is a literal year-0000 dateTime, an XSD 1.1 edge case, which
 	// falls back to indeterminate rather than wrong.)
 	if a.year == 0 || b.year == 0 || a.month < 1 || b.month < 1 || a.day < 1 || b.day < 1 {
 		return 0, false

--- a/internal/xsd/value/compare.go
+++ b/internal/xsd/value/compare.go
@@ -480,13 +480,65 @@ func compareDateTimeFields(a, b xsdDateTime) int {
 
 func compareDateTimeParsed(a, b xsdDateTime) (int, bool) {
 	if a.hasTZ != b.hasTZ {
-		return 0, false // indeterminate
+		return compareDateTimeMixedTZ(a, b)
 	}
 	if a.hasTZ {
 		a = a.normalizeToUTC()
 		b = b.normalizeToUTC()
 	}
 	return compareDateTimeFields(a, b), true
+}
+
+// compareDateTimeMixedTZ compares two date/time values when exactly one carries
+// a timezone, applying the XSD 1.0 order relation (3.2.7.4). A non-timezoned
+// value denotes the instant interval [v-14:00, v+14:00]; if that whole interval
+// lies on one side of the timezoned operand the result is determinate. Only an
+// overlapping interval is indeterminate.
+func compareDateTimeMixedTZ(a, b xsdDateTime) (int, bool) {
+	// Orient so that `tz` is the timezoned operand and `plain` has no timezone.
+	tz, plain := a, b
+	swapped := false
+	if !a.hasTZ {
+		tz, plain = b, a
+		swapped = true
+	}
+
+	tz = tz.normalizeToUTC()
+
+	// Interpret the non-timezoned operand under its two extreme timezones.
+	// +14:00 yields its earliest instant (largest subtraction from UTC),
+	// -14:00 yields its latest instant. We compare plain against tz, so we
+	// build the UTC-normalized plain value at each extreme.
+	low := plain
+	low.hasTZ = true
+	low.tzMin = 14 * 60
+	low = low.normalizeToUTC()
+
+	high := plain
+	high.hasTZ = true
+	high.tzMin = -14 * 60
+	high = high.normalizeToUTC()
+
+	cmpLow := compareDateTimeFields(low, tz)
+	cmpHigh := compareDateTimeFields(high, tz)
+
+	// Both extremes on the same side → determinate result for `plain` vs `tz`.
+	// orient converts that into the result for the original `a` vs `b` order:
+	// when the operands were not swapped, `a` is `tz` and `b` is `plain`, so
+	// the sign must be inverted.
+	orient := func(cmp int) int {
+		if swapped {
+			return cmp
+		}
+		return -cmp
+	}
+	if cmpLow > 0 && cmpHigh > 0 {
+		return orient(1), true
+	}
+	if cmpLow < 0 && cmpHigh < 0 {
+		return orient(-1), true
+	}
+	return 0, false
 }
 
 func compareDateTime(a, b string) (int, bool) {

--- a/internal/xsd/value/compare.go
+++ b/internal/xsd/value/compare.go
@@ -495,6 +495,20 @@ func compareDateTimeParsed(a, b xsdDateTime) (int, bool) {
 // lies on one side of the timezoned operand the result is determinate. Only an
 // overlapping interval is indeterminate.
 func compareDateTimeMixedTZ(a, b xsdDateTime) (int, bool) {
+	// The determinate rule normalizes a synthetic ±14:00 offset across day
+	// boundaries, which requires a full calendar date (year, month, day). The
+	// partial date/time types leave some of those components zero — gYear,
+	// gYearMonth (day=0), gMonth/gDay (year=0, and one of month/day=0), time
+	// (all zero), and gMonthDay (year=0). Applying the offset to a zero field
+	// makes normalizeToUTC borrow into a neighbouring period and yield a
+	// determinately wrong result (e.g. gYear "2020" rolling back to 2019), so
+	// those types stay indeterminate, as they were before this rule existed.
+	// (The only loss is a literal year-0000 dateTime, an XSD 1.1 edge case, which
+	// falls back to indeterminate rather than wrong.)
+	if a.year == 0 || b.year == 0 || a.month < 1 || b.month < 1 || a.day < 1 || b.day < 1 {
+		return 0, false
+	}
+
 	// Orient so that `tz` is the timezoned operand and `plain` has no timezone.
 	tz, plain := a, b
 	swapped := false

--- a/internal/xsd/value/validate_test.go
+++ b/internal/xsd/value/validate_test.go
@@ -308,15 +308,22 @@ func TestCompareValues(t *testing.T) {
 		{typeGMonthDay, "--06-01", "--06-01", 0, true},
 		{typeGMonthDay, "--12-31", "--01-01", 1, true},
 
-		// Mixed-timezone partial types: the determinate ±14:00 rule needs a full
-		// calendar date, so these stay indeterminate rather than producing a
-		// wrong determinate result from normalizing a zero year/month/day field.
+		// Mixed-timezone partial gregorian types: the determinate ±14:00 rule
+		// needs a full calendar date, so these stay indeterminate rather than
+		// producing a wrong determinate result from normalizing a zero
+		// year/month/day field.
 		{typeGYear, "2020", "2020Z", 0, false},
 		{"gYearMonth", "2020-06", "2020-06Z", 0, false},
 		{typeGMonth, "--06", "--06Z", 0, false},
 		{typeGDay, "---15", "---15Z", 0, false},
 		{typeGMonthDay, "--06-15", "--06-15Z", 0, false},
-		{lexicon.TypeTime, "12:00:00", "12:00:00Z", 0, false},
+
+		// Mixed-timezone date and time DO get the determinate ±14:00 rule: date
+		// has a full calendar date, and compareTime assigns a reference date.
+		{lexicon.TypeDate, "2019-12-01", "2020-01-01Z", -1, true}, // interval entirely below bound
+		{lexicon.TypeDate, "2020-01-01", "2020-01-01Z", 0, false}, // ±14:00 straddles -> indeterminate
+		{lexicon.TypeTime, "00:00:00", "20:00:00Z", -1, true},     // determinately earlier
+		{lexicon.TypeTime, "12:00:00", "12:00:00Z", 0, false},     // ±14:00 straddles -> indeterminate
 
 		// duration
 		{lexicon.TypeDuration, testP1Y, "P2Y", -1, true},

--- a/internal/xsd/value/validate_test.go
+++ b/internal/xsd/value/validate_test.go
@@ -303,6 +303,16 @@ func TestCompareValues(t *testing.T) {
 		{"gMonthDay", "--06-01", "--06-01", 0, true},
 		{"gMonthDay", "--12-31", "--01-01", 1, true},
 
+		// Mixed-timezone partial types: the determinate ±14:00 rule needs a full
+		// calendar date, so these stay indeterminate rather than producing a
+		// wrong determinate result from normalizing a zero year/month/day field.
+		{"gYear", "2020", "2020Z", 0, false},
+		{"gYearMonth", "2020-06", "2020-06Z", 0, false},
+		{"gMonth", "--06", "--06Z", 0, false},
+		{"gDay", "---15", "---15Z", 0, false},
+		{"gMonthDay", "--06-15", "--06-15Z", 0, false},
+		{lexicon.TypeTime, "12:00:00", "12:00:00Z", 0, false},
+
 		// duration
 		{lexicon.TypeDuration, testP1Y, "P2Y", -1, true},
 		{lexicon.TypeDuration, testP1Y, testP1Y, 0, true},

--- a/internal/xsd/value/validate_test.go
+++ b/internal/xsd/value/validate_test.go
@@ -255,7 +255,16 @@ func TestCompareValues(t *testing.T) {
 		{lexicon.TypeDateTime, testDT0, testDT0, 0, true},
 		{lexicon.TypeDateTime, testDT0, "2023-01-16T10:30:00", -1, true},
 		{lexicon.TypeDateTime, "2023-01-15T10:30:00Z", "2023-01-15T11:30:00+01:00", 0, true},
-		{lexicon.TypeDateTime, "2023-01-15T10:30:00Z", testDT0, 0, false}, // mixed TZ
+		{lexicon.TypeDateTime, "2023-01-15T10:30:00Z", testDT0, 0, false}, // mixed TZ, overlapping interval
+		// Mixed TZ but determinate under the XSD 14-hour rule: the non-timezoned
+		// operand's [v-14:00, v+14:00] interval lies entirely on one side.
+		{lexicon.TypeDateTime, "2019-12-30T00:00:00", "2020-01-01T12:00:00Z", -1, true}, // latest instant 2019-12-30T14:00Z < bound
+		{lexicon.TypeDateTime, "2020-01-01T12:00:00Z", "2019-12-30T00:00:00", 1, true},  // mirror of above
+		{lexicon.TypeDateTime, "2020-01-10T00:00:00", "2020-01-01T12:00:00Z", 1, true},  // earliest instant 2020-01-09T10:00Z > bound
+		{lexicon.TypeDateTime, "2020-01-01T12:00:00Z", "2020-01-10T00:00:00", -1, true}, // mirror of above
+		// Genuinely indeterminate: ±14:00 interval straddles the bound.
+		{lexicon.TypeDateTime, "2020-01-01T00:00:00", "2020-01-01T12:00:00Z", 0, false},
+		{lexicon.TypeDateTime, "2020-01-01T12:00:00Z", "2020-01-01T00:00:00", 0, false},
 
 		// date
 		{"date", "2023-01-15", "2023-01-16", -1, true},

--- a/internal/xsd/value/validate_test.go
+++ b/internal/xsd/value/validate_test.go
@@ -20,6 +20,11 @@ const (
 	testT0       = "10:30:00"
 	testAB       = "a:b"
 	testFoo      = "foo"
+
+	typeGYear     = "gYear"
+	typeGMonth    = "gMonth"
+	typeGDay      = "gDay"
+	typeGMonthDay = "gMonthDay"
 )
 
 func TestBuiltinTypeValidation(t *testing.T) {
@@ -54,7 +59,7 @@ func TestBuiltinTypeValidation(t *testing.T) {
 			invalid:  []string{"", "P", "PT", "1Y", "-P", "-PT", testAbc},
 		},
 		{
-			typeName: "gYear",
+			typeName: typeGYear,
 			valid:    []string{"2023", "-0001", "2023Z", "2023+09:00", "10000"},
 			invalid:  []string{"", "23", testAbc, "2023-01"},
 		},
@@ -64,17 +69,17 @@ func TestBuiltinTypeValidation(t *testing.T) {
 			invalid:  []string{"", "2023", "2023-1", testAbc},
 		},
 		{
-			typeName: "gMonth",
+			typeName: typeGMonth,
 			valid:    []string{"--01", "--12", "--06Z", "--06+09:00"},
 			invalid:  []string{"", "-01", "01", testAbc},
 		},
 		{
-			typeName: "gMonthDay",
+			typeName: typeGMonthDay,
 			valid:    []string{"--01-15", "--12-31", "--06-01Z", "--06-01+09:00"},
 			invalid:  []string{"", "--0115", "-01-15", testAbc},
 		},
 		{
-			typeName: "gDay",
+			typeName: typeGDay,
 			valid:    []string{"---01", "---31", "---15Z", "---15+09:00"},
 			invalid:  []string{"", "--01", "01", testAbc},
 		},
@@ -280,37 +285,37 @@ func TestCompareValues(t *testing.T) {
 		{lexicon.TypeTime, "10:30:00Z", "11:30:00+01:00", 0, true},
 
 		// gYear
-		{"gYear", "2023", "2024", -1, true},
-		{"gYear", "2023", "2023", 0, true},
-		{"gYear", "-0001", "2023", -1, true},
+		{typeGYear, "2023", "2024", -1, true},
+		{typeGYear, "2023", "2023", 0, true},
+		{typeGYear, "-0001", "2023", -1, true},
 
 		// gYearMonth
 		{"gYearMonth", "2023-01", "2023-02", -1, true},
 		{"gYearMonth", "2023-06", "2023-06", 0, true},
 
 		// gMonth
-		{"gMonth", "--01", "--02", -1, true},
-		{"gMonth", "--12", "--12", 0, true},
-		{"gMonth", "--12", "--01", 1, true},
+		{typeGMonth, "--01", "--02", -1, true},
+		{typeGMonth, "--12", "--12", 0, true},
+		{typeGMonth, "--12", "--01", 1, true},
 
 		// gDay
-		{"gDay", "---01", "---02", -1, true},
-		{"gDay", "---15", "---15", 0, true},
-		{"gDay", "---31", "---01", 1, true},
+		{typeGDay, "---01", "---02", -1, true},
+		{typeGDay, "---15", "---15", 0, true},
+		{typeGDay, "---31", "---01", 1, true},
 
 		// gMonthDay
-		{"gMonthDay", "--01-15", "--01-16", -1, true},
-		{"gMonthDay", "--06-01", "--06-01", 0, true},
-		{"gMonthDay", "--12-31", "--01-01", 1, true},
+		{typeGMonthDay, "--01-15", "--01-16", -1, true},
+		{typeGMonthDay, "--06-01", "--06-01", 0, true},
+		{typeGMonthDay, "--12-31", "--01-01", 1, true},
 
 		// Mixed-timezone partial types: the determinate ±14:00 rule needs a full
 		// calendar date, so these stay indeterminate rather than producing a
 		// wrong determinate result from normalizing a zero year/month/day field.
-		{"gYear", "2020", "2020Z", 0, false},
+		{typeGYear, "2020", "2020Z", 0, false},
 		{"gYearMonth", "2020-06", "2020-06Z", 0, false},
-		{"gMonth", "--06", "--06Z", 0, false},
-		{"gDay", "---15", "---15Z", 0, false},
-		{"gMonthDay", "--06-15", "--06-15Z", 0, false},
+		{typeGMonth, "--06", "--06Z", 0, false},
+		{typeGDay, "---15", "---15Z", 0, false},
+		{typeGMonthDay, "--06-15", "--06-15Z", 0, false},
 		{lexicon.TypeTime, "12:00:00", "12:00:00Z", 0, false},
 
 		// duration

--- a/internal/xsd/value/validate_test.go
+++ b/internal/xsd/value/validate_test.go
@@ -16,6 +16,7 @@ const (
 	test1foo     = "1foo"
 	testUnderBar = "_bar"
 	testDT0      = "2023-01-15T10:30:00"
+	refDateTimeZ = "2020-01-01T12:00:00Z"
 	testT0       = "10:30:00"
 	testAB       = "a:b"
 	testFoo      = "foo"
@@ -258,13 +259,13 @@ func TestCompareValues(t *testing.T) {
 		{lexicon.TypeDateTime, "2023-01-15T10:30:00Z", testDT0, 0, false}, // mixed TZ, overlapping interval
 		// Mixed TZ but determinate under the XSD 14-hour rule: the non-timezoned
 		// operand's [v-14:00, v+14:00] interval lies entirely on one side.
-		{lexicon.TypeDateTime, "2019-12-30T00:00:00", "2020-01-01T12:00:00Z", -1, true}, // latest instant 2019-12-30T14:00Z < bound
-		{lexicon.TypeDateTime, "2020-01-01T12:00:00Z", "2019-12-30T00:00:00", 1, true},  // mirror of above
-		{lexicon.TypeDateTime, "2020-01-10T00:00:00", "2020-01-01T12:00:00Z", 1, true},  // earliest instant 2020-01-09T10:00Z > bound
-		{lexicon.TypeDateTime, "2020-01-01T12:00:00Z", "2020-01-10T00:00:00", -1, true}, // mirror of above
+		{lexicon.TypeDateTime, "2019-12-30T00:00:00", refDateTimeZ, -1, true}, // latest instant 2019-12-30T14:00Z < bound
+		{lexicon.TypeDateTime, refDateTimeZ, "2019-12-30T00:00:00", 1, true},  // mirror of above
+		{lexicon.TypeDateTime, "2020-01-10T00:00:00", refDateTimeZ, 1, true},  // earliest instant 2020-01-09T10:00Z > bound
+		{lexicon.TypeDateTime, refDateTimeZ, "2020-01-10T00:00:00", -1, true}, // mirror of above
 		// Genuinely indeterminate: ±14:00 interval straddles the bound.
-		{lexicon.TypeDateTime, "2020-01-01T00:00:00", "2020-01-01T12:00:00Z", 0, false},
-		{lexicon.TypeDateTime, "2020-01-01T12:00:00Z", "2020-01-01T00:00:00", 0, false},
+		{lexicon.TypeDateTime, "2020-01-01T00:00:00", refDateTimeZ, 0, false},
+		{lexicon.TypeDateTime, refDateTimeZ, "2020-01-01T00:00:00", 0, false},
 
 		// date
 		{"date", "2023-01-15", "2023-01-16", -1, true},

--- a/xsd/validate_datetime_facet_test.go
+++ b/xsd/validate_datetime_facet_test.go
@@ -1,0 +1,111 @@
+package xsd_test
+
+import (
+	"fmt"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDateTimeTimezoneFacetBounds covers min/maxInclusive facet checks where the
+// facet value and the instance value differ in whether they carry a timezone.
+//
+// Per the XSD order relation (XSD 1.0 3.2.7.4), a non-timezoned value spans the
+// instant interval [v-14:00, v+14:00]. When that whole interval lies below or
+// above the timezoned operand, the comparison is determinate even though the
+// timezone presence differs. Only an overlapping interval is indeterminate, and
+// an indeterminate comparison passes the facet check.
+func TestDateTimeTimezoneFacetBounds(t *testing.T) {
+	t.Parallel()
+
+	schemaFor := func(facet, value string) string {
+		return fmt.Sprintf(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:simpleType>
+      <xs:restriction base="xs:dateTime">
+        <xs:%s value="%s"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>`, facet, value)
+	}
+
+	cases := []struct {
+		name     string
+		facet    string
+		bound    string
+		instance string
+		valid    bool
+	}{
+		// minInclusive bound with a timezone, no-TZ instance.
+		{
+			name:     "min determinate below rejects",
+			facet:    "minInclusive",
+			bound:    "2020-01-01T12:00:00Z",
+			instance: "2019-12-30T00:00:00", // latest instant 2019-12-30T14:00Z still below bound
+			valid:    false,
+		},
+		{
+			name:     "min indeterminate accepts",
+			facet:    "minInclusive",
+			bound:    "2020-01-01T12:00:00Z",
+			instance: "2020-01-01T00:00:00", // +/-14:00 interval straddles the bound
+			valid:    true,
+		},
+		// maxInclusive bound with a timezone, no-TZ instance.
+		{
+			name:     "max determinate above rejects",
+			facet:    "maxInclusive",
+			bound:    "2020-01-01T12:00:00Z",
+			instance: "2020-01-10T00:00:00", // earliest instant 2020-01-09T10:00Z still above bound
+			valid:    false,
+		},
+		{
+			name:     "max indeterminate accepts",
+			facet:    "maxInclusive",
+			bound:    "2020-01-01T12:00:00Z",
+			instance: "2020-01-01T00:00:00", // +/-14:00 interval straddles the bound
+			valid:    true,
+		},
+		// Mirror: no-TZ bound, timezoned instance.
+		{
+			name:     "min no-tz bound tz instance rejects",
+			facet:    "minInclusive",
+			bound:    "2020-01-01T12:00:00",
+			instance: "2019-12-30T14:00:00Z", // determinately below the bound's earliest instant
+			valid:    false,
+		},
+		{
+			name:     "max no-tz bound tz instance rejects",
+			facet:    "maxInclusive",
+			bound:    "2020-01-01T12:00:00",
+			instance: "2020-01-03T03:00:00Z", // determinately above the bound's latest instant
+			valid:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			schemaDOC, err := helium.NewParser().Parse(t.Context(), []byte(schemaFor(tc.facet, tc.bound)))
+			require.NoError(t, err)
+			schema, err := xsd.NewCompiler().Compile(t.Context(), schemaDOC)
+			require.NoError(t, err)
+
+			instance := fmt.Sprintf("<root>%s</root>", tc.instance)
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(instance))
+			require.NoError(t, err)
+
+			var errs string
+			err = validateWithOutput(t, xsd.NewValidator(schema), doc, &errs)
+			if tc.valid {
+				require.NoError(t, err, "expected valid, got errors: %s", errs)
+				return
+			}
+			require.Error(t, err)
+		})
+	}
+}

--- a/xsd/validate_datetime_facet_test.go
+++ b/xsd/validate_datetime_facet_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestDateTimeTimezoneFacetBounds covers min/maxInclusive facet checks where the
-// facet value and the instance value differ in whether they carry a timezone.
+// TestDateTimeTimezoneFacetBounds covers min/max Inclusive and Exclusive facet
+// checks where the facet value and the instance value differ in whether they
+// carry a timezone.
 //
 // Per the XSD order relation (XSD 1.0 3.2.7.4), a non-timezoned value spans the
 // instant interval [v-14:00, v+14:00]. When that whole interval lies below or
@@ -82,6 +83,22 @@ func TestDateTimeTimezoneFacetBounds(t *testing.T) {
 			facet:    "maxInclusive",
 			bound:    "2020-01-01T12:00:00",
 			instance: "2020-01-03T03:00:00Z", // determinately above the bound's latest instant
+			valid:    false,
+		},
+		// Exclusive facets use the same comparison; a determinately out-of-range
+		// no-TZ instance must still be rejected.
+		{
+			name:     "minExclusive determinate below rejects",
+			facet:    "minExclusive",
+			bound:    "2020-06-01T12:00:00Z",
+			instance: "2020-05-30T00:00:00", // latest instant 2020-05-30T14:00Z still below bound
+			valid:    false,
+		},
+		{
+			name:     "maxExclusive determinate above rejects",
+			facet:    "maxExclusive",
+			bound:    "2020-06-01T12:00:00Z",
+			instance: "2020-06-10T00:00:00", // earliest instant 2020-06-09T10:00Z still above bound
 			valid:    false,
 		},
 	}


### PR DESCRIPTION
- `compareDateTimeParsed` returned indeterminate for any mixed-timezone pair, so determinately-out-of-range no-TZ values silently passed min/maxInclusive facets.
- Apply the XSD order relation: a non-timezoned value spans `[v-14:00, v+14:00]`; compare both extremes and return a determinate result when they agree, indeterminate only on true overlap.
- Benefits all date/time-family types routing through `compareDateTimeParsed`.
