### PR TITLE
relaxng: enforce basedir on all resolved hrefs

### DIFF
--- a/relaxng/basedir_escape_test.go
+++ b/relaxng/basedir_escape_test.go
@@ -1,0 +1,155 @@
+package relaxng_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/relaxng"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingFS wraps an fs.FS and records every path handed to Open, so a
+// test can assert that no path outside the configured BaseDir ever reaches
+// the filesystem.
+type recordingFS struct {
+	fsys   fs.FS
+	mu     sync.Mutex
+	opened []string
+}
+
+func (r *recordingFS) Open(name string) (fs.File, error) {
+	r.mu.Lock()
+	r.opened = append(r.opened, name)
+	r.mu.Unlock()
+	return r.fsys.Open(name)
+}
+
+func (r *recordingFS) openedPaths() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.opened))
+	copy(out, r.opened)
+	return out
+}
+
+// osFS opens absolute OS paths verbatim, mirroring the package default
+// (iofs.PermissiveRoot). os.DirFS/MapFS reject absolute names via
+// fs.ValidPath, so a raw os.Open-backed FS is required to exercise the
+// path-containment guard against real outside files.
+type osFS struct{}
+
+func (osFS) Open(name string) (fs.File, error) { return os.Open(name) }
+
+// A grammar that loads fine on its own, used as the "outside" target the
+// guard must refuse to read.
+const escapeTargetRNG = `<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <define name="root"><element name="root"><text/></element></define>
+  <start><ref name="root"/></start>
+</grammar>`
+
+const innerRNG = `<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <define name="root"><element name="root"><text/></element></define>
+</grammar>`
+
+// resolveHref applied its base-directory containment check to only one of
+// its three return paths. An absolute href, and an href resolved through an
+// escaping xml:base, both returned before the check and could read files
+// outside the configured BaseDir. These cases must be rejected and must
+// never reach the filesystem; a normal in-base relative href must still load.
+func TestCompile_BaseDirContainsAllResolvedHrefs(t *testing.T) {
+	t.Parallel()
+
+	// Lay out an "outside" directory holding the secret target and a
+	// separate "base" directory the compiler is confined to.
+	root := t.TempDir()
+	outsideDir := filepath.Join(root, "outside")
+	baseDir := filepath.Join(root, "base")
+	require.NoError(t, os.MkdirAll(outsideDir, 0o755))
+	require.NoError(t, os.MkdirAll(baseDir, 0o755))
+
+	outsidePath := filepath.Join(outsideDir, "escape.rng")
+	require.NoError(t, os.WriteFile(outsidePath, []byte(escapeTargetRNG), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(baseDir, "inner.rng"), []byte(innerRNG), 0o644))
+
+	compile := func(t *testing.T, schema string) (*recordingFS, string) {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schema))
+		require.NoError(t, err)
+		// Anchor the document inside baseDir so NodeGetBase can resolve
+		// xml:base against a real in-base location.
+		doc.SetURL(filepath.Join(baseDir, "main.rng"))
+
+		rec := &recordingFS{fsys: osFS{}}
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, err = relaxng.NewCompiler().FS(rec).BaseDir(baseDir).ErrorHandler(collector).Compile(t.Context(), doc)
+		require.NoError(t, err)
+		_ = collector.Close()
+		_, compileErrors := partitionCompileErrors(collector.Errors())
+		return rec, compileErrors
+	}
+
+	assertNoOutsideOpen := func(t *testing.T, rec *recordingFS) {
+		t.Helper()
+		for _, p := range rec.openedPaths() {
+			require.False(t, strings.Contains(filepath.Clean(p), outsideDir),
+				"outside path must never reach Open; got %q", p)
+		}
+	}
+
+	t.Run("absolute href outside base", func(t *testing.T) {
+		t.Parallel()
+		schema := `<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <include href="` + outsidePath + `"/>
+  <start><ref name="root"/></start>
+</grammar>`
+		rec, errs := compile(t, schema)
+		require.Contains(t, errs, "escapes base directory",
+			"absolute outside href must be rejected; got: %s", errs)
+		assertNoOutsideOpen(t, rec)
+	})
+
+	t.Run("escaping xml:base with relative href", func(t *testing.T) {
+		t.Parallel()
+		// xml:base climbs out of baseDir, then the relative href dives back
+		// into the outside directory. NodeGetBase resolves against the
+		// in-base document URL, producing a path above baseDir.
+		schema := `<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" xmlns:xml="http://www.w3.org/XML/1998/namespace">
+  <div xml:base="../outside/">
+    <include href="escape.rng"/>
+  </div>
+  <start><ref name="root"/></start>
+</grammar>`
+		rec, errs := compile(t, schema)
+		require.Contains(t, errs, "escapes base directory",
+			"escaping xml:base must be rejected; got: %s", errs)
+		assertNoOutsideOpen(t, rec)
+	})
+
+	t.Run("in-base relative href still loads", func(t *testing.T) {
+		t.Parallel()
+		schema := `<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <include href="inner.rng"/>
+  <start><ref name="root"/></start>
+</grammar>`
+		rec, errs := compile(t, schema)
+		require.Empty(t, errs, "in-base relative href must compile cleanly; got: %s", errs)
+
+		var sawInner bool
+		for _, p := range rec.openedPaths() {
+			if strings.HasSuffix(filepath.Clean(p), filepath.Join("base", "inner.rng")) {
+				sawInner = true
+			}
+		}
+		require.True(t, sawInner, "in-base include should have been opened; opened: %v", rec.openedPaths())
+	})
+}

