### PR TITLE
xpath3: validate and bound to-operator operands

### DIFF
--- a/xpath3/eval_operators.go
+++ b/xpath3/eval_operators.go
@@ -153,7 +153,7 @@ func evalRangeExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContext, e
 		return validNilSequence, nil
 	}
 	if seqLen(startSeq) > 1 || seqLen(endSeq) > 1 {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "to operator operands must be a single xs:integer"}
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "to operator operands must each be xs:integer? (at most one item)"}
 	}
 	sa, err := AtomizeItem(startSeq.Get(0))
 	if err != nil {

--- a/xpath3/eval_operators.go
+++ b/xpath3/eval_operators.go
@@ -152,6 +152,9 @@ func evalRangeExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContext, e
 	if seqLen(startSeq) == 0 || seqLen(endSeq) == 0 {
 		return validNilSequence, nil
 	}
+	if seqLen(startSeq) > 1 || seqLen(endSeq) > 1 {
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "to operator operands must be a single xs:integer"}
+	}
 	sa, err := AtomizeItem(startSeq.Get(0))
 	if err != nil {
 		return nil, err
@@ -177,8 +180,12 @@ func evalRangeExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContext, e
 		if sv > ev {
 			return validNilSequence, nil
 		}
-		count := ev - sv + 1
-		if count > int64(ec.maxNodes) {
+		// Compute the span with big.Int: ev-sv+1 can overflow int64 even when
+		// both bounds fit (e.g. minInt64 .. maxInt64), which would wrap the
+		// count and bypass the limit check or build a negative-length range.
+		span := new(big.Int).Sub(big.NewInt(ev), big.NewInt(sv))
+		span.Add(span, big.NewInt(1))
+		if !span.IsInt64() || span.Int64() > int64(ec.maxNodes) {
 			return nil, ErrNodeSetLimit
 		}
 		return NewRangeSequence(sv, ev), nil

--- a/xpath3/xpath3_test.go
+++ b/xpath3/xpath3_test.go
@@ -183,6 +183,75 @@ func TestNilContextRangeExpr(t *testing.T) {
 	require.Equal(t, 10, result.Sequence().Len())
 }
 
+func TestRangeOperator(t *testing.T) {
+	t.Parallel()
+
+	t.Run("result", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			expr string
+			want []int64
+		}{
+			{`1 to 3`, []int64{1, 2, 3}},
+			{`() to 3`, nil},
+			{`1 to ()`, nil},
+		}
+		for _, tc := range cases {
+			t.Run(tc.expr, func(t *testing.T) {
+				t.Parallel()
+				result, err := evaluate(t.Context(), nil, tc.expr)
+				require.NoError(t, err)
+				seq := result.Sequence()
+				if len(tc.want) == 0 {
+					// An empty sequence surfaces as a nil Sequence.
+					require.Nil(t, seq)
+					return
+				}
+				require.Equal(t, len(tc.want), seq.Len())
+				for i, want := range tc.want {
+					av, ok := seq.Get(i).(xpath3.AtomicValue)
+					require.True(t, ok)
+					require.Equal(t, want, av.IntegerVal())
+				}
+			})
+		}
+	})
+
+	t.Run("cardinality XPTY0004", func(t *testing.T) {
+		t.Parallel()
+		for _, expr := range []string{`(1, 2) to 3`, `1 to (2, 3)`} {
+			t.Run(expr, func(t *testing.T) {
+				t.Parallel()
+				_, err := evaluate(t.Context(), nil, expr)
+				require.Error(t, err)
+				var xpErr *xpath3.XPathError
+				require.ErrorAs(t, err, &xpErr)
+				require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code)
+			})
+		}
+	})
+
+	t.Run("overflow", func(t *testing.T) {
+		t.Parallel()
+		// Spans whose size exceeds int64 must hit the node-set limit, not
+		// wrap (which previously returned empty or panicked with a negative
+		// length).
+		for _, expr := range []string{
+			`-9223372036854775808 to 9223372036854775807`,
+			`-9223372036854775803 to 9223372036854775807`,
+		} {
+			t.Run(expr, func(t *testing.T) {
+				t.Parallel()
+				var err error
+				require.NotPanics(t, func() {
+					_, err = evaluate(t.Context(), nil, expr)
+				})
+				require.ErrorIs(t, err, xpath3.ErrNodeSetLimit)
+			})
+		}
+	})
+}
+
 func TestNilContextWithContextItem(t *testing.T) {
 	t.Parallel()
 	// Evaluating "." with a context item (atomic value) and nil node must succeed.


### PR DESCRIPTION
Fixes two defects in the xpath3 `to` range operator (`evalRangeExpr`):

- Cardinality: multi-item operands were silently truncated via `Get(0)`; now a length>1 operand raises XPTY0004 as required by XPath 3.1 §3.5.
- Overflow: the int64 fast path computed `ev - sv + 1`, which wraps for spans exceeding int64 (e.g. `minInt64 to maxInt64`), bypassing the node-set limit or building a negative-length range that panics. The span is now computed with big.Int before the limit check.

Adds regression tests covering cardinality, normal/empty results, and overflow. `go test ./xpath3/... ./xslt3/...` passes.
