### PR TITLE
c14n: emit empty output for empty node set

### DIFF
--- a/c14n/c14n.go
+++ b/c14n/c14n.go
@@ -23,6 +23,7 @@ type canonicalizerCfg struct {
 	mode              Mode
 	withComments      bool
 	nodeSet           []helium.Node
+	nodeSetSet        bool // true once NodeSet was explicitly configured (even if empty)
 	inclusivePrefixes []string
 	baseURI           string
 }
@@ -59,6 +60,7 @@ func (c Canonicalizer) Comments() Canonicalizer {
 func (c Canonicalizer) NodeSet(nodes []helium.Node) Canonicalizer {
 	c = c.clone()
 	c.cfg.nodeSet = append([]helium.Node(nil), nodes...)
+	c.cfg.nodeSetSet = true
 	return c
 }
 
@@ -94,7 +96,7 @@ func (c Canonicalizer) Canonicalize(doc *helium.Document, out io.Writer) error {
 	}
 	can.withComments = cfg.withComments
 	can.baseURI = cfg.baseURI
-	if len(cfg.nodeSet) > 0 {
+	if cfg.nodeSetSet {
 		can.nodeSet = make(map[helium.Node]struct{}, len(cfg.nodeSet))
 		for _, n := range cfg.nodeSet {
 			can.nodeSet[n] = struct{}{}

--- a/c14n/c14n_test.go
+++ b/c14n/c14n_test.go
@@ -314,6 +314,28 @@ func TestZeroValueCanonicalizerFluent(t *testing.T) {
 	require.Contains(t, string(got), `<!-- comment -->`)
 }
 
+func TestEmptyNodeSetEmitsEmpty(t *testing.T) {
+	t.Parallel()
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root><child/></root>`))
+	require.NoError(t, err)
+
+	// An explicitly EMPTY node set must produce EMPTY output per the C14N spec.
+	got, err := c14n.NewCanonicalizer(c14n.C14N10).NodeSet([]helium.Node{}).CanonicalizeTo(doc)
+	require.NoError(t, err)
+	require.Len(t, got, 0, "empty node set must emit empty output, got %q", string(got))
+}
+
+func TestNoNodeSetEmitsFullDocument(t *testing.T) {
+	t.Parallel()
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root><child/></root>`))
+	require.NoError(t, err)
+
+	// Without NodeSet, the whole document is canonicalized.
+	got, err := c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(doc)
+	require.NoError(t, err)
+	require.Equal(t, `<root><child></child></root>`, string(got))
+}
+
 func TestRelativeNamespaceURIRejected(t *testing.T) {
 	t.Parallel()
 	// C14N spec requires failure on relative namespace URIs.


### PR DESCRIPTION
- `NodeSet([]helium.Node{})` (explicitly empty) now produces empty output per the C14N spec, instead of full-document output.
- Root cause: node-set mode was gated on `len(nodeSet) > 0`, so an empty set left `nodeSet` nil and `isVisible` treated every node as visible. Added a `nodeSetSet` flag and always allocate the (possibly empty) visibility map when NodeSet is configured.
- Regression tests: empty node set yields empty output; no NodeSet yields the full document.