### PR TITLE
xsd: compare identity-constraint keys by value

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -52,6 +52,11 @@ the schema facet's in-scope namespaces.
   3. Check unique/key: all key-sequences must be unique
   4. Check keyref: all key-sequences must exist in referenced constraint table
   - XPath uses namespace context from schema, not instance
+  - Key comparison is value-space aware (XSD 3.11.4): each field value is
+    canonicalized via its declared simple type (`resolveFieldBuiltinLocal` →
+    `value.CanonicalKey`) before map-key use, so `5`/`+5`/`05` collide for
+    xs:integer. Raw values are retained for error display; fields whose type
+    cannot be resolved fall back to raw-string comparison.
 
 ### Key Data Model
 

--- a/internal/xsd/value/canonicalkey_test.go
+++ b/internal/xsd/value/canonicalkey_test.go
@@ -1,0 +1,34 @@
+package value_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/internal/xsd/value"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCanonicalKey covers value-space canonicalization used for identity-
+// constraint keys, focusing on whiteSpace handling per type and float vs double
+// precision.
+func TestCanonicalKey(t *testing.T) {
+	key := func(s, typ string) string {
+		k, _ := value.CanonicalKey(s, typ)
+		return k
+	}
+
+	// xs:string is whiteSpace=preserve: leading/trailing space is significant,
+	// so distinct strings must NOT collide.
+	require.NotEqual(t, key("a", "string"), key("a ", "string"), `"a" and "a " must differ for xs:string`)
+	require.Equal(t, "a ", key("a ", "string"), "xs:string must be preserved verbatim")
+
+	// Collapse types (token, etc.) and list types collapse internal whitespace,
+	// so separator-only differences ARE value-equal.
+	require.Equal(t, key("a b", "token"), key("a  b", "token"), "xs:token collapses internal whitespace")
+	require.Equal(t, key("x y", "IDREFS"), key("x  y", "IDREFS"), "xs:IDREFS collapses internal whitespace")
+	require.Equal(t, key("x y", "IDREFS"), key(" x y ", "IDREFS"), "xs:IDREFS trims leading/trailing")
+
+	// xs:float uses 32-bit IEEE: 16777216 and 16777217 round to the same float32
+	// (2^24 boundary) and must collide, while as xs:double they stay distinct.
+	require.Equal(t, key("16777216", "float"), key("16777217", "float"), "values equal in float32 must collide for xs:float")
+	require.NotEqual(t, key("16777216", "double"), key("16777217", "double"), "distinct doubles must not collide for xs:double")
+}

--- a/internal/xsd/value/canonicalkey_test.go
+++ b/internal/xsd/value/canonicalkey_test.go
@@ -31,4 +31,9 @@ func TestCanonicalKey(t *testing.T) {
 	// (2^24 boundary) and must collide, while as xs:double they stay distinct.
 	require.Equal(t, key("16777216", "float"), key("16777217", "float"), "values equal in float32 must collide for xs:float")
 	require.NotEqual(t, key("16777216", "double"), key("16777217", "double"), "distinct doubles must not collide for xs:double")
+
+	// Signed zero: -0 and 0 are value-equal, so they must produce the same key.
+	require.Equal(t, key("0", "double"), key("-0", "double"), "-0 and 0 must collide for xs:double")
+	require.Equal(t, key("0", "float"), key("-0", "float"), "-0 and 0 must collide for xs:float")
+	require.Equal(t, key("0.0", "double"), key("-0.0", "double"), "-0.0 and 0.0 must collide")
 }

--- a/internal/xsd/value/compare.go
+++ b/internal/xsd/value/compare.go
@@ -1,6 +1,7 @@
 package value
 
 import (
+	"fmt"
 	"math"
 	"math/big"
 	"strconv"
@@ -39,6 +40,85 @@ func Compare(a, b, builtinLocal string) (int, bool) {
 		}
 		return cmp, true
 	}
