### PR TITLE
xmldsig1: reject unsupported reference transforms

### DIFF
--- a/xmldsig1/transform_reject_test.go
+++ b/xmldsig1/transform_reject_test.go
@@ -63,8 +63,31 @@ func TestVerifyReferenceRejectsUnsupportedTransformWithEnveloped(t *testing.T) {
 	require.Same(t, sigElem, root.FirstChild(), "signature element must be restored after rejection")
 }
 
-// Sanity: errors.Is wiring is correct (defensive, mirrors caller expectations).
+// TestUnsupportedTransformErrorWrapping asserts that an unsupported-transform
+// error stays matchable via errors.Is(ErrUnsupportedTransform) even after it is
+// wrapped in the caller-facing VerificationError type, so callers can reliably
+// distinguish this failure mode.
 func TestUnsupportedTransformErrorWrapping(t *testing.T) {
-	err := errors.New("wrapped")
-	require.False(t, errors.Is(err, ErrUnsupportedTransform))
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root><data>hi</data></root>`))
+	require.NoError(t, err)
+
+	ref := parsedReference{
+		uri:             "",
+		digestAlgorithm: DigestSHA256,
+		transforms: []parsedTransform{
+			{algorithm: TransformXPath},
+		},
+	}
+
+	_, refErr := verifyReference(doc, nil, ref)
+	require.Error(t, refErr)
+
+	// Wrap in the actual type callers receive and confirm errors.Is still
+	// reaches ErrUnsupportedTransform through it.
+	wrapped := &VerificationError{Reference: 0, URI: "", Err: refErr}
+	require.ErrorIs(t, wrapped, ErrUnsupportedTransform)
+	require.ErrorAs(t, error(wrapped), new(*VerificationError))
+
+	// Negative control: an unrelated error must not match.
+	require.False(t, errors.Is(errors.New("unrelated"), ErrUnsupportedTransform))
 }

--- a/xmldsig1/transform_reject_test.go
+++ b/xmldsig1/transform_reject_test.go
@@ -1,0 +1,70 @@
+package xmldsig1
+
+import (
+	"errors"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerifyReferenceRejectsUnsupportedTransform guards against
+// signature-coverage fail-open: a Reference that declares a transform the
+// verifier cannot apply must be rejected before digesting, rather than
+// silently ignored and verified against the untransformed canonical bytes.
+//
+// This exercises verifyReference directly because SignedInfo (which contains
+// the Transforms list) is itself protected by the signature value, so the
+// unsupported transform must be caught at the per-reference stage.
+func TestVerifyReferenceRejectsUnsupportedTransform(t *testing.T) {
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root><data>hello</data></root>`))
+	require.NoError(t, err)
+
+	// A whole-document reference whose only transform is an unsupported URI
+	// (the XPath transform). digestValue is irrelevant: rejection must happen
+	// before the digest is even computed.
+	ref := parsedReference{
+		uri:             "",
+		digestAlgorithm: DigestSHA256,
+		transforms: []parsedTransform{
+			{algorithm: TransformXPath},
+		},
+	}
+
+	_, err = verifyReference(doc, nil, ref)
+	require.ErrorIs(t, err, ErrUnsupportedTransform)
+}
+
+// TestVerifyReferenceRejectsUnsupportedTransformWithEnveloped ensures the
+// enveloped detach/restore path also rejects an unsupported sibling transform
+// (and restores the Signature element rather than leaving it detached).
+func TestVerifyReferenceRejectsUnsupportedTransformWithEnveloped(t *testing.T) {
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"/></root>`))
+	require.NoError(t, err)
+
+	root := doc.DocumentElement()
+	sigElem, ok := helium.AsNode[*helium.Element](root.FirstChild())
+	require.True(t, ok)
+
+	ref := parsedReference{
+		uri:             "",
+		digestAlgorithm: DigestSHA256,
+		transforms: []parsedTransform{
+			{algorithm: TransformEnvelopedSignature},
+			{algorithm: "urn:bogus:transform"},
+		},
+	}
+
+	_, err = verifyReference(doc, sigElem, ref)
+	require.ErrorIs(t, err, ErrUnsupportedTransform)
+
+	// The Signature element must have been reattached, not left detached.
+	require.Same(t, sigElem, root.FirstChild(), "signature element must be restored after rejection")
+}
+
+// Sanity: errors.Is wiring is correct (defensive, mirrors caller expectations).
+func TestUnsupportedTransformErrorWrapping(t *testing.T) {
+	err := errors.New("wrapped")
+	require.False(t, errors.Is(err, ErrUnsupportedTransform))
+}

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -3,6 +3,7 @@ package xmldsig1
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -121,12 +122,17 @@ func verifyReference(doc *helium.Document, sigElem *helium.Element, ref parsedRe
 		default:
 			// Reattach the Signature element we detached above before
 			// bailing out, so a rejected reference does not leave the
-			// document structurally modified. A restore failure here cannot
-			// mask the rejection, so its error is intentionally discarded.
+			// document structurally modified. The rejection is the primary
+			// error, but if restore itself fails the document is left mutated,
+			// so surface that failure too (joined) rather than dropping it
+			// silently. errors.Is(ErrUnsupportedTransform) still holds.
+			rejectErr := fmt.Errorf("%w: %s", ErrUnsupportedTransform, t.algorithm)
 			if hasEnveloped {
-				_ = anchor.restore(sigElem)
+				if rerr := anchor.restore(sigElem); rerr != nil {
+					rejectErr = errors.Join(rejectErr, fmt.Errorf("failed to restore detached Signature element: %w", rerr))
+				}
 			}
-			return nil, fmt.Errorf("%w: %s", ErrUnsupportedTransform, t.algorithm)
+			return nil, rejectErr
 		}
 	}
 

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -105,7 +105,10 @@ func verifyReference(doc *helium.Document, sigElem *helium.Element, ref parsedRe
 		helium.UnlinkNode(sigElem)
 	}
 
