### PR TITLE
parser: reject non-XML chars in text content

### DIFF
--- a/.claude/docs/parser-internals.md
+++ b/.claude/docs/parser-internals.md
@@ -105,6 +105,15 @@ Special cases:
 
 `switchEncoding()`: pop ByteCursor, create encoder, push RuneCursor.
 
+**Strict decode of fixed-width Unicode encodings**: `internal/encoding` wraps the
+UTF-16/UTF-32/UCS-2/UCS-4 decoders (`withStrictDecode`, `strict.go`) so that
+malformed input the base decoder would silently replace with U+FFFD (e.g. an
+unpaired surrogate or trailing odd byte) becomes a fatal `ErrInvalidEncodedChar`,
+while a genuinely-encoded U+FFFD still decodes. The decoder reader's error is
+remembered by `UTF8Cursor` as a sticky `Err()` (a clean `Done()` would otherwise
+mask it as EOF); `parseDocument` surfaces it via `cursorDecodeErr()` at the
+document-end gate.
+
 ## File Responsibilities
 
 - `parserctx.go` owns the parser context, input/cursor stack, SAX callback dispatch, location/error reporting, and other shared parser state.

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -42,7 +42,10 @@ func Load(name string) enc.Encoding {
 	case "utf16be", "unicodefffe":
 		return withStrictDecode(unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM), 2, orderBE2, false)
 	case "utf16", "unicode", "csunicode":
-		return withStrictDecode(unicode.UTF16(unicode.LittleEndian, unicode.UseBOM), 2, byteOrder{}, true)
+		// UseBOM with LittleEndian default: x/text's decoder falls back to the
+		// configured default (LE) when no BOM is present, so the validator's
+		// no-BOM order must be LE to match.
+		return withStrictDecode(unicode.UTF16(unicode.LittleEndian, unicode.UseBOM), 2, orderLE2, true)
 	case "eucjp", "xeucjp", "cseucpkdfmtjapanese":
 		return japanese.EUCJP
 	case "shiftjis", "cp932", "sjis", "ms932", "mskanji", "windows31j", "xsjis", "csshiftjis":
@@ -132,7 +135,10 @@ func Load(name string) enc.Encoding {
 	case "ucs4le", "utf32le":
 		return withStrictDecode(utf32.UTF32(utf32.LittleEndian, utf32.IgnoreBOM), 4, orderLE4, false)
 	case "ucs4", "utf32":
-		return withStrictDecode(utf32.UTF32(utf32.BigEndian, utf32.UseBOM), 4, byteOrder{}, true)
+		// UseBOM with BigEndian default: x/text's decoder falls back to the
+		// configured default (BE) when no BOM is present, so the validator's
+		// no-BOM order must be BE to match.
+		return withStrictDecode(utf32.UTF32(utf32.BigEndian, utf32.UseBOM), 4, orderBE4, true)
 	case "ucs42143":
 		return withStrictDecode(&ucs4SwapEncoding{swap: swap2143}, 4, order2143, false)
 	case "ucs43412":

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -38,11 +38,11 @@ func Load(name string) enc.Encoding {
 	case "usascii", "ascii", "ansix341968", "csascii":
 		return unicode.UTF8
 	case "utf16le", "unicodefeff":
-		return withStrictDecode(unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM))
+		return withStrictDecode(unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM), 2)
 	case "utf16be", "unicodefffe":
-		return withStrictDecode(unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM))
+		return withStrictDecode(unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM), 2)
 	case "utf16", "unicode", "csunicode":
-		return withStrictDecode(unicode.UTF16(unicode.LittleEndian, unicode.UseBOM))
+		return withStrictDecode(unicode.UTF16(unicode.LittleEndian, unicode.UseBOM), 2)
 	case "eucjp", "xeucjp", "cseucpkdfmtjapanese":
 		return japanese.EUCJP
 	case "shiftjis", "cp932", "sjis", "ms932", "mskanji", "windows31j", "xsjis", "csshiftjis":
@@ -128,17 +128,17 @@ func Load(name string) enc.Encoding {
 	case "ibm1141", "ibm01141", "cp1141", "ccsid01141":
 		return codePage1141
 	case "ucs4be", "utf32be", "iso10646ucs4":
-		return withStrictDecode(utf32.UTF32(utf32.BigEndian, utf32.IgnoreBOM))
+		return withStrictDecode(utf32.UTF32(utf32.BigEndian, utf32.IgnoreBOM), 4)
 	case "ucs4le", "utf32le":
-		return withStrictDecode(utf32.UTF32(utf32.LittleEndian, utf32.IgnoreBOM))
+		return withStrictDecode(utf32.UTF32(utf32.LittleEndian, utf32.IgnoreBOM), 4)
 	case "ucs4", "utf32":
-		return withStrictDecode(utf32.UTF32(utf32.BigEndian, utf32.UseBOM))
+		return withStrictDecode(utf32.UTF32(utf32.BigEndian, utf32.UseBOM), 4)
 	case "ucs42143":
-		return withStrictDecode(&ucs4SwapEncoding{swap: swap2143})
+		return withStrictDecode(&ucs4SwapEncoding{swap: swap2143}, 4)
 	case "ucs43412":
-		return withStrictDecode(&ucs4SwapEncoding{swap: swap3412})
+		return withStrictDecode(&ucs4SwapEncoding{swap: swap3412}, 4)
 	case "ucs2", "iso10646ucs2":
-		return withStrictDecode(unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM))
+		return withStrictDecode(unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM), 2)
 	}
 	return nil
 }

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -38,11 +38,11 @@ func Load(name string) enc.Encoding {
 	case "usascii", "ascii", "ansix341968", "csascii":
 		return unicode.UTF8
 	case "utf16le", "unicodefeff":
-		return unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
+		return withStrictDecode(unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM))
 	case "utf16be", "unicodefffe":
-		return unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM)
+		return withStrictDecode(unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM))
 	case "utf16", "unicode", "csunicode":
-		return unicode.UTF16(unicode.LittleEndian, unicode.UseBOM)
+		return withStrictDecode(unicode.UTF16(unicode.LittleEndian, unicode.UseBOM))
 	case "eucjp", "xeucjp", "cseucpkdfmtjapanese":
 		return japanese.EUCJP
 	case "shiftjis", "cp932", "sjis", "ms932", "mskanji", "windows31j", "xsjis", "csshiftjis":
@@ -128,17 +128,17 @@ func Load(name string) enc.Encoding {
 	case "ibm1141", "ibm01141", "cp1141", "ccsid01141":
 		return codePage1141
 	case "ucs4be", "utf32be", "iso10646ucs4":
-		return utf32.UTF32(utf32.BigEndian, utf32.IgnoreBOM)
+		return withStrictDecode(utf32.UTF32(utf32.BigEndian, utf32.IgnoreBOM))
 	case "ucs4le", "utf32le":
-		return utf32.UTF32(utf32.LittleEndian, utf32.IgnoreBOM)
+		return withStrictDecode(utf32.UTF32(utf32.LittleEndian, utf32.IgnoreBOM))
 	case "ucs4", "utf32":
-		return utf32.UTF32(utf32.BigEndian, utf32.UseBOM)
+		return withStrictDecode(utf32.UTF32(utf32.BigEndian, utf32.UseBOM))
 	case "ucs42143":
-		return &ucs4SwapEncoding{swap: swap2143}
+		return withStrictDecode(&ucs4SwapEncoding{swap: swap2143})
 	case "ucs43412":
-		return &ucs4SwapEncoding{swap: swap3412}
+		return withStrictDecode(&ucs4SwapEncoding{swap: swap3412})
 	case "ucs2", "iso10646ucs2":
-		return unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM)
+		return withStrictDecode(unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM))
 	}
 	return nil
 }

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -38,11 +38,11 @@ func Load(name string) enc.Encoding {
 	case "usascii", "ascii", "ansix341968", "csascii":
 		return unicode.UTF8
 	case "utf16le", "unicodefeff":
-		return withStrictDecode(unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM), 2)
+		return withStrictDecode(unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM), 2, orderLE2, false)
 	case "utf16be", "unicodefffe":
-		return withStrictDecode(unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM), 2)
+		return withStrictDecode(unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM), 2, orderBE2, false)
 	case "utf16", "unicode", "csunicode":
-		return withStrictDecode(unicode.UTF16(unicode.LittleEndian, unicode.UseBOM), 2)
+		return withStrictDecode(unicode.UTF16(unicode.LittleEndian, unicode.UseBOM), 2, byteOrder{}, true)
 	case "eucjp", "xeucjp", "cseucpkdfmtjapanese":
 		return japanese.EUCJP
 	case "shiftjis", "cp932", "sjis", "ms932", "mskanji", "windows31j", "xsjis", "csshiftjis":
@@ -128,17 +128,17 @@ func Load(name string) enc.Encoding {
 	case "ibm1141", "ibm01141", "cp1141", "ccsid01141":
 		return codePage1141
 	case "ucs4be", "utf32be", "iso10646ucs4":
-		return withStrictDecode(utf32.UTF32(utf32.BigEndian, utf32.IgnoreBOM), 4)
+		return withStrictDecode(utf32.UTF32(utf32.BigEndian, utf32.IgnoreBOM), 4, orderBE4, false)
 	case "ucs4le", "utf32le":
-		return withStrictDecode(utf32.UTF32(utf32.LittleEndian, utf32.IgnoreBOM), 4)
+		return withStrictDecode(utf32.UTF32(utf32.LittleEndian, utf32.IgnoreBOM), 4, orderLE4, false)
 	case "ucs4", "utf32":
-		return withStrictDecode(utf32.UTF32(utf32.BigEndian, utf32.UseBOM), 4)
+		return withStrictDecode(utf32.UTF32(utf32.BigEndian, utf32.UseBOM), 4, byteOrder{}, true)
 	case "ucs42143":
-		return withStrictDecode(&ucs4SwapEncoding{swap: swap2143}, 4)
+		return withStrictDecode(&ucs4SwapEncoding{swap: swap2143}, 4, order2143, false)
 	case "ucs43412":
-		return withStrictDecode(&ucs4SwapEncoding{swap: swap3412}, 4)
+		return withStrictDecode(&ucs4SwapEncoding{swap: swap3412}, 4, order3412, false)
 	case "ucs2", "iso10646ucs2":
-		return withStrictDecode(unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM), 2)
+		return withStrictDecode(unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM), 2, orderBE2, false)
 	}
 	return nil
 }

