### PR TITLE
schematron: validate attribute context nodes

### DIFF
--- a/schematron/schematron_test.go
+++ b/schematron/schematron_test.go
@@ -781,6 +781,36 @@ func TestUnionContextIntegration(t *testing.T) {
 	require.NotContains(t, got, "other")
 }
 
+func TestAttributeContext(t *testing.T) {
+	t.Parallel()
+	// A rule whose context selects an attribute (context="@id" becomes
+	// //@id) must run its asserts against each attribute node. The assert
+	// fails for short id values. Before the fix, attribute context nodes
+	// were silently skipped and the document validated.
+	schema, errs := compileTestSchema(t, `<schema xmlns="http://purl.oclc.org/dsdl/schematron">
+		<pattern>
+			<rule context="@id">
+				<assert test="string-length(.) &gt; 3">id too short</assert>
+			</rule>
+		</pattern>
+	</schema>`)
+	require.Equal(t, "", errs)
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root id="a"><child id="b"/></root>`))
+	require.NoError(t, err)
+
+	collected, err := validateAndCollect(t, schema, doc)
+	require.ErrorIs(t, err, schematron.ErrValidationFailed)
+	require.NotEmpty(t, collected)
+
+	var paths []string
+	for _, ve := range collected {
+		paths = append(paths, ve.Path)
+	}
+	require.Contains(t, paths, "/root/@id")
+	require.Contains(t, paths, "/root/child/@id")
+}
+
 func TestZeroCompilerFluent(t *testing.T) {
 	t.Parallel()
 	var c schematron.Compiler

--- a/schematron/validate.go
+++ b/schematron/validate.go
@@ -33,7 +33,10 @@ func validateDocument(ctx context.Context, doc *helium.Document, schema *Schema,
 			}
 
 			for _, node := range result.NodeSet {
-				if node.Type() != helium.ElementNode {
+				// A rule context may resolve to element or attribute
+				// nodes (e.g. context="@id" becomes //@id). Other node
+				// types are not valid rule contexts.
+				if node.Type() != helium.ElementNode && node.Type() != helium.AttributeNode {
 					continue
 				}
 
@@ -245,6 +248,18 @@ func xpathResultToValue(r *xpath1.Result) any {
 func getNodePath(n helium.Node) string {
 	if n == nil {
 		return ""
+	}
+
+	// Attribute leaves are not part of the element ancestry walk below
+	// (which only collects element nodes). Compute the owning element's
+	// path and append /@<name>, matching libxml2's xmlGetNodePath
+	// (e.g. /root/@id).
+	if n.Type() == helium.AttributeNode {
+		parent := getNodePath(n.Parent())
+		if parent == "/" {
+			parent = ""
+		}
+		return parent + "/@" + n.Name()
 	}
 
 	var parts []string


### PR DESCRIPTION
- `schematron/validate.go` no longer drops attribute context nodes, so rules with `context="@id"` (compiled to `//@id`) actually run their asserts/reports
- `getNodePath` now reports attribute leaves as `/parent/@name` (matching libxml2's `xmlGetNodePath`) instead of the parent element path
- adds regression test covering an attribute-context assert and the `/root/@id` path