+}
+
+// CanonicalKey maps a lexical value to a value-space canonical string for the
+// given builtin type, so lexically-distinct but value-equal inputs (e.g. "5"
+// and "+5" for xs:integer) produce the same key. It returns (key, true) when a
+// canonical form is defined; otherwise (collapsed-whitespace value, false) for
+// string-family types and anything unrecognized or unparsable.
+func CanonicalKey(s, builtinLocal string) (string, bool) {
+	trimmed := strings.TrimSpace(s)
+	switch builtinLocal {
+	case "boolean":
+		if trimmed == "true" || trimmed == "1" {
+			return "1", true
+		}
+		if trimmed == "false" || trimmed == "0" {
+			return "0", true
+		}
+		return trimmed, false
+	case "float", "double":
+		f, ok := parseXSDFloat(trimmed)
+		if !ok {
+			return trimmed, false
+		}
+		if math.IsNaN(f) {
+			return "NaN", true
+		}
+		if math.IsInf(f, 1) {
+			return "INF", true
+		}
+		if math.IsInf(f, -1) {
+			return "-INF", true
+		}
+		return strconv.FormatFloat(f, 'g', -1, 64), true
+	case "dateTime", "date", "time", "gYear", "gYearMonth", "gMonth", "gDay", "gMonthDay":
+		return canonicalDateTimeKey(trimmed, builtinLocal)
+	case "decimal", "integer",
+		"nonPositiveInteger", "negativeInteger", "long", "int", "short", "byte",
+		"nonNegativeInteger", "unsignedLong", "unsignedInt", "unsignedShort", "unsignedByte",
+		"positiveInteger":
+		r, ok := new(big.Rat).SetString(trimmed)
+		if !ok {
+			return trimmed, false
+		}
+		return r.RatString(), true
+	default:
+		// String-family and unrecognized types compare by their lexical
+		// (whitespace-collapsed) value.
+		return trimmed, false
+	}
+}
+
+func canonicalDateTimeKey(s, builtinLocal string) (string, bool) {
+	var dt xsdDateTime
+	var ok bool
+	switch builtinLocal {
+	case "dateTime":
+		dt, ok = parseXSDDateTime(s)
+	case "date":
+		dt, ok = parseXSDDate(s)
+	case "time":
+		dt, ok = parseXSDTime(s)
+	case "gYear":
+		dt, ok = parseXSDGYear(s)
+	case "gYearMonth":
+		dt, ok = parseXSDGYearMonth(s)
+	case "gMonth":
+		dt, ok = parseXSDGMonth(s)
+	case "gDay":
+		dt, ok = parseXSDGDay(s)
+	case "gMonthDay":
+		dt, ok = parseXSDGMonthDay(s)
+	}
+	if !ok {
+		return s, false
+	}
+	if dt.hasTZ {
+		dt = dt.normalizeToUTC()
+	}
+	return fmt.Sprintf("%d|%d|%d|%d|%d|%g|%t", dt.year, dt.month, dt.day, dt.hour, dt.min, dt.sec, dt.hasTZ), true
 }
 
 // CompareDecimal compares two decimal string values using math/big.Rat.

--- a/internal/xsd/value/compare.go
+++ b/internal/xsd/value/compare.go
@@ -123,6 +123,9 @@ func canonicalFloatKey(s string, bitSize int) (string, bool) {
 	if bitSize == 32 {
 		f = float64(float32(f)) // round to xs:float precision
 	}
+	if f == 0 {
+		f = 0 // normalize -0 to +0; they are equal in the value space
+	}
 	return strconv.FormatFloat(f, 'g', -1, bitSize), true
 }
 