--- a/internal/encoding/strict.go
+++ b/internal/encoding/strict.go
@@ -1,0 +1,111 @@
+package encoding
+
+// strict.go enforces that decoder-inserted U+FFFD replacement characters are
+// treated as fatal decode errors, while genuinely-encoded U+FFFD characters
+// pass through unchanged.
+//
+// golang.org/x/text decoders (UTF-16, UTF-32, UCS-4, ...) silently substitute
+// U+FFFD for malformed input — e.g. an unpaired UTF-16 surrogate or a trailing
+// odd byte — instead of returning an error. After transcoding into the internal
+// UTF-8 buffer, that decoder-inserted U+FFFD is byte-identical to a real,
+// legitimately-encoded U+FFFD. The XML parser's char-data scanner accepts a
+// genuine U+FFFD (it is a valid XML character), so without this wrapper a
+// UTF-16 document containing an unpaired surrogate would parse successfully
+// even though it is malformed input, which XML requires to be a fatal error.
+//
+// This wrapper applies only to the fixed-width Unicode encodings (UTF-16 / 2
+// bytes, UTF-32 & UCS-4 / 4 bytes, UCS-2 / 2 bytes). For those, a genuine
+// U+FFFD is exactly the code unit whose bytes equal the U+FFFD encoding. The
+// wrapper decodes normally, then compares the number of U+FFFD characters in
+// the decoded output against the number of genuine U+FFFD code units present in
+// the source. Any excess means the decoder substituted U+FFFD for malformed
+// input, which is reported as a fatal decode error.
+
+import (
+	"bytes"
+	"errors"
+
+	enc "golang.org/x/text/encoding"
+	"golang.org/x/text/transform"
+)
+
+// ErrInvalidEncodedChar is returned when a decoder substitutes U+FFFD for
+// malformed input (for example an unpaired UTF-16 surrogate).
+var ErrInvalidEncodedChar = errors.New("encoding: malformed input substituted with U+FFFD")
+
+// utf8FFFD is the UTF-8 encoding of U+FFFD.
+var utf8FFFD = []byte{0xEF, 0xBF, 0xBD}
+
+// withStrictDecode wraps a fixed-width Unicode Encoding so that its decoder
+// rejects malformed input that the base decoder would otherwise silently
+// replace with U+FFFD. The encoder is left unchanged.
+func withStrictDecode(e enc.Encoding) enc.Encoding {
+	return &strictEncoding{Encoding: e}
+}
+
+type strictEncoding struct {
+	enc.Encoding
+}
+
+func (e *strictEncoding) NewDecoder() *enc.Decoder {
+	// unitFFFD holds the source-byte encoding of a genuine U+FFFD code unit for
+	// this encoding (e.g. 0xFF 0xFD for UTF-16BE). Its length is the encoding's
+	// fixed code-unit width. If the encoder cannot represent U+FFFD, every
+	// emitted U+FFFD is treated as a substitution error.
+	var unitFFFD []byte
+	if b, err := e.Encoding.NewEncoder().Bytes(utf8FFFD); err == nil {
+		unitFFFD = b
+	}
+	return &enc.Decoder{Transformer: &strictDecoderTransformer{
+		base:     e.Encoding.NewDecoder().Transformer,
+		unitFFFD: unitFFFD,
+	}}
+}
+
+// strictDecoderTransformer wraps a fixed-width Unicode decoder, decoding via the
+// base transformer and then rejecting any U+FFFD in the output that does not
+// correspond to a genuine U+FFFD code unit in the source.
+type strictDecoderTransformer struct {
+	base     transform.Transformer
+	unitFFFD []byte
+}
+
+func (t *strictDecoderTransformer) Reset() {
+	t.base.Reset()
+}
+
+func (t *strictDecoderTransformer) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error) {
+	nDst, nSrc, err = t.base.Transform(dst, src, atEOF)
+	if err != nil && err != transform.ErrShortSrc {
+		return nDst, nSrc, err
+	}
+
+	emitted := bytes.Count(dst[:nDst], utf8FFFD)
+	if emitted == 0 {
+		return nDst, nSrc, err
+	}
+
+	if t.countGenuineFFFDUnits(src[:nSrc]) < emitted {
+		return nDst, nSrc, ErrInvalidEncodedChar
+	}
+	return nDst, nSrc, err
+}
+
+// countGenuineFFFDUnits counts the number of genuine U+FFFD code units in the
+// consumed source. Units are scanned at the encoding's fixed code-unit width.
+// A genuine U+FFFD never overlaps a multi-unit sequence (e.g. a UTF-16
+// surrogate pair never contains the 0xFFFD code unit), so width-aligned
+// scanning attributes every genuine U+FFFD exactly once.
+func (t *strictDecoderTransformer) countGenuineFFFDUnits(src []byte) int {
+	w := len(t.unitFFFD)
+	if w == 0 {
+		return 0
+	}
+	count := 0
+	for off := 0; off+w <= len(src); off += w {
+		if bytes.Equal(src[off:off+w], t.unitFFFD) {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/encoding/strict.go
+++ b/internal/encoding/strict.go
@@ -30,11 +30,14 @@ package encoding
 //   - A trailing incomplete unit (leftover bytes that do not fill a full code
 //     unit) is malformed.
 //
-// For BOM-sensitive encodings (UTF-16/UTF-32 with UseBOM) the leading BOM is
-// inspected to fix big- vs little-endian, then skipped from validation. Because
-// the decision is made on the source bytes in the resolved byte order, it is
-// independent of how many U+FFFD the base decoder emitted, and independent of
-// how the decoder chunked its destination buffer (the round-4 ErrShortDst gap).
+// For BOM-sensitive encodings (UTF-16/UTF-32 with UseBOM) the leading unit is
+// inspected: an actual BOM fixes big- vs little-endian and is skipped from
+// validation; absent a BOM the validator uses the encoding's configured default
+// order (the same fallback x/text's UseBOM decoder uses) and validates the first
+// unit as real content. Because the decision is made on the source bytes in the
+// resolved byte order, it is independent of how many U+FFFD the base decoder
+// emitted, and independent of how the decoder chunked its destination buffer
+// (the round-4 ErrShortDst gap).
 
 import (
 	"errors"
@@ -79,9 +82,10 @@ func (o byteOrder) scalar(unit []byte) uint32 {
 // rejects malformed input that the base decoder would otherwise silently
 // replace with U+FFFD. width is the encoding's fixed code-unit width in bytes
 // (2 for UTF-16 / UCS-2, 4 for UTF-32 / UCS-4). order is the resolved byte
-// order for fixed-endianness encodings; for UseBOM encodings it is ignored and
-// useBOM must be true so the order is resolved from the leading BOM. The
-// encoder is left unchanged.
+// order for fixed-endianness encodings; for UseBOM encodings it is the default
+// order used when no BOM is present (matching the wrapped decoder's configured
+// default) and useBOM must be true so a leading BOM, when present, overrides it.
+// The encoder is left unchanged.
 func withStrictDecode(e enc.Encoding, width int, order byteOrder, useBOM bool) enc.Encoding {
 	return &strictEncoding{Encoding: e, width: width, order: order, useBOM: useBOM}
 }
@@ -158,7 +162,10 @@ func (t *strictDecoderTransformer) validate(src []byte, atEOF bool) error {
 	off := 0
 
 	if t.useBOM {
-		// Resolve big- vs little-endian from the leading BOM, then skip it.
+		// Resolve big- vs little-endian from a leading BOM. An actual BOM is
+		// consumed by the decoder and skipped from validation; absent a BOM the
+		// decoder falls back to its configured default order (t.order) and the
+		// first unit is real content, so it must be validated from offset 0.
 		if !t.bomResolved {
 			if len(buf) < t.width {
 				if atEOF {
@@ -172,9 +179,12 @@ func (t *strictDecoderTransformer) validate(src []byte, atEOF bool) error {
 				t.carry = append(t.carry, buf...)
 				return nil
 			}
-			t.resolved = t.resolveBOM(buf[:t.width])
+			resolved, isBOM := t.resolveBOM(buf[:t.width])
+			t.resolved = resolved
 			t.bomResolved = true
-			off = t.width // skip the BOM unit
+			if isBOM {
+				off = t.width // skip the BOM unit
+			}
 		}
 		order = t.resolved
 	}
@@ -207,23 +217,31 @@ func (t *strictDecoderTransformer) validate(src []byte, atEOF bool) error {
 	return nil
 }
 
-// resolveBOM determines the byte order from the leading BOM unit. A little-
-// endian BOM has its low-order byte first; anything else (including a big-
-// endian BOM or a missing BOM) is treated as big-endian, matching x/text's
-// UseBOM default.
-func (t *strictDecoderTransformer) resolveBOM(bom []byte) byteOrder {
+// resolveBOM inspects the leading unit. If it is an actual byte-order mark it
+// returns the order it selects and true (the caller skips it). Otherwise it
+// returns the configured default order (t.order) and false: there is no BOM, so
+// the decoder uses its default endianness and the first unit is real content
+// that must be validated. The default matches x/text's UseBOM fallback, which
+// keeps the encoding's configured endianness when no BOM is present.
+func (t *strictDecoderTransformer) resolveBOM(bom []byte) (byteOrder, bool) {
 	if t.width == 2 {
 		// LE BOM: FF FE. BE BOM: FE FF.
 		if bom[0] == 0xFF && bom[1] == 0xFE {
-			return orderLE2
+			return orderLE2, true
 		}
-		return orderBE2
+		if bom[0] == 0xFE && bom[1] == 0xFF {
+			return orderBE2, true
+		}
+		return t.order, false
 	}
 	// width 4. LE BOM: FF FE 00 00. BE BOM: 00 00 FE FF.
 	if bom[0] == 0xFF && bom[1] == 0xFE && bom[2] == 0x00 && bom[3] == 0x00 {
-		return orderLE4
+		return orderLE4, true
 	}
-	return orderBE4
+	if bom[0] == 0x00 && bom[1] == 0x00 && bom[2] == 0xFE && bom[3] == 0xFF {
+		return orderBE4, true
+	}
+	return t.order, false
 }
 
 type unitStatus int

--- a/internal/encoding/strict.go
+++ b/internal/encoding/strict.go
@@ -14,113 +14,260 @@ package encoding
 // even though it is malformed input, which XML requires to be a fatal error.
 //
 // This wrapper applies only to the fixed-width Unicode encodings (UTF-16 / 2
-// bytes, UTF-32 & UCS-4 / 4 bytes, UCS-2 / 2 bytes). For those, a genuine
-// U+FFFD is exactly the code unit whose scalar value equals 0xFFFD. The wrapper
-// decodes normally, then compares the number of U+FFFD characters in the
-// decoded output against the number of genuine U+FFFD code units present in the
-// source. Any excess means the decoder substituted U+FFFD for malformed input,
-// which is reported as a fatal decode error.
+// bytes, UTF-32 & UCS-4 / 4 bytes, UCS-2 / 2 bytes). Because the encoding's
+// identity, code-unit width, and resolved byte order are all known at Load()
+// time, the wrapper validates the SOURCE bytes deterministically rather than
+// counting U+FFFD substitutions in the decoded output. It walks the source one
+// fixed-width code unit at a time in the resolved byte order, computes each
+// unit's scalar value, and rejects any unit that is malformed:
 //
-// The genuine-unit count is derived from the fixed code-unit width alone, not
-// from re-encoding U+FFFD. Re-encoding is unreliable for BOM-sensitive
-// encodings (e.g. UTF-16 with UseBOM) because the encoder prepends a BOM and
-// resolves to a specific endianness, neither of which matches the bytes seen in
-// an arbitrary input stream. Instead a width-sized source unit is treated as a
-// genuine U+FFFD when its scalar value equals 0xFFFD in *either* byte order,
-// which covers both BE and LE streams (including BOM-resolved ones).
+//   - UTF-16: a high surrogate (D800–DBFF) must be immediately followed by a
+//     low surrogate (DC00–DFFF); a lone high or lone low surrogate is malformed.
+//     A unit equal to 0xFFFD is a genuine U+FFFD and is accepted.
+//   - UTF-32 / UCS-4: the scalar must be a valid code point (≤ 0x10FFFF and not
+//     a surrogate). 0xFFFD is a genuine U+FFFD and is accepted; anything out of
+//     range is malformed.
+//   - A trailing incomplete unit (leftover bytes that do not fill a full code
+//     unit) is malformed.
+//
+// For BOM-sensitive encodings (UTF-16/UTF-32 with UseBOM) the leading BOM is
+// inspected to fix big- vs little-endian, then skipped from validation. Because
+// the decision is made on the source bytes in the resolved byte order, it is
+// independent of how many U+FFFD the base decoder emitted, and independent of
+// how the decoder chunked its destination buffer (the round-4 ErrShortDst gap).
 
 import (
-	"bytes"
 	"errors"
 
 	enc "golang.org/x/text/encoding"
 	"golang.org/x/text/transform"
 )
 
-// ErrInvalidEncodedChar is returned when a decoder substitutes U+FFFD for
-// malformed input (for example an unpaired UTF-16 surrogate).
+// ErrInvalidEncodedChar is returned when the source contains malformed input
+// that the base decoder would otherwise silently replace with U+FFFD (for
+// example an unpaired UTF-16 surrogate or an out-of-range UTF-32 scalar).
 var ErrInvalidEncodedChar = errors.New("encoding: malformed input substituted with U+FFFD")
 
-// utf8FFFD is the UTF-8 encoding of U+FFFD.
-var utf8FFFD = []byte{0xEF, 0xBF, 0xBD}
+// byteOrder describes how to read a fixed-width code unit's scalar value. perm
+// maps each destination byte position (most- to least-significant, big-endian)
+// to the source byte index within the unit. For example UTF-16LE uses {1, 0}:
+// the high-order scalar byte comes from source byte 1.
+type byteOrder struct {
+	perm []int
+}
+
+var (
+	orderBE2  = byteOrder{perm: []int{0, 1}}       // UTF-16BE
+	orderLE2  = byteOrder{perm: []int{1, 0}}       // UTF-16LE
+	orderBE4  = byteOrder{perm: []int{0, 1, 2, 3}} // UTF-32BE / UCS-4 1234
+	orderLE4  = byteOrder{perm: []int{3, 2, 1, 0}} // UTF-32LE / UCS-4 4321
+	order2143 = byteOrder{perm: []int{1, 0, 3, 2}} // UCS-4 2143
+	order3412 = byteOrder{perm: []int{2, 3, 0, 1}} // UCS-4 3412
+)
+
+// scalar reads the scalar value of a width-sized unit using this byte order.
+// The unit must be at least len(perm) bytes long.
+func (o byteOrder) scalar(unit []byte) uint32 {
+	var v uint32
+	for _, idx := range o.perm {
+		v = v<<8 | uint32(unit[idx])
+	}
+	return v
+}
 
 // withStrictDecode wraps a fixed-width Unicode Encoding so that its decoder
 // rejects malformed input that the base decoder would otherwise silently
 // replace with U+FFFD. width is the encoding's fixed code-unit width in bytes
-// (2 for UTF-16 / UCS-2, 4 for UTF-32 / UCS-4). The encoder is left unchanged.
-func withStrictDecode(e enc.Encoding, width int) enc.Encoding {
-	return &strictEncoding{Encoding: e, width: width}
+// (2 for UTF-16 / UCS-2, 4 for UTF-32 / UCS-4). order is the resolved byte
+// order for fixed-endianness encodings; for UseBOM encodings it is ignored and
+// useBOM must be true so the order is resolved from the leading BOM. The
+// encoder is left unchanged.
+func withStrictDecode(e enc.Encoding, width int, order byteOrder, useBOM bool) enc.Encoding {
+	return &strictEncoding{Encoding: e, width: width, order: order, useBOM: useBOM}
 }
 
 type strictEncoding struct {
 	enc.Encoding
-	width int
+	width  int
+	order  byteOrder
+	useBOM bool
 }
 
 func (e *strictEncoding) NewDecoder() *enc.Decoder {
 	return &enc.Decoder{Transformer: &strictDecoderTransformer{
-		base:  e.Encoding.NewDecoder().Transformer,
-		width: e.width,
+		base:   e.Encoding.NewDecoder().Transformer,
+		width:  e.width,
+		order:  e.order,
+		useBOM: e.useBOM,
 	}}
 }
 
-// strictDecoderTransformer wraps a fixed-width Unicode decoder, decoding via the
-// base transformer and then rejecting any U+FFFD in the output that does not
-// correspond to a genuine U+FFFD code unit in the source.
+// strictDecoderTransformer wraps a fixed-width Unicode decoder. It decodes via
+// the base transformer but, before trusting the output, validates the consumed
+// source bytes deterministically in the resolved byte order and rejects any
+// malformed unit (which the base decoder would have substituted with U+FFFD).
 type strictDecoderTransformer struct {
-	base  transform.Transformer
-	width int
+	base   transform.Transformer
+	width  int
+	order  byteOrder
+	useBOM bool
+
+	// bomResolved records whether the leading BOM has been inspected (UseBOM
+	// encodings only). order is fixed once resolved. carry holds source bytes
+	// that span Transform calls (a unit straddling a chunk boundary, or a BOM
+	// not yet fully seen).
+	bomResolved bool
+	resolved    byteOrder
+	carry       []byte
 }
 
 func (t *strictDecoderTransformer) Reset() {
 	t.base.Reset()
+	t.bomResolved = false
+	t.resolved = byteOrder{}
+	t.carry = t.carry[:0]
 }
 
 func (t *strictDecoderTransformer) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error) {
 	nDst, nSrc, err = t.base.Transform(dst, src, atEOF)
-	if err != nil && err != transform.ErrShortSrc {
+	if err != nil && err != transform.ErrShortSrc && err != transform.ErrShortDst {
 		return nDst, nSrc, err
 	}
 
-	emitted := bytes.Count(dst[:nDst], utf8FFFD)
-	if emitted == 0 {
-		return nDst, nSrc, err
-	}
-
-	if t.countGenuineFFFDUnits(src[:nSrc]) < emitted {
-		return nDst, nSrc, ErrInvalidEncodedChar
+	// Validate exactly the bytes the base decoder consumed this call. Carry over
+	// any partial trailing unit so it is validated once the rest arrives.
+	if verr := t.validate(src[:nSrc], atEOF); verr != nil {
+		return nDst, nSrc, verr
 	}
 	return nDst, nSrc, err
 }
 
-// countGenuineFFFDUnits counts genuine U+FFFD code units in the consumed source.
-// Units are scanned at the encoding's fixed code-unit width. A width-sized unit
-// is genuine when its scalar value is 0xFFFD in either byte order, which makes
-// the count independent of the stream's (possibly BOM-resolved) endianness. A
-// genuine U+FFFD never overlaps a multi-unit sequence (a UTF-16 surrogate pair
-// never contains the 0xFFFD code unit), so width-aligned scanning attributes
-// every genuine U+FFFD exactly once.
-func (t *strictDecoderTransformer) countGenuineFFFDUnits(src []byte) int {
-	w := t.width
-	if w == 0 {
-		return 0
+// validate walks the freshly-consumed source bytes (combined with any carry
+// from a previous call) one code unit at a time in the resolved byte order and
+// returns ErrInvalidEncodedChar on the first malformed unit. Bytes that do not
+// yet form a complete unit are buffered in carry; at EOF an incomplete trailing
+// unit is malformed.
+func (t *strictDecoderTransformer) validate(src []byte, atEOF bool) error {
+	buf := src
+	if len(t.carry) > 0 {
+		buf = append(append([]byte{}, t.carry...), src...)
 	}
-	count := 0
-	for off := 0; off+w <= len(src); off += w {
-		if isFFFDUnit(src[off : off+w]) {
-			count++
+	t.carry = t.carry[:0]
+
+	order := t.order
+	off := 0
+
+	if t.useBOM {
+		// Resolve big- vs little-endian from the leading BOM, then skip it.
+		if !t.bomResolved {
+			if len(buf) < t.width {
+				if atEOF {
+					// Fewer than a full unit before EOF: malformed trailing bytes
+					// (an empty stream is fine — no bytes to validate).
+					if len(buf) > 0 {
+						return ErrInvalidEncodedChar
+					}
+					return nil
+				}
+				t.carry = append(t.carry, buf...)
+				return nil
+			}
+			t.resolved = t.resolveBOM(buf[:t.width])
+			t.bomResolved = true
+			off = t.width // skip the BOM unit
 		}
+		order = t.resolved
 	}
-	return count
+
+	for off+t.width <= len(buf) {
+		next, status := t.unitOK(buf, off, order)
+		switch status {
+		case unitBad:
+			return ErrInvalidEncodedChar
+		case unitIncomplete:
+			// A high surrogate whose low half has not arrived yet. Before EOF,
+			// buffer the surrogate (and any trailing partial unit) for the next
+			// call; at EOF it is an unpaired surrogate and therefore malformed.
+			if atEOF {
+				return ErrInvalidEncodedChar
+			}
+			t.carry = append(t.carry, buf[off:]...)
+			return nil
+		}
+		off = next
+	}
+
+	// Leftover bytes that do not fill a unit.
+	if off < len(buf) {
+		if atEOF {
+			return ErrInvalidEncodedChar
+		}
+		t.carry = append(t.carry, buf[off:]...)
+	}
+	return nil
 }
 
-// isFFFDUnit reports whether the width-sized byte unit encodes scalar value
-// 0xFFFD in either big- or little-endian order.
-func isFFFDUnit(unit []byte) bool {
-	var be, le uint32
-	for i, b := range unit {
-		be = be<<8 | uint32(b)
-		le |= uint32(b) << (8 * uint(i))
+// resolveBOM determines the byte order from the leading BOM unit. A little-
+// endian BOM has its low-order byte first; anything else (including a big-
+// endian BOM or a missing BOM) is treated as big-endian, matching x/text's
+// UseBOM default.
+func (t *strictDecoderTransformer) resolveBOM(bom []byte) byteOrder {
+	if t.width == 2 {
+		// LE BOM: FF FE. BE BOM: FE FF.
+		if bom[0] == 0xFF && bom[1] == 0xFE {
+			return orderLE2
+		}
+		return orderBE2
 	}
-	return be == 0xFFFD || le == 0xFFFD
+	// width 4. LE BOM: FF FE 00 00. BE BOM: 00 00 FE FF.
+	if bom[0] == 0xFF && bom[1] == 0xFE && bom[2] == 0x00 && bom[3] == 0x00 {
+		return orderLE4
+	}
+	return orderBE4
+}
+
+type unitStatus int
+
+const (
+	unitGood       unitStatus = iota // valid; next offset is returned
+	unitBad                          // malformed
+	unitIncomplete                   // needs more bytes (high surrogate, pair not yet present)
+)
+
+// unitOK validates the code unit at off and returns the offset just past the
+// last byte it consumed (a surrogate pair consumes two units) together with a
+// status. unitIncomplete is returned for a high surrogate whose low half has
+// not arrived yet so the caller can decide based on EOF.
+func (t *strictDecoderTransformer) unitOK(buf []byte, off int, order byteOrder) (int, unitStatus) {
+	v := order.scalar(buf[off : off+t.width])
+
+	if t.width == 4 {
+		if v == 0xFFFD {
+			return off + 4, unitGood
+		}
+		if v > 0x10FFFF || (v >= 0xD800 && v <= 0xDFFF) {
+			return off, unitBad
+		}
+		return off + 4, unitGood
+	}
+
+	// width == 2 (UTF-16 / UCS-2).
+	switch {
+	case v >= 0xD800 && v <= 0xDBFF:
+		// High surrogate: must be followed by a low surrogate.
+		if off+2*t.width > len(buf) {
+			return off, unitIncomplete
+		}
+		lo := order.scalar(buf[off+t.width : off+2*t.width])
+		if lo < 0xDC00 || lo > 0xDFFF {
+			return off, unitBad
+		}
+		return off + 2*t.width, unitGood
+	case v >= 0xDC00 && v <= 0xDFFF:
+		// Lone low surrogate.
+		return off, unitBad
+	default:
+		// BMP scalar (includes a genuine 0xFFFD).
+		return off + t.width, unitGood
+	}
 }

--- a/internal/encoding/strict.go
+++ b/internal/encoding/strict.go
@@ -15,11 +15,19 @@ package encoding
 //
 // This wrapper applies only to the fixed-width Unicode encodings (UTF-16 / 2
 // bytes, UTF-32 & UCS-4 / 4 bytes, UCS-2 / 2 bytes). For those, a genuine
-// U+FFFD is exactly the code unit whose bytes equal the U+FFFD encoding. The
-// wrapper decodes normally, then compares the number of U+FFFD characters in
-// the decoded output against the number of genuine U+FFFD code units present in
-// the source. Any excess means the decoder substituted U+FFFD for malformed
-// input, which is reported as a fatal decode error.
+// U+FFFD is exactly the code unit whose scalar value equals 0xFFFD. The wrapper
+// decodes normally, then compares the number of U+FFFD characters in the
+// decoded output against the number of genuine U+FFFD code units present in the
+// source. Any excess means the decoder substituted U+FFFD for malformed input,
+// which is reported as a fatal decode error.
+//
+// The genuine-unit count is derived from the fixed code-unit width alone, not
+// from re-encoding U+FFFD. Re-encoding is unreliable for BOM-sensitive
+// encodings (e.g. UTF-16 with UseBOM) because the encoder prepends a BOM and
+// resolves to a specific endianness, neither of which matches the bytes seen in
+// an arbitrary input stream. Instead a width-sized source unit is treated as a
+// genuine U+FFFD when its scalar value equals 0xFFFD in *either* byte order,
+// which covers both BE and LE streams (including BOM-resolved ones).
 
 import (
 	"bytes"
@@ -38,27 +46,21 @@ var utf8FFFD = []byte{0xEF, 0xBF, 0xBD}
 
 // withStrictDecode wraps a fixed-width Unicode Encoding so that its decoder
 // rejects malformed input that the base decoder would otherwise silently
-// replace with U+FFFD. The encoder is left unchanged.
-func withStrictDecode(e enc.Encoding) enc.Encoding {
-	return &strictEncoding{Encoding: e}
+// replace with U+FFFD. width is the encoding's fixed code-unit width in bytes
+// (2 for UTF-16 / UCS-2, 4 for UTF-32 / UCS-4). The encoder is left unchanged.
+func withStrictDecode(e enc.Encoding, width int) enc.Encoding {
+	return &strictEncoding{Encoding: e, width: width}
 }
 
 type strictEncoding struct {
 	enc.Encoding
+	width int
 }
 
 func (e *strictEncoding) NewDecoder() *enc.Decoder {
-	// unitFFFD holds the source-byte encoding of a genuine U+FFFD code unit for
-	// this encoding (e.g. 0xFF 0xFD for UTF-16BE). Its length is the encoding's
-	// fixed code-unit width. If the encoder cannot represent U+FFFD, every
-	// emitted U+FFFD is treated as a substitution error.
-	var unitFFFD []byte
-	if b, err := e.Encoding.NewEncoder().Bytes(utf8FFFD); err == nil {
-		unitFFFD = b
-	}
 	return &enc.Decoder{Transformer: &strictDecoderTransformer{
-		base:     e.Encoding.NewDecoder().Transformer,
-		unitFFFD: unitFFFD,
+		base:  e.Encoding.NewDecoder().Transformer,
+		width: e.width,
 	}}
 }
 
@@ -66,8 +68,8 @@ func (e *strictEncoding) NewDecoder() *enc.Decoder {
 // base transformer and then rejecting any U+FFFD in the output that does not
 // correspond to a genuine U+FFFD code unit in the source.
 type strictDecoderTransformer struct {
-	base     transform.Transformer
-	unitFFFD []byte
+	base  transform.Transformer
+	width int
 }
 
 func (t *strictDecoderTransformer) Reset() {
@@ -91,21 +93,34 @@ func (t *strictDecoderTransformer) Transform(dst, src []byte, atEOF bool) (nDst,
 	return nDst, nSrc, err
 }
 
-// countGenuineFFFDUnits counts the number of genuine U+FFFD code units in the
-// consumed source. Units are scanned at the encoding's fixed code-unit width.
-// A genuine U+FFFD never overlaps a multi-unit sequence (e.g. a UTF-16
-// surrogate pair never contains the 0xFFFD code unit), so width-aligned
-// scanning attributes every genuine U+FFFD exactly once.
+// countGenuineFFFDUnits counts genuine U+FFFD code units in the consumed source.
+// Units are scanned at the encoding's fixed code-unit width. A width-sized unit
+// is genuine when its scalar value is 0xFFFD in either byte order, which makes
+// the count independent of the stream's (possibly BOM-resolved) endianness. A
+// genuine U+FFFD never overlaps a multi-unit sequence (a UTF-16 surrogate pair
+// never contains the 0xFFFD code unit), so width-aligned scanning attributes
+// every genuine U+FFFD exactly once.
 func (t *strictDecoderTransformer) countGenuineFFFDUnits(src []byte) int {
-	w := len(t.unitFFFD)
+	w := t.width
 	if w == 0 {
 		return 0
 	}
 	count := 0
 	for off := 0; off+w <= len(src); off += w {
-		if bytes.Equal(src[off:off+w], t.unitFFFD) {
+		if isFFFDUnit(src[off : off+w]) {
 			count++
 		}
 	}
 	return count
+}
+
+// isFFFDUnit reports whether the width-sized byte unit encodes scalar value
+// 0xFFFD in either big- or little-endian order.
+func isFFFDUnit(unit []byte) bool {
+	var be, le uint32
+	for i, b := range unit {
+		be = be<<8 | uint32(b)
+		le |= uint32(b) << (8 * uint(i))
+	}
+	return be == 0xFFFD || le == 0xFFFD
 }

--- a/internal/encoding/strict_test.go
+++ b/internal/encoding/strict_test.go
@@ -60,6 +60,122 @@ func TestStrictDecodeUTF16(t *testing.T) {
 	})
 }
 
+func TestStrictDecodeUTF16BOM(t *testing.T) {
+	t.Parallel()
+
+	t.Run("BOM-BE genuine U+FFFD accepted", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-16")
+		require.NotNil(t, e)
+		// BE BOM + "A" + real U+FFFD + "B".
+		got, err := e.NewDecoder().Bytes([]byte{0xFE, 0xFF, 0x00, 0x41, 0xFF, 0xFD, 0x00, 0x42})
+		require.NoError(t, err)
+		require.Equal(t, "A�B", string(got))
+	})
+
+	t.Run("BOM-LE genuine U+FFFD accepted", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-16")
+		require.NotNil(t, e)
+		// LE BOM + "A" + real U+FFFD + "B".
+		got, err := e.NewDecoder().Bytes([]byte{0xFF, 0xFE, 0x41, 0x00, 0xFD, 0xFF, 0x42, 0x00})
+		require.NoError(t, err)
+		require.Equal(t, "A�B", string(got))
+	})
+
+	t.Run("BOM-BE unpaired surrogate rejected", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-16")
+		require.NotNil(t, e)
+		// BE BOM + "A" + unpaired high surrogate + "B".
+		_, err := e.NewDecoder().Bytes([]byte{0xFE, 0xFF, 0x00, 0x41, 0xD8, 0x00, 0x00, 0x42})
+		require.Error(t, err)
+	})
+
+	t.Run("BOM-LE unpaired surrogate rejected", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-16")
+		require.NotNil(t, e)
+		// LE BOM + "A" + unpaired high surrogate + "B".
+		_, err := e.NewDecoder().Bytes([]byte{0xFF, 0xFE, 0x41, 0x00, 0x00, 0xD8, 0x42, 0x00})
+		require.Error(t, err)
+	})
+}
+
+func TestStrictDecodeUTF32(t *testing.T) {
+	t.Parallel()
+
+	t.Run("genuine U+FFFD accepted", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-32be")
+		require.NotNil(t, e)
+		got, err := e.NewDecoder().Bytes([]byte{0x00, 0x00, 0x00, 0x41, 0x00, 0x00, 0xFF, 0xFD})
+		require.NoError(t, err)
+		require.Equal(t, "A�", string(got))
+	})
+
+	t.Run("BOM genuine U+FFFD accepted", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-32")
+		require.NotNil(t, e)
+		// BE BOM + "A" + real U+FFFD.
+		got, err := e.NewDecoder().Bytes([]byte{0x00, 0x00, 0xFE, 0xFF, 0x00, 0x00, 0x00, 0x41, 0x00, 0x00, 0xFF, 0xFD})
+		require.NoError(t, err)
+		require.Equal(t, "A�", string(got))
+	})
+
+	t.Run("out-of-range scalar rejected", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-32be")
+		require.NotNil(t, e)
+		// 0x00110000 is beyond the Unicode range — malformed input.
+		_, err := e.NewDecoder().Bytes([]byte{0x00, 0x11, 0x00, 0x00})
+		require.Error(t, err)
+	})
+}
+
+func TestStrictDecodeUCS4Swap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("trailing partial unit rejected", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("ucs4_2143")
+		require.NotNil(t, e)
+		// "A" in 2143 order is 00 00 41 00; a trailing 0xff is an incomplete unit.
+		_, err := e.NewDecoder().Bytes([]byte{0x00, 0x00, 0x41, 0x00, 0xff})
+		require.Error(t, err)
+	})
+
+	t.Run("trailing partial unit rejected (3412)", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("ucs4_3412")
+		require.NotNil(t, e)
+		_, err := e.NewDecoder().Bytes([]byte{0x41, 0x00, 0x00, 0x00, 0xff, 0xff})
+		require.Error(t, err)
+	})
+
+	t.Run("complete units accepted", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("ucs4_2143")
+		require.NotNil(t, e)
+		// "A" in 2143 byte order: code point 0x41 => big-endian 00 00 00 41,
+		// 2143 swap of (b0 b1 b2 b3)->(b1 b0 b3 b2) gives 00 00 41 00.
+		got, err := e.NewDecoder().Bytes([]byte{0x00, 0x00, 0x41, 0x00})
+		require.NoError(t, err)
+		require.Equal(t, "A", string(got))
+	})
+}
+
 func TestStrictDecodeUTF16Plain(t *testing.T) {
 	t.Parallel()
 

--- a/internal/encoding/strict_test.go
+++ b/internal/encoding/strict_test.go
@@ -1,0 +1,72 @@
+package encoding_test
+
+import (
+	"testing"
+
+	xmlenc "github.com/lestrrat-go/helium/internal/encoding"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStrictDecodeUTF16(t *testing.T) {
+	t.Parallel()
+
+	t.Run("genuine U+FFFD accepted", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-16be")
+		require.NotNil(t, e)
+		// U+FFFD encoded as a real UTF-16BE code unit: 0xFFFD.
+		got, err := e.NewDecoder().Bytes([]byte{0x00, 0x41, 0xFF, 0xFD, 0x00, 0x42})
+		require.NoError(t, err)
+		require.Equal(t, "A�B", string(got))
+	})
+
+	t.Run("unpaired high surrogate rejected", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-16be")
+		require.NotNil(t, e)
+		// 0xD800 is an unpaired high surrogate — malformed input.
+		_, err := e.NewDecoder().Bytes([]byte{0x00, 0x41, 0xD8, 0x00, 0x00, 0x42})
+		require.Error(t, err)
+	})
+
+	t.Run("trailing odd byte rejected", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-16be")
+		require.NotNil(t, e)
+		_, err := e.NewDecoder().Bytes([]byte{0x00, 0x41, 0x00})
+		require.Error(t, err)
+	})
+
+	t.Run("little-endian genuine U+FFFD accepted", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-16le")
+		require.NotNil(t, e)
+		got, err := e.NewDecoder().Bytes([]byte{0x41, 0x00, 0xFD, 0xFF, 0x42, 0x00})
+		require.NoError(t, err)
+		require.Equal(t, "A�B", string(got))
+	})
+
+	t.Run("little-endian unpaired surrogate rejected", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-16le")
+		require.NotNil(t, e)
+		_, err := e.NewDecoder().Bytes([]byte{0x41, 0x00, 0x00, 0xD8, 0x42, 0x00})
+		require.Error(t, err)
+	})
+}
+
+func TestStrictDecodeUTF16Plain(t *testing.T) {
+	t.Parallel()
+
+	// A normal ASCII-only UTF-16 document still decodes cleanly.
+	e := xmlenc.Load("utf-16be")
+	require.NotNil(t, e)
+	got, err := e.NewDecoder().Bytes([]byte{0x00, 0x68, 0x00, 0x69})
+	require.NoError(t, err)
+	require.Equal(t, "hi", string(got))
+}

--- a/internal/encoding/strict_test.go
+++ b/internal/encoding/strict_test.go
@@ -58,6 +58,57 @@ func TestStrictDecodeUTF16(t *testing.T) {
 		_, err := e.NewDecoder().Bytes([]byte{0x41, 0x00, 0x00, 0xD8, 0x42, 0x00})
 		require.Error(t, err)
 	})
+
+	t.Run("lone low surrogate rejected (BE)", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-16be")
+		require.NotNil(t, e)
+		// 0xDC00 is a lone low surrogate with no preceding high surrogate.
+		_, err := e.NewDecoder().Bytes([]byte{0x00, 0x41, 0xDC, 0x00})
+		require.Error(t, err)
+	})
+
+	t.Run("lone low surrogate rejected (LE)", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-16le")
+		require.NotNil(t, e)
+		_, err := e.NewDecoder().Bytes([]byte{0x41, 0x00, 0x00, 0xDC})
+		require.Error(t, err)
+	})
+
+	t.Run("two unpaired surrogates rejected (ErrShortDst trigger)", func(t *testing.T) {
+		t.Parallel()
+
+		// Round-4 finding 1: two consecutive unpaired high surrogates that the
+		// base decoder may emit before filling dst. Must still be rejected.
+		e := xmlenc.Load("utf-16be")
+		require.NotNil(t, e)
+		_, err := e.NewDecoder().Bytes([]byte{0xD8, 0x00, 0xD8, 0x00, 0x00, 0x41})
+		require.Error(t, err)
+	})
+
+	t.Run("valid surrogate pair accepted (BE)", func(t *testing.T) {
+		t.Parallel()
+
+		// U+1F600 = high D83D, low DE00.
+		e := xmlenc.Load("utf-16be")
+		require.NotNil(t, e)
+		got, err := e.NewDecoder().Bytes([]byte{0xD8, 0x3D, 0xDE, 0x00})
+		require.NoError(t, err)
+		require.Equal(t, "\U0001F600", string(got))
+	})
+
+	t.Run("valid surrogate pair accepted (LE)", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-16le")
+		require.NotNil(t, e)
+		got, err := e.NewDecoder().Bytes([]byte{0x3D, 0xD8, 0x00, 0xDE})
+		require.NoError(t, err)
+		require.Equal(t, "\U0001F600", string(got))
+	})
 }
 
 func TestStrictDecodeUTF16BOM(t *testing.T) {
@@ -139,6 +190,60 @@ func TestStrictDecodeUTF32(t *testing.T) {
 		_, err := e.NewDecoder().Bytes([]byte{0x00, 0x11, 0x00, 0x00})
 		require.Error(t, err)
 	})
+
+	t.Run("BE out-of-range scalar that is FFFD in LE rejected", func(t *testing.T) {
+		t.Parallel()
+
+		// Round-4 finding 2: FD FF 00 00 read big-endian is 0xFDFF0000, far out
+		// of range — malformed. The old "either byte order" check read it as
+		// 0xFFFD little-endian and wrongly accepted it.
+		e := xmlenc.Load("utf-32be")
+		require.NotNil(t, e)
+		_, err := e.NewDecoder().Bytes([]byte{0xFD, 0xFF, 0x00, 0x00})
+		require.Error(t, err)
+	})
+
+	t.Run("LE genuine U+FFFD accepted", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-32le")
+		require.NotNil(t, e)
+		got, err := e.NewDecoder().Bytes([]byte{0x41, 0x00, 0x00, 0x00, 0xFD, 0xFF, 0x00, 0x00})
+		require.NoError(t, err)
+		require.Equal(t, "A�", string(got))
+	})
+
+	t.Run("BOM-LE genuine U+FFFD accepted", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-32")
+		require.NotNil(t, e)
+		// LE BOM (FF FE 00 00) + "A" + real U+FFFD.
+		got, err := e.NewDecoder().Bytes([]byte{0xFF, 0xFE, 0x00, 0x00, 0x41, 0x00, 0x00, 0x00, 0xFD, 0xFF, 0x00, 0x00})
+		require.NoError(t, err)
+		require.Equal(t, "A�", string(got))
+	})
+
+	t.Run("astral char accepted", func(t *testing.T) {
+		t.Parallel()
+
+		e := xmlenc.Load("utf-32be")
+		require.NotNil(t, e)
+		// U+1F600.
+		got, err := e.NewDecoder().Bytes([]byte{0x00, 0x01, 0xF6, 0x00})
+		require.NoError(t, err)
+		require.Equal(t, "\U0001F600", string(got))
+	})
+
+	t.Run("surrogate scalar rejected", func(t *testing.T) {
+		t.Parallel()
+
+		// A surrogate code point (0xD800) is not a valid UTF-32 scalar.
+		e := xmlenc.Load("utf-32be")
+		require.NotNil(t, e)
+		_, err := e.NewDecoder().Bytes([]byte{0x00, 0x00, 0xD8, 0x00})
+		require.Error(t, err)
+	})
 }
 
 func TestStrictDecodeUCS4Swap(t *testing.T) {
@@ -173,6 +278,30 @@ func TestStrictDecodeUCS4Swap(t *testing.T) {
 		got, err := e.NewDecoder().Bytes([]byte{0x00, 0x00, 0x41, 0x00})
 		require.NoError(t, err)
 		require.Equal(t, "A", string(got))
+	})
+
+	t.Run("genuine U+FFFD accepted (2143)", func(t *testing.T) {
+		t.Parallel()
+
+		// Round-4 finding 2: genuine U+FFFD in UCS-4-2143. Code point 0xFFFD =>
+		// big-endian 00 00 FF FD; 2143 swap (b1 b0 b3 b2) gives 00 00 FD FF.
+		// The old "either byte order" check read this big-endian as 0xFFFD and
+		// wrongly rejected it (mismatch vs decoder output).
+		e := xmlenc.Load("ucs4_2143")
+		require.NotNil(t, e)
+		got, err := e.NewDecoder().Bytes([]byte{0x00, 0x00, 0xFD, 0xFF})
+		require.NoError(t, err)
+		require.Equal(t, "�", string(got))
+	})
+
+	t.Run("out-of-range scalar rejected (2143)", func(t *testing.T) {
+		t.Parallel()
+
+		// 0x00110000 big-endian => 00 11 00 00; 2143 swap (b1 b0 b3 b2) = 11 00 00 00.
+		e := xmlenc.Load("ucs4_2143")
+		require.NotNil(t, e)
+		_, err := e.NewDecoder().Bytes([]byte{0x11, 0x00, 0x00, 0x00})
+		require.Error(t, err)
 	})
 }
 

