### PR TITLE
xsd: fix char-class subtraction in pattern facets

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -54,14 +54,18 @@ processed lexical space), so a numeric-looking string enum `"5"` does not accept
 `"5.0"`.
 
 Pattern facets are stored per restriction step as `FacetSet.Patterns []string`,
-compiled once into `FacetSet.compiledPatterns` at schema compile time. Patterns in
-the same step are ORed (value valid if it matches any); patterns from different
-derivation steps are ANDed, enforced by `validateFacets` walking the base-type
-chain and validating each step's `FacetSet` independently. Each pattern is
-translated from XSD regex to Go's RE2 via `internal/xsdregex` (the same translator
-`xpath3` uses for `fn:matches`) before compiling, so XSD-only constructs (`\i`,
-`\c`, `\p{Is...}` blocks) are enforced rather than silently skipped. A pattern that
-still cannot be translated/compiled is stored as nil and skipped (lenient).
+compiled once into `FacetSet.compiledPatterns` (`[]*xsdregex.Regexp`) at schema
+compile time via `xsdregex.Compile`. Patterns in the same step are ORed (value
+valid if it matches any); patterns from different derivation steps are ANDed,
+enforced by `validateFacets` walking the base-type chain and validating each
+step's `FacetSet` independently. `xsdregex.Compile` translates XSD regex to Go's
+RE2 (the same translator `xpath3` uses for `fn:matches`), so XSD-only constructs
+(`\i`, `\c`, `\p{Is...}` blocks) are enforced rather than silently skipped;
+patterns using XML Schema character-class subtraction (`[a-z-[aeiou]]`) or
+quantifier bounds beyond RE2's limit are compiled with the regexp2 backtracking
+engine, which RE2 cannot. A pattern that is not a valid XSD regular expression is
+reported as a schema parser error (`The value '…' is not a valid regular
+expression.`); its `compiledPatterns` entry stays nil and is skipped at validation.
 
 **Pass 2 — Identity Constraints** (`validateIDConstraints` via second `helium.Walk()`):
 - For elements with IDCs (xs:unique, xs:key, xs:keyref):

--- a/internal/xsdregex/regex.go
+++ b/internal/xsdregex/regex.go
@@ -6,9 +6,19 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/dlclark/regexp2"
 )
+
+// DefaultMatchTimeout bounds how long the regexp2 backtracking engine spends on
+// a single pattern-facet match before giving up. Patterns that use constructs
+// RE2 cannot handle (character-class subtraction, large quantifiers) compile to
+// regexp2, which is vulnerable to catastrophic backtracking on adversarial
+// inputs; this is a defense-in-depth ceiling for those matches. RE2-compiled
+// patterns are linear-time and unaffected. Set to 0 to disable; mutating it
+// affects only subsequently-compiled patterns.
+var DefaultMatchTimeout = 5 * time.Second
 
 // errCodeFORX0002 mirrors the XPath FORX0002 ("invalid regular expression")
 // error code. This package is layering-neutral (no xpath3 dependency); callers