--- a/relaxng/basedir_escape_test.go
+++ b/relaxng/basedir_escape_test.go
@@ -98,7 +98,12 @@ func TestCompile_BaseDirContainsAllResolvedHrefs(t *testing.T) {
 	assertNoOutsideOpen := func(t *testing.T, rec *recordingFS) {
 		t.Helper()
 		for _, p := range rec.openedPaths() {
-			require.False(t, strings.Contains(filepath.Clean(p), outsideDir),
+			rel, err := filepath.Rel(outsideDir, filepath.Clean(p))
+			// p is within outsideDir when Rel succeeds and the result
+			// doesn't climb out via "..". A leading ".." (or rel == "..")
+			// means p sits above/outside outsideDir, which is fine.
+			inside := err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+			require.False(t, inside,
 				"outside path must never reach Open; got %q", p)
 		}
 	}

--- a/relaxng/parse.go
+++ b/relaxng/parse.go
@@ -381,21 +381,68 @@ func (c *compiler) resolveHref(_ context.Context, elem *helium.Element, href str
 	// path so the containment comparison below is meaningful. A non-file
 	// URI scheme (http, etc.) is not a local path, so there is nothing to
 	// contain and it is returned untouched.
+	//
+	// Scheme detection must anchor at the start of the string: a substring
+	// match on "://" would misclassify local paths such as
+	// "/tmp/x://../etc/passwd" as remote URIs and skip the containment
+	// check entirely.
 	checkPath := resolved
-	if strings.HasPrefix(checkPath, "file://") {
+	switch scheme := uriScheme(checkPath); {
+	case scheme == "file":
 		if u, err := url.Parse(checkPath); err == nil {
+			// Decode percent-escapes (e.g. "%2e%2e") so encoded traversal
+			// cannot slip past the containment comparison below.
 			checkPath = u.Path
+			if u.Host != "" {
+				checkPath = u.Host + u.Path
+			}
 		}
-	} else if strings.Contains(checkPath, "://") {
+	case scheme != "":
+		// A genuine non-file URI scheme (http, https, ...) is not a local
+		// path; there is nothing to contain.
 		return resolved, nil
 	}
 
-	if rel, err := filepath.Rel(c.baseDir, filepath.Clean(checkPath)); err == nil {
-		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			return "", fmt.Errorf("href %q escapes base directory", href)
-		}
+	// filepath.Rel fails when one path is absolute and the other relative
+	// (e.g. a relative baseDir against an absolute href). That mismatch is
+	// itself a containment failure: an absolute href can never be proven to
+	// live inside a relative baseDir, so reject rather than silently skip.
+	rel, err := filepath.Rel(c.baseDir, filepath.Clean(checkPath))
+	if err != nil {
+		return "", fmt.Errorf("href %q escapes base directory", href)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("href %q escapes base directory", href)
 	}
 	return resolved, nil
+}
+
+// uriScheme returns the URI scheme of s if s begins with a "<scheme>://"
+// prefix where <scheme> is a valid RFC 3986 scheme (ALPHA *( ALPHA / DIGIT
+// / "+" / "-" / "." )). It returns "" when s carries no leading scheme, so
+// local filesystem paths — even ones that happen to contain "://" later in
+// the string — are not mistaken for URIs.
+func uriScheme(s string) string {
+	i := strings.Index(s, "://")
+	if i <= 0 {
+		return ""
+	}
+	scheme := s[:i]
+	for j := range len(scheme) {
+		ch := scheme[j]
+		switch {
+		case ch >= 'a' && ch <= 'z', ch >= 'A' && ch <= 'Z':
+			// always valid
+		case j == 0:
+			// first char must be a letter
+			return ""
+		case ch >= '0' && ch <= '9', ch == '+', ch == '-', ch == '.':
+			// valid in non-leading position
+		default:
+			return ""
+		}
+	}
+	return strings.ToLower(scheme)
 }
 
 // parseInclude parses an <include> element.

--- a/relaxng/parse.go
+++ b/relaxng/parse.go
@@ -422,9 +422,14 @@ func (c *compiler) resolveHref(_ context.Context, elem *helium.Element, href str
 // / "+" / "-" / "." )). It returns "" when s carries no leading scheme, so
 // local filesystem paths — even ones that happen to contain "://" later in
 // the string — are not mistaken for URIs.
+//
+// Single-character schemes are rejected (treated as non-URI): on Windows a
+// path like "C://..." would otherwise be read as scheme "c" and skip the
+// baseDir containment check, even though it is an absolute local path. No
+// real URI scheme used for href resolution is a single letter.
 func uriScheme(s string) string {
 	i := strings.Index(s, "://")
-	if i <= 0 {
+	if i < 2 {
 		return ""
 	}
 	scheme := s[:i]

--- a/relaxng/parse.go
+++ b/relaxng/parse.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"net/url"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -347,25 +348,54 @@ func combinePatterns(existing, incoming *pattern, mode string) *pattern {
 // Mirrors xsd's validateSchemaPath; defense-in-depth alongside whatever
 // path constraints the configured fs.FS enforces.
 func (c *compiler) resolveHref(_ context.Context, elem *helium.Element, href string) (string, error) {
-	if filepath.IsAbs(href) {
-		return href, nil
-	}
-	if doc := elem.OwnerDocument(); doc != nil {
-		base := helium.NodeGetBase(doc, elem)
-		if base != "" {
-			return helium.BuildURI(href, base), nil
-		}
-	}
-	if c.baseDir != "" {
-		joined := filepath.Join(c.baseDir, href)
-		if rel, err := filepath.Rel(c.baseDir, joined); err == nil {
-			if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-				return "", fmt.Errorf("href %q escapes base directory", href)
+	// Resolve the href to a concrete path first, then enforce baseDir
+	// containment once for every locally-resolved path. Resolving and
+	// checking in a single place prevents the absolute-href and xml:base
+	// branches from bypassing the containment guard.
+	var resolved string
+	switch {
+	case filepath.IsAbs(href):
+		resolved = href
+	default:
+		if doc := elem.OwnerDocument(); doc != nil {
+			if base := helium.NodeGetBase(doc, elem); base != "" {
+				resolved = helium.BuildURI(href, base)
 			}
 		}
-		return joined, nil
+		if resolved == "" && c.baseDir != "" {
+			resolved = filepath.Join(c.baseDir, href)
+		}
+		if resolved == "" {
+			resolved = href
+		}
 	}
-	return href, nil
+
+	if c.baseDir == "" {
+		// No base directory configured: nothing to contain. Preserve the
+		// historically permissive behavior.
+		return resolved, nil
+	}
+
+	// BuildURI may hand back a file:// URI (e.g. when an ancestor xml:base
+	// or the document URL carries that scheme). Reduce it to a filesystem
+	// path so the containment comparison below is meaningful. A non-file
+	// URI scheme (http, etc.) is not a local path, so there is nothing to
+	// contain and it is returned untouched.
+	checkPath := resolved
+	if strings.HasPrefix(checkPath, "file://") {
+		if u, err := url.Parse(checkPath); err == nil {
+			checkPath = u.Path
+		}
+	} else if strings.Contains(checkPath, "://") {
+		return resolved, nil
+	}
+
+	if rel, err := filepath.Rel(c.baseDir, filepath.Clean(checkPath)); err == nil {
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return "", fmt.Errorf("href %q escapes base directory", href)
+		}
+	}
+	return resolved, nil
 }
 
 // parseInclude parses an <include> element.

--- a/relaxng/path_escape_test.go
+++ b/relaxng/path_escape_test.go
@@ -3,6 +3,7 @@ package relaxng_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -117,6 +118,12 @@ func TestCompile_RejectsAbsoluteHrefWithRelativeBaseDir(t *testing.T) {
 // containment check.
 func TestCompile_RejectsSchemeLikeLocalPathEscape(t *testing.T) {
 	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		// The directory name contains ":" which is invalid on Windows
+		// filesystems; the behavior under test is OS-independent.
+		t.Skip("path component with ':' is not a valid Windows filename")
+	}
 
 	root := t.TempDir()
 	outsideDir := filepath.Join(root, "x://outside")

--- a/relaxng/path_escape_test.go
+++ b/relaxng/path_escape_test.go
@@ -1,6 +1,8 @@
 package relaxng_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -70,4 +72,79 @@ func TestCompile_RejectsParentEscapeInHref(t *testing.T) {
 		require.True(t, strings.Contains(got, "escapes base directory"),
 			"error should mention escape; got: %s", got)
 	})
+}
+
+// An absolute href cannot be proven contained in a *relative* baseDir:
+// filepath.Rel returns an error in that case, and the guard must treat that
+// as a containment failure rather than silently allowing the load. Without
+// the fix this reintroduces the absolute-href escape.
+func TestCompile_RejectsAbsoluteHrefWithRelativeBaseDir(t *testing.T) {
+	t.Parallel()
+
+	const includer = `<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <include href="/etc/passwd"/>
+  <start><ref name="root"/></start>
+</grammar>`
+
+	const escapeRNG = `<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <define name="root"><element name="root"><text/></element></define>
+  <start><ref name="root"/></start>
+</grammar>`
+
+	fsys := fstest.MapFS{
+		"schemas/main.rng": &fstest.MapFile{Data: []byte(includer)},
+		"etc/passwd":       &fstest.MapFile{Data: []byte(escapeRNG)},
+	}
+
+	data, err := fsys.ReadFile("schemas/main.rng")
+	require.NoError(t, err)
+	doc, err := helium.NewParser().Parse(t.Context(), data)
+	require.NoError(t, err)
+
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	_, err = relaxng.NewCompiler().FS(fsys).BaseDir("schemas").ErrorHandler(collector).Compile(t.Context(), doc)
+	require.NoError(t, err)
+	_ = collector.Close()
+	_, compileErrors := partitionCompileErrors(collector.Errors())
+	require.True(t, strings.Contains(compileErrors, "escapes base directory"),
+		"absolute href against relative baseDir must be rejected; got: %s", compileErrors)
+}
+
+// A local filesystem path that merely contains "://" somewhere (not as a
+// leading scheme) must not be mistaken for a remote URI and skip the
+// containment check.
+func TestCompile_RejectsSchemeLikeLocalPathEscape(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	outsideDir := filepath.Join(root, "x://outside")
+	baseDir := filepath.Join(root, "base")
+	require.NoError(t, os.MkdirAll(outsideDir, 0o755))
+	require.NoError(t, os.MkdirAll(baseDir, 0o755))
+
+	const escapeRNG = `<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <define name="root"><element name="root"><text/></element></define>
+  <start><ref name="root"/></start>
+</grammar>`
+	outsidePath := filepath.Join(outsideDir, "escape.rng")
+	require.NoError(t, os.WriteFile(outsidePath, []byte(escapeRNG), 0o644))
+
+	schema := `<?xml version="1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <include href="` + outsidePath + `"/>
+  <start><ref name="root"/></start>
+</grammar>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(schema))
+	require.NoError(t, err)
+
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	_, err = relaxng.NewCompiler().FS(osFS{}).BaseDir(baseDir).ErrorHandler(collector).Compile(t.Context(), doc)
+	require.NoError(t, err)
+	_ = collector.Close()
+	_, compileErrors := partitionCompileErrors(collector.Errors())
+	require.True(t, strings.Contains(compileErrors, "escapes base directory"),
+		"scheme-like local path must not bypass containment; got: %s", compileErrors)
 }


### PR DESCRIPTION
- resolveHref now resolves the href first, then applies the BaseDir containment check once for every locally-resolved path
- closes a path-traversal gap where absolute hrefs and escaping xml:base bypassed the check and read files outside BaseDir
- adds a recording-FS regression test covering absolute-href escape, xml:base escape, and the in-base relative href