### PR TITLE
xpath3: require xs:integer array positions

### DIFF
--- a/xpath3/functions.go
+++ b/xpath3/functions.go
@@ -399,18 +399,6 @@ func coerceToInteger(a AtomicValue) (AtomicValue, error) {
 	return a, nil
 }
 
-// seqToDouble atomizes the first item to a float64.
-func seqToDouble(seq Sequence) float64 {
-	if seqLen(seq) == 0 {
-		return 0
-	}
-	a, err := AtomizeItem(seq.Get(0))
-	if err != nil {
-		return 0
-	}
-	return a.ToFloat64()
-}
-
 func init() {
 	registerFn("boolean", 1, 1, fnBoolean)
 	registerFn("not", 1, 1, fnNot)

--- a/xpath3/functions_array.go
+++ b/xpath3/functions_array.go
@@ -111,10 +111,16 @@ func fnArraySubarray(_ context.Context, args []Sequence) (Sequence, error) {
 	if err != nil {
 		return nil, err
 	}
-	start := int(seqToDouble(args[1]))
+	start, err := extractArrayIndex(args[1])
+	if err != nil {
+		return nil, err
+	}
 	length := a.Size() - start + 1
 	if len(args) > 2 {
-		length = int(seqToDouble(args[2]))
+		length, err = extractArrayIndex(args[2])
+		if err != nil {
+			return nil, err
+		}
 	}
 	sub, err := a.SubArray(start, length)
 	if err != nil {
@@ -136,7 +142,14 @@ func fnArrayRemove(_ context.Context, args []Sequence) (Sequence, error) {
 		if err != nil {
 			return nil, err
 		}
-		pos := int(av.ToFloat64())
+		if !isIntegerDerived(av.TypeName) {
+			return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("array:remove position must be xs:integer, got %s", av.TypeName)}
+		}
+		iv, ok := av.Int64Val()
+		if !ok {
+			return nil, &XPathError{Code: errCodeFOAY0001, Message: "array:remove position out of range"}
+		}
+		pos := int(iv)
 		if pos < 1 || pos > size {
 			return nil, &XPathError{Code: errCodeFOAY0001, Message: fmt.Sprintf("array:remove: position %d out of range 1..%d", pos, size)}
 		}
@@ -157,7 +170,10 @@ func fnArrayInsertBefore(_ context.Context, args []Sequence) (Sequence, error) {
 	if err != nil {
 		return nil, err
 	}
-	pos := int(seqToDouble(args[1]))
+	pos, err := extractArrayIndex(args[1])
+	if err != nil {
+		return nil, err
+	}
 	members := a.members0()
 	if pos < 1 || pos > len(members)+1 {
 		return nil, &XPathError{Code: errCodeFOAY0001, Message: "array index out of bounds"}

--- a/xpath3/functions_array.go
+++ b/xpath3/functions_array.go
@@ -79,6 +79,16 @@ func extractArrayIndex(seq Sequence) (int, error) {
 	if !ok {
 		return 0, &XPathError{Code: errCodeFOAY0001, Message: "array index out of range"}
 	}
+	// On 64-bit platforms int(iv) is exact; on 32-bit, clamp out-of-int values
+	// to the int extremes so the caller's 1..size bounds check still rejects
+	// them (as out of range) rather than wrapping into a valid-looking index.
+	const maxInt = int(^uint(0) >> 1)
+	if iv > int64(maxInt) {
+		return maxInt, nil
+	}
+	if iv < int64(-maxInt-1) {
+		return -maxInt - 1, nil
+	}
 	return int(iv), nil
 }
 
@@ -149,11 +159,12 @@ func fnArrayRemove(_ context.Context, args []Sequence) (Sequence, error) {
 		if !ok {
 			return nil, &XPathError{Code: errCodeFOAY0001, Message: "array:remove position out of range"}
 		}
-		pos := int(iv)
-		if pos < 1 || pos > size {
-			return nil, &XPathError{Code: errCodeFOAY0001, Message: fmt.Sprintf("array:remove: position %d out of range 1..%d", pos, size)}
+		// Range-check on int64 before converting so an out-of-int value cannot
+		// wrap into a valid-looking position (e.g. on 32-bit platforms).
+		if iv < 1 || iv > int64(size) {
+			return nil, &XPathError{Code: errCodeFOAY0001, Message: fmt.Sprintf("array:remove: position %d out of range 1..%d", iv, size)}
 		}
-		positions[pos] = struct{}{}
+		positions[int(iv)] = struct{}{}
 	}
 	members := a.members0()
 	var result []Sequence

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -432,6 +432,8 @@ func TestFnArrayIntegerPositions(t *testing.T) {
 		for _, expr := range []string{
 			`array:remove([1, 2], 5)`,
 			`array:insert-before([1, 2], 0, 9)`,
+			// Huge start+length must not overflow into a make() panic.
+			`array:subarray([1], 6917529027641081856, 6917529027641081856)`,
 		} {
 			t.Run(expr, func(t *testing.T) {
 				evalErrCode(t, expr, "FOAY0001")

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -397,6 +397,81 @@ func TestFnArray(t *testing.T) {
 	})
 }
 
+// --- array position-argument integer validation ---
+
+func TestFnArrayIntegerPositions(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	evalErrCode := func(t *testing.T, expr, code string) {
+		t.Helper()
+		compiled, err := xpath3.NewCompiler().Compile(expr)
+		require.NoError(t, err)
+		_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.Error(t, err, "expected error for %q", expr)
+		require.ErrorIs(t, err, &xpath3.XPathError{Code: code}, "expected error code %s for %q", code, expr)
+	}
+
+	// Non-integer or wrong-cardinality position arguments must raise XPTY0004.
+	t.Run("XPTY0004", func(t *testing.T) {
+		for _, expr := range []string{
+			`array:remove([1, 2], 1.5)`,
+			`array:subarray([1, 2, 3], 1.5)`,
+			`array:subarray([1, 2, 3], 2, 1.5)`,
+			`array:subarray([1, 2, 3], ())`,
+			`array:insert-before([1, 2], 1.5, 9)`,
+			`array:insert-before([1, 2], (), 9)`,
+		} {
+			t.Run(expr, func(t *testing.T) {
+				evalErrCode(t, expr, "XPTY0004")
+			})
+		}
+	})
+
+	// Out-of-range integer positions must raise FOAY0001.
+	t.Run("FOAY0001", func(t *testing.T) {
+		for _, expr := range []string{
+			`array:remove([1, 2], 5)`,
+			`array:insert-before([1, 2], 0, 9)`,
+		} {
+			t.Run(expr, func(t *testing.T) {
+				evalErrCode(t, expr, "FOAY0001")
+			})
+		}
+	})
+
+	// Valid invocations must continue to work (no regression).
+	t.Run("valid", func(t *testing.T) {
+		tests := []struct {
+			expr   string
+			expect []int64
+		}{
+			{`array:remove([1, 2], 1)`, []int64{2}},
+			{`array:remove([1, 2, 3], (1, 2))`, []int64{3}},
+			{`array:remove([1, 2, 3], ())`, []int64{1, 2, 3}},
+			{`array:subarray([1, 2, 3], 2)`, []int64{2, 3}},
+			{`array:subarray([1, 2, 3], 2, 1)`, []int64{2}},
+			{`array:insert-before([1, 2], 1, 9)`, []int64{9, 1, 2}},
+			{`array:insert-before([1, 2], 3, 9)`, []int64{1, 2, 9}},
+		}
+		for _, tc := range tests {
+			t.Run(tc.expr, func(t *testing.T) {
+				seq := evalExpr(t, doc, tc.expr)
+				require.Equal(t, 1, seq.Len())
+				arr, ok := seq.Get(0).(xpath3.ArrayItem)
+				require.True(t, ok, "expected array result")
+				require.Equal(t, len(tc.expect), arr.Size())
+				for i, want := range tc.expect {
+					member, err := arr.Get(i + 1)
+					require.NoError(t, err)
+					require.Equal(t, 1, member.Len())
+					av := member.Get(0).(xpath3.AtomicValue)
+					require.Equal(t, want, av.IntegerVal())
+				}
+			})
+		}
+	})
+}
+
 // --- URI functions ---
 
 func TestFnURI(t *testing.T) {

--- a/xpath3/types.go
+++ b/xpath3/types.go
@@ -910,10 +910,14 @@ func (a ArrayItem) get0(index int) (Sequence, error) {
 
 // SubArray returns a new array from start to end (1-based, inclusive).
 func (a ArrayItem) SubArray(start, length int) (ArrayItem, error) {
-	if start < 1 || length < 0 || start+length-1 > len(a.members) {
+	size := len(a.members)
+	// Bounds are checked without forming start+length, which can overflow for
+	// huge positions and bypass the guard, leading to a make([]Sequence, length)
+	// panic. With start>=1 established first, size-start+1 cannot overflow.
+	if start < 1 || start > size+1 || length < 0 || length > size-start+1 {
 		return ArrayItem{}, &XPathError{
 			Code:    errCodeFOAY0001,
-			Message: fmt.Sprintf("array subarray(%d, %d) out of bounds (size %d)", start, length, len(a.members)),
+			Message: fmt.Sprintf("array subarray(%d, %d) out of bounds (size %d)", start, length, size),
 		}
 	}
 	newMembers := make([]Sequence, length)


### PR DESCRIPTION
- `array:subarray`, `array:insert-before`, `array:remove` now validate position args as `xs:integer` via the checked `extractArrayIndex` path instead of float-truncating with `seqToDouble`
- non-integer / wrong-cardinality positions raise `XPTY0004`; out-of-range integers raise `FOAY0001`
- `array:remove(arr, ())` still returns the array unchanged (`xs:integer*` allows empty)
