### PR TITLE
html: avoid rcdata hang on invalid end tag

### DIFF
--- a/html/parser.go
+++ b/html/parser.go
@@ -1103,8 +1103,21 @@ func (p *parser) parseRCDATAContent(tagName string) {
 				_ = p.emitCharacters([]byte(text))
 			}
 			if !p.cur.Done() && p.cur.Peek() == '<' {
-				// Check if this is the end tag — if not, emit '<' as text
-				if p.cur.PeekAt(1) != '/' || !p.hasPrefixFold(endTag) {
+				// Only stop on a *valid* end tag: matched prefix followed by a
+				// valid terminator char. A matched-prefix-but-invalid tag such
+				// as "</titlex" must NOT be treated as the end tag; otherwise
+				// the '<' would be neither emitted nor advanced and the
+				// for-loop would spin forever. Mirror the RAWTEXT validEnd
+				// check, and always advance past '<' when it is not a valid end
+				// tag so the cursor is guaranteed to progress.
+				validEnd := false
+				if p.cur.PeekAt(1) == '/' && p.hasPrefixFold(endTag) {
+					switch p.cur.PeekAt(len(endTag)) {
+					case 0, '>', ' ', '\t', '\n', '\r':
+						validEnd = true
+					}
+				}
+				if !validEnd {
 					_ = p.emitCharacters([]byte("<"))
 					_ = p.cur.Advance(1)
 				}

--- a/html/rcdata_loop_test.go
+++ b/html/rcdata_loop_test.go
@@ -1,0 +1,39 @@
+package html_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/helium/html"
+)
+
+// TestRCDATAInvalidEndTagNoHang guards against an infinite loop in
+// parseRCDATAContent when a matched-prefix-but-invalid end tag such as
+// "</titlex" is encountered. Before the fix these inputs hung forever; a
+// watchdog converts a regression into a failure instead of stalling the suite.
+func TestRCDATAInvalidEndTagNoHang(t *testing.T) {
+	inputs := []string{
+		"<title></titlex",
+		"<title></titlex>",
+		"<textarea></textareax",
+	}
+
+	for _, input := range inputs {
+		input := input
+		t.Run(input, func(t *testing.T) {
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				// We don't care about the result, only that it returns.
+				_, _ = html.NewParser().Parse(context.Background(), []byte(input))
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(3 * time.Second):
+				t.Fatal("parse hang detected (rcdata invalid end tag infinite loop)")
+			}
+		})
+	}
+}

--- a/html/rcdata_loop_test.go
+++ b/html/rcdata_loop_test.go
@@ -1,7 +1,6 @@
 package html_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -20,18 +19,23 @@ func TestRCDATAInvalidEndTagNoHang(t *testing.T) {
 	}
 
 	for _, input := range inputs {
-		input := input
 		t.Run(input, func(t *testing.T) {
+			ctx := t.Context()
 			done := make(chan struct{})
 			go func() {
 				defer close(done)
 				// We don't care about the result, only that it returns.
-				_, _ = html.NewParser().Parse(context.Background(), []byte(input))
+				_, _ = html.NewParser().Parse(ctx, []byte(input))
 			}()
+
+			// Stoppable timer so the watchdog doesn't linger after the
+			// parse returns in the common (fast) case.
+			watchdog := time.NewTimer(3 * time.Second)
+			defer watchdog.Stop()
 
 			select {
 			case <-done:
-			case <-time.After(3 * time.Second):
+			case <-watchdog.C:
 				t.Fatal("parse hang detected (rcdata invalid end tag infinite loop)")
 			}
 		})


### PR DESCRIPTION
- `parseRCDATAContent` could infinite-loop on a matched-prefix-but-invalid end tag (e.g. `</titlex`): the `<` was neither emitted nor advanced, spinning the loop forever.
- Mirror the RAWTEXT `validEnd` check so text collection stops only on a *valid* end tag; otherwise emit `<` and advance, guaranteeing cursor progress.
- Adds a watchdog regression test for `<title></titlex`, `<title></titlex>`, `<textarea></textareax`.