@@ -1157,8 +1167,10 @@ type Regexp struct {
 // MatchString reports whether the whole string s is matched by the pattern.
 func (r *Regexp) MatchString(s string) bool {
 	if r.backtrack != nil {
-		// regexp2 only returns an error on match-timeout; pattern-facet matches
-		// have no configured timeout, so a non-nil error is not possible here.
+		// regexp2 is a backtracking engine; the only error it returns is a
+		// match-timeout (see DefaultMatchTimeout). A timed-out match cannot be
+		// proven to satisfy the pattern, so report it as a non-match rather than
+		// letting a catastrophic-backtracking input hang the caller.
 		ok, _ := r.backtrack.MatchString(s)
 		return ok
 	}
@@ -1199,6 +1211,11 @@ func Compile(pattern string) (*Regexp, error) {
 		re, err := regexp2.Compile(`\A(?:`+translated+`)\z`, regexp2.RE2)
 		if err != nil {
 			return nil, &regexError{Code: errCodeFORX0002, Message: fmt.Sprintf("invalid regular expression: %s", err)}
+		}
+		// Bound backtracking so an adversarial pattern/value cannot hang the
+		// process (catastrophic backtracking). 0 disables the timeout.
+		if t := DefaultMatchTimeout; t > 0 {
+			re.MatchTimeout = t
 		}
 		return &Regexp{backtrack: re}, nil
 	}

--- a/internal/xsdregex/regex.go
+++ b/internal/xsdregex/regex.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+
+	"github.com/dlclark/regexp2"
 )
 
 // errCodeFORX0002 mirrors the XPath FORX0002 ("invalid regular expression")
@@ -1142,6 +1144,57 @@ func rejectPerlSpecific(pattern string) error {
 // Translate converts an XPath/XML Schema regex pattern into a Go RE2 pattern.
 func Translate(pattern string, dotAll, ignoreCase bool) (string, error) {
 	return translateXPathRegex(pattern, dotAll, ignoreCase)
+}
+
+// Regexp is a compiled XML Schema pattern-facet regular expression. It matches
+// the whole input value (the pattern is anchored at both ends) against either
+// Go's RE2 engine or, for constructs RE2 lacks, the regexp2 backtracking engine.
+type Regexp struct {
+	std       *regexp.Regexp
+	backtrack *regexp2.Regexp
+}
+
+// MatchString reports whether the whole string s is matched by the pattern.
+func (r *Regexp) MatchString(s string) bool {
+	if r.backtrack != nil {
+		// regexp2 only returns an error on match-timeout; pattern-facet matches
+		// have no configured timeout, so a non-nil error is not possible here.
+		ok, _ := r.backtrack.MatchString(s)
+		return ok
+	}
+	return r.std.MatchString(s)
+}
+
+// Compile translates and compiles an XML Schema pattern-facet regular
+// expression, anchoring it so it matches the entire value. Patterns that use
+// XML Schema character-class subtraction ([a-z-[aeiou]]) or quantifier bounds
+// beyond RE2's limit are compiled with the regexp2 backtracking engine, which
+// supports those constructs natively; all other patterns use Go's RE2 engine.
+// It returns an error for patterns that are not valid XML Schema regular
+// expressions, so callers can report a schema error rather than silently
+// ignoring the facet.
+func Compile(pattern string) (*Regexp, error) {
+	translated, err := translateXPathRegex(pattern, false, false)
+	if err != nil {
+		return nil, err
+	}
+
+	// RE2 implements neither character-class subtraction nor unbounded
+	// quantifiers; route those to the backtracking engine instead of letting
+	// RE2 misinterpret (subtraction) or reject (large bounds) them.
+	if hasXPathCharClassSubtraction(pattern) || hasLargeXPathQuantifier(pattern) {
+		re, err := regexp2.Compile(`\A(?:`+translated+`)\z`, regexp2.RE2)
+		if err != nil {
+			return nil, &regexError{Code: errCodeFORX0002, Message: fmt.Sprintf("invalid regular expression: %s", err)}
+		}
+		return &Regexp{backtrack: re}, nil
+	}
+
+	re, err := regexp.Compile(`\A(?:` + translated + `)\z`)
+	if err != nil {
+		return nil, &regexError{Code: errCodeFORX0002, Message: fmt.Sprintf("invalid regular expression: %s", err)}
+	}
+	return &Regexp{std: re}, nil
 }
 
 // Validate rejects patterns Go's regexp accepts but the XPath/XSD regex spec forbids.

--- a/internal/xsdregex/regex.go
+++ b/internal/xsdregex/regex.go
@@ -1174,6 +1174,19 @@ func (r *Regexp) MatchString(s string) bool {
 // expressions, so callers can report a schema error rather than silently
 // ignoring the facet.
 func Compile(pattern string) (*Regexp, error) {
+	// Enforce the XSD/XPath regex grammar up front, independent of which engine
+	// compiles the pattern. RE2 happens to reject some non-XSD constructs (e.g.
+	// \1 back-references) but accepts others (e.g. \b word boundaries), and the
+	// regexp2 backtracking engine accepts both — so without these checks an
+	// invalid pattern routed to regexp2 (back-reference + character-class
+	// subtraction) would be silently accepted. XSD regex has no back-references.
+	if err := rejectPerlSpecific(pattern); err != nil {
+		return nil, err
+	}
+	if err := validateXPathRegex(pattern, false); err != nil {
+		return nil, err
+	}
+
 	translated, err := translateXPathRegex(pattern, false, false)
 	if err != nil {
 		return nil, err

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"regexp"
 	"strings"
 
 	helium "github.com/lestrrat-go/helium"
@@ -452,7 +451,7 @@ func (c *compiler) parseSimpleType(ctx context.Context, elem *helium.Element) (*
 }
 
 // parseFacets extracts facet constraints from an xs:restriction element.
-func (c *compiler) parseFacets(_ context.Context, restriction *helium.Element) *FacetSet {
+func (c *compiler) parseFacets(ctx context.Context, restriction *helium.Element) *FacetSet {
 	var fs *FacetSet
 
 	for child := range helium.Children(restriction) {
@@ -538,15 +537,19 @@ func (c *compiler) parseFacets(_ context.Context, restriction *helium.Element) *
 				fs = &FacetSet{}
 			}
 			// Multiple <xs:pattern> in the same restriction step are ORed.
-			// Compile once here; a nil entry (compile failure) is skipped
-			// during validation, preserving the previous lenient behavior.
-			// XSD regex supports constructs Go's RE2 lacks (\i, \c, \p{Is...}
-			// blocks); translate first so they are enforced rather than
-			// silently skipped. An untranslatable pattern stays nil (lenient).
+			// Compile once here, index-aligned with Patterns. XSD regex
+			// supports constructs Go's RE2 lacks: \i, \c, \p{Is...} blocks
+			// (translated to RE2) and character-class subtraction / large
+			// quantifiers (compiled with the regexp2 backtracking engine).
+			// A pattern that is not a valid XSD regex is a schema error rather
+			// than silently ignored; its compiledPatterns entry stays nil.
 			fs.Patterns = append(fs.Patterns, val)
-			var re *regexp.Regexp
-			if translated, terr := xsdregex.Translate(val, false, false); terr == nil {
-				re, _ = regexp.Compile("^(?:" + translated + ")$")
+			re, rerr := xsdregex.Compile(val)
+			if rerr != nil {
+				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, ce.Line(),
+					ce.LocalName(), "pattern",
+					fmt.Sprintf("The value '%s' is not a valid regular expression.", val)), helium.ErrorLevelFatal))
+				c.errorCount++
 			}
 			fs.compiledPatterns = append(fs.compiledPatterns, re)
 		}

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -548,7 +548,7 @@ func (c *compiler) parseFacets(ctx context.Context, restriction *helium.Element)
 			if rerr != nil {
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, ce.Line(),
 					ce.LocalName(), "pattern",
-					fmt.Sprintf("The value '%s' is not a valid regular expression.", val)), helium.ErrorLevelFatal))
+					fmt.Sprintf("The value '%s' is not a valid regular expression: %s.", val, rerr)), helium.ErrorLevelFatal))
 				c.errorCount++
 			}
 			fs.compiledPatterns = append(fs.compiledPatterns, re)