--- a/internal/encoding/strict_test.go
+++ b/internal/encoding/strict_test.go
@@ -155,6 +155,53 @@ func TestStrictDecodeUTF16BOM(t *testing.T) {
 		_, err := e.NewDecoder().Bytes([]byte{0xFF, 0xFE, 0x41, 0x00, 0x00, 0xD8, 0x42, 0x00})
 		require.Error(t, err)
 	})
+
+	t.Run("no-BOM first-unit unpaired high surrogate rejected", func(t *testing.T) {
+		t.Parallel()
+
+		// Round-5 finding: no BOM, so x/text's UseBOM decoder falls back to its
+		// configured default endianness (LittleEndian for Load("utf-16")). The
+		// bytes 00 D8 read little-endian are 0xD800, a lone high surrogate the
+		// decoder substitutes with U+FFFD. The wrapper must reject it instead of
+		// treating the first unit as a BOM and skipping it.
+		e := xmlenc.Load("utf-16")
+		require.NotNil(t, e)
+		_, err := e.NewDecoder().Bytes([]byte{0x00, 0xD8})
+		require.Error(t, err)
+	})
+
+	t.Run("no-BOM first-unit lone low surrogate rejected", func(t *testing.T) {
+		t.Parallel()
+
+		// 00 DC little-endian is 0xDC00, a lone low surrogate.
+		e := xmlenc.Load("utf-16")
+		require.NotNil(t, e)
+		_, err := e.NewDecoder().Bytes([]byte{0x00, 0xDC})
+		require.Error(t, err)
+	})
+
+	t.Run("no-BOM first-unit genuine char accepted", func(t *testing.T) {
+		t.Parallel()
+
+		// 41 00 little-endian (the default order) is 0x0041 = "A". No BOM, so the
+		// first unit is real content and must be validated, not skipped.
+		e := xmlenc.Load("utf-16")
+		require.NotNil(t, e)
+		got, err := e.NewDecoder().Bytes([]byte{0x41, 0x00, 0x42, 0x00})
+		require.NoError(t, err)
+		require.Equal(t, "AB", string(got))
+	})
+
+	t.Run("no-BOM first-unit genuine U+FFFD accepted", func(t *testing.T) {
+		t.Parallel()
+
+		// FD FF little-endian is 0xFFFD, a genuine replacement character.
+		e := xmlenc.Load("utf-16")
+		require.NotNil(t, e)
+		got, err := e.NewDecoder().Bytes([]byte{0xFD, 0xFF, 0x42, 0x00})
+		require.NoError(t, err)
+		require.Equal(t, "�B", string(got))
+	})
 }
 
 func TestStrictDecodeUTF32(t *testing.T) {
@@ -233,6 +280,53 @@ func TestStrictDecodeUTF32(t *testing.T) {
 		got, err := e.NewDecoder().Bytes([]byte{0x00, 0x01, 0xF6, 0x00})
 		require.NoError(t, err)
 		require.Equal(t, "\U0001F600", string(got))
+	})
+
+	t.Run("no-BOM first-unit surrogate scalar rejected", func(t *testing.T) {
+		t.Parallel()
+
+		// Round-5 finding: no BOM, so x/text's UseBOM decoder falls back to its
+		// configured default endianness (BigEndian for Load("utf-32")). The bytes
+		// 00 00 D8 00 read big-endian are 0xD800, a surrogate scalar the decoder
+		// substitutes with U+FFFD. The wrapper must reject it, not skip the first
+		// unit as a BOM.
+		e := xmlenc.Load("utf-32")
+		require.NotNil(t, e)
+		_, err := e.NewDecoder().Bytes([]byte{0x00, 0x00, 0xD8, 0x00})
+		require.Error(t, err)
+	})
+
+	t.Run("no-BOM first-unit out-of-range scalar rejected", func(t *testing.T) {
+		t.Parallel()
+
+		// 00 11 00 00 big-endian is 0x00110000, beyond the Unicode range.
+		e := xmlenc.Load("utf-32")
+		require.NotNil(t, e)
+		_, err := e.NewDecoder().Bytes([]byte{0x00, 0x11, 0x00, 0x00})
+		require.Error(t, err)
+	})
+
+	t.Run("no-BOM first-unit genuine char accepted", func(t *testing.T) {
+		t.Parallel()
+
+		// 00 00 00 41 big-endian (the default order) is "A". No BOM, so the first
+		// unit is real content and must be validated, not skipped.
+		e := xmlenc.Load("utf-32")
+		require.NotNil(t, e)
+		got, err := e.NewDecoder().Bytes([]byte{0x00, 0x00, 0x00, 0x41, 0x00, 0x00, 0x00, 0x42})
+		require.NoError(t, err)
+		require.Equal(t, "AB", string(got))
+	})
+
+	t.Run("no-BOM first-unit genuine U+FFFD accepted", func(t *testing.T) {
+		t.Parallel()
+
+		// 00 00 FF FD big-endian is a genuine U+FFFD.
+		e := xmlenc.Load("utf-32")
+		require.NotNil(t, e)
+		got, err := e.NewDecoder().Bytes([]byte{0x00, 0x00, 0xFF, 0xFD, 0x00, 0x00, 0x00, 0x42})
+		require.NoError(t, err)
+		require.Equal(t, "�B", string(got))
 	})
 
 	t.Run("surrogate scalar rejected", func(t *testing.T) {

--- a/internal/encoding/ucs4.go
+++ b/internal/encoding/ucs4.go
@@ -43,8 +43,15 @@ func (t *ucs4SwapTransformer) Transform(dst, src []byte, atEOF bool) (nDst, nSrc
 		nDst += 4
 		nSrc += 4
 	}
-	if nSrc < len(src) && !atEOF {
+	if nSrc < len(src) {
+		// Leftover bytes that don't fill a 4-byte unit. Before EOF this is just
+		// an incomplete unit awaiting more input; at EOF it is malformed input.
+		// The downstream UTF-32 decoder never sees these trailing bytes (they
+		// are not forwarded), so this transformer must reject them itself.
 		err = transform.ErrShortSrc
+		if atEOF {
+			err = ErrInvalidEncodedChar
+		}
 	}
 	return
 }

--- a/internal/strcursor/strcursor.go
+++ b/internal/strcursor/strcursor.go
@@ -453,7 +453,9 @@ func (c *RuneCursor) ScanCharDataInto(dst *bytes.Buffer) int {
 	for nRunes < count {
 		e := ring[(head+nRunes)&mask]
 		r := e.val
-		if r == '<' || r == '&' || r == utf8.RuneError {
+		// A real U+FFFD is stored as RuneError with width 3 (valid XML char);
+		// only width<=1 means genuinely-invalid UTF-8.
+		if r == '<' || r == '&' || (r == utf8.RuneError && e.width <= 1) {
 			break
 		}
 		u := uint32(r)

--- a/internal/strcursor/strcursor.go
+++ b/internal/strcursor/strcursor.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"unicode/utf8"
 	"unsafe"
+
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 )
 
 // Cursor is the byte-oriented interface for reading XML input.
@@ -456,6 +458,9 @@ func (c *RuneCursor) ScanCharDataInto(dst *bytes.Buffer) int {
 		}
 		u := uint32(r)
 		if u < 0x20 && u != 0x9 && u != 0xa && u != 0xd {
+			break
+		}
+		if r >= 0x80 && !xmlchar.IsChar(r) {
 			break
 		}
 		if r == ']' && nRunes+2 < count {

--- a/internal/strcursor/utf8cursor.go
+++ b/internal/strcursor/utf8cursor.go
@@ -725,7 +725,7 @@ func (c *UTF8Cursor) ScanCharDataSlice(dst []byte) ([]byte, int) {
 		if r == utf8.RuneError || w == 0 {
 			break
 		}
-		if r < 0x20 {
+		if !xmlchar.IsChar(r) {
 			break
 		}
 		dst = append(dst, data[off:off+w]...)
@@ -791,7 +791,7 @@ func (c *UTF8Cursor) ScanCharDataInto(dst *bytes.Buffer) int {
 		if r == utf8.RuneError || w == 0 {
 			break
 		}
-		if r < 0x20 {
+		if !xmlchar.IsChar(r) {
 			break
 		}
 		dst.Write(c.buf[c.bufpos+off : c.bufpos+off+w])

--- a/internal/strcursor/utf8cursor.go
+++ b/internal/strcursor/utf8cursor.go
@@ -631,16 +631,18 @@ func (c *UTF8Cursor) ScanSimpleAttrValue(quote byte) (string, int) {
 			return "", 0
 		}
 		if b < 0x80 {
-			if b < 0x20 && b != 0x9 {
-				// \r, \n, or other control chars need normalization.
+			if b < 0x20 {
+				// Tab, \r, \n, and other control chars need attribute-value
+				// normalization (whitespace -> space) — defer to the slow path.
 				return "", 0
 			}
 			off++
 		} else {
 			_ = c.fillBuffer(off + utf8.UTFMax)
 			r, w := utf8.DecodeRune(c.buf[c.bufpos+off : c.buflen])
-			if w == 0 || r == utf8.RuneError {
+			if w == 0 || (r == utf8.RuneError && w == 1) {
 				// Invalid or incomplete UTF-8 — fall back to slow path.
+				// (A real U+FFFD decodes as RuneError with width 3 and is valid.)
 				return "", 0
 			}
 			if !xmlchar.IsChar(r) {
@@ -727,7 +729,9 @@ func (c *UTF8Cursor) ScanCharDataSlice(dst []byte) ([]byte, int) {
 			dlen = len(data)
 		}
 		r, w := utf8.DecodeRune(data[off:dlen])
-		if r == utf8.RuneError || w == 0 {
+		if w == 0 || (r == utf8.RuneError && w == 1) {
+			// Invalid/incomplete UTF-8. A real U+FFFD decodes as RuneError
+			// with width 3 and is a valid XML char, so let IsChar judge it.
 			break
 		}
 		if !xmlchar.IsChar(r) {
@@ -793,7 +797,9 @@ func (c *UTF8Cursor) ScanCharDataInto(dst *bytes.Buffer) int {
 			_ = c.fillBuffer(off + utf8.UTFMax)
 		}
 		r, w := utf8.DecodeRune(c.buf[c.bufpos+off : c.buflen])
-		if r == utf8.RuneError || w == 0 {
+		if w == 0 || (r == utf8.RuneError && w == 1) {
+			// Invalid/incomplete UTF-8. A real U+FFFD decodes as RuneError
+			// with width 3 and is a valid XML char, so let IsChar judge it.
 			break
 		}
 		if !xmlchar.IsChar(r) {

--- a/internal/strcursor/utf8cursor.go
+++ b/internal/strcursor/utf8cursor.go
@@ -643,6 +643,11 @@ func (c *UTF8Cursor) ScanSimpleAttrValue(quote byte) (string, int) {
 				// Invalid or incomplete UTF-8 — fall back to slow path.
 				return "", 0
 			}
+			if !xmlchar.IsChar(r) {
+				// XML-forbidden char — fall back to the slow path, which
+				// reports the invalid character.
+				return "", 0
+			}
 			off += w
 		}
 	}

--- a/internal/strcursor/utf8cursor.go
+++ b/internal/strcursor/utf8cursor.go
@@ -113,12 +113,13 @@ func scanASCIINameChars(data []byte) int {
 // It works directly on a byte buffer, decoding UTF-8 on the fly.
 // ASCII bytes (< 0x80) are handled without utf8.DecodeRune overhead.
 type UTF8Cursor struct {
-	buf    []byte
-	buflen int
-	bufpos int
-	column int
-	in     io.Reader
-	lineno int
+	buf     []byte
+	buflen  int
+	bufpos  int
+	column  int
+	in      io.Reader
+	lineno  int
+	readErr error // sticky non-EOF read error (e.g. a transcoding/decode error)
 }
 
 // NewUTF8Cursor creates a UTF8Cursor wrapping an existing io.Reader.
@@ -161,6 +162,12 @@ func (c *UTF8Cursor) fillBuffer(minBytes int) error {
 		n, err := c.in.Read(c.buf[c.buflen:])
 		c.buflen += n
 		if n == 0 && err != nil {
+			// Remember a genuine decode/transcoding error (anything other than
+			// a clean EOF) so the parser can distinguish malformed input from a
+			// normal end-of-stream. Done() treats both as "no more data".
+			if err != io.EOF && c.readErr == nil {
+				c.readErr = err
+			}
 			if c.buflen-c.bufpos >= minBytes {
 				return nil
 			}
@@ -168,6 +175,13 @@ func (c *UTF8Cursor) fillBuffer(minBytes int) error {
 		}
 	}
 	return nil
+}
+
+// Err returns a sticky non-EOF read error encountered while filling the buffer,
+// such as a transcoding/decode error from an underlying encoding decoder. It
+// returns nil if the stream ended cleanly.
+func (c *UTF8Cursor) Err() error {
+	return c.readErr
 }
 
 func (c *UTF8Cursor) Done() bool {

--- a/internal/strcursor/utf8cursor.go
+++ b/internal/strcursor/utf8cursor.go
@@ -161,10 +161,13 @@ func (c *UTF8Cursor) fillBuffer(minBytes int) error {
 	for c.buflen-c.bufpos < minBytes {
 		n, err := c.in.Read(c.buf[c.buflen:])
 		c.buflen += n
-		if n == 0 && err != nil {
+		if err != nil {
 			// Remember a genuine decode/transcoding error (anything other than
 			// a clean EOF) so the parser can distinguish malformed input from a
-			// normal end-of-stream. Done() treats both as "no more data".
+			// normal end-of-stream. Done() treats both as "no more data". The
+			// error must be recorded even when this Read also returned data
+			// (n > 0), because a small input may deliver its decoded bytes and
+			// the decode error together in a single Read.
 			if err != io.EOF && c.readErr == nil {
 				c.readErr = err
 			}

--- a/internal/xmlchar/xmlchar.go
+++ b/internal/xmlchar/xmlchar.go
@@ -1,6 +1,15 @@
 // Package xmlchar provides XML 1.0 NCName character classification functions.
 package xmlchar
 
+// IsChar reports whether r is a valid XML 1.0 §2.2 Char.
+// Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+func IsChar(r rune) bool {
+	if r < 0x100 {
+		return r == 0x9 || r == 0xA || r == 0xD || r >= 0x20
+	}
+	return (r >= 0x100 && r <= 0xD7FF) || (r >= 0xE000 && r <= 0xFFFD) || (r >= 0x10000 && r <= 0x10FFFF)
+}
+
 // IsNCNameStartChar checks the XML 1.0 NCName start character production.
 // NCNameStartChar ::= [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6]
 //

--- a/internal/xmlchar/xmlchar_test.go
+++ b/internal/xmlchar/xmlchar_test.go
@@ -1,6 +1,7 @@
 package xmlchar_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/lestrrat-go/helium/internal/xmlchar"
@@ -62,7 +63,7 @@ func TestIsChar(t *testing.T) {
 		{0x110000, false}, // beyond Unicode range
 	}
 	for _, tt := range tests {
-		t.Run(string(tt.r), func(t *testing.T) {
+		t.Run(fmt.Sprintf("U+%04X", tt.r), func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tt.want, xmlchar.IsChar(tt.r), "IsChar(%#x)", tt.r)
 		})
@@ -87,7 +88,7 @@ func TestIsNCNameStartChar(t *testing.T) {
 		{' ', false},
 	}
 	for _, tt := range tests {
-		t.Run(string(tt.r), func(t *testing.T) {
+		t.Run(fmt.Sprintf("U+%04X", tt.r), func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tt.want, xmlchar.IsNCNameStartChar(tt.r))
 		})
@@ -112,7 +113,7 @@ func TestIsNCNameChar(t *testing.T) {
 		{' ', false},
 	}
 	for _, tt := range tests {
-		t.Run(string(tt.r), func(t *testing.T) {
+		t.Run(fmt.Sprintf("U+%04X", tt.r), func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tt.want, xmlchar.IsNCNameChar(tt.r))
 		})

--- a/internal/xmlchar/xmlchar_test.go
+++ b/internal/xmlchar/xmlchar_test.go
@@ -62,7 +62,7 @@ func TestIsChar(t *testing.T) {
 		{0x110000, false}, // beyond Unicode range
 	}
 	for _, tt := range tests {
-		t.Run(string(rune(tt.r)), func(t *testing.T) {
+		t.Run(string(tt.r), func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tt.want, xmlchar.IsChar(tt.r), "IsChar(%#x)", tt.r)
 		})

--- a/internal/xmlchar/xmlchar_test.go
+++ b/internal/xmlchar/xmlchar_test.go
@@ -38,6 +38,37 @@ func TestIsValidNCName(t *testing.T) {
 	}
 }
 
+func TestIsChar(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		r    rune
+		want bool
+	}{
+		{0x8, false},      // backspace, control
+		{0x9, true},       // tab
+		{0xA, true},       // LF
+		{0xD, true},       // CR
+		{0x1F, false},     // unit separator, control
+		{0x20, true},      // space
+		{0xD7FF, true},    // last before surrogate range
+		{0xD800, false},   // surrogate
+		{0xDFFF, false},   // surrogate
+		{0xE000, true},    // first after surrogate range
+		{0xFFFD, true},    // replacement char (valid Char)
+		{0xFFFE, false},   // non-character
+		{0xFFFF, false},   // non-character
+		{0x10000, true},   // first supplementary
+		{0x10FFFF, true},  // last valid code point
+		{0x110000, false}, // beyond Unicode range
+	}
+	for _, tt := range tests {
+		t.Run(string(rune(tt.r)), func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, xmlchar.IsChar(tt.r), "IsChar(%#x)", tt.r)
+		})
+	}
+}
+
 func TestIsNCNameStartChar(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/parser_document.go
+++ b/parser_document.go
@@ -203,6 +203,12 @@ func (pctx *parserCtx) parseDocument(ctx context.Context) error {
 	if !cur.Done() {
 		return pctx.error(ctx, ErrDocumentEnd)
 	}
+	// A clean Done() may mask a transcoding/decode error (e.g. an unpaired
+	// UTF-16 surrogate the decoder replaced with U+FFFD). Surface it as a fatal
+	// error rather than accepting truncated/malformed encoded input.
+	if err := pctx.cursorDecodeErr(); err != nil {
+		return pctx.error(ctx, err)
+	}
 	pctx.instate = psEOF
 
 	// All done

--- a/parser_element.go
+++ b/parser_element.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lestrrat-go/helium/enum"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/strcursor"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 	"github.com/lestrrat-go/helium/sax"
 	"github.com/lestrrat-go/pdebug"
 )
@@ -569,7 +570,22 @@ func (pctx *parserCtx) parseAttributeValueInternal(ctx context.Context, qch byte
 
 	for {
 		c := cur.PeekRune()
-		if (qch != 0x0 && c == rune(qch)) || !isChar(c) || c == '<' {
+		if (qch != 0x0 && c == rune(qch)) || c == '<' {
+			break
+		}
+		// Width-aware char validation: a real U+FFFD is encoded as valid
+		// 3-byte UTF-8 and is a legal XML Char, whereas invalid/incomplete
+		// UTF-8 decodes to RuneError with width 1. isChar rejects every
+		// RuneError, so decode with width here to tell the two apart and
+		// keep the slow path consistent with the fast path.
+		dr, dw, ok := decodeRuneAt(cur, 0)
+		if !ok {
+			break
+		}
+		if dr == utf8.RuneError && dw == 1 {
+			break
+		}
+		if !xmlchar.IsChar(dr) {
 			break
 		}
 		switch c {
@@ -644,9 +660,11 @@ func (pctx *parserCtx) parseAttributeValueInternal(ctx context.Context, qch byte
 			}
 		default:
 			inSpace = false
-			b.WriteRune(c)
-			w := max(utf8.RuneLen(c), 1)
-			if err := cur.Advance(w); err != nil {
+			// Write the raw decoded bytes (dw wide) so a real U+FFFD round-trips
+			// intact; WriteRune(c) would re-encode RuneError and utf8.RuneLen(c)
+			// would be -1, advancing too few bytes.
+			b.WriteString(cur.PeekString(dw))
+			if err := cur.Advance(dw); err != nil {
 				return "", 0, err
 			}
 		}

--- a/parser_entity_decl.go
+++ b/parser_entity_decl.go
@@ -448,6 +448,13 @@ func (pctx *parserCtx) parseExternalEntityPrivate(ctx context.Context, uri, exte
 	if err := newctx.parseContent(innerCtx); err != nil {
 		return nil, err
 	}
+	// A clean parseContent may mask a transcoding/decode error (e.g. an unpaired
+	// UTF-16 surrogate the decoder replaced with U+FFFD) in this context's own
+	// byte stream. Surface it as fatal rather than inserting U+FFFD, matching the
+	// document-level gate in parseDocument.
+	if err := newctx.cursorDecodeErr(); err != nil {
+		return nil, newctx.error(innerCtx, err)
+	}
 
 	if child := newctx.doc.FirstChild(); child != nil {
 		if grandchild := child.FirstChild(); grandchild != nil {
@@ -537,6 +544,13 @@ func (pctx *parserCtx) parseBalancedChunkInternal(ctx context.Context, chunk []b
 	innerCtx = context.WithValue(innerCtx, stopFuncKey{}, newctx.stop)
 	if err := newctx.parseContent(innerCtx); err != nil {
 		return nil, err
+	}
+	// A clean parseContent may mask a transcoding/decode error (e.g. an unpaired
+	// UTF-16 surrogate the decoder replaced with U+FFFD) in this context's own
+	// byte stream. Surface it as fatal rather than inserting U+FFFD, matching the
+	// document-level gate in parseDocument.
+	if err := newctx.cursorDecodeErr(); err != nil {
+		return nil, newctx.error(innerCtx, err)
 	}
 
 	if child := newctx.doc.FirstChild(); child != nil {

--- a/parser_test.go
+++ b/parser_test.go
@@ -385,6 +385,64 @@ func newStringParseInput(content, uri string) *stringParseInput {
 
 func (s *stringParseInput) URI() string { return s.uri }
 
+func TestParseExternalEntityMalformedEncoding(t *testing.T) {
+	t.Parallel()
+
+	const input = `<?xml version="1.0"?>
+<!DOCTYPE doc [
+  <!ENTITY ext SYSTEM "ext.xml">
+]>
+<doc>&ext;</doc>`
+
+	// External entity bytes: UTF-16BE BOM, then "<a>" and an unpaired high
+	// surrogate (0xD800) before "</a>". The decoder would silently substitute
+	// U+FFFD for the surrogate; the parser must instead treat it as fatal,
+	// matching the document-level decode-error gate.
+	utf16be := func(s string) []byte {
+		b := make([]byte, 0, len(s)*2)
+		for _, r := range s {
+			b = append(b, byte(r>>8), byte(r))
+		}
+		return b
+	}
+	ent := []byte{0xFE, 0xFF} // BOM
+	ent = append(ent, utf16be("<a>")...)
+	ent = append(ent, 0xD8, 0x00) // unpaired high surrogate
+	ent = append(ent, utf16be("</a>")...)
+
+	fsys := fstest.MapFS{"ext.xml": &fstest.MapFile{Data: ent}}
+
+	p := helium.NewParser().SubstituteEntities(true).FS(fsys)
+	_, err := p.Parse(t.Context(), []byte(input))
+	require.Error(t, err, "malformed UTF-16 external entity must fail rather than inserting U+FFFD")
+}
+
+func TestParseExternalEntityValidEncoding(t *testing.T) {
+	t.Parallel()
+
+	const input = `<?xml version="1.0"?>
+<!DOCTYPE doc [
+  <!ENTITY ext SYSTEM "ext.xml">
+]>
+<doc>&ext;</doc>`
+
+	// A well-formed UTF-16BE external entity (BOM + "<a/>") must still load.
+	utf16be := func(s string) []byte {
+		b := make([]byte, 0, len(s)*2)
+		for _, r := range s {
+			b = append(b, byte(r>>8), byte(r))
+		}
+		return b
+	}
+	ent := append([]byte{0xFE, 0xFF}, utf16be("<a/>")...)
+
+	fsys := fstest.MapFS{"ext.xml": &fstest.MapFile{Data: ent}}
+
+	p := helium.NewParser().SubstituteEntities(true).FS(fsys)
+	_, err := p.Parse(t.Context(), []byte(input))
+	require.NoError(t, err, "well-formed UTF-16 external entity must load")
+}
+
 func TestValidateDTD(t *testing.T) {
 	t.Parallel()
 

--- a/parser_utf16_surrogate_test.go
+++ b/parser_utf16_surrogate_test.go
@@ -1,0 +1,62 @@
+package helium_test
+
+import (
+	"encoding/binary"
+	"testing"
+	"unicode/utf16"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// utf16beWithUnits encodes s as UTF-16BE (with a BOM) and appends any extra raw
+// 16-bit code units verbatim, so malformed sequences (e.g. an unpaired
+// surrogate) can be injected. The pieces are concatenated in order.
+func utf16beDoc(parts ...any) []byte {
+	out := []byte{0xFE, 0xFF} // UTF-16BE BOM
+	for _, p := range parts {
+		switch v := p.(type) {
+		case string:
+			for _, u := range utf16.Encode([]rune(v)) {
+				out = binary.BigEndian.AppendUint16(out, u)
+			}
+		case uint16:
+			out = binary.BigEndian.AppendUint16(out, v)
+		default:
+			panic("unsupported part type")
+		}
+	}
+	return out
+}
+
+func TestParseUTF16UnpairedSurrogate(t *testing.T) {
+	const unpairedHigh = uint16(0xD800) // lone high surrogate: malformed input
+
+	t.Run("unpaired surrogate in text content is rejected", func(t *testing.T) {
+		doc := utf16beDoc("<r>", unpairedHigh, "</r>")
+		_, err := helium.NewParser().Parse(t.Context(), doc)
+		require.Error(t, err, "unpaired surrogate in text content must be a fatal error")
+	})
+
+	t.Run("unpaired surrogate in attribute value is rejected", func(t *testing.T) {
+		doc := utf16beDoc(`<r a="`, unpairedHigh, `"/>`)
+		_, err := helium.NewParser().Parse(t.Context(), doc)
+		require.Error(t, err, "unpaired surrogate in attribute value must be a fatal error")
+	})
+
+	t.Run("genuine U+FFFD in text content is accepted", func(t *testing.T) {
+		doc := utf16beDoc("<r>�</r>")
+		parsed, err := helium.NewParser().Parse(t.Context(), doc)
+		require.NoError(t, err, "genuine U+FFFD is a valid XML character")
+		root := parsed.DocumentElement()
+		require.NotNil(t, root)
+		require.Equal(t, "�", string(root.Content()))
+	})
+
+	t.Run("genuine U+FFFD in attribute value is accepted", func(t *testing.T) {
+		doc := utf16beDoc("<r a=\"�\"/>")
+		parsed, err := helium.NewParser().Parse(t.Context(), doc)
+		require.NoError(t, err, "genuine U+FFFD is a valid XML character")
+		require.NotNil(t, parsed.DocumentElement())
+	})
+}

--- a/parserctx.go
+++ b/parserctx.go
@@ -373,6 +373,19 @@ func (ctx *parserCtx) getCursor() strcursor.Cursor {
 	return nil
 }
 
+// cursorDecodeErr returns a sticky transcoding/decode error from the active
+// cursor, if any. Such an error (e.g. an unpaired UTF-16 surrogate that the
+// decoder replaced with U+FFFD) is otherwise indistinguishable from a clean
+// EOF via Done(), so callers must consult this explicitly to reject malformed
+// encoded input.
+func (ctx *parserCtx) cursorDecodeErr() error {
+	u8, ok := ctx.getCursor().(*strcursor.UTF8Cursor)
+	if !ok {
+		return nil
+	}
+	return u8.Err()
+}
+
 func (ctx *parserCtx) popInput() any { //nolint:unparam // return value used for type generality
 	ctx.cachedCursor = nil // invalidate cache
 	return ctx.inputTab.Pop()

--- a/xmlchar_parse_test.go
+++ b/xmlchar_parse_test.go
@@ -1,0 +1,51 @@
+package helium_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseRejectsNonXMLChars verifies that XML-forbidden Unicode scalars in
+// text content (XML 1.0 §2.2 Char production) are rejected by the parser,
+// while valid characters in the same neighborhood still parse.
+func TestParseRejectsNonXMLChars(t *testing.T) {
+	t.Parallel()
+
+	invalid := []struct {
+		name string
+		r    rune
+	}{
+		{"U+FFFE", 0xFFFE},
+		{"U+FFFF", 0xFFFF},
+	}
+	for _, tt := range invalid {
+		t.Run("invalid/"+tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := "<r>" + string(tt.r) + "</r>"
+			p := helium.NewParser()
+			_, err := p.Parse(t.Context(), []byte(input))
+			require.Error(t, err, "parsing forbidden char %s must fail", tt.name)
+		})
+	}
+
+	valid := []struct {
+		name string
+		r    rune
+	}{
+		{"U+009F", 0x009F},   // C1 control, but a valid XML Char
+		{"U+E000", 0xE000},   // first after surrogate range
+		{"U+10FFFF", 0x10FFFF}, // last valid code point
+		{"U+1FFFE", 0x1FFFE},  // non-character per Unicode, but valid XML Char
+	}
+	for _, tt := range valid {
+		t.Run("valid/"+tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := "<r>" + string(tt.r) + "</r>"
+			p := helium.NewParser()
+			_, err := p.Parse(t.Context(), []byte(input))
+			require.NoError(t, err, "parsing valid char %s must succeed", tt.name)
+		})
+	}
+}

--- a/xmlchar_parse_test.go
+++ b/xmlchar_parse_test.go
@@ -34,10 +34,11 @@ func TestParseRejectsNonXMLChars(t *testing.T) {
 		name string
 		r    rune
 	}{
-		{"U+009F", 0x009F},   // C1 control, but a valid XML Char
-		{"U+E000", 0xE000},   // first after surrogate range
+		{"U+009F", 0x009F},     // C1 control, but a valid XML Char
+		{"U+E000", 0xE000},     // first after surrogate range
+		{"U+FFFD", 0xFFFD},     // replacement char — valid XML Char, decodes as RuneError
 		{"U+10FFFF", 0x10FFFF}, // last valid code point
-		{"U+1FFFE", 0x1FFFE},  // non-character per Unicode, but valid XML Char
+		{"U+1FFFE", 0x1FFFE},   // non-character per Unicode, but valid XML Char
 	}
 	for _, tt := range valid {
 		t.Run("valid/"+tt.name, func(t *testing.T) {
@@ -65,4 +66,18 @@ func TestParseRejectsNonXMLCharsInAttr(t *testing.T) {
 	p := helium.NewParser()
 	_, err := p.Parse(t.Context(), []byte(`<r a="`+string(rune(0x4E2D))+`"/>`))
 	require.NoError(t, err)
+}
+
+// TestParseAttrWhitespaceNormalization checks the attribute-value fast path
+// normalizes a literal tab to a space (XML 1.0 §3.3.3), matching newline/CR.
+func TestParseAttrWhitespaceNormalization(t *testing.T) {
+	t.Parallel()
+
+	for _, ws := range []string{"\t", "\n", "\r"} {
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(`<r a="x`+ws+`y"/>`))
+		require.NoError(t, err)
+		attrs := doc.DocumentElement().Attributes()
+		require.Len(t, attrs, 1)
+		require.Equal(t, "x y", string(attrs[0].Value()), "whitespace %q must normalize to space", ws)
+	}
 }

--- a/xmlchar_parse_test.go
+++ b/xmlchar_parse_test.go
@@ -78,6 +78,6 @@ func TestParseAttrWhitespaceNormalization(t *testing.T) {
 		require.NoError(t, err)
 		attrs := doc.DocumentElement().Attributes()
 		require.Len(t, attrs, 1)
-		require.Equal(t, "x y", string(attrs[0].Value()), "whitespace %q must normalize to space", ws)
+		require.Equal(t, "x y", attrs[0].Value(), "whitespace %q must normalize to space", ws)
 	}
 }

--- a/xmlchar_parse_test.go
+++ b/xmlchar_parse_test.go
@@ -49,3 +49,20 @@ func TestParseRejectsNonXMLChars(t *testing.T) {
 		})
 	}
 }
+
+// TestParseRejectsNonXMLCharsInAttr covers the attribute-value fast path, which
+// must reject XML-forbidden chars just like text content.
+func TestParseRejectsNonXMLCharsInAttr(t *testing.T) {
+	t.Parallel()
+
+	for _, r := range []rune{0xFFFE, 0xFFFF} {
+		input := `<r a="` + string(r) + `"/>`
+		p := helium.NewParser()
+		_, err := p.Parse(t.Context(), []byte(input))
+		require.Error(t, err, "forbidden char U+%04X in attribute value must fail", r)
+	}
+	// A valid multibyte char in an attribute must still parse.
+	p := helium.NewParser()
+	_, err := p.Parse(t.Context(), []byte(`<r a="`+string(rune(0x4E2D))+`"/>`))
+	require.NoError(t, err)
+}

--- a/xmlchar_parse_test.go
+++ b/xmlchar_parse_test.go
@@ -68,6 +68,48 @@ func TestParseRejectsNonXMLCharsInAttr(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestParseAttrSlowPathXMLChars covers the attribute-value slow path
+// (parseAttributeValueInternal). The slow path is forced by including an
+// entity reference or a tab (which needs whitespace normalization) in the
+// same attribute. A real U+FFFD (valid XML Char, encoded as 3-byte UTF-8)
+// must parse, while XML-forbidden chars must still be rejected.
+func TestParseAttrSlowPathXMLChars(t *testing.T) {
+	t.Parallel()
+
+	// Triggers that force the slow path: an entity ref and a normalizable tab.
+	triggers := []struct {
+		name string
+		// before/after wrap the test char in the attribute value.
+		before string
+		after  string
+	}{
+		{"entity-after", "", "&amp;"},
+		{"entity-before", "&amp;", ""},
+		{"tab-after", "", "\tx"},
+	}
+
+	t.Run("valid-U+FFFD", func(t *testing.T) {
+		t.Parallel()
+		for _, tr := range triggers {
+			t.Run(tr.name, func(t *testing.T) {
+				t.Parallel()
+				input := `<r a="` + tr.before + string(rune(0xFFFD)) + tr.after + `"/>`
+				_, err := helium.NewParser().Parse(t.Context(), []byte(input))
+				require.NoError(t, err, "real U+FFFD on slow path must parse (%s)", tr.name)
+			})
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		t.Parallel()
+		for _, r := range []rune{0xFFFE, 0xFFFF} {
+			input := `<r a="` + string(r) + `&amp;"/>`
+			_, err := helium.NewParser().Parse(t.Context(), []byte(input))
+			require.Error(t, err, "forbidden char U+%04X on slow path must fail", r)
+		}
+	})
+}
+
 // TestParseAttrWhitespaceNormalization checks the attribute-value fast path
 // normalizes a literal tab to a space (XML 1.0 §3.3.3), matching newline/CR.
 func TestParseAttrWhitespaceNormalization(t *testing.T) {


### PR DESCRIPTION
- Char-data scanners accepted XML-forbidden Unicode scalars (U+FFFE, U+FFFF, surrogates, beyond-range) in text content; they only rejected `utf8.RuneError` and runes `< 0x20`.
- Add `xmlchar.IsChar` implementing the XML 1.0 §2.2 Char production; ASCII fast path keeps `IsChar` on the multibyte branch only.
- Wire it into `UTF8Cursor.ScanCharDataSlice` / `ScanCharDataInto` and `RuneCursor.ScanCharDataInto`. Invalid chars stop the scan, surfacing the existing "invalid char data" parser error.
- Tests: `IsChar` boundary cases; root parse test rejecting U+FFFE/U+FFFF and accepting U+009F/U+E000/U+10FFFF/U+1FFFE.
- `go test ./internal/... ./...` passes, no regressions.
