### PR TITLE
xpath3: retry spurious regexp2 match timeouts

### DIFF
--- a/xpath3/functions_string.go
+++ b/xpath3/functions_string.go
@@ -1102,16 +1102,17 @@ func isRegexMatchTimeout(err error) bool {
 // which only refreshes the stale clock when its updater is not running.)
 //
 // A genuine timeout only fires after roughly `budget` of wall-clock time has
-// elapsed, whereas a spurious one fires near-instantly. So when fn reports a
-// timeout but far less than the budget has actually elapsed, the result is
-// bogus and we retry — by then the clock goroutine is live and the match
-// completes normally. Genuine ReDoS timeouts (elapsed on the order of budget)
-// are propagated unchanged, preserving the DoS-protection contract.
+// elapsed, whereas a spurious one fires well before that. So when fn reports a
+// timeout but less than half the budget (budget/2) has actually elapsed, the
+// result is treated as bogus and we retry — by then the clock goroutine is
+// live and the match completes normally. Timeouts that fire at or beyond
+// budget/2 (genuine ReDoS) are propagated unchanged, preserving the
+// DoS-protection contract.
 func withSpuriousTimeoutRetry[T any](budget time.Duration, fn func() (T, error)) (T, error) {
 	const maxAttempts = 3
 	var v T
 	var err error
-	for attempt := 0; attempt < maxAttempts; attempt++ {
+	for range maxAttempts {
 		start := time.Now()
 		v, err = fn()
 		if !isRegexMatchTimeout(err) {

--- a/xpath3/functions_string.go
+++ b/xpath3/functions_string.go
@@ -1083,18 +1083,80 @@ var compiledXPathRegexCache sync.Map
 // the timeout in effect at the time they were compiled.
 var DefaultRegexMatchTimeout = 5 * time.Second
 
+// isRegexMatchTimeout reports whether err is regexp2's wall-clock match-timeout
+// error. regexp2 returns an unexported, untyped fmt error for timeouts, so the
+// only stable discriminator is its message text.
+func isRegexMatchTimeout(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "match timeout")
+}
+
+// withSpuriousTimeoutRetry runs fn, retrying when it reports a regexp2 match
+// timeout that cannot be genuine.
+//
+// regexp2 enforces MatchTimeout via a shared "fastclock" background goroutine
+// that stamps the current time into an atomic every ~100ms. On a heavily
+// loaded host that goroutine can be starved for seconds and then jump the
+// clock forward in a single step; a match that has barely started then sees
+// its deadline already crossed and fails with a "match timeout" almost
+// immediately. (This is the residual race left after regexp2 v1.12.0's fix,
+// which only refreshes the stale clock when its updater is not running.)
+//
+// A genuine timeout only fires after roughly `budget` of wall-clock time has
+// elapsed, whereas a spurious one fires near-instantly. So when fn reports a
+// timeout but far less than the budget has actually elapsed, the result is
+// bogus and we retry — by then the clock goroutine is live and the match
+// completes normally. Genuine ReDoS timeouts (elapsed on the order of budget)
+// are propagated unchanged, preserving the DoS-protection contract.
+func withSpuriousTimeoutRetry[T any](budget time.Duration, fn func() (T, error)) (T, error) {
+	const maxAttempts = 3
+	var v T
+	var err error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		start := time.Now()
+		v, err = fn()
+		if !isRegexMatchTimeout(err) {
+			return v, err
+		}
+		// A real timeout burns ~budget of wall time before firing; treat
+		// anything well short of that as a spurious fastclock jump and retry.
+		if budget <= 0 || time.Since(start) >= budget/2 {
+			return v, err
+		}
+	}
+	return v, err
+}
+
 func (r *compiledXPathRegex) MatchString(s string) (bool, error) {
 	if r.backtrack != nil {
-		return r.backtrack.MatchString(s)
+		return withSpuriousTimeoutRetry(r.backtrack.MatchTimeout, func() (bool, error) {
+			return r.backtrack.MatchString(s)
+		})
 	}
 	return r.std.MatchString(s), nil
 }
 
 func (r *compiledXPathRegex) ReplaceAllString(s, replacement string) (string, error) {
 	if r.backtrack != nil {
-		return r.backtrack.Replace(s, replacement, -1, -1)
+		return withSpuriousTimeoutRetry(r.backtrack.MatchTimeout, func() (string, error) {
+			return r.backtrack.Replace(s, replacement, -1, -1)
+		})
 	}
 	return r.std.ReplaceAllString(s, replacement), nil
+}
+
+// findStringMatch and findNextMatch wrap regexp2's match iteration with the
+// same spurious-timeout retry applied to MatchString, so multi-match callers
+// (Split, FindAllStringSubmatchIndex) are equally resilient to fastclock jumps.
+func (r *compiledXPathRegex) findStringMatch(s string) (*regexp2.Match, error) {
+	return withSpuriousTimeoutRetry(r.backtrack.MatchTimeout, func() (*regexp2.Match, error) {
+		return r.backtrack.FindStringMatch(s)
+	})
+}
+
+func (r *compiledXPathRegex) findNextMatch(m *regexp2.Match) (*regexp2.Match, error) {
+	return withSpuriousTimeoutRetry(r.backtrack.MatchTimeout, func() (*regexp2.Match, error) {
+		return r.backtrack.FindNextMatch(m)
+	})
 }
 
 func (r *compiledXPathRegex) Split(s string, n int) ([]string, error) {
@@ -1106,7 +1168,10 @@ func (r *compiledXPathRegex) Split(s string, n int) ([]string, error) {
 	var parts []string
 	last := 0
 	count := 0
-	match, err := r.backtrack.FindStringMatch(s)
+	match, err := r.findStringMatch(s)
+	if err != nil {
+		return nil, err
+	}
 	for match != nil {
 		if n > 0 && count >= n-1 {
 			break
@@ -1116,13 +1181,10 @@ func (r *compiledXPathRegex) Split(s string, n int) ([]string, error) {
 		parts = append(parts, s[last:start])
 		last = end
 		count++
-		match, err = r.backtrack.FindNextMatch(match)
+		match, err = r.findNextMatch(match)
 		if err != nil {
 			return nil, err
 		}
-	}
-	if err != nil {
-		return nil, err
 	}
 	parts = append(parts, s[last:])
 	return parts, nil
@@ -1135,7 +1197,10 @@ func (r *compiledXPathRegex) FindAllStringSubmatchIndex(s string, n int) ([][]in
 
 	offsets := runeByteOffsets(s)
 	var result [][]int
-	match, err := r.backtrack.FindStringMatch(s)
+	match, err := r.findStringMatch(s)
+	if err != nil {
+		return nil, err
+	}
 	for match != nil {
 		groups := match.Groups()
 		entry := make([]int, 0, len(groups)*2)
@@ -1152,12 +1217,12 @@ func (r *compiledXPathRegex) FindAllStringSubmatchIndex(s string, n int) ([][]in
 		if n > 0 && len(result) >= n {
 			break
 		}
-		match, err = r.backtrack.FindNextMatch(match)
+		match, err = r.findNextMatch(match)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return result, err
+	return result, nil
 }
 
 func (r *compiledXPathRegex) NumSubexp() int {

--- a/xpath3/regex_spurious_timeout_internal_test.go
+++ b/xpath3/regex_spurious_timeout_internal_test.go
@@ -1,0 +1,80 @@
+package xpath3
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTimeout mimics regexp2's untyped wall-clock timeout error.
+func fakeTimeout() error {
+	return fmt.Errorf("match timeout after 5s on input `x`")
+}
+
+// withSpuriousTimeoutRetry distinguishes a spurious fastclock timeout (fires
+// almost immediately) from a genuine ReDoS timeout (burns ~budget of wall
+// time), retrying only the former. These cases pin that behavior without
+// depending on regexp2's flaky background clock.
+func TestWithSpuriousTimeoutRetry(t *testing.T) {
+	t.Run("spurious timeout is retried then succeeds", func(t *testing.T) {
+		calls := 0
+		v, err := withSpuriousTimeoutRetry(time.Second, func() (int, error) {
+			calls++
+			if calls == 1 {
+				return 0, fakeTimeout() // instant: far below budget/2
+			}
+			return 42, nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, 42, v)
+		require.Equal(t, 2, calls, "should retry exactly once after the spurious timeout")
+	})
+
+	t.Run("genuine timeout is propagated without retry", func(t *testing.T) {
+		const budget = 40 * time.Millisecond
+		calls := 0
+		_, err := withSpuriousTimeoutRetry(budget, func() (int, error) {
+			calls++
+			time.Sleep(budget) // elapsed >= budget/2 => genuine
+			return 0, fakeTimeout()
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "match timeout")
+		require.Equal(t, 1, calls, "a genuine timeout must not be retried")
+	})
+
+	t.Run("persistent spurious timeout gives up after max attempts", func(t *testing.T) {
+		calls := 0
+		_, err := withSpuriousTimeoutRetry(time.Second, func() (int, error) {
+			calls++
+			return 0, fakeTimeout() // always instant
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "match timeout")
+		require.Equal(t, 3, calls, "should stop after maxAttempts")
+	})
+
+	t.Run("non-timeout error is returned immediately", func(t *testing.T) {
+		sentinel := errors.New("boom")
+		calls := 0
+		_, err := withSpuriousTimeoutRetry(time.Second, func() (int, error) {
+			calls++
+			return 0, sentinel
+		})
+		require.ErrorIs(t, err, sentinel)
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("zero budget disables retry", func(t *testing.T) {
+		calls := 0
+		_, err := withSpuriousTimeoutRetry(0, func() (int, error) {
+			calls++
+			return 0, fakeTimeout()
+		})
+		require.Error(t, err)
+		require.Equal(t, 1, calls, "no budget means we cannot tell spurious from genuine")
+	})
+}

--- a/xpath3/regex_timeout_test.go
+++ b/xpath3/regex_timeout_test.go
@@ -18,7 +18,7 @@ import (
 func TestRegexMatchTimeout_BoundsCatastrophicBacktracking(t *testing.T) {
 	// regexp2's fastclock has ~100ms granularity, so a 150ms budget
 	// realizes as ~150-300ms wall time. The elapsed bound is well below
-	// the 1s default DefaultRegexMatchTimeout — a passing assertion
+	// the 5s default DefaultRegexMatchTimeout — a passing assertion
 	// here proves the lowered budget actually took effect.
 	const matchBudget = 150 * time.Millisecond
 	const elapsedBound = 750 * time.Millisecond


### PR DESCRIPTION
- regexp2's wall-clock `MatchTimeout` is enforced by a shared fastclock goroutine that, when starved on a loaded runner, jumps forward in one step and fires a bogus "match timeout" on a match that just started (flaky `TestQT3_fn_matches/cbcl-matches-053`); v1.12.0 only closes the not-running half of the race
- `withSpuriousTimeoutRetry` retries timeouts that fire well before the budget elapses (spurious), while propagating genuine ones (elapsed ≥ budget/2) so DoS protection is unchanged
- wraps `MatchString`/`ReplaceAllString`/`Split`/`FindAllStringSubmatchIndex`; deterministic coverage in `regex_spurious_timeout_internal_test.go`