--- a/xsd/schema.go
+++ b/xsd/schema.go
@@ -1,9 +1,9 @@
 package xsd
 
 import (
-	"regexp"
 	"slices"
 
+	"github.com/lestrrat-go/helium/internal/xsdregex"
 	"github.com/lestrrat-go/helium/xpath1"
 )
 
@@ -231,7 +231,7 @@ type FacetSet struct {
 	// compiledPatterns holds the regexes for Patterns, compiled once at schema
 	// compile time and index-aligned with Patterns. A nil entry means the
 	// pattern failed to compile and is skipped during validation.
-	compiledPatterns []*regexp.Regexp
+	compiledPatterns []*xsdregex.Regexp
 	WhiteSpace       *string
 }
 

--- a/xsd/validate_pattern_regex_test.go
+++ b/xsd/validate_pattern_regex_test.go
@@ -1,7 +1,6 @@
 package xsd_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -95,8 +94,7 @@ func TestPatternFacetInvalidRegexp(t *testing.T) {
 
 	_, errs := compileWithErrors(t, schema)
 	require.NotEmpty(t, errs, "invalid pattern regexp should be a schema error")
-	require.True(t, strings.Contains(errs, "not a valid regular expression"),
-		"expected invalid-regexp diagnostic, got: %s", errs)
+	require.Contains(t, errs, "not a valid regular expression")
 }
 
 // TestPatternFacetRejectsNonXSDConstructs checks that constructs outside the XSD

