### PR TITLE
xsd: OR multiple same-step pattern facets

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -53,6 +53,11 @@ anyURI types stay lexical-only (their value space equals their whitespace-
 processed lexical space), so a numeric-looking string enum `"5"` does not accept
 `"5.0"`.
 
+Pattern facets are stored per restriction step as `FacetSet.Patterns []string`.
+Patterns in the same step are ORed (value valid if it matches any); patterns from
+different derivation steps are ANDed, enforced by `validateFacets` walking the
+base-type chain and validating each step's `FacetSet` independently.
+
 **Pass 2 — Identity Constraints** (`validateIDConstraints` via second `helium.Walk()`):
 - For elements with IDCs (xs:unique, xs:key, xs:keyref):
   1. Evaluate selector XPath → node set

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"regexp"
 	"strings"
 
 	helium "github.com/lestrrat-go/helium"
@@ -536,7 +537,14 @@ func (c *compiler) parseFacets(_ context.Context, restriction *helium.Element) *
 				fs = &FacetSet{}
 			}
 			// Multiple <xs:pattern> in the same restriction step are ORed.
+			// Compile once here; a nil entry (compile failure) is skipped
+			// during validation, preserving the previous lenient behavior.
 			fs.Patterns = append(fs.Patterns, val)
+			re, err := regexp.Compile("^(?:" + val + ")$")
+			if err != nil {
+				re = nil
+			}
+			fs.compiledPatterns = append(fs.compiledPatterns, re)
 		}
 	}
 

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -535,7 +535,8 @@ func (c *compiler) parseFacets(_ context.Context, restriction *helium.Element) *
 			if fs == nil {
 				fs = &FacetSet{}
 			}
-			fs.Pattern = &val
+			// Multiple <xs:pattern> in the same restriction step are ORed.
+			fs.Patterns = append(fs.Patterns, val)
 		}
 	}
 

--- a/xsd/schema.go
+++ b/xsd/schema.go
@@ -1,6 +1,7 @@
 package xsd
 
 import (
+	"regexp"
 	"slices"
 
 	"github.com/lestrrat-go/helium/xpath1"
@@ -226,8 +227,12 @@ type FacetSet struct {
 	// Per XSD, patterns in the same step are ORed (a value is valid if it
 	// matches any of them); patterns from different derivation steps are ANDed,
 	// which is handled by validating each step's FacetSet along the type chain.
-	Patterns   []string
-	WhiteSpace *string
+	Patterns []string
+	// compiledPatterns holds the regexes for Patterns, compiled once at schema
+	// compile time and index-aligned with Patterns. A nil entry means the
+	// pattern failed to compile and is skipped during validation.
+	compiledPatterns []*regexp.Regexp
+	WhiteSpace       *string
 }
 
 // AttrUse represents an attribute use in a complex type definition.

--- a/xsd/schema.go
+++ b/xsd/schema.go
@@ -222,8 +222,12 @@ type FacetSet struct {
 	Length         *int
 	MinLength      *int
 	MaxLength      *int
-	Pattern        *string
-	WhiteSpace     *string
+	// Patterns holds the <xs:pattern> facets from a single restriction step.
+	// Per XSD, patterns in the same step are ORed (a value is valid if it
+	// matches any of them); patterns from different derivation steps are ANDed,
+	// which is handled by validating each step's FacetSet along the type chain.
+	Patterns   []string
+	WhiteSpace *string
 }
 
 // AttrUse represents an attribute use in a complex type definition.

--- a/xsd/simplevalue_facets.go
+++ b/xsd/simplevalue_facets.go
@@ -225,11 +225,29 @@ func checkFacets(ctx context.Context, value string, valueNS map[string]string, f
 		}
 	}
 
