### PR TITLE
xpath3: range-check codepoints-to-string input

### DIFF
--- a/internal/lexicon/ns.go
+++ b/internal/lexicon/ns.go
@@ -34,6 +34,11 @@ const (
 	// internally and asserted by both xpath3 and xslt3 test fixtures.
 	ErrXPTY0004 = "XPTY0004"
 
+	// ErrFOCH0001 is the W3C XPath/XQuery error code raised when a codepoint
+	// is not a valid XML character (e.g. fn:codepoints-to-string with an
+	// out-of-range value). Used by xpath3 and asserted by test fixtures.
+	ErrFOCH0001 = "FOCH0001"
+
 	// NamespaceXML is the XML namespace URI (predeclared, prefix "xml").
 	NamespaceXML = "http://www.w3.org/XML/1998/namespace"
 

--- a/xpath3/functions_string.go
+++ b/xpath3/functions_string.go
@@ -143,10 +143,22 @@ func itemToCodepoint(item Item) (int, error) {
 	// Fast path: extract int64 directly from *big.Int (avoids big.Float allocation)
 	if isIntegerDerived(a.TypeName) {
 		if n, ok := a.Value.(*big.Int); ok {
+			// A value beyond int64 range cannot be a valid XML codepoint;
+			// Int64() would silently wrap mod 2^64, so reject it here.
+			if !n.IsInt64() {
+				return 0, &XPathError{Code: "FOCH0001", Message: fmt.Sprintf("invalid XML character [%s]", n.String())}
+			}
 			return int(n.Int64()), nil
 		}
 	}
-	return int(a.ToFloat64()), nil
+	// Non-integer fallback: a fractional value is not a valid codepoint.
+	// Reject it as a type error, but keep accepting integer-valued floats
+	// (e.g. 65.0) so arithmetic-derived integer values still work.
+	f := a.ToFloat64()
+	if f != math.Trunc(f) {
+		return 0, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("codepoints-to-string: non-integer codepoint %v", f)}
+	}
+	return int(f), nil
 }
 
 // isValidXMLCodepoint returns true if the codepoint is a valid XML character.

--- a/xpath3/functions_string.go
+++ b/xpath3/functions_string.go
@@ -108,7 +108,7 @@ func fnCodepointsToString(ctx context.Context, args []Sequence) (Sequence, error
 			return nil, err
 		}
 		if !isValid(cp) {
-			return nil, &XPathError{Code: "FOCH0001", Message: fmt.Sprintf("invalid XML character [x%X]", cp)}
+			return nil, &XPathError{Code: lexicon.ErrFOCH0001, Message: fmt.Sprintf("invalid XML character [x%X]", cp)}
 		}
 		return SingleString(string(rune(cp))), nil
 	}
@@ -120,7 +120,7 @@ func fnCodepointsToString(ctx context.Context, args []Sequence) (Sequence, error
 			return nil, err
 		}
 		if !isValid(cp) {
-			return nil, &XPathError{Code: "FOCH0001", Message: fmt.Sprintf("invalid XML character [x%X]", cp)}
+			return nil, &XPathError{Code: lexicon.ErrFOCH0001, Message: fmt.Sprintf("invalid XML character [x%X]", cp)}
 		}
 		b.WriteRune(rune(cp))
 	}
@@ -146,17 +146,49 @@ func itemToCodepoint(item Item) (int, error) {
 			// A value beyond int64 range cannot be a valid XML codepoint;
 			// Int64() would silently wrap mod 2^64, so reject it here.
 			if !n.IsInt64() {
-				return 0, &XPathError{Code: "FOCH0001", Message: fmt.Sprintf("invalid XML character [%s]", n.String())}
+				return 0, &XPathError{Code: lexicon.ErrFOCH0001, Message: fmt.Sprintf("invalid XML character [%s]", n.String())}
 			}
-			return int(n.Int64()), nil
+			v := n.Int64()
+			// Validate the codepoint range BEFORE the int conversion: on 32-bit
+			// platforms int(v) for an out-of-range v wraps/truncates, which would
+			// let a spurious value pass the later isValid check.
+			if v < 0 || v > utf8.MaxRune {
+				return 0, &XPathError{Code: lexicon.ErrFOCH0001, Message: fmt.Sprintf("invalid XML character [%d]", v)}
+			}
+			return int(v), nil
 		}
+	}
+	// xs:decimal is stored as *big.Rat. Check integrality exactly here rather
+	// than via float64: a high-precision fractional decimal such as
+	// 65.000000000000000000000000001 rounds to an integer float64 and would
+	// otherwise slip past the fractional check below.
+	if r, ok := a.Value.(*big.Rat); ok {
+		if !r.IsInt() {
+			return 0, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("codepoints-to-string: non-integer codepoint %s", r.RatString())}
+		}
+		n := r.Num()
+		if !n.IsInt64() {
+			return 0, &XPathError{Code: lexicon.ErrFOCH0001, Message: fmt.Sprintf("invalid XML character [%s]", n.String())}
+		}
+		v := n.Int64()
+		if v < 0 || v > utf8.MaxRune {
+			return 0, &XPathError{Code: lexicon.ErrFOCH0001, Message: fmt.Sprintf("invalid XML character [%d]", v)}
+		}
+		return int(v), nil
 	}
 	// Non-integer fallback: a fractional value is not a valid codepoint.
 	// Reject it as a type error, but keep accepting integer-valued floats
 	// (e.g. 65.0) so arithmetic-derived integer values still work.
 	f := a.ToFloat64()