--- a/xsd/validate_pattern_regex_test.go
+++ b/xsd/validate_pattern_regex_test.go
@@ -98,3 +98,36 @@ func TestPatternFacetInvalidRegexp(t *testing.T) {
 	require.True(t, strings.Contains(errs, "not a valid regular expression"),
 		"expected invalid-regexp diagnostic, got: %s", errs)
 }
+
+// TestPatternFacetRejectsNonXSDConstructs checks that constructs outside the XSD
+// regex grammar are rejected even when the pattern would otherwise compile under
+// the regexp2 backtracking engine. XSD has no back-references, and \b is a
+// Perl-specific escape; both must be schema errors rather than silently accepted.
+func TestPatternFacetRejectsNonXSDConstructs(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		pattern string
+	}{
+		// Back-reference combined with character-class subtraction would route to
+		// regexp2 (which supports back-references) and be silently accepted.
+		{"backref with subtraction", `([a-z-[aeiou]])\1`},
+		// \b word boundary compiles under RE2 but is not valid XSD regex.
+		{"perl word boundary", `\bword\b`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" type="t"/>
+  <xs:simpleType name="t">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="` + tc.pattern + `"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`
+
+			_, errs := compileWithErrors(t, schema)
+			require.NotEmpty(t, errs, "non-XSD regex construct should be a schema error")
+		})
+	}
+}

--- a/xsd/validate_pattern_regex_test.go
+++ b/xsd/validate_pattern_regex_test.go
@@ -1,6 +1,11 @@
 package xsd_test
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 // TestPatternFacetXSDRegexConstructs checks that pattern facets using XSD regex
 // constructs Go's RE2 does not support (\i, \c name-character escapes, \p{Is...}
@@ -45,4 +50,51 @@ func TestPatternFacetXSDRegexConstructs(t *testing.T) {
 			t.Errorf("café should be invalid (é is outside BasicLatin), but validated")
 		}
 	})
+}
+
+// TestPatternFacetCharClassSubtraction checks that XML Schema character-class
+// subtraction ([a-z-[aeiou]]) is honored. RE2 has no subtraction, so the value
+// is matched with the regexp2 backtracking engine instead.
+func TestPatternFacetCharClassSubtraction(t *testing.T) {
+	t.Parallel()
+
+	schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" type="t"/>
+  <xs:simpleType name="t">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z-[aeiou]]"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`
+
+	// 'b' is in a-z but not in the subtracted vowels: must be accepted.
+	if err := compileAndValidate(t, schema, "<root>b</root>", nil); err != nil {
+		t.Errorf("b should be valid ([a-z] minus vowels): %v", err)
+	}
+	// 'a' is a vowel: must be rejected.
+	var out string
+	if err := compileAndValidate(t, schema, "<root>a</root>", &out); err == nil {
+		t.Errorf("a should be invalid (subtracted vowel), but validated")
+	}
+}
+
+// TestPatternFacetInvalidRegexp checks that a pattern facet whose value is not a
+// valid XSD regular expression is reported as a schema error instead of being
+// silently ignored.
+func TestPatternFacetInvalidRegexp(t *testing.T) {
+	t.Parallel()
+
+	schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" type="t"/>
+  <xs:simpleType name="t">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[\q]"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`
+
+	_, errs := compileWithErrors(t, schema)
+	require.NotEmpty(t, errs, "invalid pattern regexp should be a schema error")
+	require.True(t, strings.Contains(errs, "not a valid regular expression"),
+		"expected invalid-regexp diagnostic, got: %s", errs)
 }


### PR DESCRIPTION
- Route XSD pattern facets with character-class subtraction (`[a-z-[aeiou]]`) and large quantifiers to the regexp2 backtracking engine; RE2 mishandled them, wrongly rejecting valid values
- Report invalid pattern-facet regexes as schema errors instead of silently dropping them
- Add `xsdregex.Compile` (engine selection + anchored whole-value match) and switch `FacetSet.compiledPatterns` to `[]*xsdregex.Regexp`
