### PR TITLE
xpath3: validate integer/cardinality in sequence fns

### DIFF
--- a/xpath3/functions.go
+++ b/xpath3/functions.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
 	"os"
 	"strings"
@@ -334,7 +335,16 @@ func coerceArgToInteger(seq Sequence) (int64, error) {
 	case int64:
 		return v, nil
 	case *big.Int:
-		return v.Int64(), nil
+		// Int64() silently wraps a value outside int64 range. Clamp to the
+		// signed-64 extremes so callers treat it as out of range rather than a
+		// wrapped (valid-looking) position.
+		if v.IsInt64() {
+			return v.Int64(), nil
+		}
+		if v.Sign() < 0 {
+			return math.MinInt64, nil
+		}
+		return math.MaxInt64, nil
 	default:
 		return 0, fmt.Errorf("xpath3: internal error: expected integer value for %s, got %T", a.TypeName, a.Value)
 	}

--- a/xpath3/functions_sequence.go
+++ b/xpath3/functions_sequence.go
@@ -62,15 +62,20 @@ func fnInsertBefore(_ context.Context, args []Sequence) (Sequence, error) {
 	if err != nil {
 		return nil, err
 	}
-	pos := int(posVal)
 	inserts := args[2]
-
-	if pos < 1 {
-		pos = 1
-	}
 	tItems := seqMaterialize(target)
-	if pos > len(tItems)+1 {
+
+	// Clamp on the int64 value so an oversized position cannot wrap when
+	// converted to int (e.g. on 32-bit platforms): a position past the end
+	// must insert at the end, a position before the start at position 1.
+	var pos int
+	switch {
+	case posVal < 1:
+		pos = 1
+	case posVal > int64(len(tItems)+1):
 		pos = len(tItems) + 1
+	default:
+		pos = int(posVal)
 	}
 
 	iItems := seqMaterialize(inserts)

--- a/xpath3/functions_sequence.go
+++ b/xpath3/functions_sequence.go
@@ -57,14 +57,12 @@ func fnTail(_ context.Context, args []Sequence) (Sequence, error) {
 
 func fnInsertBefore(_ context.Context, args []Sequence) (Sequence, error) {
 	target := args[0]
-	if seqLen(args[1]) == 0 {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "fn:insert-before: position argument is an empty sequence"}
-	}
-	a, err := AtomizeItem(args[1].Get(0))
+	// $position is xs:integer: reject empty/multi-item/non-integer (XPTY0004).
+	posVal, err := coerceArgToInteger(args[1])
 	if err != nil {
 		return nil, err
 	}
-	pos := int(a.ToFloat64())
+	pos := int(posVal)
 	inserts := args[2]
 
 	if pos < 1 {
@@ -117,6 +115,9 @@ func fnSubsequence(_ context.Context, args []Sequence) (Sequence, error) {
 	if seqLen(args[1]) == 0 {
 		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "subsequence: starting position is required"}
 	}
+	if seqLen(args[1]) > 1 {
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "subsequence: starting position must be a single value"}
+	}
 	a, err := AtomizeItem(args[1].Get(0))
 	if err != nil {
 		return nil, err
@@ -139,6 +140,9 @@ func fnSubsequence(_ context.Context, args []Sequence) (Sequence, error) {
 	}
 	var lengthF float64
 	if hasLength {
+		if seqLen(args[2]) > 1 {
+			return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "subsequence: length must be a single value"}
+		}
 		la, err := AtomizeItem(args[2].Get(0))
 		if err != nil {
 			return nil, err

--- a/xpath3/functions_sequence.go
+++ b/xpath3/functions_sequence.go
@@ -92,12 +92,13 @@ func fnRemove(_ context.Context, args []Sequence) (Sequence, error) {
 	if err != nil {
 		return nil, err
 	}
-	pos := int(posVal)
-
 	tItems := seqMaterialize(target)
-	if pos < 1 || pos > len(tItems) {
+	// Range-check on int64 before converting so an out-of-int position cannot
+	// wrap into a valid index (e.g. on 32-bit platforms).
+	if posVal < 1 || posVal > int64(len(tItems)) {
 		return target, nil
 	}
+	pos := int(posVal)
 
 	result := make(ItemSlice, 0, len(tItems)-1)
 	result = append(result, tItems[:pos-1]...)

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -537,3 +537,54 @@ func TestFnImplicitTimezoneReturnsDuration(t *testing.T) {
 	require.Len(t, atomics, 1)
 	require.Equal(t, xpath3.TypeDayTimeDuration, atomics[0].TypeName)
 }
+
+// TestFnSequenceIntegerCardinalityArgs verifies fn:remove/fn:insert-before/
+// fn:subsequence enforce integer/cardinality rules on their position args
+// instead of wrapping (big.Int) or silently ignoring extra/invalid items.
+func TestFnSequenceIntegerCardinalityArgs(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	evalErrCode := func(t *testing.T, expr, code string) {
+		t.Helper()
+		compiled, err := xpath3.NewCompiler().Compile(expr)
+		require.NoError(t, err)
+		_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.Error(t, err, "expected error for %q", expr)
+		require.ErrorIs(t, err, &xpath3.XPathError{Code: code}, "expected %s for %q", code, expr)
+	}
+	evalStrings := func(t *testing.T, expr string) []string {
+		t.Helper()
+		seq := evalExpr(t, doc, expr)
+		out := make([]string, seq.Len())
+		for i := 0; i < seq.Len(); i++ {
+			out[i] = seq.Get(i).(xpath3.AtomicValue).StringVal()
+		}
+		return out
+	}
+
+	t.Run("XPTY0004", func(t *testing.T) {
+		for _, expr := range []string{
+			`insert-before(("a"), "not-a-position", "b")`,
+			`insert-before(("a"), 2.9, "b")`,
+			`insert-before(("a"), (1, 2), "b")`,
+			`subsequence(("a","b","c"), (2, 3))`,
+			`subsequence(("a","b","c"), 2, (1, 2))`,
+		} {
+			t.Run(expr, func(t *testing.T) { evalErrCode(t, expr, "XPTY0004") })
+		}
+	})
+
+	t.Run("oversized integer leaves fn:remove unchanged", func(t *testing.T) {
+		require.Equal(t, []string{"a", "b"}, evalStrings(t, `remove(("a","b"), 18446744073709551617)`))
+		require.Equal(t, []string{"a", "b"}, evalStrings(t, `remove(("a","b"), -18446744073709551617)`))
+	})
+
+	t.Run("valid still works", func(t *testing.T) {
+		require.Equal(t, []string{"b"}, evalStrings(t, `remove(("a","b"), 1)`))
+		require.Equal(t, []string{"x", "a", "b"}, evalStrings(t, `insert-before(("a","b"), 1, "x")`))
+		require.Equal(t, []string{"a", "b", "x"}, evalStrings(t, `insert-before(("a","b"), 99, "x")`))
+		require.Equal(t, []string{"b", "c"}, evalStrings(t, `subsequence(("a","b","c"), 2)`))
+		require.Equal(t, []string{"b"}, evalStrings(t, `subsequence(("a","b","c"), 2, 1)`))
+		require.Equal(t, []string{"c"}, evalStrings(t, `subsequence(("a","b","c"), 2.6)`))
+	})
+}

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -556,7 +556,7 @@ func TestFnSequenceIntegerCardinalityArgs(t *testing.T) {
 		t.Helper()
 		seq := evalExpr(t, doc, expr)
 		out := make([]string, seq.Len())
-		for i := 0; i < seq.Len(); i++ {
+		for i := range seq.Len() {
 			out[i] = seq.Get(i).(xpath3.AtomicValue).StringVal()
 		}
 		return out


### PR DESCRIPTION
- `fn:insert-before` now routes `$position` through the checked xs:integer coercion, rejecting non-integer / wrong-cardinality positions with XPTY0004 (previously truncated strings/decimals to a clamped position)
- `fn:subsequence` rejects multi-item `$startingLoc`/`$length` with XPTY0004 (previously silently used only the first item)
- `coerceArgToInteger` no longer wraps an out-of-int64 `big.Int` via `Int64()`; it clamps to the signed-64 extremes so `fn:remove` treats an oversized position as out of range (leaving the sequence unchanged) instead of removing a wrapped index
