### PR TITLE
parser: guard malformed character references

### DIFF
--- a/parser_charref_panic_test.go
+++ b/parser_charref_panic_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMalformedCharRefNoPanic guards against the index-out-of-range panic in
 // parseStringCharRef when malformed character references appear inside entity
-// declarations. Each malformed input must yield a non-nil error rather than
-// panic.
+// declarations. Each malformed input must yield a structured
+// helium.ErrParseError rather than panic.
 func TestMalformedCharRefNoPanic(t *testing.T) {
 	malformed := []string{
 		`<!DOCTYPE root [<!ENTITY e "&#">]><root>&e;</root>`,
@@ -25,6 +25,8 @@ func TestMalformedCharRefNoPanic(t *testing.T) {
 			require.NotPanics(t, func() {
 				_, err := helium.NewParser().SubstituteEntities(true).Parse(t.Context(), []byte(input))
 				require.Error(t, err, "malformed char ref must return an error")
+				var pe helium.ErrParseError
+				require.ErrorAs(t, err, &pe, "malformed char ref must return a helium.ErrParseError")
 			})
 		})
 	}
@@ -49,6 +51,8 @@ func TestOutOfRangeCharRefRejected(t *testing.T) {
 			require.NotPanics(t, func() {
 				_, err := helium.NewParser().SubstituteEntities(true).Parse(t.Context(), []byte(input))
 				require.Error(t, err, "out-of-range char ref must return an error")
+				var pe helium.ErrParseError
+				require.ErrorAs(t, err, &pe, "out-of-range char ref must return a helium.ErrParseError")
 			})
 		})
 	}

--- a/parser_charref_panic_test.go
+++ b/parser_charref_panic_test.go
@@ -1,0 +1,46 @@
+package helium_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMalformedCharRefNoPanic guards against the index-out-of-range panic in
+// parseStringCharRef when malformed character references appear inside entity
+// declarations. Each malformed input must yield a non-nil error rather than
+// panic.
+func TestMalformedCharRefNoPanic(t *testing.T) {
+	malformed := []string{
+		`<!DOCTYPE root [<!ENTITY e "&#">]><root>&e;</root>`,
+		`<!DOCTYPE root [<!ENTITY e "&#x">]><root>&e;</root>`,
+		`<!DOCTYPE root [<!ENTITY e "&#1">]><root>&e;</root>`,
+		`<!DOCTYPE root [<!ENTITY e "&#xZ">]><root>&e;</root>`,
+		`<!DOCTYPE root [<!ENTITY e "&#;">]><root>&e;</root>`,
+	}
+
+	for _, input := range malformed {
+		t.Run(input, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				_, err := helium.NewParser().SubstituteEntities(true).Parse(t.Context(), []byte(input))
+				require.Error(t, err, "malformed char ref must return an error")
+			})
+		})
+	}
+}
+
+// TestValidCharRefStillWorks guards against over-rejection: a valid decimal
+// character reference entity must still parse and expand correctly.
+func TestValidCharRefStillWorks(t *testing.T) {
+	input := `<!DOCTYPE root [<!ENTITY e "&#65;">]><root>&e;</root>`
+	doc, err := helium.NewParser().SubstituteEntities(true).Parse(t.Context(), []byte(input))
+	require.NoError(t, err, "valid char ref must parse")
+	require.NotNil(t, doc)
+
+	root := doc.DocumentElement()
+	require.NotNil(t, root)
+	child := root.FirstChild()
+	require.NotNil(t, child, "expanded entity must produce a text child")
+	require.Equal(t, "A", string(child.Content()), "&#65; must expand to 'A'")
+}

--- a/parser_charref_panic_test.go
+++ b/parser_charref_panic_test.go
@@ -30,6 +30,30 @@ func TestMalformedCharRefNoPanic(t *testing.T) {
 	}
 }
 
