### PR TITLE
xpath3: allow partial application on maps and arrays

### DIFF
--- a/.claude/docs/xpath3-eval.md
+++ b/.claude/docs/xpath3-eval.md
@@ -126,7 +126,9 @@ Check instance-of → error `XPDY0050` if not.
 Resolve by name/arity in builtins or user registry → evaluate args → call.
 
 ### DynamicFunctionCall
-Evaluate func expr → must be FunctionItem → check arity → invoke.
+Evaluate func expr → callee is adapted via `asFunctionItem` (FunctionItem, or
+MapItem/ArrayItem as arity-1 lookup functions) → check arity → invoke. Map/array
+lookup shares `mapLookup`/`arrayLookup` with both the direct-call and partial paths.
 
 ### InlineFunctionExpr
 Capture current variable scope snapshot → return FunctionItem with closure.
@@ -139,6 +141,9 @@ FunctionCall with PlaceholderExpr in args:
 1. Evaluate non-placeholder args
 2. Create FunctionItem closing over fixed-position args
 3. New arity = placeholder count
+
+Dynamic partial application (`$m(?)`, `$a(?)`) accepts any function item; maps and
+arrays are adapted via `asFunctionItem`, so `$m(?)("k")` and `$a(?)(2)` work.
 
 ### MapConstructorExpr
 Evaluate key/value pairs → keys must atomize to AtomicValue → build MapItem.

--- a/.claude/docs/xpath3-eval.md
+++ b/.claude/docs/xpath3-eval.md
@@ -126,9 +126,10 @@ Check instance-of → error `XPDY0050` if not.
 Resolve by name/arity in builtins or user registry → evaluate args → call.
 
 ### DynamicFunctionCall
-Evaluate func expr → callee is adapted via `asFunctionItem` (FunctionItem, or
-MapItem/ArrayItem as arity-1 lookup functions) → check arity → invoke. Map/array
-lookup shares `mapLookup`/`arrayLookup` with both the direct-call and partial paths.
+Evaluate func expr → switch on the callee item: FunctionItem checks arity and
+invokes directly; MapItem/ArrayItem are arity-1 lookup functions resolved via
+`mapLookup`/`arrayLookup`. The placeholder/partial path instead adapts the callee
+through `asFunctionItem`, which shares the same `mapLookup`/`arrayLookup` helpers.
 
 ### InlineFunctionExpr
 Capture current variable scope snapshot → return FunctionItem with closure.

--- a/xpath3/eval_funcall.go
+++ b/xpath3/eval_funcall.go
@@ -69,7 +69,7 @@ func evalDynamicFunctionCall(evalFn exprEvaluator, ctx context.Context, ec *eval
 	}
 
 	if hasPlaceholders {
-		fi, ok := funcSeq.Get(0).(FunctionItem)
+		fi, ok := asFunctionItem(funcSeq.Get(0))
 		if !ok {
 			return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "partial application requires function item"}
 		}
@@ -114,44 +114,76 @@ func evalDynamicFunctionCall(evalFn exprEvaluator, ctx context.Context, ec *eval
 		return v.Invoke(withDynamicCall(ec.fnContext(ctx)), args)
 	case MapItem:
 		// Maps are functions: $map($key) → value
-		if len(args) != 1 || seqLen(args[0]) != 1 {
-			return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "map lookup requires exactly one argument"}
-		}
-		key, err := AtomizeItem(args[0].Get(0))
-		if err != nil {
-			return nil, err
-		}
-		val, ok := v.Get(key)
-		if !ok {
-			return validNilSequence, nil
-		}
-		return val, nil
+		return mapLookup(v, args)
 	case ArrayItem:
 		// Arrays are functions: $array($index) → member
-		if len(args) != 1 || seqLen(args[0]) != 1 {
-			return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "array lookup requires exactly one argument"}
-		}
-		key, err := AtomizeItem(args[0].Get(0))
-		if err != nil {
-			return nil, err
-		}
-		if key.TypeName == TypeUntypedAtomic {
-			key, err = CastAtomic(key, TypeInteger)
-			if err != nil {
-				return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "array lookup requires xs:integer index"}
-			}
-		}
-		if !isIntegerDerived(key.TypeName) {
-			return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "array lookup requires xs:integer index"}
-		}
-		idx, err := checkedArrayIndex(key)
-		if err != nil {
-			return nil, err
-		}
-		return v.Get(idx)
+		return arrayLookup(v, args)
 	default:
 		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("dynamic function call requires function item, got %T", funcSeq.Get(0))}
 	}