--- a/internal/xsd/value/compare.go
+++ b/internal/xsd/value/compare.go
@@ -57,9 +57,9 @@ func Compare(a, b, builtinLocal string) (int, bool) {
 // canonical form is defined; otherwise (collapsed-whitespace value, false) for
 // string-family types and anything unrecognized or unparsable.
 func CanonicalKey(s, builtinLocal string) (string, bool) {
-	trimmed := strings.TrimSpace(s)
 	switch builtinLocal {
 	case "boolean":
+		trimmed := strings.TrimSpace(s)
 		if trimmed == "true" || trimmed == "1" {
 			return "1", true
 		}
@@ -67,37 +67,74 @@ func CanonicalKey(s, builtinLocal string) (string, bool) {
 			return "0", true
 		}
 		return trimmed, false
-	case "float", "double":
-		f, ok := parseXSDFloat(trimmed)
-		if !ok {
-			return trimmed, false
-		}
-		if math.IsNaN(f) {
-			return "NaN", true
-		}
-		if math.IsInf(f, 1) {
-			return "INF", true
-		}
-		if math.IsInf(f, -1) {
-			return "-INF", true
-		}
-		return strconv.FormatFloat(f, 'g', -1, 64), true
+	case "float":
+		return canonicalFloatKey(s, 32) // xs:float is 32-bit IEEE-754
+	case "double":
+		return canonicalFloatKey(s, 64)
 	case "dateTime", "date", "time", "gYear", "gYearMonth", "gMonth", "gDay", "gMonthDay":
-		return canonicalDateTimeKey(trimmed, builtinLocal)
+		return canonicalDateTimeKey(strings.TrimSpace(s), builtinLocal)
 	case "decimal", "integer",
 		"nonPositiveInteger", "negativeInteger", "long", "int", "short", "byte",
 		"nonNegativeInteger", "unsignedLong", "unsignedInt", "unsignedShort", "unsignedByte",
 		"positiveInteger":
+		trimmed := strings.TrimSpace(s)
 		r, ok := new(big.Rat).SetString(trimmed)
 		if !ok {
 			return trimmed, false
 		}
 		return r.RatString(), true
+	case "string":
+		// whiteSpace=preserve: the value space is the exact lexical string, so
+		// leading/trailing/internal whitespace is significant. Do not alter it.
+		return s, false
+	case "normalizedString":
+		// whiteSpace=replace: tab/newline/carriage-return become spaces.
+		return whitespaceReplace(s), false
+	case "NMTOKENS", "IDREFS", "ENTITIES":
+		// List types: collapse internal whitespace so token sequences that
+		// differ only in separator whitespace are value-equal.
+		return strings.Join(strings.Fields(s), " "), false
 	default:
-		// String-family and unrecognized types compare by their lexical
-		// (whitespace-collapsed) value.
+		// Remaining string-derived types (token, NMTOKEN, Name, NCName, ID,
+		// IDREF, ENTITY, language, anyURI, …) have whiteSpace=collapse.
+		return strings.Join(strings.Fields(s), " "), false
+	}
+}
+
+// canonicalFloatKey canonicalizes an xs:float/xs:double value at the given IEEE
+// precision (bitSize 32 for xs:float, 64 for xs:double). Using the correct
+// precision ensures values that are equal in xs:float's 32-bit value space (but
+// distinct as 64-bit doubles) map to the same key, and vice versa.
+func canonicalFloatKey(s string, bitSize int) (string, bool) {
+	trimmed := strings.TrimSpace(s)
+	f, ok := parseXSDFloat(trimmed)
+	if !ok {
 		return trimmed, false
 	}
+	if math.IsNaN(f) {
+		return "NaN", true
+	}
+	if math.IsInf(f, 1) {
+		return "INF", true
+	}
+	if math.IsInf(f, -1) {
+		return "-INF", true
+	}
+	if bitSize == 32 {
+		f = float64(float32(f)) // round to xs:float precision
+	}
+	return strconv.FormatFloat(f, 'g', -1, bitSize), true
+}
+
+// whitespaceReplace applies the XSD whiteSpace="replace" normalization: each
+// tab, newline, and carriage return becomes a single space.
+func whitespaceReplace(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' || r == '\r' {
+			return ' '
+		}
+		return r
+	}, s)
 }
 
 func canonicalDateTimeKey(s, builtinLocal string) (string, bool) {

--- a/xsd/validate_idc.go
+++ b/xsd/validate_idc.go
@@ -292,15 +292,27 @@ func resolveElemType(target, host *helium.Element, hostDecl *ElementDecl, schema
 		return nil
 	}
 
-	// Build the ancestor chain from host's child down to target.
+	// Build the ancestor chain from host's child down to target, tracking
+	// whether the walk actually reaches host. If it doesn't (target is not in
+	// host's subtree as far as the element ancestry shows), descending host's
+	// content model would match unrelated names and yield a wrong type, so fall
+	// back to the global element declaration instead.
 	var chain []*helium.Element
-	for cur := target; cur != nil && cur != host; {
+	reached := false
+	for cur := target; cur != nil; {
+		if cur == host {
+			reached = true
+			break
+		}
 		chain = append(chain, cur)
 		parent, ok := cur.Parent().(*helium.Element)
 		if !ok {
 			break
 		}
 		cur = parent
+	}
+	if !reached {
+		return resolveElemTypeFallback(target, schema)
 	}
 
 	td := hostType(host, hostDecl, schema)

--- a/xsd/validate_idc.go
+++ b/xsd/validate_idc.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/xsd/value"
 	"github.com/lestrrat-go/helium/xpath1"
 )
 
@@ -17,7 +18,8 @@ type idcTable struct {
 
 // idcEntry holds a single key-sequence value and the node that produced it.
 type idcEntry struct {
-	values []string        // one value per field
+	values []string        // raw field values (for human-readable error display)
+	canon  []string        // value-space canonical field values (for key comparison)
 	node   helium.Node     // the node selected by the selector
 	elem   *helium.Element // the element (for line number reporting)
 }
@@ -37,7 +39,7 @@ func (vc *validationContext) validateIDConstraints(ctx context.Context, elem *he
 	for _, idc := range edecl.IDCs {
 		// Use the schema's namespace context for XPath evaluation.
 		ev := xpath1.NewEvaluator().AdditionalNamespaces(idc.Namespaces)
-		table, err := evaluateIDC(ctx, ev, elem, idc)
+		table, err := evaluateIDC(ctx, ev, elem, edecl, idc, vc.schema)
 		if err != nil {
 			continue
 		}
@@ -81,7 +83,7 @@ func (vc *validationContext) validateIDConstraints(ctx context.Context, elem *he
 }
 
 // evaluateIDC evaluates the selector and field XPaths for a single IDC.
-func evaluateIDC(ctx context.Context, ev xpath1.Evaluator, elem *helium.Element, idc *IDConstraint) (*idcTable, error) {
+func evaluateIDC(ctx context.Context, ev xpath1.Evaluator, elem *helium.Element, edecl *ElementDecl, idc *IDConstraint, schema *Schema) (*idcTable, error) {
 	// Evaluate selector XPath using pre-compiled expression when available.
 	var selectorResult *xpath1.Result
 	var err error
@@ -131,12 +133,14 @@ func evaluateIDC(ctx context.Context, ev xpath1.Evaluator, elem *helium.Element,
 			}
 
 			var value string
+			var fieldNode helium.Node
 			switch fieldResult.Type {
 			case xpath1.NodeSetResult:
 				if len(fieldResult.NodeSet) == 0 {
 					allPresent = false
 				} else {
-					value = nodeStringValue(fieldResult.NodeSet[0])
+					fieldNode = fieldResult.NodeSet[0]
+					value = nodeStringValue(fieldNode)
 				}
 			case xpath1.StringResult:
 				value = fieldResult.String
@@ -144,6 +148,13 @@ func evaluateIDC(ctx context.Context, ev xpath1.Evaluator, elem *helium.Element,
 				value = fmt.Sprintf("%v", fieldResult.Number)
 			}
 			entry.values = append(entry.values, value)
+
+			// Canonicalize to the value space using the field's declared
+			// simple type, so lexically-distinct but value-equal keys (e.g.
+			// "5" and "+5" for xs:integer) compare equal. Falls back to the
+			// raw value when the type cannot be resolved.
+			builtinLocal := resolveFieldBuiltinLocal(fieldNode, elem, edecl, schema)
+			entry.canon = append(entry.canon, canonicalKey(value, builtinLocal))
 		}
 
 		if allPresent {
@@ -168,12 +179,12 @@ func nodeStringValue(n helium.Node) string {
 
 // checkUniqueness checks that all key-sequences in the table are unique.
 func (vc *validationContext) checkUniqueness(ctx context.Context, table *idcTable, idc *IDConstraint) error {
-	seen := make(map[string]bool)
+	seen := make(map[string]struct{})
 	var lastErr error
 
 	for _, entry := range table.keys {
-		key := formatKeySequence(entry.values)
-		if seen[key] {
+		key := formatKeySequence(entry.canon)
+		if _, dup := seen[key]; dup {
 			elemName := entryDisplayName(entry)
 			idcName := idcDisplayName(idc, vc.schema)
 			msg := fmt.Sprintf("Duplicate key-sequence %s in unique identity-constraint '%s'.",
@@ -183,7 +194,7 @@ func (vc *validationContext) checkUniqueness(ctx context.Context, table *idcTabl
 			}
 			lastErr = fmt.Errorf("duplicate key-sequence")
 		}
-		seen[key] = true
+		seen[key] = struct{}{}
 	}
 
 	return lastErr
@@ -191,16 +202,16 @@ func (vc *validationContext) checkUniqueness(ctx context.Context, table *idcTabl
 
 // checkKeyRef checks that every key-sequence in the keyref table has a match in the referenced table.
 func (vc *validationContext) checkKeyRef(ctx context.Context, keyrefTable, refTable *idcTable, idc *IDConstraint) error {
-	// Build set of referenced key-sequences.
-	refKeys := make(map[string]bool, len(refTable.keys))
+	// Build set of referenced key-sequences (value-space canonical).
+	refKeys := make(map[string]struct{}, len(refTable.keys))
 	for _, entry := range refTable.keys {
-		refKeys[formatKeySequence(entry.values)] = true
+		refKeys[formatKeySequence(entry.canon)] = struct{}{}
 	}
 
 	var lastErr error
 	for _, entry := range keyrefTable.keys {
-		key := formatKeySequence(entry.values)
-		if !refKeys[key] {
+		key := formatKeySequence(entry.canon)
+		if _, ok := refKeys[key]; !ok {
 			elemName := entryDisplayName(entry)
 			idcName := idcDisplayName(idc, vc.schema)
 			msg := fmt.Sprintf("No match found for key-sequence %s of keyref '%s'.",
@@ -213,6 +224,175 @@ func (vc *validationContext) checkKeyRef(ctx context.Context, keyrefTable, refTa
 	}
 
 	return lastErr
+}
+
+// canonicalKey maps a raw field value to a value-space canonical key for the
+// given builtin type. An empty builtinLocal (unresolved type) falls back to the
+// raw value, preserving the previous lexical-only behavior for that field.
+func canonicalKey(raw, builtinLocal string) string {
+	if builtinLocal == "" {
+		return raw
+	}
+	key, _ := value.CanonicalKey(raw, builtinLocal)
+	return key
+}
+
+// resolveFieldBuiltinLocal resolves the builtin XSD base local name of the
+// simple type declared for an IDC field node. host/hostDecl are the element the
+// constraint is declared on, used to descend the schema content model down to
+// the field node. Returns "" when the type cannot be determined, in which case
+// the caller falls back to raw-string comparison for that field.
+func resolveFieldBuiltinLocal(n helium.Node, host *helium.Element, hostDecl *ElementDecl, schema *Schema) string {
+	switch v := n.(type) {
+	case *helium.Element:
+		td := resolveElemType(v, host, hostDecl, schema)
+		if td == nil {
+			return ""
+		}
+		return builtinBaseLocal(td)
+	case *helium.Attribute:
+		return resolveAttrBuiltinLocal(v, host, hostDecl, schema)
+	default:
+		return ""
+	}
+}
+
+// resolveAttrBuiltinLocal resolves the builtin base local of an attribute's
+// declared type, preferring the owning element's complex-type attribute uses
+// and falling back to a matching global attribute declaration.
+func resolveAttrBuiltinLocal(attr *helium.Attribute, host *helium.Element, hostDecl *ElementDecl, schema *Schema) string {
+	aqn := QName{Local: attr.LocalName(), NS: attr.URI()}
+
+	if owner, ok := attr.Parent().(*helium.Element); ok {
+		if td := resolveElemType(owner, host, hostDecl, schema); td != nil {
+			if at := attrUseType(td, aqn, schema); at != nil {
+				return builtinBaseLocal(at)
+			}
+		}
+	}
+
+	if ga, ok := schema.globalAttrs[aqn]; ok {
+		if td, ok := schema.types[ga.TypeName]; ok {
+			return builtinBaseLocal(td)
+		}
+	}
+	return ""
+}
+
+// resolveElemType resolves the schema type of an instance element by descending
+// the host element's content model along the element's ancestor chain. The
+// element must be a descendant of host (true for IDC selector/field results).
+// Falls back to a global element declaration lookup.
+func resolveElemType(target, host *helium.Element, hostDecl *ElementDecl, schema *Schema) *TypeDef {
+	if target == host {
+		if hostDecl != nil {
+			return hostDecl.Type
+		}
+		return nil
+	}
+
+	// Build the ancestor chain from host's child down to target.
+	var chain []*helium.Element
+	for cur := target; cur != nil && cur != host; {
+		chain = append(chain, cur)
+		parent, ok := cur.Parent().(*helium.Element)
+		if !ok {
+			break
+		}
+		cur = parent
+	}
+
+	td := hostType(host, hostDecl, schema)
+	// Descend from host's type through each level (outermost ancestor last in chain).
+	for i := len(chain) - 1; i >= 0; i-- {
+		if td == nil {
+			break
+		}
+		qn := QName{Local: chain[i].LocalName(), NS: chain[i].URI()}
+		decl := childElemDecl(td, qn, schema)
+		if decl == nil {
+			return resolveElemTypeFallback(target, schema)
+		}
+		td = decl.Type
+	}
+	if td != nil {
+		return td
+	}
+	return resolveElemTypeFallback(target, schema)
+}
+
+func resolveElemTypeFallback(target *helium.Element, schema *Schema) *TypeDef {
+	decl := lookupElemDecl(target, schema)
+	if decl == nil {
+		return nil
+	}
+	return decl.Type
+}
+
+// hostType returns the type of the host element, preferring its declaration.
+func hostType(host *helium.Element, hostDecl *ElementDecl, schema *Schema) *TypeDef {
+	if hostDecl != nil && hostDecl.Type != nil {
+		return hostDecl.Type
+	}
+	decl := lookupElemDecl(host, schema)
+	if decl == nil {
+		return nil
+	}
+	return decl.Type
+}
+
+// childElemDecl finds a child element declaration matching qn within a type's
+// content model (walking the base-type chain), resolving substitution-group
+// members through global declarations as a fallback.
+func childElemDecl(td *TypeDef, qn QName, schema *Schema) *ElementDecl {
+	for cur := td; cur != nil; cur = cur.BaseType {
+		if decl := findElemDeclInGroup(cur.ContentModel, qn); decl != nil {
+			return decl
+		}
+	}
+	if decl, ok := schema.LookupElement(qn.Local, qn.NS); ok {
+		return decl
+	}
+	return nil
+}
+
+// findElemDeclInGroup searches a model group recursively for an element
+// declaration matching qn.
+func findElemDeclInGroup(mg *ModelGroup, qn QName) *ElementDecl {
+	if mg == nil {
+		return nil
+	}
+	for _, p := range mg.Particles {
+		switch term := p.Term.(type) {
+		case *ElementDecl:
+			if term.Name == qn {
+				return term
+			}
+		case *ModelGroup:
+			if decl := findElemDeclInGroup(term, qn); decl != nil {
+				return decl
+			}
+		}
+	}
+	return nil
+}
+
+// attrUseType walks a complex type's base chain to find the declared type of an
+// attribute use matching the given QName.
+func attrUseType(td *TypeDef, aqn QName, schema *Schema) *TypeDef {
+	for cur := td; cur != nil; cur = cur.BaseType {
+		for _, au := range cur.Attributes {
+			if au.Name != aqn {
+				continue
+			}
+			at, ok := schema.types[au.TypeName]
+			if !ok {
+				return nil
+			}
+			return at
+		}
+	}
+	return nil
 }
 
 // formatKeySequence creates a unique string key from a sequence of values (for map lookups).

--- a/xsd/validate_idc.go
+++ b/xsd/validate_idc.go
@@ -3,6 +3,7 @@ package xsd
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	helium "github.com/lestrrat-go/helium"
@@ -304,11 +305,11 @@ func resolveElemType(target, host *helium.Element, hostDecl *ElementDecl, schema
 
 	td := hostType(host, hostDecl, schema)
 	// Descend from host's type through each level (outermost ancestor last in chain).
-	for i := len(chain) - 1; i >= 0; i-- {
+	for _, node := range slices.Backward(chain) {
 		if td == nil {
 			break
 		}
-		qn := QName{Local: chain[i].LocalName(), NS: chain[i].URI()}
+		qn := QName{Local: node.LocalName(), NS: node.URI()}
 		decl := childElemDecl(td, qn, schema)
 		if decl == nil {
 			return resolveElemTypeFallback(target, schema)

--- a/xsd/validate_idc_value_space_test.go
+++ b/xsd/validate_idc_value_space_test.go
@@ -1,0 +1,127 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIDCValueSpaceKeys covers identity-constraint key comparison in the XSD
+// value space rather than the lexical space (XSD 3.11.4). For an xs:integer
+// field, "5", "+5", and "05" denote the same value and must be treated as the
+// same key for uniqueness and keyref matching.
+func TestIDCValueSpaceKeys(t *testing.T) {
+	t.Parallel()
+
+	const uniqueSchema = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="n" type="xs:integer"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="itemKey">
+      <xs:selector xpath="item"/>
+      <xs:field xpath="@n"/>
+    </xs:unique>
+  </xs:element>
+</xs:schema>`
+
+	const keyrefSchema = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="n" type="xs:integer"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="ref" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="r" type="xs:integer"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="itemKey">
+      <xs:selector xpath="item"/>
+      <xs:field xpath="@n"/>
+    </xs:key>
+    <xs:keyref name="itemRef" refer="itemKey">
+      <xs:selector xpath="ref"/>
+      <xs:field xpath="@r"/>
+    </xs:keyref>
+  </xs:element>
+</xs:schema>`
+
+	compile := func(t *testing.T, src string) xsd.Validator {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+		require.NoError(t, err)
+		schema, err := xsd.NewCompiler().Compile(t.Context(), doc)
+		require.NoError(t, err)
+		return xsd.NewValidator(schema)
+	}
+
+	cases := []struct {
+		name     string
+		schema   string
+		instance string
+		valid    bool
+	}{
+		{
+			name:     "integer unique 5 and +5 is duplicate",
+			schema:   uniqueSchema,
+			instance: `<root><item n="5"/><item n="+5"/></root>`,
+			valid:    false,
+		},
+		{
+			name:     "integer unique 5 and 05 is duplicate",
+			schema:   uniqueSchema,
+			instance: `<root><item n="5"/><item n="05"/></root>`,
+			valid:    false,
+		},
+		{
+			name:     "integer unique 5 and 6 is not duplicate",
+			schema:   uniqueSchema,
+			instance: `<root><item n="5"/><item n="6"/></root>`,
+			valid:    true,
+		},
+		{
+			name:     "keyref +5 matches key 5",
+			schema:   keyrefSchema,
+			instance: `<root><item n="5"/><ref r="+5"/></root>`,
+			valid:    true,
+		},
+		{
+			name:     "dangling keyref still errors",
+			schema:   keyrefSchema,
+			instance: `<root><item n="5"/><ref r="7"/></root>`,
+			valid:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			v := compile(t, tc.schema)
+
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(tc.instance))
+			require.NoError(t, err)
+
+			var errs string
+			err = validateWithOutput(t, v, doc, &errs)
+			if tc.valid {
+				require.NoError(t, err, "expected valid, got errors: %s", errs)
+				return
+			}
+			require.Error(t, err, "expected validation error")
+		})
+	}
+}


### PR DESCRIPTION
- Compare xs:unique/key/keyref key-sequences in the XSD value space, not lexically (3.11.4)
- Canonicalize each field by its declared simple type before key/keyref matching; keep raw values for error display
- Resolve field types by descending the host element's content model; fall back to raw-string comparison when the type is unknown
