### PR TITLE
xinclude: sandbox inner parser to block xpointer XXE

### DIFF
--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -615,8 +615,18 @@ func (p *processor) parseXMLData(ctx context.Context, data []byte, uri string, s
 	// permissive resolver this is identical to the previous behavior; a custom
 	// (non-FS) resolver gets a deny-all FS so inner SYSTEM references cannot
 	// reach the host.
-	if fr, ok := p.resolver.(*fsResolver); ok {
-		parser = parser.FS(fr.fsys)
+	//
+	// Detection uses the fsBacked capability interface rather than a concrete
+	// *fsResolver assertion so callers can wrap NewFSResolver (e.g. for
+	// logging/metrics) without silently losing the in-sandbox loader. The FS
+	// is wrapped with normalizingFS because the parser builds the names it
+	// hands to Open via filepath.Join/BuildURI — OS-native separators on
+	// Windows and possibly absolute — whereas an fs.FS expects slash-separated,
+	// path.Clean'd names. Without normalization a sandbox that accepts
+	// XInclude hrefs would spuriously reject the document's own external
+	// entities/DTDs.
+	if fr, ok := p.resolver.(fsBacked); ok {
+		parser = parser.FS(normalizingFS{fsys: fr.FS()})
 	} else {
 		parser = parser.FS(denyAllFS{})
 	}
@@ -1216,6 +1226,38 @@ func (p *processor) computeFixupBases(inc *helium.Element, sourceURI string) (st
 // via [NewFSResolver].
 type fsResolver struct {
 	fsys fs.FS
+}
+
+// fsBacked is an optional capability interface that a [Resolver] may
+// implement to expose the [fs.FS] it reads from. When a resolver is
+// fsBacked, XInclude threads that same FS into the inner parser so external
+// entities and DTDs declared inside an included document load through the
+// SAME sandbox (rather than the host filesystem behind the resolver's back).
+// Resolvers that wrap [NewFSResolver] (e.g. for logging or metrics) should
+// also implement this so the in-sandbox loader is preserved through the wrap.
+type fsBacked interface {
+	FS() fs.FS
+}
+
+// FS implements [fsBacked], exposing the underlying filesystem so XInclude
+// can reuse it for the inner parser's external entity/DTD resolution.
+func (r *fsResolver) FS() fs.FS { return r.fsys }
+
+// normalizingFS adapts an [fs.FS] so it tolerates the OS-native, possibly
+// absolute names the helium parser builds via [filepath.Join]/BuildURI for
+// external entities and DTDs. It converts separators to forward slashes and
+// canonicalizes with [path.Clean] before delegating to the wrapped FS, so a
+// sandbox (os.DirFS, fstest.MapFS, os.OpenRoot) that already accepts XInclude
+// hrefs sees the document's own external references in the same shape. A
+// remaining ".." prefix still surfaces to the wrapped FS, preserving
+// path-traversal containment.
+type normalizingFS struct {
+	fsys fs.FS
+}
+
+// Open implements [fs.FS].
+func (n normalizingFS) Open(name string) (fs.File, error) {
+	return n.fsys.Open(path.Clean(filepath.ToSlash(name))) //nolint:wrapcheck // passthrough; underlying FS errors propagate verbatim
 }
 
 // denyAllFS is an fs.FS that refuses every open. It is threaded into the inner

--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -606,6 +606,20 @@ func (p *processor) loadXMLDoc(ctx context.Context, uri string, substituteEntiti
 
 func (p *processor) parseXMLData(ctx context.Context, data []byte, uri string, substituteEntities bool) (*helium.Document, error) {
 	parser := helium.NewParser().LoadExternalDTD(true).BaseURI(uri)
+	// Thread the resolver's filesystem into the inner parser so external
+	// entities and external DTDs declared inside the included document
+	// resolve through the SAME sandbox as XInclude itself, not the parser's
+	// default permissive filesystem. Otherwise an attacker-supplied included
+	// document could expand a SYSTEM entity (e.g. "/etc/passwd") off the host
+	// filesystem, bypassing a strict Resolver (XXE). For the default
+	// permissive resolver this is identical to the previous behavior; a custom
+	// (non-FS) resolver gets a deny-all FS so inner SYSTEM references cannot
+	// reach the host.
+	if fr, ok := p.resolver.(*fsResolver); ok {
+		parser = parser.FS(fr.fsys)
+	} else {
+		parser = parser.FS(denyAllFS{})
+	}
 	if substituteEntities {
 		parser = parser.SubstituteEntities(true)
 	}
@@ -1203,6 +1217,14 @@ func (p *processor) computeFixupBases(inc *helium.Element, sourceURI string) (st
 type fsResolver struct {
 	fsys fs.FS
 }
+
+// denyAllFS is an fs.FS that refuses every open. It is threaded into the inner
+// parser used for included documents when the XInclude resolver is a custom
+// (non-fsResolver) implementation, so external entities/DTDs in the included
+// document cannot reach the host filesystem behind the resolver's back.
+type denyAllFS struct{}
+
+func (denyAllFS) Open(string) (fs.File, error) { return nil, fs.ErrNotExist }
 
 func (r *fsResolver) Resolve(href, base string) (io.ReadCloser, error) {
 	// Upstream URI resolution (e.g. resolveURI) may produce OS-specific

--- a/xinclude/xinclude_test.go
+++ b/xinclude/xinclude_test.go
@@ -993,6 +993,45 @@ func TestXIncludeParseNoEntWithXPointer(t *testing.T) {
 	require.True(t, found, "included <item> element not found")
 }
 
+// TestXIncludeXPointerNoXXE verifies that an external SYSTEM entity declared
+// inside an XPointer-included document (parsed with entity substitution) cannot
+// read host files behind a strict resolver's back. The resolver here is a
+// custom (non-FS) resolver that only serves canned content, so the inner parser
+// must not fall back to the host filesystem for the SYSTEM entity.
+func TestXIncludeXPointerNoXXE(t *testing.T) {
+	t.Parallel()
+
+	secret := filepath.Join(t.TempDir(), "secret.txt")
+	const marker = "TOP-SECRET-XXE-MARKER"
+	require.NoError(t, os.WriteFile(secret, []byte(marker), 0o600))
+
+	resolver := &stringResolver{
+		files: map[string]string{
+			"entities.xml": `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ENTITY xxe SYSTEM "` + secret + `">
+]>
+<root><item>&xxe;</item></root>`,
+		},
+	}
+
+	doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
+		<xi:include href="entities.xml" xpointer="xpointer(/root/item)"/>
+	</root>`)
+
+	// Processing may succeed (entity unresolved) or fail; either is acceptable.
+	// What must never happen is the secret file's contents leaking into output.
+	_, _ = xinclude.NewProcessor().
+		Resolver(resolver).
+		NoXIncludeMarkers().
+		NoBaseFixup().
+		Process(t.Context(), doc)
+
+	got, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.NotContains(t, got, marker, "external SYSTEM entity leaked host file via XPointer include")
+}
+
 // countingResolver wraps a stringResolver and counts Resolve calls per URI.
 type countingResolver struct {
 	inner *stringResolver

--- a/xinclude/xinclude_test.go
+++ b/xinclude/xinclude_test.go
@@ -1032,6 +1032,56 @@ func TestXIncludeXPointerNoXXE(t *testing.T) {
 	require.NotContains(t, got, marker, "external SYSTEM entity leaked host file via XPointer include")
 }
 
+// fsWrapResolver wraps an FS-backed Resolver (e.g. NewFSResolver) for
+// logging/metrics-style decoration while forwarding the optional FS()
+// capability so XInclude still recognizes it as FS-backed.
+type fsWrapResolver struct {
+	inner xinclude.Resolver
+	fsys  fs.FS
+}
+
+func (r *fsWrapResolver) Resolve(href, base string) (io.ReadCloser, error) {
+	return r.inner.Resolve(href, base)
+}
+
+func (r *fsWrapResolver) FS() fs.FS { return r.fsys }
+
+// TestXIncludeWrappedFSResolverInSandbox verifies that a resolver which wraps
+// NewFSResolver but re-exposes FS() is still recognized as FS-backed: an
+// external entity declared inside the included document loads through the SAME
+// sandbox FS (not denied), so legitimate in-sandbox references keep working.
+func TestXIncludeWrappedFSResolverInSandbox(t *testing.T) {
+	t.Parallel()
+
+	const extContent = "FROM-SANDBOX-ENTITY"
+	fsys := fstest.MapFS{
+		"included.xml": &fstest.MapFile{Data: []byte(`<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ENTITY ext SYSTEM "ext.txt">
+]>
+<root><item>&ext;</item></root>`)},
+		"ext.txt": &fstest.MapFile{Data: []byte(extContent)},
+	}
+
+	resolver := &fsWrapResolver{inner: xinclude.NewFSResolver(fsys), fsys: fsys}
+
+	doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
+		<xi:include href="included.xml" xpointer="xpointer(/root/item)"/>
+	</root>`)
+
+	_, err := xinclude.NewProcessor().
+		Resolver(resolver).
+		NoXIncludeMarkers().
+		NoBaseFixup().
+		Process(t.Context(), doc)
+	require.NoError(t, err)
+
+	got, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, got, extContent,
+		"wrapped FS-backed resolver should still load in-sandbox external entity")
+}
+
 // countingResolver wraps a stringResolver and counts Resolve calls per URI.
 type countingResolver struct {
 	inner *stringResolver


### PR DESCRIPTION
- XPointer includes parse the included document with entity substitution; the inner parser used the default permissive filesystem, so an attacker-supplied included doc could expand a `SYSTEM` entity off the host FS, bypassing a strict `Resolver` (XXE)
- Thread the resolver's own `fs.FS` into the inner parser: default permissive resolver is unchanged (preserves external-DTD cases like `issue733`), `os.DirFS`-backed resolvers sandbox the inner parser, and custom resolvers get a deny-all FS
- Regression test: a strict in-memory resolver + `SYSTEM` entity pointing at a temp file no longer leaks its contents