+}
+
+// asFunctionItem adapts a callee item into a FunctionItem. In XPath 3.1 maps and
+// arrays are function items of arity 1 (the lookup function), so they support
+// both dynamic invocation and partial function application (e.g. $m(?), $a(?)).
+func asFunctionItem(item Item) (FunctionItem, bool) {
+	switch v := item.(type) {
+	case FunctionItem:
+		return v, true
+	case MapItem:
+		return FunctionItem{
+			Arity:  1,
+			Invoke: func(_ context.Context, args []Sequence) (Sequence, error) { return mapLookup(v, args) },
+		}, true
+	case ArrayItem:
+		return FunctionItem{
+			Arity:  1,
+			Invoke: func(_ context.Context, args []Sequence) (Sequence, error) { return arrayLookup(v, args) },
+		}, true
+	default:
+		return FunctionItem{}, false
+	}
+}
+
+// mapLookup implements the map-as-function call $map($key) → value.
+func mapLookup(m MapItem, args []Sequence) (Sequence, error) {
+	if len(args) != 1 || seqLen(args[0]) != 1 {
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "map lookup requires exactly one argument"}
+	}
+	key, err := AtomizeItem(args[0].Get(0))
+	if err != nil {
+		return nil, err
+	}
+	val, ok := m.Get(key)
+	if !ok {
+		return validNilSequence, nil
+	}
+	return val, nil
+}
+
+// arrayLookup implements the array-as-function call $array($index) → member.
+func arrayLookup(a ArrayItem, args []Sequence) (Sequence, error) {
+	if len(args) != 1 || seqLen(args[0]) != 1 {
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "array lookup requires exactly one argument"}
+	}
+	key, err := AtomizeItem(args[0].Get(0))
+	if err != nil {
+		return nil, err
+	}
+	if key.TypeName == TypeUntypedAtomic {
+		key, err = CastAtomic(key, TypeInteger)
+		if err != nil {
+			return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "array lookup requires xs:integer index"}
+		}
+	}
+	if !isIntegerDerived(key.TypeName) {
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "array lookup requires xs:integer index"}
+	}
+	idx, err := checkedArrayIndex(key)
+	if err != nil {
+		return nil, err
+	}
+	return a.Get(idx)
 }
 
 func evalNamedFunctionRef(ctx context.Context, ec *evalContext, e NamedFunctionRef) (Sequence, error) {

--- a/xpath3/functions_hof.go
+++ b/xpath3/functions_hof.go
@@ -295,58 +295,11 @@ func extractFunctionItem(seq Sequence) (FunctionItem, error) {
 	if seqLen(seq) != 1 {
 		return FunctionItem{}, &XPathError{Code: lexicon.ErrXPTY0004, Message: "expected single function item"}
 	}
-	switch v := seq.Get(0).(type) {
-	case FunctionItem:
-		return v, nil
-	case MapItem:
-		// Maps are functions: map($key) → value
-		return FunctionItem{
-			Arity: 1,
-			Invoke: func(ctx context.Context, args []Sequence) (Sequence, error) {
-				if len(args) != 1 || seqLen(args[0]) != 1 {
-					return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "map lookup requires exactly one argument"}
-				}
-				key, err := AtomizeItem(args[0].Get(0))
-				if err != nil {
-					return nil, err
-				}
-				val, ok := v.Get(key)
-				if !ok {
-					return validNilSequence, nil
-				}
-				return val, nil
-			},
-		}, nil
-	case ArrayItem:
-		// Arrays are functions: array($index) → member
-		return FunctionItem{
-			Arity: 1,
-			Invoke: func(ctx context.Context, args []Sequence) (Sequence, error) {
-				if len(args) != 1 || seqLen(args[0]) != 1 {
-					return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "array lookup requires exactly one argument"}
-				}
-				key, err := AtomizeItem(args[0].Get(0))
-				if err != nil {
-					return nil, err
-				}
-				if key.TypeName == TypeUntypedAtomic {
-					key, err = CastAtomic(key, TypeInteger)
-					if err != nil {
-						return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "array lookup requires xs:integer index"}
-					}
-				}
-				if !isIntegerDerived(key.TypeName) {
-					return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "array lookup requires xs:integer index"}
-				}
-				iv, ok := key.Int64Val()
-				if !ok {
-					return nil, &XPathError{Code: errCodeFOAY0001, Message: "array index out of range"}
-				}
-				idx := int(iv)
-				return v.Get(idx)
-			},
-		}, nil
-	default:
+	// asFunctionItem is the single source of truth for adapting maps and arrays
+	// (arity-1 lookup functions) into FunctionItem; see eval_funcall.go.
+	fi, ok := asFunctionItem(seq.Get(0))
+	if !ok {
 		return FunctionItem{}, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("expected function item, got %T", seq.Get(0))}
 	}
+	return fi, nil
 }

--- a/xpath3/vm_test.go
+++ b/xpath3/vm_test.go
@@ -17,6 +17,24 @@ func TestPartialApplicationPlaceholderVM(t *testing.T) {
 	require.Equal(t, "abc", value)
 }
 
+func TestPartialApplicationMapArrayVM(t *testing.T) {
+	t.Run("map placeholder", func(t *testing.T) {
+		result, err := evaluate(t.Context(), nil, `let $m := map{"a":1,"b":2} return $m(?)("b")`)
+		require.NoError(t, err)
+		value, ok := result.IsNumber()
+		require.True(t, ok)
+		require.Equal(t, 2.0, value)
+	})
+
+	t.Run("array placeholder", func(t *testing.T) {
+		result, err := evaluate(t.Context(), nil, `let $a := array{10,20,30} return $a(?)(2)`)
+		require.NoError(t, err)
+		value, ok := result.IsNumber()
+		require.True(t, ok)
+		require.Equal(t, 20.0, value)
+	})
+}
+
 func TestGeneralComparisonAgainstLargeRangeVM(t *testing.T) {
 	result, err := evaluate(t.Context(), nil, `1000000000000000020001 = 1000000000000000000000 to 1000000000000010000003`)
 	require.NoError(t, err)


### PR DESCRIPTION
- dynamic partial application (`$m(?)`, `$a(?)`) now accepts maps and arrays, which are arity-1 function items in XPath 3.1
- adapt callee via `asFunctionItem`; share `mapLookup`/`arrayLookup` between direct-call and partial paths
