### PR TITLE
xpath: match unprefixed names in no namespace

### DIFF
--- a/xpath1/eval.go
+++ b/xpath1/eval.go
@@ -304,7 +304,9 @@ func matchNameTestByLocalAndPrefix(test NameTest, n helium.Node, ec *evalContext
 		return matchPrefix(test.Prefix, n, ec)
 	}
 
-	return true
+	// XPath 1.0 has no default element namespace: an unprefixed name test
+	// matches only nodes with no namespace URI.
+	return ixpath.NodeNamespaceURI(n) == ""
 }
 
 func matchPrefix(prefix string, n helium.Node, ec *evalContext) bool {

--- a/xpath1/eval.go
+++ b/xpath1/eval.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/lexicon"
 	ixpath "github.com/lestrrat-go/helium/internal/xpath"
 	"github.com/lestrrat-go/helium/internal/xpath1/number"
 )
@@ -316,7 +317,14 @@ func matchPrefix(prefix string, n helium.Node, ec *evalContext) bool {
 			return ixpath.NodeNamespaceURI(n) == uri
 		}
 	}
-	return ixpath.NodePrefix(n) == prefix
+	// The xml prefix is always bound per the XML Namespaces spec.
+	if prefix == lexicon.PrefixXML {
+		return ixpath.NodeNamespaceURI(n) == lexicon.NamespaceXML
+	}
+	// Per XPath 1.0, prefix resolution comes from the evaluation namespace
+	// context, not the document's lexical prefixes. An unbound prefix cannot
+	// match a node merely because it happens to share the lexical prefix.
+	return false
 }
 
 func matchTypeTest(test TypeTest, n helium.Node) bool {

--- a/xpath1/eval_test.go
+++ b/xpath1/eval_test.go
@@ -69,6 +69,17 @@ func TestEvalDoubleSlash(t *testing.T) {
 	require.Len(t, r.NodeSet, 2)
 }
 
+// TestEvalUnprefixedNameTestMatchesNoNamespaceOnly verifies that an unprefixed
+// name test matches only no-namespace nodes. XPath 1.0 has no default element
+// namespace, so a node in a namespace must not match an unprefixed test.
+func TestEvalUnprefixedNameTestMatchesNoNamespaceOnly(t *testing.T) {
+	doc := parseXML(t, `<root><item xmlns="http://ex">A</item><item xmlns="">B</item></root>`)
+	r, err := xpath1.Evaluate(t.Context(), doc, "//item")
+	require.NoError(t, err)
+	require.Len(t, r.NodeSet, 1)
+	require.Equal(t, "B", string(r.NodeSet[0].Content()))
+}
+
 func TestEvalDot(t *testing.T) {
 	doc := parseXML(t, `<root/>`)
 	root := docElement(doc)

--- a/xpath1/eval_test.go
+++ b/xpath1/eval_test.go
@@ -80,6 +80,25 @@ func TestEvalUnprefixedNameTestMatchesNoNamespaceOnly(t *testing.T) {
 	require.Equal(t, "B", string(r.NodeSet[0].Content()))
 }
 
+// An undeclared prefix must not match a node merely because the document uses
+// the same lexical prefix; prefixes resolve from the evaluation namespace
+// context. With a binding supplied, the match succeeds.
+func TestEvalUndeclaredPrefixDoesNotMatchLexically(t *testing.T) {
+	doc := parseXML(t, `<root xmlns:p="urn:x"><p:foo/></root>`)
+
+	r, err := xpath1.Evaluate(t.Context(), doc, "//p:foo")
+	require.NoError(t, err)
+	require.Empty(t, r.NodeSet, "unbound prefix must not match by lexical prefix")
+
+	expr, err := xpath1.Compile("//p:foo")
+	require.NoError(t, err)
+	r2, err := xpath1.NewEvaluator().
+		Namespaces(map[string]string{"p": "urn:x"}).
+		Evaluate(t.Context(), expr, doc)
+	require.NoError(t, err)
+	require.Len(t, r2.NodeSet, 1, "bound prefix must match")
+}
+
 func TestEvalDot(t *testing.T) {
 	doc := parseXML(t, `<root/>`)
 	root := docElement(doc)

--- a/xpath3/eval_path.go
+++ b/xpath3/eval_path.go
@@ -457,7 +457,7 @@ func matchNodeTest(nt NodeTest, n helium.Node, axis AxisType, ec *evalContext) b
 			return false
 		}
 		if test.Name != "" && test.Name != "*" {
-			if !matchElementOrAttributeName(test.Name, n, ec) {
+			if !matchElementOrAttributeName(test.Name, n, ec, false) {
 				return false
 			}
 		}
@@ -479,7 +479,7 @@ func matchNodeTest(nt NodeTest, n helium.Node, axis AxisType, ec *evalContext) b
 			return false
 		}
 		if test.Name != "" && test.Name != "*" {
-			if !matchElementOrAttributeName(test.Name, n, ec) {
+			if !matchElementOrAttributeName(test.Name, n, ec, true) {
 				return false
 			}
 		}
@@ -608,7 +608,9 @@ func matchNodeTest(nt NodeTest, n helium.Node, axis AxisType, ec *evalContext) b
 // matchElementOrAttributeName matches an element/attribute name from an
 // ElementTest or AttributeTest against a node. Handles URIQualifiedNames
 // (Q{uri}local), prefixed names (prefix:local), and plain local names.
-func matchElementOrAttributeName(name string, n helium.Node, ec *evalContext) bool {
+// isAttr selects the namespace rule for an unprefixed name: attributes match
+// only no-namespace nodes, elements match the default element namespace.
+func matchElementOrAttributeName(name string, n helium.Node, ec *evalContext, isAttr bool) bool {
 	if strings.HasPrefix(name, "Q{") {
 		if idx := strings.Index(name, "}"); idx >= 0 {
 			uri := name[2:idx]
@@ -623,7 +625,15 @@ func matchElementOrAttributeName(name string, n helium.Node, ec *evalContext) bo
 	if prefix != "" {
 		return matchPrefix(prefix, n, ec)
 	}
-	return true
+	// Unprefixed name: same namespace rule as a NameTest (XPath 3.1 §3.3.2.1).
+	if isAttr {
+		return ixpath.NodeNamespaceURI(n) == ""
+	}
+	defaultNS := ""
+	if ec != nil && ec.namespaces != nil {
+		defaultNS = ec.namespaces[""]
+	}
+	return ixpath.NodeNamespaceURI(n) == defaultNS
 }
 
 func matchNameTest(test NameTest, n helium.Node, axis AxisType, ec *evalContext) bool {

--- a/xpath3/eval_path.go
+++ b/xpath3/eval_path.go
@@ -685,11 +685,13 @@ func matchNameTest(test NameTest, n helium.Node, axis AxisType, ec *evalContext)
 		// matches only attributes with no namespace URI.
 		return ixpath.NodeNamespaceURI(n) == ""
 	}
+	// Per XPath 3.1 §3.3.2.1: when no default element namespace is bound,
+	// an unprefixed name test matches only no-namespace elements.
+	defaultNS := ""
 	if ec.namespaces != nil {
-		return ixpath.NodeNamespaceURI(n) == ec.namespaces[""]
+		defaultNS = ec.namespaces[""]
 	}
-	// No namespace context at all: permissive match (any namespace).
-	return true
+	return ixpath.NodeNamespaceURI(n) == defaultNS
 }
 
 func matchPrefix(prefix string, n helium.Node, ec *evalContext) bool {

--- a/xpath3/xpath3_test.go
+++ b/xpath3/xpath3_test.go
@@ -218,6 +218,21 @@ func TestResultIsNodeSet(t *testing.T) {
 	require.Len(t, nodes, 3)
 }
 
+// TestUnprefixedNameTestMatchesNoNamespaceOnly verifies that an unprefixed
+// name test, with no namespace context configured, matches only nodes in no
+// namespace (XPath 3.1 §3.3.2.1), not nodes in an arbitrary namespace.
+func TestUnprefixedNameTestMatchesNoNamespaceOnly(t *testing.T) {
+	t.Parallel()
+	const src = `<root><item xmlns="http://ex">A</item><item xmlns="">B</item></root>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	nodes, err := find(t.Context(), doc, `//item`)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	require.Equal(t, "B", string(nodes[0].Content()))
+}
+
 func TestPrefixedFunctionMissingDoesNotFallBackToFnNamespace(t *testing.T) {
 	t.Parallel()
 	doc := parseTestDoc(t)

--- a/xpath3/xpath3_test.go
+++ b/xpath3/xpath3_test.go
@@ -233,6 +233,38 @@ func TestUnprefixedNameTestMatchesNoNamespaceOnly(t *testing.T) {
 	require.Equal(t, "B", string(nodes[0].Content()))
 }
 
+// TestUnprefixedKindTestNamespace verifies element()/attribute() kind tests
+// apply the same namespace rule as a NameTest for an unprefixed name: an
+// element kind test matches the default element namespace (no namespace here),
+// and an attribute kind test matches only no-namespace attributes.
+func TestUnprefixedKindTestNamespace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("element(foo) skips namespaced foo", func(t *testing.T) {
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root xmlns="urn:x"><foo/></root>`))
+		require.NoError(t, err)
+		nodes, err := find(t.Context(), doc, `/*/element(foo)`)
+		require.NoError(t, err)
+		require.Empty(t, nodes)
+	})
+
+	t.Run("element(foo) matches no-namespace foo", func(t *testing.T) {
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root><foo/></root>`))
+		require.NoError(t, err)
+		nodes, err := find(t.Context(), doc, `/*/element(foo)`)
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+	})
+
+	t.Run("attribute(a) skips namespaced attribute", func(t *testing.T) {
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root xmlns:p="urn:x" p:a="1"/>`))
+		require.NoError(t, err)
+		nodes, err := find(t.Context(), doc, `/root/attribute(a)`)
+		require.NoError(t, err)
+		require.Empty(t, nodes)
+	})
+}
+
 func TestPrefixedFunctionMissingDoesNotFallBackToFnNamespace(t *testing.T) {
 	t.Parallel()
 	doc := parseTestDoc(t)


### PR DESCRIPTION
- Unprefixed name tests now match only no-namespace nodes when no default element namespace is bound (XPath 3.1 §3.3.2.1); previously matched any namespace
- xpath3: collapse nil-namespace branch in `matchNameTest`; xpath1: drop unconditional `return true`
- Add xpath3 + xpath1 regression tests; full xslt3 suite still green