-	if f != math.Trunc(f) {
+	if math.IsNaN(f) || math.IsInf(f, 0) || f != math.Trunc(f) {
 		return 0, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("codepoints-to-string: non-integer codepoint %v", f)}
+	}
+	// Validate the codepoint range BEFORE the int conversion: converting an
+	// out-of-range float64 to int is implementation-defined in Go (it can wrap
+	// or overflow, especially on 32-bit platforms), which would let a spurious
+	// value slip past the later isValid check.
+	if f < 0 || f > utf8.MaxRune {
+		return 0, &XPathError{Code: lexicon.ErrFOCH0001, Message: fmt.Sprintf("invalid XML character [%v]", f)}
 	}
 	return int(f), nil
 }

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -415,21 +415,39 @@ func TestFnURI(t *testing.T) {
 func TestFnCodepointsToStringRange(t *testing.T) {
 	doc := mustParseXML(t, "<root/>")
 
-	evalErr := func(t *testing.T, expr string) {
+	evalErrCode := func(t *testing.T, expr, code string) {
 		t.Helper()
 		compiled, err := xpath3.NewCompiler().Compile(expr)
 		require.NoError(t, err)
 		_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
 		require.Error(t, err, "expected error for %q", expr)
+		require.ErrorIs(t, err, &xpath3.XPathError{Code: code}, "expected error code %s for %q", code, expr)
 	}
 
 	t.Run("non-integer is a type error", func(t *testing.T) {
-		evalErr(t, `codepoints-to-string(65.9)`)
+		evalErrCode(t, `codepoints-to-string(65.9)`, "XPTY0004")
+	})
+
+	t.Run("high-precision fractional decimal is a type error", func(t *testing.T) {
+		// xs:decimal keeps full precision (*big.Rat); this value rounds to 65.0
+		// as float64 and must not slip past the integrality check.
+		evalErrCode(t, `codepoints-to-string(65.000000000000000000000000001)`, "XPTY0004")
 	})
 
 	t.Run("value beyond int64 is FOCH0001", func(t *testing.T) {
 		// 2^64 + 65 wraps to 65 ("A") via big.Int.Int64(); must error instead.
-		evalErr(t, `codepoints-to-string(18446744073709551681)`)
+		evalErrCode(t, `codepoints-to-string(18446744073709551681)`, "FOCH0001")
+	})
+
+	t.Run("huge integer-valued float is FOCH0001", func(t *testing.T) {
+		// 1e300 is integer-valued so it passes the fractional check, but is far
+		// beyond the codepoint range; int(f) is implementation-defined, so the
+		// range must be validated before the conversion.
+		evalErrCode(t, `codepoints-to-string(1e300)`, "FOCH0001")
+	})
+
+	t.Run("negative integer-valued float is FOCH0001", func(t *testing.T) {
+		evalErrCode(t, `codepoints-to-string(-1.0)`, "FOCH0001")
 	})
 
 	t.Run("integer codepoint still works", func(t *testing.T) {

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -410,6 +410,57 @@ func TestFnURI(t *testing.T) {
 	})
 }
 
+// --- codepoints-to-string range checks ---
+
+func TestFnCodepointsToStringRange(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	evalErr := func(t *testing.T, expr string) {
+		t.Helper()
+		compiled, err := xpath3.NewCompiler().Compile(expr)
+		require.NoError(t, err)
+		_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.Error(t, err, "expected error for %q", expr)
+	}
+
+	t.Run("non-integer is a type error", func(t *testing.T) {
+		evalErr(t, `codepoints-to-string(65.9)`)
+	})
+
+	t.Run("value beyond int64 is FOCH0001", func(t *testing.T) {
+		// 2^64 + 65 wraps to 65 ("A") via big.Int.Int64(); must error instead.
+		evalErr(t, `codepoints-to-string(18446744073709551681)`)
+	})
+
+	t.Run("integer codepoint still works", func(t *testing.T) {
+		seq := evalExpr(t, doc, `codepoints-to-string(65)`)
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.Equal(t, "A", av.StringVal())
+	})
+
+	t.Run("integer-valued float still works", func(t *testing.T) {
+		seq := evalExpr(t, doc, `codepoints-to-string(65.0)`)
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.Equal(t, "A", av.StringVal())
+	})
+
+	t.Run("sequence of integers still works", func(t *testing.T) {
+		seq := evalExpr(t, doc, `codepoints-to-string((72, 73))`)
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.Equal(t, "HI", av.StringVal())
+	})
+
+	t.Run("round-trip via string-to-codepoints", func(t *testing.T) {
+		seq := evalExpr(t, doc, `codepoints-to-string(string-to-codepoints("hi"))`)
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.Equal(t, "hi", av.StringVal())
+	})
+}
+
 // --- Error function ---
 
 func TestFnError(t *testing.T) {


### PR DESCRIPTION
- `itemToCodepoint` truncated `*big.Int` values via `Int64()` (wraps mod 2^64), so e.g. 2^64+65 yielded "A" instead of FOCH0001; now rejected when `!IsInt64()`.
- The float fallback silently floored fractional values (65.9 -> "A"); non-integer-valued floats now raise XPTY0004, while integer-valued floats (65.0) still work.
- Adds regression tests; full `go test ./xpath3/...` passes with no QT3 regressions.