### PR TITLE
relaxng: backtrack token group and choice matching

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -102,6 +102,18 @@ When mandatory group child fails:
    - Re-validate remaining children at each count
    - Keep highest successful count (maximizes consumption — libxml2 semantics)
 
+### Token-Level Backtracking (`<list>` / attribute values)
+
+`matchAttrContent` (attribute values) and `matchListContent` (`<list>` content)
+match whitespace-separated tokens. `matchAttrTokensCounts` returns every
+possible token-consumption count for a pattern in greedy-preferred (descending)
+order; `groupCounts` composes children sequentially across those options and
+`repeatCounts` enumerates repetition counts. A group succeeds when some
+combination consumes exactly all tokens, so a greedy `oneOrMore`/`zeroOrMore`
+can yield tokens back to a later mandatory member, and a zero-token `choice`
+branch (e.g. `empty`) does not shadow a consuming branch. `matchAttrTokens`
+is a thin greedy-max wrapper over `matchAttrTokensCounts`.
+
 ### Error Suppression
 
 - `suppressDepth` counter incremented during choice branch exploration

--- a/relaxng/token_matcher_review_test.go
+++ b/relaxng/token_matcher_review_test.go
@@ -76,3 +76,26 @@ func TestListGroupChoiceUnderOptional(t *testing.T) {
 	require.NoError(t, validateWith(t, choiceSchema, `<a>P Q P</a>`), "choice list should validate")
 	require.Error(t, validateWith(t, choiceSchema, `<a>P Z</a>`), "non-member token must be rejected")
 }
+
+// TestListParentRef covers a <parentRef> used inside a <list> (token-level
+// matching). validatePattern treats parentRef like ref, so the token matchers
+// must resolve it too; otherwise the list wrongly fails to match.
+func TestListParentRef(t *testing.T) {
+	t.Parallel()
+
+	schema := `<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <define name="item"><value>X</value></define>
+  <start>
+    <element name="a">
+      <grammar>
+        <start>
+          <list><oneOrMore><parentRef name="item"/></oneOrMore></list>
+        </start>
+      </grammar>
+    </element>
+  </start>
+</grammar>`
+
+	require.NoError(t, validateWith(t, schema, `<a>X X X</a>`), "parentRef in list should validate")
+	require.Error(t, validateWith(t, schema, `<a>X Y</a>`), "non-member token must be rejected")
+}

