### PR TITLE
xpath1: compare node-set to boolean as a set

### DIFF
--- a/xpath1/eval.go
+++ b/xpath1/eval.go
@@ -457,6 +457,18 @@ func compareNodeSet(op TokenType, leftNodes []helium.Node, right *Result) bool {
 		}
 		return false
 	}
+	// Per XPath 1.0 REC 3.4, comparing a node-set with a boolean converts the
+	// whole node-set to a boolean (true iff non-empty), then compares booleans.
+	if right.Type == BooleanResult {
+		nsBool := len(leftNodes) > 0
+		if op == TokenEquals {
+			return nsBool == right.Bool
+		}
+		if op == TokenNotEquals {
+			return nsBool != right.Bool
+		}
+		return compareNumbers(op, boolToNumber(nsBool), boolToNumber(right.Bool))
+	}
 	for _, ln := range leftNodes {
 		if compareWithScalar(op, ixpath.StringValue(ln), right) {
 			return true
@@ -467,6 +479,18 @@ func compareNodeSet(op TokenType, leftNodes []helium.Node, right *Result) bool {
 
 // compareNodeSetRight handles comparisons where only the right operand is a node-set.
 func compareNodeSetRight(op TokenType, left *Result, rightNodes []helium.Node) bool {
+	// Per XPath 1.0 REC 3.4, comparing a boolean with a node-set converts the
+	// whole node-set to a boolean (true iff non-empty), then compares booleans.
+	if left.Type == BooleanResult {
+		nsBool := len(rightNodes) > 0
+		if op == TokenEquals {
+			return left.Bool == nsBool
+		}
+		if op == TokenNotEquals {
+			return left.Bool != nsBool
+		}
+		return compareNumbers(op, boolToNumber(left.Bool), boolToNumber(nsBool))
+	}
 	rev := reverseOp(op)
 	for _, rn := range rightNodes {
 		if compareWithScalar(rev, ixpath.StringValue(rn), left) {
@@ -474,6 +498,14 @@ func compareNodeSetRight(op TokenType, left *Result, rightNodes []helium.Node) b
 		}
 	}
 	return false
+}
+
+// boolToNumber converts a boolean to its XPath number value (true=1, false=0).
+func boolToNumber(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 // compareScalars compares two non-node-set results using XPath type coercion rules.

--- a/xpath1/eval_test.go
+++ b/xpath1/eval_test.go
@@ -224,6 +224,36 @@ func TestEvalNumericComparison(t *testing.T) {
 	require.True(t, r.Bool)
 }
 
+func TestEvalNodeSetBooleanComparison(t *testing.T) {
+	doc := parseXML(t, `<root><a/></root>`)
+	for _, tc := range []struct {
+		expr string
+		want bool
+	}{
+		// node-set vs boolean: collapse the whole node-set to a boolean
+		{`/root/a = false()`, false},
+		{`/root/a = true()`, true},
+		{`/root/a != false()`, true},
+		{`/root/nonexistent = false()`, true},
+		{`/root/nonexistent = true()`, false},
+		// mirrored (boolean on the left)
+		{`false() = /root/a`, false},
+		{`true() = /root/a`, true},
+		{`false() = /root/nonexistent`, true},
+		// GUARD: number/string node-set comparisons keep existential semantics
+		{`/root/a = ''`, true},
+		{`/root/a = 'x'`, false},
+		{`/root/a = 0`, false},
+	} {
+		t.Run(tc.expr, func(t *testing.T) {
+			r, err := xpath1.Evaluate(t.Context(), doc, tc.expr)
+			require.NoError(t, err)
+			require.Equal(t, xpath1.BooleanResult, r.Type)
+			require.Equal(t, tc.want, r.Bool)
+		})
+	}
+}
+
 // --- Arithmetic ---
 
 func TestEvalArithmetic(t *testing.T) {

--- a/xpath1/eval_test.go
+++ b/xpath1/eval_test.go
@@ -240,6 +240,12 @@ func TestEvalNodeSetBooleanComparison(t *testing.T) {
 		{`false() = /root/a`, false},
 		{`true() = /root/a`, true},
 		{`false() = /root/nonexistent`, true},
+		// relational operators: boolean(node-set) compared numerically (true=1)
+		{`/root/a > false()`, true},          // 1 > 0
+		{`/root/a < true()`, false},          // 1 < 1
+		{`/root/a >= true()`, true},          // 1 >= 1
+		{`/root/nonexistent < true()`, true}, // 0 < 1
+		{`false() < /root/a`, true},          // mirrored: 0 < 1
 		// GUARD: number/string node-set comparisons keep existential semantics
 		{`/root/a = ''`, true},
 		{`/root/a = 'x'`, false},


### PR DESCRIPTION
- Fix XPath 1.0 node-set vs boolean comparison (REC 3.4): collapse the whole node-set to a boolean (`true` iff non-empty) before comparing, instead of testing each node's string-value
- `compareNodeSet` and `compareNodeSetRight` now special-case a boolean operand at the set level
- Number/string node-set comparisons keep their existential (per-node) semantics
- Adds table-driven tests on `<root><a/></root>` covering both operand orders plus number/string guards
