### PR TITLE
xpath1: document-order external node-set vars

### DIFF
--- a/xpath1/eval.go
+++ b/xpath1/eval.go
@@ -632,7 +632,11 @@ func evalVariableExpr(ec *evalContext, e VariableExpr) (*Result, error) {
 	}
 	switch val := v.(type) {
 	case []helium.Node:
-		return &Result{Type: NodeSetResult, NodeSet: val}, nil
+		nodes, err := ixpath.DeduplicateNodes(val, ec.docOrder, maxNodeSetLength)
+		if err != nil {
+			return nil, err
+		}
+		return &Result{Type: NodeSetResult, NodeSet: nodes}, nil
 	case string:
 		return &Result{Type: StringResult, String: val}, nil
 	case float64:

--- a/xpath1/eval.go
+++ b/xpath1/eval.go
@@ -632,7 +632,15 @@ func evalVariableExpr(ec *evalContext, e VariableExpr) (*Result, error) {
 	}
 	switch val := v.(type) {
 	case []helium.Node:
-		nodes, err := ixpath.DeduplicateNodes(val, ec.docOrder, maxNodeSetLength)
+		// Caller-provided slices may contain nil entries; drop them so
+		// DeduplicateNodes (which dereferences each node) cannot panic.
+		clean := make([]helium.Node, 0, len(val))
+		for _, n := range val {
+			if n != nil {
+				clean = append(clean, n)
+			}
+		}
+		nodes, err := ixpath.DeduplicateNodes(clean, ec.docOrder, maxNodeSetLength)
 		if err != nil {
 			return nil, err
 		}

--- a/xpath1/eval.go
+++ b/xpath1/eval.go
@@ -634,9 +634,11 @@ func evalVariableExpr(ec *evalContext, e VariableExpr) (*Result, error) {
 	case []helium.Node:
 		// Caller-provided slices may contain nil entries; drop them so
 		// DeduplicateNodes (which dereferences each node) cannot panic.
+		// IsNilNode also catches typed-nil concrete pointers, which are
+		// non-nil at the interface level but still panic on dereference.
 		clean := make([]helium.Node, 0, len(val))
 		for _, n := range val {
-			if n != nil {
+			if !ixpath.IsNilNode(n) {
 				clean = append(clean, n)
 			}
 		}

--- a/xpath1/eval_test.go
+++ b/xpath1/eval_test.go
@@ -489,6 +489,23 @@ func TestEvalNodeSetVariableDocumentOrder(t *testing.T) {
 	require.Equal(t, "AAA", r.String)
 }
 
+func TestEvalNodeSetVariableTypedNil(t *testing.T) {
+	doc := parseXML(t, `<root><a/></root>`)
+	a := docElement(doc)
+	require.NotNil(t, a)
+
+	// A typed-nil concrete node pointer is non-nil at the interface level,
+	// so a naive `n != nil` filter lets it through and DeduplicateNodes
+	// panics dereferencing it. It must be filtered out instead.
+	expr, err := xpath1.Compile("count($v)")
+	require.NoError(t, err)
+	r, err := xpath1.NewEvaluator().Variables(map[string]any{
+		"v": []helium.Node{a, (*helium.Element)(nil)},
+	}).Evaluate(t.Context(), expr, doc)
+	require.NoError(t, err)
+	require.Equal(t, 1.0, r.Number)
+}
+
 // --- Complex expressions ---
 
 func TestEvalBookstoreExample(t *testing.T) {

--- a/xpath1/eval_test.go
+++ b/xpath1/eval_test.go
@@ -468,6 +468,27 @@ func TestEvalVariable(t *testing.T) {
 	require.Equal(t, 42.0, r.Number)
 }
 
+func TestEvalNodeSetVariableDocumentOrder(t *testing.T) {
+	doc := parseXML(t, `<root><a>AAA</a><b>BBB</b></root>`)
+	nodes, err := xpath1.Find(t.Context(), doc, "/root/*")
+	require.NoError(t, err)
+	require.Len(t, nodes, 2)
+	a, b := nodes[0], nodes[1]
+	require.Equal(t, "a", a.Name())
+	require.Equal(t, "b", b.Name())
+
+	// Bind $v in reversed (non-document) order. string($v) must return the
+	// value of the first node in document order ("AAA"), not the slice's
+	// first element ("BBB").
+	expr, err := xpath1.Compile("string($v)")
+	require.NoError(t, err)
+	r, err := xpath1.NewEvaluator().Variables(map[string]any{
+		"v": []helium.Node{b, a},
+	}).Evaluate(t.Context(), expr, doc)
+	require.NoError(t, err)
+	require.Equal(t, "AAA", r.String)
+}
+
 // --- Complex expressions ---
 
 func TestEvalBookstoreExample(t *testing.T) {


### PR DESCRIPTION
- `evalVariableExpr` now routes external `[]helium.Node` variables through `ixpath.DeduplicateNodes` (document-order sort + dedup), matching every other node-set producer
- Previously caller slice order leaked into `string($v)`/`number($v)`/comparisons, picking the wrong "first" node
- Adds regression test binding `$v` in reversed order and asserting `string($v)` returns the document-order first node