--- a/relaxng/token_matcher_review_test.go
+++ b/relaxng/token_matcher_review_test.go
@@ -1,0 +1,55 @@
+package relaxng_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTokenMatcherNullableOneOrMore covers oneOrMore over content that can match
+// empty (here optional) inside a <list>, followed by a mandatory member. A
+// single nullable iteration must satisfy oneOrMore so it can consume zero
+// tokens, letting the trailing member match — matching node-level
+// validateOneOrMore semantics. Without that, `<a>END</a>` is wrongly rejected.
+func TestTokenMatcherNullableOneOrMore(t *testing.T) {
+	t.Parallel()
+
+	schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <list>
+    <group>
+      <oneOrMore><optional><data type="integer"/></optional></oneOrMore>
+      <value>END</value>
+    </group>
+  </list>
+</element>`
+
+	// oneOrMore matches one zero-width iteration (consumes 0), value END matches.
+	require.NoError(t, validateWith(t, schema, `<a>END</a>`), "nullable oneOrMore then END should validate")
+	// oneOrMore consumes the integers, value END matches the last token.
+	require.NoError(t, validateWith(t, schema, `<a>1 2 END</a>`), "tokens then END should validate")
+	// Missing the mandatory END member -> invalid.
+	require.Error(t, validateWith(t, schema, `<a></a>`), "empty list must be rejected (END required)")
+	require.Error(t, validateWith(t, schema, `<a>1 2</a>`), "missing END must be rejected")
+}
+
+// TestTokenMatcherNoExponentialBlowup guards against the combinatorial blowup in
+// groupCounts/repeatCounts: a <list> group of many optionals over many tokens has
+// only len+1 distinct totals, but without memoization the enumeration explores
+// 2^N paths. With memoization this completes effectively instantly; a regression
+// would make the test hang until the timeout.
+func TestTokenMatcherNoExponentialBlowup(t *testing.T) {
+	t.Parallel()
+
+	const optionals = 40
+	var b strings.Builder
+	b.WriteString(`<element name="a" xmlns="http://relaxng.org/ns/structure/1.0"><list><group>`)
+	for range optionals {
+		b.WriteString(`<optional><data type="integer"/></optional>`)
+	}
+	b.WriteString(`</group></list></element>`)
+
+	// 20 integer tokens: 20 optionals consume one each, the rest match empty.
+	instance := `<a>1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20</a>`
+	require.NoError(t, validateWith(t, b.String(), instance))
+}

--- a/relaxng/token_matcher_review_test.go
+++ b/relaxng/token_matcher_review_test.go
@@ -53,3 +53,26 @@ func TestTokenMatcherNoExponentialBlowup(t *testing.T) {
 	instance := `<a>1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20</a>`
 	require.NoError(t, validateWith(t, b.String(), instance))
 }
+
+// TestListGroupChoiceUnderOptional covers <list>s whose children are group/choice
+// nested under optional in element content. All such lists share the
+// matchListContent token matcher (validateList now delegates to it too), so they
+// must validate with full backtracking semantics rather than being mishandled.
+func TestListGroupChoiceUnderOptional(t *testing.T) {
+	t.Parallel()
+
+	groupSchema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <optional>
+    <list><group><value>X</value><value>Y</value></group></list>
+  </optional>
+</element>`
+	require.NoError(t, validateWith(t, groupSchema, `<a>X Y</a>`), "group list should validate")
+	require.NoError(t, validateWith(t, groupSchema, `<a></a>`), "absent optional list should validate")
+	require.Error(t, validateWith(t, groupSchema, `<a>X</a>`), "incomplete group must be rejected")
+
+	choiceSchema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <list><oneOrMore><choice><value>P</value><value>Q</value></choice></oneOrMore></list>
+</element>`
+	require.NoError(t, validateWith(t, choiceSchema, `<a>P Q P</a>`), "choice list should validate")
+	require.Error(t, validateWith(t, choiceSchema, `<a>P Z</a>`), "non-member token must be rejected")
+}

--- a/relaxng/token_matcher_test.go
+++ b/relaxng/token_matcher_test.go
@@ -1,0 +1,120 @@
+package relaxng_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/relaxng"
+	"github.com/stretchr/testify/require"
+)
+
+// validateWith compiles the given RELAX NG schema and validates the XML
+// instance, returning the validation error (nil on success).
+func validateWith(t *testing.T, schema, instance string) error {
+	t.Helper()
+
+	schemaDoc, err := helium.NewParser().Parse(t.Context(), []byte(schema))
+	require.NoError(t, err, "schema should parse")
+
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	grammar, err := relaxng.NewCompiler().ErrorHandler(collector).Compile(t.Context(), schemaDoc)
+	require.NoError(t, err, "schema should compile")
+	_ = collector.Close()
+	_, compileErrors := partitionCompileErrors(collector.Errors())
+	require.Empty(t, compileErrors, "schema should compile without errors")
+
+	instanceDoc, err := helium.NewParser().Parse(t.Context(), []byte(instance))
+	require.NoError(t, err, "instance should parse")
+
+	return relaxng.NewValidator(grammar).Validate(t.Context(), instanceDoc)
+}
+
+// TestTokenMatcherChoiceShadow covers a <list> whose group has a leading
+// choice between <empty/> and a consuming branch. The zero-token <empty/>
+// branch must not shadow the consuming integer branch.
+func TestTokenMatcherChoiceShadow(t *testing.T) {
+	t.Parallel()
+
+	schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <list>
+    <group>
+      <choice>
+        <empty/>
+        <data type="integer"/>
+      </choice>
+      <data type="integer"/>
+    </group>
+  </list>
+</element>`
+
+	t.Run("valid two tokens", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a>1 2</a>`)
+		require.NoError(t, err, `"1 2" should validate`)
+	})
+
+	t.Run("invalid three tokens", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a>1 2 3</a>`)
+		require.Error(t, err, `"1 2 3" should be rejected`)
+	})
+}
+
+// TestTokenMatcherGroupBacktrack covers a <list> group where a greedy
+// <oneOrMore> must give back a token so a later mandatory <value> matches.
+func TestTokenMatcherGroupBacktrack(t *testing.T) {
+	t.Parallel()
+
+	schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <list>
+    <group>
+      <oneOrMore>
+        <data type="NMTOKEN"/>
+      </oneOrMore>
+      <value>END</value>
+    </group>
+  </list>
+</element>`
+
+	t.Run("valid trailing value", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a>a b END</a>`)
+		require.NoError(t, err, `"a b END" should validate`)
+	})
+
+	t.Run("invalid missing value", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a>a b c</a>`)
+		require.Error(t, err, `missing END should be rejected`)
+	})
+}
+
+// TestTokenMatcherChoiceShadowAttr covers the same choice-shadow shape inside
+// an attribute value (driven through matchAttrContent's patternGroup case).
+func TestTokenMatcherChoiceShadowAttr(t *testing.T) {
+	t.Parallel()
+
+	schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <attribute name="v">
+    <group>
+      <choice>
+        <empty/>
+        <data type="integer"/>
+      </choice>
+      <data type="integer"/>
+    </group>
+  </attribute>
+</element>`
+
+	t.Run("valid two tokens", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a v="1 2"/>`)
+		require.NoError(t, err, `attribute "1 2" should validate`)
+	})
+
+	t.Run("invalid three tokens", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a v="1 2 3"/>`)
+		require.Error(t, err, `attribute "1 2 3" should be rejected`)
+	})
+}

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1,6 +1,7 @@
 package relaxng
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"regexp"
@@ -1235,32 +1236,47 @@ func (v *validator) matchAttrTokensCounts(pat *pattern, tokens []string) []int {
 
 // groupCounts returns every total consumption count for matching children
 // sequentially against tokens, backtracking across each member's options.
+//
+// The set of counts children[ci:] can consume starting at tokens[off:] depends
+// only on (ci, off), not on how that offset was reached, so it is memoized.
+// Without this, the sibling enumeration is exponential — e.g. a group of N
+// optionals over the tokens explores 2^N paths even though it has only N+1
+// distinct totals.
 func (v *validator) groupCounts(children []*pattern, tokens []string) []int {
-	if len(children) == 0 {
-		return []int{0}
-	}
-	head := children[0]
-	rest := children[1:]
-	seen := map[int]struct{}{}
-	var counts []int
-	for _, n := range v.matchAttrTokensCounts(head, tokens) {
-		for _, m := range v.groupCounts(rest, tokens[n:]) {
-			total := n + m
-			if _, ok := seen[total]; ok {
-				continue
-			}
-			seen[total] = struct{}{}
-			counts = append(counts, total)
+	memo := map[[2]int][]int{}
+	var rec func(ci, off int) []int
+	rec = func(ci, off int) []int {
+		if ci >= len(children) {
+			return []int{0}
 		}
+		key := [2]int{ci, off}
+		if cached, ok := memo[key]; ok {
+			return cached
+		}
+		seen := map[int]struct{}{}
+		var counts []int
+		for _, n := range v.matchAttrTokensCounts(children[ci], tokens[off:]) {
+			for _, m := range rec(ci+1, off+n) {
+				total := n + m
+				if _, ok := seen[total]; ok {
+					continue
+				}
+				seen[total] = struct{}{}
+				counts = append(counts, total)
+			}
+		}
+		sortDescending(counts)
+		memo[key] = counts
+		return counts
 	}
-	sortDescending(counts)
-	return counts
+	return rec(0, 0)
 }
 
 // repeatCounts returns every consumption count for matching content repeatedly
 // (at least minReps times) against tokens.
 func (v *validator) repeatCounts(content *pattern, tokens []string, minReps int) []int {
-	seen := map[int]struct{}{}
+	seen := map[int]struct{}{}     // offsets already recorded as results
+	explored := map[int]struct{}{} // offsets whose deeper recursion is done
 	var counts []int
 	var recurse func(offset, reps int)
 	recurse = func(offset, reps int) {
@@ -1270,10 +1286,26 @@ func (v *validator) repeatCounts(content *pattern, tokens []string, minReps int)
 				counts = append(counts, offset)
 			}
 		}
+		// The offsets reachable from here don't depend on reps, so explore each
+		// offset only once. Without this, overlapping repetition paths make the
+		// enumeration exponential.
+		if _, done := explored[offset]; done {
+			return
+		}
+		explored[offset] = struct{}{}
 		for _, n := range v.matchAttrTokensCounts(content, tokens[offset:]) {
 			if n == 0 {
-				// Zero-width repetition cannot make progress; stop to avoid
-				// looping forever.
+				// A zero-width match cannot make progress, so we must not
+				// recurse (it would loop forever). But it is still a valid
+				// iteration: if taking it once satisfies minReps, record the
+				// current offset. This lets oneOrMore match nullable content
+				// (optional/empty/text), matching node-level validateOneOrMore.
+				if reps+1 >= minReps {
+					if _, ok := seen[offset]; !ok {
+						seen[offset] = struct{}{}
+						counts = append(counts, offset)
+					}
+				}
 				continue
 			}
 			recurse(offset+n, reps+1)
@@ -1286,7 +1318,7 @@ func (v *validator) repeatCounts(content *pattern, tokens []string, minReps int)
 
 // sortDescending sorts counts in place, largest first (greedy-preferred).
 func sortDescending(counts []int) {
-	slices.SortFunc(counts, func(a, b int) int { return b - a })
+	slices.SortFunc(counts, func(a, b int) int { return cmp.Compare(b, a) })
 }
 
 func (v *validator) validateGroup(pat *pattern, state *validState) int {

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1052,10 +1052,8 @@ func (v *validator) matchAttrContent(pat *pattern, text string, elem *helium.Ele
 		// consumption options so a greedy repetition or a zero-token choice
 		// branch cannot strand a later mandatory member.
 		tokens := strings.Fields(text)
-		for _, n := range v.groupCounts(pat.children, tokens) {
-			if n == len(tokens) {
-				return 0
-			}
+		if slices.Contains(v.groupCounts(pat.children, tokens), len(tokens)) {
+			return 0
 		}
 		return -1
 	case patternEmpty:
@@ -1093,10 +1091,8 @@ func (v *validator) matchListContent(pat *pattern, text string, elem *helium.Ele
 	// Backtrack across each member's consumption options so a greedy
 	// repetition or a zero-token choice branch cannot strand a later
 	// mandatory member.
-	for _, n := range v.groupCounts(pat.children, tokens) {
-		if n == len(tokens) {
-			return 0
-		}
+	if slices.Contains(v.groupCounts(pat.children, tokens), len(tokens)) {
+		return 0
 	}
 
 	// No combination consumed the whole list. Report a best-effort error by

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1468,76 +1468,15 @@ func (v *validator) validateValue(pat *pattern, state *validState) int {
 }
 
 func (v *validator) validateList(pat *pattern, state *validState) int {
+	// Delegate to the shared token matcher so every <list> path — element
+	// content and this validatePattern path (lists nested under
+	// optional/oneOrMore/choice, or at grammar.start) — uses the same
+	// backtracking semantics. The previous hand-rolled matcher here only
+	// handled data/value/(zero|one)OrMore-of-data and silently ignored
+	// group/choice/optional/nested children. Pass a nil element: the naive
+	// path has no element context for per-token error reporting.
 	text := v.collectText(state)
-	tokens := strings.Fields(text)
-
-	if len(pat.children) == 0 {
-		if len(tokens) == 0 {
-			return 0
-		}
-		return -1
-	}
-
-	for _, child := range pat.children {
-		switch child.kind {
-		case patternData:
-			if len(tokens) == 0 {
-				return -1
-			}
-			if v.matchData(child, tokens[0]) != 0 {
-				return -1
-			}
-			tokens = tokens[1:]
-		case patternValue:
-			if len(tokens) == 0 {
-				return -1
-			}
-			if v.matchValue(child, tokens[0]) != 0 {
-				return -1
-			}
-			tokens = tokens[1:]
-		case patternOneOrMore:
-			if len(tokens) == 0 {
-				return -1
-			}
-			for len(tokens) > 0 {
-				matched := false
-				for _, cc := range child.children {
-					if cc.kind == patternData {
-						if v.matchData(cc, tokens[0]) == 0 {
-							tokens = tokens[1:]
-							matched = true
-							break
-						}
-					}
-				}
-				if !matched {
-					break
-				}
-			}
-		case patternZeroOrMore:
-			for len(tokens) > 0 {
-				matched := false
-				for _, cc := range child.children {
-					if cc.kind == patternData {
-						if v.matchData(cc, tokens[0]) == 0 {
-							tokens = tokens[1:]
-							matched = true
-							break
-						}
-					}
-				}
-				if !matched {
-					break
-				}
-			}
-		}
-	}
-
-	if len(tokens) > 0 {
-		return -1
-	}
-	return 0
+	return v.matchListContent(pat, text, nil)
 }
 
 // collectText consumes text nodes from the state and returns their content.

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1068,7 +1068,7 @@ func (v *validator) matchAttrContent(pat *pattern, text string, elem *helium.Ele
 		}
 		content := wrapChildren(pat.children)
 		return v.matchAttrContent(content, text, elem)
-	case patternRef:
+	case patternRef, patternParentRef:
 		def, ok := v.grammar.defines[pat.name]
 		if !ok {
 			return -1
@@ -1207,7 +1207,7 @@ func (v *validator) matchAttrTokensCounts(pat *pattern, tokens []string) []int {
 		return []int{0}
 	case patternEmpty:
 		return []int{0}
-	case patternRef:
+	case patternRef, patternParentRef:
 		def, ok := v.grammar.defines[pat.name]
 		if !ok {
 			return nil

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1048,20 +1048,16 @@ func (v *validator) matchAttrContent(pat *pattern, text string, elem *helium.Ele
 		}
 		return 0
 	case patternGroup:
-		// Sequential match on tokens
+		// Sequential match on tokens, backtracking across each member's
+		// consumption options so a greedy repetition or a zero-token choice
+		// branch cannot strand a later mandatory member.
 		tokens := strings.Fields(text)
-		offset := 0
-		for _, child := range pat.children {
-			n, ok := v.matchAttrTokens(child, tokens[offset:])
-			if !ok {
-				return -1
+		for _, n := range v.groupCounts(pat.children, tokens) {
+			if n == len(tokens) {
+				return 0
 			}
-			offset += n
 		}
-		if offset != len(tokens) {
-			return -1
-		}
-		return 0
+		return -1
 	case patternEmpty:
 		if strings.TrimSpace(text) == "" {
 			return 0
@@ -1094,26 +1090,34 @@ func (v *validator) matchAttrContent(pat *pattern, text string, elem *helium.Ele
 // matchListContent validates a string against a list pattern.
 func (v *validator) matchListContent(pat *pattern, text string, elem *helium.Element) int {
 	tokens := strings.Fields(text)
-	offset := 0
-	for _, child := range pat.children {
-		n, ok := v.matchAttrTokens(child, tokens[offset:])
-		if !ok {
-			if elem != nil {
+	// Backtrack across each member's consumption options so a greedy
+	// repetition or a zero-token choice branch cannot strand a later
+	// mandatory member.
+	for _, n := range v.groupCounts(pat.children, tokens) {
+		if n == len(tokens) {
+			return 0
+		}
+	}
+
+	// No combination consumed the whole list. Report a best-effort error by
+	// replaying members greedily to find where matching first stalls.
+	if elem != nil {
+		offset := 0
+		for _, child := range pat.children {
+			n, ok := v.matchAttrTokens(child, tokens[offset:])
+			if !ok {
 				if typeName := listDataTypeName(child); typeName != "" {
 					v.addError(elem, fmt.Sprintf("failed to validate type %s", typeName))
 				}
+				return -1
 			}
-			return -1
+			offset += n
 		}
-		offset += n
-	}
-	if offset != len(tokens) {
-		if elem != nil {
+		if offset < len(tokens) {
 			v.addError(elem, fmt.Sprintf("Extra data in list: %s", tokens[offset]))
 		}
-		return -1
 	}
-	return 0
+	return -1
 }
 
 // listDataTypeName extracts the data type name from a pattern for list error reporting.
@@ -1136,101 +1140,157 @@ func listDataTypeName(pat *pattern) string {
 	return ""
 }
 
-// matchAttrTokens matches tokens against a pattern, returning how many tokens were consumed.
+// matchAttrTokens matches tokens against a pattern, returning how many tokens
+// were consumed. It prefers the greedy (largest) match; callers needing the
+// full set of consumption options use matchAttrTokensCounts.
 func (v *validator) matchAttrTokens(pat *pattern, tokens []string) (int, bool) {
-	if pat == nil {
+	counts := v.matchAttrTokensCounts(pat, tokens)
+	if len(counts) == 0 {
 		return 0, false
+	}
+	return counts[0], true
+}
+
+// matchAttrTokensCounts returns every token-consumption count that pat can
+// match against the leading tokens, in greedy-preferred (descending) order
+// with duplicates removed. An empty slice means the pattern cannot match.
+//
+// Returning the full set (rather than a single count) lets the group matcher
+// backtrack: a greedy oneOrMore/zeroOrMore that over-consumes can yield tokens
+// back when a later mandatory member fails, and a choice with a zero-token
+// branch (e.g. empty) does not shadow a consuming branch.
+func (v *validator) matchAttrTokensCounts(pat *pattern, tokens []string) []int {
+	if pat == nil {
+		return nil
 	}
 	switch pat.kind {
 	case patternData:
 		if len(tokens) == 0 {
-			return 0, false
+			return nil
 		}
 		if v.matchData(pat, tokens[0]) == 0 {
-			return 1, true
+			return []int{1}
 		}
-		return 0, false
+		return nil
 	case patternValue:
 		if len(tokens) == 0 {
-			return 0, false
+			return nil
 		}
 		if v.matchValue(pat, tokens[0]) == 0 {
-			return 1, true
+			return []int{1}
 		}
-		return 0, false
+		return nil
 	case patternChoice:
+		seen := map[int]struct{}{}
+		var counts []int
 		for _, child := range pat.children {
-			n, ok := v.matchAttrTokens(child, tokens)
-			if ok {
-				return n, true
+			for _, n := range v.matchAttrTokensCounts(child, tokens) {
+				if _, ok := seen[n]; ok {
+					continue
+				}
+				seen[n] = struct{}{}
+				counts = append(counts, n)
 			}
 		}
-		return 0, false
+		sortDescending(counts)
+		return counts
 	case patternOneOrMore:
 		content := wrapChildren(pat.children)
-		total := 0
-		// Must match at least once
-		n, ok := v.matchAttrTokens(content, tokens[total:])
-		if !ok {
-			return 0, false
-		}
-		total += n
-		// Then zero or more
-		for total < len(tokens) {
-			n, ok = v.matchAttrTokens(content, tokens[total:])
-			if !ok {
-				break
-			}
-			if n == 0 {
-				break
-			}
-			total += n
-		}
-		return total, true
+		return v.repeatCounts(content, tokens, 1)
 	case patternZeroOrMore:
 		content := wrapChildren(pat.children)
-		total := 0
-		for total < len(tokens) {
-			n, ok := v.matchAttrTokens(content, tokens[total:])
-			if !ok || n == 0 {
-				break
-			}
-			total += n
-		}
-		return total, true
+		return v.repeatCounts(content, tokens, 0)
 	case patternGroup:
-		total := 0
-		for _, child := range pat.children {
-			n, ok := v.matchAttrTokens(child, tokens[total:])
-			if !ok {
-				return 0, false
-			}
-			total += n
-		}
-		return total, true
+		return v.groupCounts(pat.children, tokens)
 	case patternText:
-		// Text in a list: consume one token
+		// Text in a list: consume one token (or none when empty).
 		if len(tokens) > 0 {
-			return 1, true
+			return []int{1}
 		}
-		return 0, true
+		return []int{0}
 	case patternEmpty:
-		return 0, true
+		return []int{0}
 	case patternRef:
 		def, ok := v.grammar.defines[pat.name]
 		if !ok {
-			return 0, false
+			return nil
 		}
-		return v.matchAttrTokens(def, tokens)
+		return v.matchAttrTokensCounts(def, tokens)
 	case patternOptional:
 		content := wrapChildren(pat.children)
-		n, ok := v.matchAttrTokens(content, tokens)
-		if ok && n > 0 {
-			return n, true
+		seen := map[int]struct{}{0: {}}
+		counts := []int{}
+		for _, n := range v.matchAttrTokensCounts(content, tokens) {
+			if n == 0 {
+				continue
+			}
+			if _, ok := seen[n]; ok {
+				continue
+			}
+			seen[n] = struct{}{}
+			counts = append(counts, n)
 		}
-		return 0, true
+		counts = append(counts, 0)
+		sortDescending(counts)
+		return counts
 	}
-	return 0, false
+	return nil
+}
+
+// groupCounts returns every total consumption count for matching children
+// sequentially against tokens, backtracking across each member's options.
+func (v *validator) groupCounts(children []*pattern, tokens []string) []int {
+	if len(children) == 0 {
+		return []int{0}
+	}
+	head := children[0]
+	rest := children[1:]
+	seen := map[int]struct{}{}
+	var counts []int
+	for _, n := range v.matchAttrTokensCounts(head, tokens) {
+		for _, m := range v.groupCounts(rest, tokens[n:]) {
+			total := n + m
+			if _, ok := seen[total]; ok {
+				continue
+			}
+			seen[total] = struct{}{}
+			counts = append(counts, total)
+		}
+	}
+	sortDescending(counts)
+	return counts
+}
+
+// repeatCounts returns every consumption count for matching content repeatedly
+// (at least minReps times) against tokens.
+func (v *validator) repeatCounts(content *pattern, tokens []string, minReps int) []int {
+	seen := map[int]struct{}{}
+	var counts []int
+	var recurse func(offset, reps int)
+	recurse = func(offset, reps int) {
+		if reps >= minReps {
+			if _, ok := seen[offset]; !ok {
+				seen[offset] = struct{}{}
+				counts = append(counts, offset)
+			}
+		}
+		for _, n := range v.matchAttrTokensCounts(content, tokens[offset:]) {
+			if n == 0 {
+				// Zero-width repetition cannot make progress; stop to avoid
+				// looping forever.
+				continue
+			}
+			recurse(offset+n, reps+1)
+		}
+	}
+	recurse(0, 0)
+	sortDescending(counts)
+	return counts
+}
+
+// sortDescending sorts counts in place, largest first (greedy-preferred).
+func sortDescending(counts []int) {
+	slices.SortFunc(counts, func(a, b int) int { return b - a })
 }
 
 func (v *validator) validateGroup(pat *pattern, state *validState) int {


### PR DESCRIPTION
- Token matchers for `<list>` and attribute values now enumerate all consumption counts and backtrack, so a greedy `oneOrMore`/`zeroOrMore` yields tokens back to a later mandatory member.
- Token-level `choice` no longer lets a zero-token branch (e.g. `empty`) shadow a consuming branch.