-	// Find the c14n method.
+	// Find the c14n method. Fail closed: any transform whose URI we cannot
+	// apply must be rejected before digesting, otherwise a Reference could
+	// declare an unsupported transform (XPath, Base64, custom URI) and still
+	// verify against the untransformed canonical bytes.
 	c14nMethod := ExcC14N10
 	var prefixes []string
 	for _, t := range ref.transforms {
@@ -113,6 +116,17 @@ func verifyReference(doc *helium.Document, sigElem *helium.Element, ref parsedRe
 		case C14N10, C14N10Comments, ExcC14N10, ExcC14N10Comments, C14N11URI, C14N11Comments:
 			c14nMethod = t.algorithm
 			prefixes = t.prefixes
+		case TransformEnvelopedSignature:
+			// Handled in the separate enveloped-signature pass above; no-op here.
+		default:
+			// Reattach the Signature element we detached above before
+			// bailing out, so a rejected reference does not leave the
+			// document structurally modified. A restore failure here cannot
+			// mask the rejection, so its error is intentionally discarded.
+			if hasEnveloped {
+				_ = anchor.restore(sigElem)
+			}
+			return nil, fmt.Errorf("%w: %s", ErrUnsupportedTransform, t.algorithm)
 		}
 	}
 

--- a/xmldsig1/xmldsig1_test.go
+++ b/xmldsig1/xmldsig1_test.go
@@ -275,6 +275,29 @@ func TestSignerImmutability(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestVerifyAcceptsEnvelopedExcC14N guards against the unsupported-transform
+// rejection over-rejecting: a normal enveloped + exclusive-c14n signature must
+// still verify (both transform URIs must pass the new default-arm guard).
+func TestVerifyAcceptsEnvelopedExcC14N(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.ReferenceConfig{
+			URI:             "",
+			DigestAlgorithm: xmldsig1.DigestSHA256,
+			Transforms:      []xmldsig1.Transform{xmldsig1.Enveloped(), xmldsig1.ExcC14NTransform()},
+		})
+
+	err := signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key)
+	require.NoError(t, err)
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+}
+
 func TestSignVerifyWithFragmentReference(t *testing.T) {
 	xml := `<root><data Id="mydata">Hello</data></root>`
 	key := generateRSAKey(t)


### PR DESCRIPTION
- `verifyReference` silently ignored any Reference transform outside the c14n/enveloped allowlist, so a Reference could declare an unsupported transform (XPath, Base64, custom URI) and still verify against the untransformed canonical bytes (fail-open signature coverage).
- Add a `default` arm to the c14n-selection switch that returns `ErrUnsupportedTransform` before digesting; `TransformEnvelopedSignature` is an explicit no-op case (handled in the separate enveloped pass).
- Regression tests: white-box `verifyReference` rejection (plain + enveloped detach/restore) and a positive enveloped + exc-c14n round-trip to guard against over-rejection.