+// TestOutOfRangeCharRefRejected guards against an out-of-range character
+// reference wrapping int32 into a valid-looking rune. These exercise the
+// content-path parser (parseCharRef) and the parameter-entity declaration
+// branch, both of which must report an error rather than silently producing a
+// bogus character.
+func TestOutOfRangeCharRefRejected(t *testing.T) {
+	cases := []string{
+		// Content path: 4294967337 = 0x100000029 wraps to 0x29 (')').
+		`<root>&#4294967337;</root>`,
+		`<root>&#x100000029;</root>`,
+		// Parameter-entity value must propagate the same error.
+		`<!DOCTYPE root [<!ENTITY % p "&#4294967337;"> %p;]><root/>`,
+	}
+
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				_, err := helium.NewParser().SubstituteEntities(true).Parse(t.Context(), []byte(input))
+				require.Error(t, err, "out-of-range char ref must return an error")
+			})
+		})
+	}
+}
+
 // TestValidCharRefStillWorks guards against over-rejection: a valid decimal
 // character reference entity must still parse and expand correctly.
 func TestValidCharRefStillWorks(t *testing.T) {

--- a/parser_entity_decl.go
+++ b/parser_entity_decl.go
@@ -251,13 +251,14 @@ func (pctx *parserCtx) parseEntityDecl(ctx context.Context) error {
 		if c := cur.Peek(); c == '"' || c == '\'' {
 			literal, value, err = pctx.parseEntityValue(ctx)
 			hasOrig = true
-			if err == nil {
-				if s := pctx.sax; s != nil {
-					switch err := s.EntityDecl(ctx, name, enum.InternalGeneralEntity, "", "", value); err {
-					case nil, sax.ErrHandlerUnspecified:
-					default:
-						return pctx.error(ctx, err)
-					}
+			if err != nil {
+				return pctx.error(ctx, err)
+			}
+			if s := pctx.sax; s != nil {
+				switch err := s.EntityDecl(ctx, name, enum.InternalGeneralEntity, "", "", value); err {
+				case nil, sax.ErrHandlerUnspecified:
+				default:
+					return pctx.error(ctx, err)
 				}
 			}
 		} else {

--- a/parser_entity_decl.go
+++ b/parser_entity_decl.go
@@ -217,12 +217,13 @@ func (pctx *parserCtx) parseEntityDecl(ctx context.Context) error {
 		if c := cur.Peek(); c == '"' || c == '\'' {
 			literal, value, err = pctx.parseEntityValue(ctx)
 			hasOrig = true
-			if err == nil {
-				switch err := pctx.fireSAXCallback(ctx, cbEntityDecl, name, value); err {
-				case nil, sax.ErrHandlerUnspecified:
-				default:
-					return pctx.error(ctx, err)
-				}
+			if err != nil {
+				return pctx.error(ctx, err)
+			}
+			switch err := pctx.fireSAXCallback(ctx, cbEntityDecl, name, value); err {
+			case nil, sax.ErrHandlerUnspecified:
+			default:
+				return pctx.error(ctx, err)
 			}
 		} else {
 			literal, uri, err = pctx.parseExternalID(ctx)

--- a/parser_entity_ref.go
+++ b/parser_entity_ref.go
@@ -306,7 +306,7 @@ func parseStringCharRef(s []byte) (r rune, width int, err error) {
 			return
 		}
 		if val > unicode.MaxRune {
-			err = errors.New("hex CharRef out of range")
+			err = errors.New("CharRef out of range")
 			width = 0
 			return
 		}

--- a/parser_entity_ref.go
+++ b/parser_entity_ref.go
@@ -547,6 +547,12 @@ func (ctx *parserCtx) parseCharRef() (r rune, err error) {
 				err = errors.New("invalid hex CharRef")
 				return
 			}
+			// Stop accumulating once the value is out of range so an
+			// oversized reference cannot wrap int32 into a valid-looking rune.
+			if val > unicode.MaxRune {
+				err = ErrInvalidChar
+				return
+			}
 			if err := cur.Advance(1); err != nil {
 				return utf8.RuneError, err
 			}
@@ -563,6 +569,12 @@ func (ctx *parserCtx) parseCharRef() (r rune, err error) {
 				val = val*10 + int32(c-'0')
 			} else {
 				err = errors.New("invalid decimal CharRef")
+				return
+			}
+			// Stop accumulating once the value is out of range so an
+			// oversized reference cannot wrap int32 into a valid-looking rune.
+			if val > unicode.MaxRune {
+				err = ErrInvalidChar
 				return
 			}
 			if err := cur.Advance(1); err != nil {

--- a/parser_entity_ref.go
+++ b/parser_entity_ref.go
@@ -277,16 +277,28 @@ func parseStringCharRef(s []byte) (r rune, width int, err error) {
 	width += 2
 	s = s[2:]
 
+	if len(s) == 0 {
+		err = errors.New("malformed CharRef")
+		return
+	}
+
 	var accumulator func(int32, rune) (int32, error)
 	if s[0] == 'x' {
 		s = s[1:]
 		width++
 		accumulator = accumulateHexCharRef
+		if len(s) == 0 {
+			err = errors.New("malformed CharRef")
+			width = 0
+			return
+		}
 	} else {
 		accumulator = accumulateDecimalCharRef
 	}
 
-	for c := s[0]; c != ';'; c = s[0] {
+	digits := 0
+	for len(s) > 0 && s[0] != ';' {
+		c := s[0]
 		val, err = accumulator(val, rune(c))
 		if err != nil {
 			width = 0
@@ -298,15 +310,25 @@ func parseStringCharRef(s []byte) (r rune, width int, err error) {
 			return
 		}
 
+		digits++
 		s = s[1:]
 		width++
 	}
 
-	if s[0] == ';' {
-		s = s[1:]
-		_ = s
-		width++
+	if digits == 0 {
+		err = errors.New("malformed CharRef")
+		width = 0
+		return
 	}
+
+	if len(s) == 0 || s[0] != ';' {
+		err = errors.New("malformed CharRef")
+		width = 0
+		return
+	}
+	s = s[1:]
+	_ = s
+	width++
 
 	r = val
 	if !isXMLCharValue(uint32(val)) {

--- a/parser_entity_ref.go
+++ b/parser_entity_ref.go
@@ -279,6 +279,7 @@ func parseStringCharRef(s []byte) (r rune, width int, err error) {
 
 	if len(s) == 0 {
 		err = errors.New("malformed CharRef")
+		width = 0
 		return
 	}
 


### PR DESCRIPTION
- `parseStringCharRef` indexed the byte slice without bounds checks after consuming `&#`, panicking with "index out of range" on malformed char refs (e.g. `&#`, `&#x`, `&#1`) inside entity declarations.
- Add length/digit/terminator guards so malformed char refs return a structured parse error; propagate the previously-dropped `parseEntityValue` error in `parseEntityDecl`.
- Regression test covers the panicking inputs plus `&#xZ`/`&#;`, and asserts `&#65;` still expands to "A".