### PR TITLE
writer: propagate io.Writer errors

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -52,6 +52,37 @@ type writeSession struct {
 	isXHTML        bool
 	encoding       string // document encoding, used for XHTML meta injection
 	indent         int    // current indent depth (used when format is true)
+	err            error  // sticky write error; once set, further writes are skipped
+}
+
+// writeString writes str to out, recording the first error encountered into
+// s.err. Once s.err is set, subsequent writes are skipped so the sticky error
+// is preserved and propagated by the terminal serialization methods.
+func (s *writeSession) writeString(out io.Writer, str string) {
+	if s.err != nil {
+		return
+	}
+	if _, err := io.WriteString(out, str); err != nil {
+		s.err = err
+	}
+}
+
+// writeBytes writes b to out, recording the first error encountered into s.err.
+func (s *writeSession) writeBytes(out io.Writer, b []byte) {
+	if s.err != nil {
+		return
+	}
+	if _, err := out.Write(b); err != nil {
+		s.err = err
+	}
+}
+
+// check records err into the sticky s.err (keeping the first one) so callers
+// that obtain an error from a leaf helper can funnel it through the session.
+func (s *writeSession) check(err error) {
+	if s.err == nil && err != nil {
+		s.err = err
+	}
 }
 
 // NewWriter creates a new Writer with default settings.
@@ -118,7 +149,7 @@ func (s *writeSession) writeIndent(out io.Writer) {
 	}
 	str := s.indentStr()
 	for range s.indent {
-		_, _ = io.WriteString(out, str)
+		s.writeString(out, str)
 	}
 }
 
@@ -196,9 +227,9 @@ func (d Writer) writeDoc(out io.Writer, doc *Document) error {
 				return err
 			}
 		}
-		_, _ = io.WriteString(out, "\n")
+		s.writeString(out, "\n")
 	}
-	return nil
+	return s.err
 }
 
 func (d *writeSession) dumpDocContent(out io.Writer, n Node) error {
@@ -211,25 +242,25 @@ func (d *writeSession) dumpDocContent(out io.Writer, n Node) error {
 	if !ok {
 		return nil
 	}
-	_, _ = io.WriteString(out, `<?xml version="`)
+	d.writeString(out, `<?xml version="`)
 	version := doc.Version()
 	if version == "" {
 		version = "1.0"
 	}
-	_, _ = io.WriteString(out, version+`"`)
+	d.writeString(out, version+`"`)
 
 	if encoding := doc.encoding; encoding != "" {
-		_, _ = io.WriteString(out, ` encoding="`+encoding+`"`)
+		d.writeString(out, ` encoding="`+encoding+`"`)
 	}
 
 	switch doc.Standalone() {
 	case StandaloneExplicitNo:
-		_, _ = io.WriteString(out, ` standalone="`+lexicon.ValueNo+`"`)
+		d.writeString(out, ` standalone="`+lexicon.ValueNo+`"`)
 	case StandaloneExplicitYes:
-		_, _ = io.WriteString(out, ` standalone="`+lexicon.ValueYes+`"`)
+		d.writeString(out, ` standalone="`+lexicon.ValueYes+`"`)
 	}
-	_, _ = io.WriteString(out, "?>\n")
-	return nil
+	d.writeString(out, "?>\n")
+	return d.err
 }
 
 // writeNode is the internal implementation for node serialization.
@@ -254,27 +285,27 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 		}
 		return nil
 	case CommentNode:
-		_, _ = io.WriteString(out, "<!--")
-		_, _ = out.Write(n.Content())
-		_, _ = io.WriteString(out, "-->")
-		return nil
+		d.writeString(out, "<!--")
+		d.writeBytes(out, n.Content())
+		d.writeString(out, "-->")
+		return d.err
 	case ProcessingInstructionNode:
 		// Mirrors xmlsave.c XML_PI_NODE handling.
 		if pi, ok := AsNode[*ProcessingInstruction](n); ok {
-			_, _ = io.WriteString(out, "<?")
-			_, _ = io.WriteString(out, pi.target)
+			d.writeString(out, "<?")
+			d.writeString(out, pi.target)
 			if pi.data != "" {
-				_, _ = io.WriteString(out, " ")
-				_, _ = io.WriteString(out, pi.data)
+				d.writeString(out, " ")
+				d.writeString(out, pi.data)
 			}
-			_, _ = io.WriteString(out, "?>")
+			d.writeString(out, "?>")
 		}
-		return nil
+		return d.err
 	case EntityRefNode:
