### PR TITLE
xpath: reject fragment in base uri for empty arg

### DIFF
--- a/internal/unparsedtext/unparsedtext.go
+++ b/internal/unparsedtext/unparsedtext.go
@@ -114,6 +114,11 @@ func ResolveURI(_ context.Context, cfg *Config, href string) (string, error) {
 
 	if href == "" {
 		if cfg != nil && cfg.BaseURI != "" {
+			// An empty href resolves to the base URI verbatim; the base URI
+			// must not carry a fragment identifier either.
+			if strings.Contains(cfg.BaseURI, "#") {
+				return "", &Error{Code: ErrCodeRetrieval, Message: "base URI must not contain a fragment identifier"}
+			}
 			return cfg.BaseURI, nil
 		}
 		return "", &Error{Code: ErrCodeRetrieval, Message: "empty href and no base URI available"}

--- a/internal/unparsedtext/unparsedtext_test.go
+++ b/internal/unparsedtext/unparsedtext_test.go
@@ -594,3 +594,22 @@ func TestLoadTextHTTP(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "hello from http", text)
 }
+
+func TestResolveURIFragmentBaseURI(t *testing.T) {
+	t.Run("empty href with fragmented base URI is rejected", func(t *testing.T) {
+		cfg := &unparsedtext.Config{BaseURI: "file:///tmp/data.txt#frag"}
+		_, err := unparsedtext.ResolveURI(t.Context(), cfg, "")
+		require.Error(t, err)
+		var ue *unparsedtext.Error
+		require.ErrorAs(t, err, &ue)
+		require.Equal(t, unparsedtext.ErrCodeRetrieval, ue.Code)
+		require.Contains(t, ue.Message, "fragment")
+	})
+
+	t.Run("empty href with plain base URI still resolves", func(t *testing.T) {
+		cfg := &unparsedtext.Config{BaseURI: "file:///tmp/data.txt"}
+		resolved, err := unparsedtext.ResolveURI(t.Context(), cfg, "")
+		require.NoError(t, err)
+		require.Equal(t, "file:///tmp/data.txt", resolved)
+	})
+}

--- a/xpath3/evaluator_test.go
+++ b/xpath3/evaluator_test.go
@@ -140,3 +140,23 @@ func TestEvaluator(t *testing.T) {
 		require.InDelta(t, 3.0, n, 0.001)
 	})
 }
+
+func TestDocEmptyArgFragmentBaseURI(t *testing.T) {
+	// doc("") resolves to the base URI verbatim. When that base URI carries a
+	// fragment identifier the call must raise FODC0005, the same as a fragment
+	// in an explicit argument.
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root/>`))
+	require.NoError(t, err)
+
+	expr, err := xpath3.NewCompiler().Compile(`doc("")`)
+	require.NoError(t, err)
+
+	_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		BaseURI("file:///tmp/doc.xml#frag").
+		Evaluate(t.Context(), expr, doc)
+	require.Error(t, err)
+
+	var xerr *xpath3.XPathError
+	require.ErrorAs(t, err, &xerr)
+	require.Equal(t, "FODC0005", xerr.Code)
+}

--- a/xpath3/functions_node.go
+++ b/xpath3/functions_node.go
@@ -950,6 +950,12 @@ func loadDoc(ctx context.Context, uri string) (helium.Node, error) {
 	if err != nil {
 		return nil, err
 	}
+	// An empty argument resolves to the base URI verbatim, which may itself
+	// carry a fragment identifier. Re-check the resolved URI so doc("") with a
+	// fragmented base URI is rejected the same as a fragmented argument.
+	if strings.Contains(resolved, "#") {
+		return nil, &XPathError{Code: errCodeFODC0005, Message: "fn:doc: URI must not contain a fragment identifier"}
+	}
 	if ec := getFnContext(ctx); ec != nil {
 		if doc, ok := ec.docCache[resolved]; ok {
 			return doc, nil


### PR DESCRIPTION
- `fn:doc("")` now raises FODC0005 when the static base URI carries a fragment identifier (was silently bypassed; only the raw argument was checked)
- `unparsed-text("")` / `json-doc("")` now raise FOUT1170 when the base URI carries a fragment (empty-href branch in `unparsedtext.ResolveURI` returned the base URI verbatim)
- regression tests added in `xpath3` and `internal/unparsedtext`