-	// Pattern.
-	if fs.Pattern != nil {
-		re, err := regexp.Compile("^(?:" + *fs.Pattern + ")$")
-		if err == nil && !re.MatchString(value) {
-			msg := fmt.Sprintf("[facet 'pattern'] The value '%s' is not accepted by the pattern '%s'.", value, *fs.Pattern)
+	// Pattern: multiple <xs:pattern> facets in the same restriction step are
+	// ORed — the value is valid if it matches any of them.
+	if len(fs.Patterns) > 0 {
+		matched := false
+		anyValid := false
+		for _, p := range fs.Patterns {
+			re, err := regexp.Compile("^(?:" + p + ")$")
+			if err != nil {
+				continue
+			}
+			anyValid = true
+			if re.MatchString(value) {
+				matched = true
+				break
+			}
+		}
+		if anyValid && !matched {
+			var msg string
+			if len(fs.Patterns) == 1 {
+				msg = fmt.Sprintf("[facet 'pattern'] The value '%s' is not accepted by the pattern '%s'.", value, fs.Patterns[0])
+			} else {
+				msg = fmt.Sprintf("[facet 'pattern'] The value '%s' is not accepted by the patterns '%s'.", value, strings.Join(fs.Patterns, "', '"))
+			}
 			vc.reportValidityError(ctx, filename, line, elemName, msg)
 			anyErr = fmt.Errorf("pattern")
 		}

--- a/xsd/simplevalue_facets.go
+++ b/xsd/simplevalue_facets.go
@@ -3,7 +3,6 @@ package xsd
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"slices"
 	"strings"
 
@@ -226,13 +225,14 @@ func checkFacets(ctx context.Context, value string, valueNS map[string]string, f
 	}
 
 	// Pattern: multiple <xs:pattern> facets in the same restriction step are
-	// ORed — the value is valid if it matches any of them.
+	// ORed — the value is valid if it matches any of them. Regexes are compiled
+	// once at schema compile time (FacetSet.compiledPatterns); a nil entry means
+	// that pattern failed to compile and is skipped.
 	if len(fs.Patterns) > 0 {
 		matched := false
 		anyValid := false
-		for _, p := range fs.Patterns {
-			re, err := regexp.Compile("^(?:" + p + ")$")
-			if err != nil {
+		for _, re := range fs.compiledPatterns {
+			if re == nil {
 				continue
 			}
 			anyValid = true

--- a/xsd/validate_pattern_or_test.go
+++ b/xsd/validate_pattern_or_test.go
@@ -1,0 +1,76 @@
+package xsd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPatternFacetSameStepOR checks that multiple <xs:pattern> facets in the
+// same restriction step are ORed: a value is valid if it matches any of them.
+func TestPatternFacetSameStepOR(t *testing.T) {
+	t.Parallel()
+
+	schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" type="codeType"/>
+  <xs:simpleType name="codeType">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z]+"/>
+      <xs:pattern value="[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`
+
+	t.Run("matches first pattern", func(t *testing.T) {
+		require.NoError(t, compileAndValidate(t, schemaXML, "<root>abc</root>", nil))
+	})
+
+	t.Run("matches second pattern", func(t *testing.T) {
+		require.NoError(t, compileAndValidate(t, schemaXML, "<root>123</root>", nil))
+	})
+
+	t.Run("matches neither pattern", func(t *testing.T) {
+		var out string
+		err := compileAndValidate(t, schemaXML, "<root>ab12</root>", &out)
+		require.Error(t, err)
+		require.Contains(t, out, "[facet 'pattern']")
+	})
+}
+
+// TestPatternFacetCrossStepAND checks that patterns from different derivation
+// steps are ANDed: the value must satisfy every step's pattern facet.
+func TestPatternFacetCrossStepAND(t *testing.T) {
+	t.Parallel()
+
+	schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" type="step2"/>
+  <xs:simpleType name="step1">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="step2">
+    <xs:restriction base="step1">
+      <xs:pattern value=".{4}"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`
+
+	t.Run("satisfies both steps", func(t *testing.T) {
+		require.NoError(t, compileAndValidate(t, schemaXML, "<root>ab12</root>", nil))
+	})
+
+	t.Run("fails outer-step length", func(t *testing.T) {
+		var out string
+		err := compileAndValidate(t, schemaXML, "<root>abc</root>", &out)
+		require.Error(t, err)
+		require.Contains(t, out, "[facet 'pattern']")
+	})
+
+	t.Run("fails inner-step charset", func(t *testing.T) {
+		var out string
+		err := compileAndValidate(t, schemaXML, "<root>AB12</root>", &out)
+		require.Error(t, err)
+		require.Contains(t, out, "[facet 'pattern']")
+	})
+}


### PR DESCRIPTION
- multiple `<xs:pattern>` facets in one restriction step are now ORed (value valid if it matches any), per XSD; previously only the last pattern was kept
- cross-step patterns remain ANDed via the existing base-type chain walk
- `FacetSet.Pattern *string` → `FacetSet.Patterns []string`