-		_, _ = io.WriteString(out, "&")
-		_, _ = io.WriteString(out, n.Name())
-		_, _ = io.WriteString(out, ";")
-		return nil
+		d.writeString(out, "&")
+		d.writeString(out, n.Name())
+		d.writeString(out, ";")
+		return d.err
 	case TextNode:
 		c := n.Content()
 		if n.Name() == xmlTextNoEnc {
@@ -296,25 +327,25 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 		// Splits content on "]]>" sequences so the output is well-formed.
 		c := n.Content()
 		if len(c) == 0 {
-			_, _ = io.WriteString(out, "<![CDATA[]]>")
+			d.writeString(out, "<![CDATA[]]>")
 		} else {
 			start := 0
 			for i := 0; i+2 < len(c); i++ {
 				if c[i] == ']' && c[i+1] == ']' && c[i+2] == '>' {
 					end := i + 2
-					_, _ = io.WriteString(out, "<![CDATA[")
-					_, _ = out.Write(c[start:end])
-					_, _ = io.WriteString(out, "]]>")
+					d.writeString(out, "<![CDATA[")
+					d.writeBytes(out, c[start:end])
+					d.writeString(out, "]]>")
 					start = end
 				}
 			}
 			if start < len(c) {
-				_, _ = io.WriteString(out, "<![CDATA[")
-				_, _ = out.Write(c[start:])
-				_, _ = io.WriteString(out, "]]>")
+				d.writeString(out, "<![CDATA[")
+				d.writeBytes(out, c[start:])
+				d.writeString(out, "]]>")
 			}
 		}
-		return nil
+		return d.err
 	case ElementDeclNode:
 		if edecl, ok := AsNode[*ElementDecl](n); ok {
 			if err = d.dumpElementDecl(out, edecl); err != nil {
@@ -364,8 +395,8 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 		name = n.Name()
 	}
 
-	_, _ = io.WriteString(out, "<")
-	_, _ = io.WriteString(out, name)
+	d.writeString(out, "<")
+	d.writeString(out, name)
 
 	if len(nslist) > 0 {
 		if err := d.dumpNsList(out, nslist); err != nil {
@@ -376,7 +407,7 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 	if e, ok := n.(*Element); ok {
 		for attr := e.properties; attr != nil; {
 			g := pdebug.IPrintf("START WriteNode(fallthrough->attribute(%s))", attr.Name())
-			_, _ = io.WriteString(out, " "+attr.Name()+`="`)
+			d.writeString(out, " "+attr.Name()+`="`)
 			count := 0
 			for achld := range Children(attr) {
 				count++
@@ -390,7 +421,7 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 					}
 				}
 			}
-			_, _ = io.WriteString(out, `"`)
+			d.writeString(out, `"`)
 			g.IRelease("END DUmpNode(fallthrough->attribute(%s))", attr.Name())
 			a := attr.NextSibling()
 			if a == nil {
@@ -403,22 +434,22 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 
 		if child := e.FirstChild(); child == nil {
 			if d.noEmpty {
-				_, _ = io.WriteString(out, "></")
-				_, _ = io.WriteString(out, name)
-				_, _ = io.WriteString(out, ">")
+				d.writeString(out, "></")
+				d.writeString(out, name)
+				d.writeString(out, ">")
 			} else {
-				_, _ = io.WriteString(out, "/>")
+				d.writeString(out, "/>")
 			}
-			return nil
+			return d.err
 		}
 	}
 
-	_, _ = io.WriteString(out, ">")
+	d.writeString(out, ">")
 
 	if child := n.FirstChild(); child != nil {
 		textOnly := d.format && hasOnlyTextChildren(n)
 		if d.format && !textOnly {
-			_, _ = io.WriteString(out, "\n")
+			d.writeString(out, "\n")
 			d.indent++
 		}
 		for ; child != nil; child = child.NextSibling() {
@@ -429,7 +460,7 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 				return err
 			}
 			if d.format && !textOnly {
-				_, _ = io.WriteString(out, "\n")
+				d.writeString(out, "\n")
 			}
 		}
 		if d.format && !textOnly {
@@ -438,9 +469,9 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 		}
 	}
 
-	_, _ = io.WriteString(out, "</")
-	_, _ = io.WriteString(out, name)
-	_, _ = io.WriteString(out, ">")
+	d.writeString(out, "</")
+	d.writeString(out, name)
+	d.writeString(out, ">")
 
-	return nil
+	return d.err
 }

--- a/writer.go
+++ b/writer.go
@@ -62,8 +62,13 @@ func (s *writeSession) writeString(out io.Writer, str string) {
 	if s.err != nil {
 		return
 	}
-	if _, err := io.WriteString(out, str); err != nil {
+	n, err := io.WriteString(out, str)
+	if err != nil {
 		s.err = err
+		return
+	}
+	if n != len(str) {
+		s.err = io.ErrShortWrite
 	}
 }
 
@@ -72,8 +77,13 @@ func (s *writeSession) writeBytes(out io.Writer, b []byte) {
 	if s.err != nil {
 		return
 	}
-	if _, err := out.Write(b); err != nil {
+	n, err := out.Write(b)
+	if err != nil {
 		s.err = err
+		return
+	}
+	if n != len(b) {
+		s.err = io.ErrShortWrite
 	}
 }
 
@@ -398,6 +408,10 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 	d.writeString(out, "<")
 	d.writeString(out, name)
 
+	if d.err != nil {
+		return d.err
+	}
+
 	if len(nslist) > 0 {
 		if err := d.dumpNsList(out, nslist); err != nil {
 			return err
@@ -408,6 +422,9 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 		for attr := e.properties; attr != nil; {
 			g := pdebug.IPrintf("START WriteNode(fallthrough->attribute(%s))", attr.Name())
 			d.writeString(out, " "+attr.Name()+`="`)
+			if d.err != nil {
+				return d.err
+			}
 			count := 0
 			for achld := range Children(attr) {
 				count++

--- a/writer_dtd.go
+++ b/writer_dtd.go
@@ -26,11 +26,11 @@ func (d *writeSession) dumpDTD(out io.Writer, n Node) error {
 	d.writeString(out, "<!DOCTYPE ")
 	d.writeString(out, dtd.Name())
 
-	if dtd.externalID != "" {
+	if d.err == nil && dtd.externalID != "" {
 		pubQ := dtdQuoteChar(dtd.externalID)
 		sysQ := dtdQuoteChar(dtd.systemID)
 		d.writeString(out, fmt.Sprintf(" PUBLIC %c%s%c %c%s%c", pubQ, dtd.externalID, pubQ, sysQ, dtd.systemID, sysQ))
-	} else if dtd.systemID != "" {
+	} else if d.err == nil && dtd.systemID != "" {
 		sysQ := dtdQuoteChar(dtd.systemID)
 		d.writeString(out, fmt.Sprintf(" SYSTEM %c%s%c", sysQ, dtd.systemID, sysQ))
 	}
@@ -174,9 +174,9 @@ func (d *writeSession) dumpEntityContent(out io.Writer, content string) error {
 	if strings.IndexByte(content, '%') == -1 {
 		if err := dumpQuotedString(out, content); err != nil {
 			d.check(err)
-			return err
+			return d.err
 		}
-		return nil
+		return d.err
 	}
 
 	d.writeString(out, `"`)
@@ -186,7 +186,7 @@ func (d *writeSession) dumpEntityContent(out io.Writer, content string) error {
 		c, err := rdr.ReadByte()
 		if err != nil {
 			d.check(err)
-			return err
+			return d.err
 		}
 		switch c {
 		case '"':
@@ -226,7 +226,7 @@ func (d *writeSession) dumpEntityDecl(out io.Writer, ent *Entity) error {
 		if ent.orig != "" {
 			if err := dumpQuotedString(out, ent.orig); err != nil {
 				d.check(err)
-				return err
+				return d.err
 			}
 		} else {
 			if err := d.dumpEntityContent(out, ent.content); err != nil {
@@ -265,7 +265,7 @@ func (d *writeSession) dumpEntityDecl(out io.Writer, ent *Entity) error {
 		if ent.orig != "" {
 			if err := dumpQuotedString(out, ent.orig); err != nil {
 				d.check(err)
-				return err
+				return d.err
 			}
 		} else {
 			if err := d.dumpEntityContent(out, ent.content); err != nil {

--- a/writer_dtd.go
+++ b/writer_dtd.go
@@ -23,24 +23,24 @@ func (d *writeSession) dumpDTD(out io.Writer, n Node) error {
 	if !ok {
 		return nil
 	}
-	_, _ = io.WriteString(out, "<!DOCTYPE ")
-	_, _ = io.WriteString(out, dtd.Name())
+	d.writeString(out, "<!DOCTYPE ")
+	d.writeString(out, dtd.Name())
 
 	if dtd.externalID != "" {
 		pubQ := dtdQuoteChar(dtd.externalID)
 		sysQ := dtdQuoteChar(dtd.systemID)
-		_, _ = fmt.Fprintf(out, " PUBLIC %c%s%c %c%s%c", pubQ, dtd.externalID, pubQ, sysQ, dtd.systemID, sysQ)
+		d.writeString(out, fmt.Sprintf(" PUBLIC %c%s%c %c%s%c", pubQ, dtd.externalID, pubQ, sysQ, dtd.systemID, sysQ))
 	} else if dtd.systemID != "" {
 		sysQ := dtdQuoteChar(dtd.systemID)
-		_, _ = fmt.Fprintf(out, " SYSTEM %c%s%c", sysQ, dtd.systemID, sysQ)
+		d.writeString(out, fmt.Sprintf(" SYSTEM %c%s%c", sysQ, dtd.systemID, sysQ))
 	}
 
 	if len(dtd.entities) == 0 && len(dtd.elements) == 0 && len(dtd.pentities) == 0 && len(dtd.attributes) == 0 && len(dtd.notations) == 0 {
-		_, _ = io.WriteString(out, ">")
-		return nil
+		d.writeString(out, ">")
+		return d.err
 	}
 
-	_, _ = io.WriteString(out, " [\n")
+	d.writeString(out, " [\n")
 
 	savedFormat := d.format
 	savedIndent := d.indent
@@ -58,32 +58,32 @@ func (d *writeSession) dumpDTD(out io.Writer, n Node) error {
 	d.format = savedFormat
 	d.indent = savedIndent
 
-	_, _ = io.WriteString(out, "]>")
-	return nil
+	d.writeString(out, "]>")
+	return d.err
 }
 
 func (d *writeSession) dumpEnumeration(out io.Writer, n Enumeration) error {
 	l := len(n)
 	for i, v := range n {
-		_, _ = io.WriteString(out, v)
+		d.writeString(out, v)
 		if i != l-1 {
-			_, _ = io.WriteString(out, " | ")
+			d.writeString(out, " | ")
 		}
 	}
-	_, _ = io.WriteString(out, ")")
-	return nil
+	d.writeString(out, ")")
+	return d.err
 }
 
-func dumpElementDeclPrologue(out io.Writer, n *ElementDecl) {
-	_, _ = io.WriteString(out, "<!ELEMENT ")
+func (d *writeSession) dumpElementDeclPrologue(out io.Writer, n *ElementDecl) {
+	d.writeString(out, "<!ELEMENT ")
 	if n.prefix != "" {
-		_, _ = io.WriteString(out, n.prefix)
-		_, _ = io.WriteString(out, ":")
+		d.writeString(out, n.prefix)
+		d.writeString(out, ":")
 	}
-	_, _ = io.WriteString(out, n.name)
+	d.writeString(out, n.name)
 }
 
-func dumpElementContent(out io.Writer, n *ElementContent, glob bool) error {
+func (d *writeSession) dumpElementContent(out io.Writer, n *ElementContent, glob bool) error {
 	if pdebug.Enabled {
 		g := pdebug.IPrintf("START Writer.dumpElementContent n = '%s'", n.name)
 		defer g.IRelease("END Writer.dumpElementContent")
@@ -93,59 +93,59 @@ func dumpElementContent(out io.Writer, n *ElementContent, glob bool) error {
 	}
 
 	if glob {
-		_, _ = io.WriteString(out, "(")
+		d.writeString(out, "(")
 	}
 
 	switch n.ctype {
 	case ElementContentPCDATA:
-		_, _ = io.WriteString(out, "#PCDATA")
+		d.writeString(out, "#PCDATA")
 	case ElementContentElement:
 		if n.prefix != "" {
-			_, _ = io.WriteString(out, n.prefix)
-			_, _ = io.WriteString(out, ":")
+			d.writeString(out, n.prefix)
+			d.writeString(out, ":")
 		}
-		_, _ = io.WriteString(out, n.name)
+		d.writeString(out, n.name)
 	case ElementContentSeq:
 		switch n.c1.ctype {
 		case ElementContentOr, ElementContentSeq:
-			if err := dumpElementContent(out, n.c1, true); err != nil {
+			if err := d.dumpElementContent(out, n.c1, true); err != nil {
 				return err
 			}
 		default:
-			if err := dumpElementContent(out, n.c1, false); err != nil {
+			if err := d.dumpElementContent(out, n.c1, false); err != nil {
 				return err
 			}
 		}
-		_, _ = io.WriteString(out, " , ")
+		d.writeString(out, " , ")
 
 		if ctype := n.c2.ctype; ctype == ElementContentOr || (ctype == ElementContentSeq && n.c2.coccur != ElementContentOnce) {
-			if err := dumpElementContent(out, n.c2, true); err != nil {
+			if err := d.dumpElementContent(out, n.c2, true); err != nil {
 				return err
 			}
 		} else {
-			if err := dumpElementContent(out, n.c2, false); err != nil {
+			if err := d.dumpElementContent(out, n.c2, false); err != nil {
 				return err
 			}
 		}
 	case ElementContentOr:
 		switch n.c1.ctype {
 		case ElementContentOr, ElementContentSeq:
-			if err := dumpElementContent(out, n.c1, true); err != nil {
+			if err := d.dumpElementContent(out, n.c1, true); err != nil {
 				return err
 			}
 		default:
-			if err := dumpElementContent(out, n.c1, false); err != nil {
+			if err := d.dumpElementContent(out, n.c1, false); err != nil {
 				return err
 			}
 		}
-		_, _ = io.WriteString(out, " | ")
+		d.writeString(out, " | ")
 
 		if ctype := n.c2.ctype; ctype == ElementContentSeq || (ctype == ElementContentOr && n.c2.coccur != ElementContentOnce) {
-			if err := dumpElementContent(out, n.c2, true); err != nil {
+			if err := d.dumpElementContent(out, n.c2, true); err != nil {
 				return err
 			}
 		} else {
-			if err := dumpElementContent(out, n.c2, false); err != nil {
+			if err := d.dumpElementContent(out, n.c2, false); err != nil {
 				return err
 			}
 		}
@@ -154,67 +154,63 @@ func dumpElementContent(out io.Writer, n *ElementContent, glob bool) error {
 	}
 
 	if glob {
-		_, _ = io.WriteString(out, ")")
+		d.writeString(out, ")")
 	}
 
 	switch n.coccur {
 	case ElementContentOnce:
 	case ElementContentOpt:
-		_, _ = io.WriteString(out, "?")
+		d.writeString(out, "?")
 	case ElementContentMult:
-		_, _ = io.WriteString(out, "*")
+		d.writeString(out, "*")
 	case ElementContentPlus:
-		_, _ = io.WriteString(out, "+")
+		d.writeString(out, "+")
 	}
 
-	return nil
+	return d.err
 }
 
-func dumpEntityContent(out io.Writer, content string) error {
+func (d *writeSession) dumpEntityContent(out io.Writer, content string) error {
 	if strings.IndexByte(content, '%') == -1 {
 		if err := dumpQuotedString(out, content); err != nil {
+			d.check(err)
 			return err
 		}
 		return nil
 	}
 
-	_, _ = io.WriteString(out, `"`)
+	d.writeString(out, `"`)
 	rdr := strings.NewReader(content)
 	buf := bytes.Buffer{}
 	for rdr.Len() > 0 {
 		c, err := rdr.ReadByte()
 		if err != nil {
+			d.check(err)
 			return err
 		}
 		switch c {
 		case '"':
 			if buf.Len() > 0 {
-				if _, err := buf.WriteTo(out); err != nil {
-					return err
-				}
+				d.writeBytes(out, buf.Bytes())
 				buf.Reset()
 			}
-			_, _ = io.WriteString(out, "&quot;")
+			d.writeString(out, "&quot;")
 		case '%':
 			if buf.Len() > 0 {
-				if _, err := buf.WriteTo(out); err != nil {
-					return err
-				}
+				d.writeBytes(out, buf.Bytes())
 				buf.Reset()
 			}
-			_, _ = io.WriteString(out, "&#x25;")
+			d.writeString(out, "&#x25;")
 		default:
 			_ = buf.WriteByte(c)
 		}
 	}
 	if buf.Len() > 0 {
-		if _, err := buf.WriteTo(out); err != nil {
-			return err
-		}
+		d.writeBytes(out, buf.Bytes())
 	}
-	_, _ = io.WriteString(out, `"`)
+	d.writeString(out, `"`)
 
-	return nil
+	return d.err
 }
 
 func (d *writeSession) dumpEntityDecl(out io.Writer, ent *Entity) error {
@@ -224,147 +220,149 @@ func (d *writeSession) dumpEntityDecl(out io.Writer, ent *Entity) error {
 
 	switch etype := ent.entityType; etype {
 	case enum.InternalGeneralEntity:
-		_, _ = io.WriteString(out, "<!ENTITY ")
-		_, _ = io.WriteString(out, ent.name)
-		_, _ = io.WriteString(out, " ")
+		d.writeString(out, "<!ENTITY ")
+		d.writeString(out, ent.name)
+		d.writeString(out, " ")
 		if ent.orig != "" {
 			if err := dumpQuotedString(out, ent.orig); err != nil {
+				d.check(err)
 				return err
 			}
 		} else {
-			if err := dumpEntityContent(out, ent.content); err != nil {
+			if err := d.dumpEntityContent(out, ent.content); err != nil {
 				return err
 			}
 		}
-		_, _ = io.WriteString(out, ">\n")
+		d.writeString(out, ">\n")
 	case enum.ExternalGeneralParsedEntity, enum.ExternalGeneralUnparsedEntity:
-		_, _ = io.WriteString(out, "<!ENTITY ")
-		_, _ = io.WriteString(out, ent.name)
+		d.writeString(out, "<!ENTITY ")
+		d.writeString(out, ent.name)
 		if ent.externalID != "" {
-			_, _ = io.WriteString(out, " PUBLIC ")
-			_ = dumpQuotedString(out, ent.externalID)
-			_, _ = io.WriteString(out, " ")
-			_ = dumpQuotedString(out, ent.systemID)
+			d.writeString(out, " PUBLIC ")
+			d.check(dumpQuotedString(out, ent.externalID))
+			d.writeString(out, " ")
+			d.check(dumpQuotedString(out, ent.systemID))
 		} else {
-			_, _ = io.WriteString(out, " SYSTEM ")
-			_ = dumpQuotedString(out, ent.systemID)
+			d.writeString(out, " SYSTEM ")
+			d.check(dumpQuotedString(out, ent.systemID))
 		}
 
 		if etype == enum.ExternalGeneralUnparsedEntity {
 			if ent.content != "" {
-				_, _ = io.WriteString(out, " NDATA ")
+				d.writeString(out, " NDATA ")
 				if ent.orig != "" {
-					_, _ = io.WriteString(out, ent.orig)
+					d.writeString(out, ent.orig)
 				} else {
-					_, _ = io.WriteString(out, ent.content)
+					d.writeString(out, ent.content)
 				}
 			}
 		}
-		_, _ = io.WriteString(out, ">\n")
+		d.writeString(out, ">\n")
 	case enum.InternalParameterEntity:
-		_, _ = io.WriteString(out, "<!ENTITY % ")
-		_, _ = io.WriteString(out, ent.name)
-		_, _ = io.WriteString(out, " ")
+		d.writeString(out, "<!ENTITY % ")
+		d.writeString(out, ent.name)
+		d.writeString(out, " ")
 		if ent.orig != "" {
 			if err := dumpQuotedString(out, ent.orig); err != nil {
+				d.check(err)
 				return err
 			}
 		} else {
-			if err := dumpEntityContent(out, ent.content); err != nil {
+			if err := d.dumpEntityContent(out, ent.content); err != nil {
 				return err
 			}
 		}
-		_, _ = io.WriteString(out, ">\n")
+		d.writeString(out, ">\n")
 	case enum.ExternalParameterEntity:
-		_, _ = io.WriteString(out, "<!ENTITY % ")
-		_, _ = io.WriteString(out, ent.name)
+		d.writeString(out, "<!ENTITY % ")
+		d.writeString(out, ent.name)
 		if ent.externalID != "" {
-			_, _ = io.WriteString(out, " PUBLIC ")
-			_ = dumpQuotedString(out, ent.externalID)
-			_, _ = io.WriteString(out, " ")
-			_ = dumpQuotedString(out, ent.systemID)
+			d.writeString(out, " PUBLIC ")
+			d.check(dumpQuotedString(out, ent.externalID))
+			d.writeString(out, " ")
+			d.check(dumpQuotedString(out, ent.systemID))
 		} else {
-			_, _ = io.WriteString(out, " SYSTEM ")
-			_ = dumpQuotedString(out, ent.systemID)
+			d.writeString(out, " SYSTEM ")
+			d.check(dumpQuotedString(out, ent.systemID))
 		}
 	default:
 		return errors.New("invalid entity type")
 	}
-	return nil
+	return d.err
 }
 
-func (d *writeSession) dumpNotationDecl(out io.Writer, n *Notation) error { //nolint:unparam // always nil but matches other dump methods
-	_, _ = io.WriteString(out, "<!NOTATION ")
-	_, _ = io.WriteString(out, n.name)
+func (d *writeSession) dumpNotationDecl(out io.Writer, n *Notation) error {
+	d.writeString(out, "<!NOTATION ")
+	d.writeString(out, n.name)
 	if n.publicID != "" {
-		_, _ = io.WriteString(out, " PUBLIC ")
-		_ = dumpQuotedString(out, n.publicID)
+		d.writeString(out, " PUBLIC ")
+		d.check(dumpQuotedString(out, n.publicID))
 		if n.systemID != "" {
-			_, _ = io.WriteString(out, " ")
-			_ = dumpQuotedString(out, n.systemID)
+			d.writeString(out, " ")
+			d.check(dumpQuotedString(out, n.systemID))
 		}
 	} else {
-		_, _ = io.WriteString(out, " SYSTEM ")
-		_ = dumpQuotedString(out, n.systemID)
+		d.writeString(out, " SYSTEM ")
+		d.check(dumpQuotedString(out, n.systemID))
 	}
-	_, _ = io.WriteString(out, " >\n")
-	return nil
+	d.writeString(out, " >\n")
+	return d.err
 }
 
 func (d *writeSession) dumpElementDecl(out io.Writer, n *ElementDecl) error {
 	switch n.decltype {
 	case enum.EmptyElementType:
-		dumpElementDeclPrologue(out, n)
-		_, _ = io.WriteString(out, " EMPTY>\n")
+		d.dumpElementDeclPrologue(out, n)
+		d.writeString(out, " EMPTY>\n")
 	case enum.AnyElementType:
-		dumpElementDeclPrologue(out, n)
-		_, _ = io.WriteString(out, " ANY>\n")
+		d.dumpElementDeclPrologue(out, n)
+		d.writeString(out, " ANY>\n")
 	case enum.MixedElementType, enum.ElementElementType:
-		dumpElementDeclPrologue(out, n)
-		_, _ = io.WriteString(out, " ")
-		if err := dumpElementContent(out, n.content, true); err != nil {
+		d.dumpElementDeclPrologue(out, n)
+		d.writeString(out, " ")
+		if err := d.dumpElementContent(out, n.content, true); err != nil {
 			return err
 		}
-		_, _ = io.WriteString(out, ">\n")
+		d.writeString(out, ">\n")
 	default:
 		return errors.New("invalid element decl")
 	}
-	return nil
+	return d.err
 }
 
 func (d *writeSession) dumpAttributeDecl(out io.Writer, n *AttributeDecl) error {
-	_, _ = io.WriteString(out, "<!ATTLIST ")
-	_, _ = io.WriteString(out, n.elem)
-	_, _ = io.WriteString(out, " ")
+	d.writeString(out, "<!ATTLIST ")
+	d.writeString(out, n.elem)
+	d.writeString(out, " ")
 	if n.prefix != "" {
-		_, _ = io.WriteString(out, n.prefix)
-		_, _ = io.WriteString(out, ":")
+		d.writeString(out, n.prefix)
+		d.writeString(out, ":")
 	}
-	_, _ = io.WriteString(out, n.name)
+	d.writeString(out, n.name)
 	switch n.atype {
 	case enum.AttrCDATA:
-		_, _ = io.WriteString(out, " CDATA")
+		d.writeString(out, " CDATA")
 	case enum.AttrID:
-		_, _ = io.WriteString(out, " ID")
+		d.writeString(out, " ID")
 	case enum.AttrIDRef:
-		_, _ = io.WriteString(out, " IDREF")
+		d.writeString(out, " IDREF")
 	case enum.AttrIDRefs:
-		_, _ = io.WriteString(out, " IDREFS")
+		d.writeString(out, " IDREFS")
 	case enum.AttrEntity:
-		_, _ = io.WriteString(out, " ENTITY")
+		d.writeString(out, " ENTITY")
 	case enum.AttrEntities:
-		_, _ = io.WriteString(out, " ENTITIES")
+		d.writeString(out, " ENTITIES")
 	case enum.AttrNmtoken:
-		_, _ = io.WriteString(out, " NMTOKEN")
+		d.writeString(out, " NMTOKEN")
 	case enum.AttrNmtokens:
-		_, _ = io.WriteString(out, " NMTOKENS")
+		d.writeString(out, " NMTOKENS")
 	case enum.AttrEnumeration:
-		_, _ = io.WriteString(out, " (")
+		d.writeString(out, " (")
 		if err := d.dumpEnumeration(out, n.tree); err != nil {
 			return err
 		}
 	case enum.AttrNotation:
-		_, _ = io.WriteString(out, " NOTATION (")
+		d.writeString(out, " NOTATION (")
 		if err := d.dumpEnumeration(out, n.tree); err != nil {
 			return err
 		}
@@ -375,22 +373,22 @@ func (d *writeSession) dumpAttributeDecl(out io.Writer, n *AttributeDecl) error 
 	switch n.def {
 	case enum.AttrDefaultNone:
 	case enum.AttrDefaultRequired:
-		_, _ = io.WriteString(out, " #REQUIRED")
+		d.writeString(out, " #REQUIRED")
 	case enum.AttrDefaultImplied:
-		_, _ = io.WriteString(out, " #IMPLIED")
+		d.writeString(out, " #IMPLIED")
 	case enum.AttrDefaultFixed:
-		_, _ = io.WriteString(out, " #FIXED")
+		d.writeString(out, " #FIXED")
 	default:
 		return errors.New("invalid AttributeDecl default value type")
 	}
 
 	if n.defvalue != "" {
-		_, _ = io.WriteString(out, ` "`)
-		_ = escapeAttrValue(out, []byte(n.defvalue), d.escapeNonASCII)
-		_, _ = io.WriteString(out, `"`)
+		d.writeString(out, ` "`)
+		d.check(escapeAttrValue(out, []byte(n.defvalue), d.escapeNonASCII))
+		d.writeString(out, `"`)
 	}
-	_, _ = io.WriteString(out, ">\n")
-	return nil
+	d.writeString(out, ">\n")
+	return d.err
 }
 
 func (d *writeSession) dumpNsList(out io.Writer, nslist []*Namespace) error {

--- a/writer_test.go
+++ b/writer_test.go
@@ -175,6 +175,90 @@ func (w *namespaceFailWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// errShortWrite is returned by failAfterNWriter once its byte budget runs out.
+var errShortWrite = errors.New("short write")
+
+// failAfterNWriter accepts up to limit bytes and then fails every subsequent
+// write, simulating an io.Writer that breaks mid-stream.
+type failAfterNWriter struct {
+	limit   int
+	written int
+}
+
+func (w *failAfterNWriter) Write(p []byte) (int, error) {
+	if w.written >= w.limit {
+		return 0, errShortWrite
+	}
+	remaining := w.limit - w.written
+	if len(p) <= remaining {
+		w.written += len(p)
+		return len(p), nil
+	}
+	w.written = w.limit
+	return remaining, errShortWrite
+}
+
+// docWithEverything builds a document that exercises the XML declaration, a
+// DTD (with ENTITY/ELEMENT/ATTLIST/NOTATION decls), comments, PIs, an entity
+// reference, CDATA, and nested elements with attributes.
+const docWithEverything = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE root [
+<!ELEMENT root (child*)>
+<!ATTLIST root id CDATA #IMPLIED>
+<!ENTITY greeting "hello">
+<!NOTATION gif SYSTEM "image/gif">
+]>
+<!--a top level comment-->
+<?app instruction?>
+<root id="r1"><child>&greeting; world</child><child><![CDATA[<raw> & data]]></child></root>`
+
+func TestWritePropagatesWriteError(t *testing.T) {
+	t.Parallel()
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(docWithEverything))
+	require.NoError(t, err)
+
+	// Determine the full serialized length so we can fail at every prefix.
+	full, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.NotEmpty(t, full)
+
+	// Failing immediately must surface a non-nil error (previously nil).
+	require.ErrorIs(t, helium.Write(&failAfterNWriter{limit: 0}, doc), errShortWrite,
+		"serialization must report the writer error")
+
+	// Failing at any intermediate offset must also surface a non-nil error.
+	for limit := 1; limit < len(full); limit += 7 {
+		err := helium.Write(&failAfterNWriter{limit: limit}, doc)
+		require.Errorf(t, err, "write that fails after %d bytes must return an error", limit)
+	}
+}
+
+func TestWriteOutputUnchanged(t *testing.T) {
+	t.Parallel()
+
+	// The success path must remain byte-for-byte identical after routing all
+	// writes through the sticky-error session helpers.
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(docWithEverything))
+	require.NoError(t, err)
+
+	str, err := helium.WriteString(doc)
+	require.NoError(t, err)
+
+	expected := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE root [
+<!ELEMENT root (child)*>
+<!ATTLIST root id CDATA #IMPLIED>
+<!ENTITY greeting "hello">
+<!NOTATION gif SYSTEM "image/gif" >
+]>
+<!--a top level comment-->
+<?app instruction?>
+<root id="r1"><child>&greeting; world</child><child><![CDATA[<raw> & data]]></child></root>
+`
+	require.Equal(t, expected, str)
+}
+
 func TestFormatOutput(t *testing.T) {
 	t.Parallel()
 

--- a/writer_xhtml.go
+++ b/writer_xhtml.go
@@ -67,8 +67,8 @@ func (d *writeSession) dumpXHTMLNode(out io.Writer, n Node) error {
 		name = n.Name()
 	}
 
-	_, _ = io.WriteString(out, "<")
-	_, _ = io.WriteString(out, name)
+	d.writeString(out, "<")
+	d.writeString(out, name)
 
 	nslist := e.Namespaces()
 	if len(nslist) > 0 {
@@ -85,7 +85,7 @@ func (d *writeSession) dumpXHTMLNode(out io.Writer, n Node) error {
 		}
 	}
 	if localName == "html" && e.ns == nil && !hasDefaultNs {
-		_, _ = io.WriteString(out, ` xmlns="http://www.w3.org/1999/xhtml"`)
+		d.writeString(out, ` xmlns="http://www.w3.org/1999/xhtml"`)
 	}
 
 	d.dumpXHTMLAttrList(out, e)
@@ -103,36 +103,36 @@ func (d *writeSession) dumpXHTMLNode(out io.Writer, n Node) error {
 
 	if e.FirstChild() == nil {
 		if (e.ns == nil || e.ns.Prefix() == "") && xhtmlVoidElements[localName] && !addMeta {
-			_, _ = io.WriteString(out, " />")
+			d.writeString(out, " />")
 		} else {
 			if addMeta {
-				_, _ = io.WriteString(out, ">")
+				d.writeString(out, ">")
 				if d.format {
-					_, _ = io.WriteString(out, "\n")
+					d.writeString(out, "\n")
 					d.indent++
 					d.writeIndent(out)
 				}
 				d.writeMetaContentType(out)
 				if d.format {
-					_, _ = io.WriteString(out, "\n")
+					d.writeString(out, "\n")
 					d.indent--
 					d.writeIndent(out)
 				}
 			} else {
-				_, _ = io.WriteString(out, ">")
+				d.writeString(out, ">")
 			}
-			_, _ = io.WriteString(out, "</")
-			_, _ = io.WriteString(out, name)
-			_, _ = io.WriteString(out, ">")
+			d.writeString(out, "</")
+			d.writeString(out, name)
+			d.writeString(out, ">")
 		}
-		return nil
+		return d.err
 	}
 
-	_, _ = io.WriteString(out, ">")
+	d.writeString(out, ">")
 
 	textOnly := d.format && hasOnlyTextChildren(e)
 	if d.format && !textOnly {
-		_, _ = io.WriteString(out, "\n")
+		d.writeString(out, "\n")
 		d.indent++
 	}
 
@@ -142,7 +142,7 @@ func (d *writeSession) dumpXHTMLNode(out io.Writer, n Node) error {
 		}
 		d.writeMetaContentType(out)
 		if d.format && !textOnly {
-			_, _ = io.WriteString(out, "\n")
+			d.writeString(out, "\n")
 		}
 	}
 
@@ -160,7 +160,7 @@ func (d *writeSession) dumpXHTMLNode(out io.Writer, n Node) error {
 			}
 		}
 		if d.format && !textOnly {
-			_, _ = io.WriteString(out, "\n")
+			d.writeString(out, "\n")
 		}
 	}
 
@@ -169,10 +169,10 @@ func (d *writeSession) dumpXHTMLNode(out io.Writer, n Node) error {
 		d.writeIndent(out)
 	}
 
-	_, _ = io.WriteString(out, "</")
-	_, _ = io.WriteString(out, name)
-	_, _ = io.WriteString(out, ">")
-	return nil
+	d.writeString(out, "</")
+	d.writeString(out, name)
+	d.writeString(out, ">")
+	return d.err
 }
 
 func (d *writeSession) dumpXHTMLAttrList(out io.Writer, e *Element) {
@@ -193,23 +193,23 @@ func (d *writeSession) dumpXHTMLAttrList(out io.Writer, e *Element) {
 			xmlLangAttr = attr
 		}
 
-		_, _ = io.WriteString(out, " ")
-		_, _ = io.WriteString(out, attrName)
-		_, _ = io.WriteString(out, `="`)
+		d.writeString(out, " ")
+		d.writeString(out, attrName)
+		d.writeString(out, `="`)
 
 		attrValue := attr.Value()
 		if attrValue == "" && htmlBooleanAttrs[attrName] {
-			_, _ = io.WriteString(out, attrName)
+			d.writeString(out, attrName)
 		} else {
 			for achld := range Children(attr) {
 				if achld.Type() == TextNode {
-					_ = escapeAttrValue(out, achld.Content(), d.escapeNonASCII)
+					d.check(escapeAttrValue(out, achld.Content(), d.escapeNonASCII))
 				} else {
-					_ = d.writeNode(out, achld)
+					d.check(d.writeNode(out, achld))
 				}
 			}
 		}
-		_, _ = io.WriteString(out, `"`)
+		d.writeString(out, `"`)
 
 		next, ok := AsNode[*Attribute](attr.NextSibling())
 		if !ok {
@@ -219,19 +219,19 @@ func (d *writeSession) dumpXHTMLAttrList(out io.Writer, e *Element) {
 	}
 
 	if nameAttr != nil && idAttr == nil && xhtmlNameIDElements[localName] {
-		_, _ = io.WriteString(out, ` id="`)
-		_ = escapeAttrValue(out, nameAttr.Content(), d.escapeNonASCII)
-		_, _ = io.WriteString(out, `"`)
+		d.writeString(out, ` id="`)
+		d.check(escapeAttrValue(out, nameAttr.Content(), d.escapeNonASCII))
+		d.writeString(out, `"`)
 	}
 
 	if langAttr != nil && xmlLangAttr == nil {
-		_, _ = io.WriteString(out, ` xml:lang="`)
-		_ = escapeAttrValue(out, langAttr.Content(), d.escapeNonASCII)
-		_, _ = io.WriteString(out, `"`)
+		d.writeString(out, ` xml:lang="`)
+		d.check(escapeAttrValue(out, langAttr.Content(), d.escapeNonASCII))
+		d.writeString(out, `"`)
 	} else if xmlLangAttr != nil && langAttr == nil {
-		_, _ = io.WriteString(out, ` lang="`)
-		_ = escapeAttrValue(out, xmlLangAttr.Content(), d.escapeNonASCII)
-		_, _ = io.WriteString(out, `"`)
+		d.writeString(out, ` lang="`)
+		d.check(escapeAttrValue(out, xmlLangAttr.Content(), d.escapeNonASCII))
+		d.writeString(out, `"`)
 	}
 }
 
@@ -265,7 +265,7 @@ func (d *writeSession) writeMetaContentType(out io.Writer) {
 	if enc == "" {
 		enc = "UTF-8"
 	}
-	_, _ = io.WriteString(out, `<meta http-equiv="Content-Type" content="text/html; charset=`)
-	_, _ = io.WriteString(out, enc)
-	_, _ = io.WriteString(out, `" />`)
+	d.writeString(out, `<meta http-equiv="Content-Type" content="text/html; charset=`)
+	d.writeString(out, enc)
+	d.writeString(out, `" />`)
 }


### PR DESCRIPTION
- Route every ignored XML serializer write (decl/comment/PI/entityref/CDATA/tags/attrs/DTD/ENTITY/ATTLIST/NOTATION) through a sticky-error `writeSession`, so a failing `io.Writer` now surfaces instead of returning nil.
- Mechanical and behavior-preserving: the success path is byte-for-byte identical (covered by a new unchanged-output test); a new failure test asserts errors propagate at every write offset.
