### PR TITLE
xpath3: exact normalization of large integer map keys

### DIFF
--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -2,6 +2,7 @@ package xpath3_test
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/lestrrat-go/helium/internal/lexicon"
@@ -353,6 +354,65 @@ func TestFnMap(t *testing.T) {
 		require.Equal(t, 1, seq.Len())
 		av := seq.Get(0).(xpath3.AtomicValue)
 		require.Equal(t, int64(2), av.IntegerVal())
+	})
+
+	// Regression: two distinct xs:integer keys whose magnitude exceeds
+	// MaxFloat64 (~1.8e308) must not collide. Before the fix, both were
+	// normalized through ToFloat64 -> +Inf and shared one bucket, producing
+	// a false XQDY0137 duplicate-key error / wrong map size.
+	t.Run("huge integer keys do not collide", func(t *testing.T) {
+		k1 := "1" + strings.Repeat("0", 400) // > MaxFloat64
+		k2 := "2" + strings.Repeat("0", 400) // distinct, also > MaxFloat64
+		expr := `map:size(map { ` + k1 + `: "a", ` + k2 + `: "b" })`
+		seq := evalExpr(t, doc, expr)
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.Equal(t, int64(2), av.IntegerVal())
+	})
+
+	t.Run("huge integer key lookup", func(t *testing.T) {
+		k1 := "1" + strings.Repeat("0", 400)
+		k2 := "2" + strings.Repeat("0", 400)
+		expr := `map:get(map { ` + k1 + `: "a", ` + k2 + `: "b" }, ` + k2 + `)`
+		seq := evalExpr(t, doc, expr)
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.Equal(t, "b", av.StringVal())
+	})
+
+	// Guard: normal small integer keys are unaffected.
+	t.Run("small integer keys", func(t *testing.T) {
+		seq := evalExpr(t, doc, `map:size(map { 1: "a", 2: "b" })`)
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.Equal(t, int64(2), av.IntegerVal())
+
+		got := evalExpr(t, doc, `map:get(map { 1: "a", 2: "b" }, 2)`)
+		require.Equal(t, 1, got.Len())
+		require.Equal(t, "b", got.Get(0).(xpath3.AtomicValue).StringVal())
+	})
+
+	// Guard: integer and decimal keys that compare equal (1 and 1.0) are the
+	// same key per XPath "same key" rules, so the map constructor must reject
+	// them as a duplicate (XQDY0137). This confirms the fix preserves
+	// cross-type numeric key equality for in-range values.
+	t.Run("integer and decimal equal keys are duplicate", func(t *testing.T) {
+		compiled, err := xpath3.NewCompiler().Compile(`map { 1: "a", 1.0: "b" }`)
+		require.NoError(t, err)
+		_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "XQDY0137")
+	})
+
+	// Guard: a huge integer key and the equal huge decimal key are still the
+	// same key (both > MaxFloat64), and must be rejected as a duplicate.
+	t.Run("huge integer and decimal equal keys are duplicate", func(t *testing.T) {
+		big := "1" + strings.Repeat("0", 400)
+		compiled, err := xpath3.NewCompiler().Compile(`map { ` + big + `: "a", ` + big + `.0: "b" }`)
+		require.NoError(t, err)
+		_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "XQDY0137")
 	})
 }
 

--- a/xpath3/types.go
+++ b/xpath3/types.go
@@ -540,6 +540,22 @@ func normalizeMapKey(key AtomicValue) mapKey {
 		if v, ok := key.Value.(int64); ok {
 			return mapKey{typeName: familyNumeric, value: v}
 		}
+		// Exact numeric types must normalize with exact arithmetic, never float64:
+		// ToFloat64 overflows values > MaxFloat64 to +Inf, collapsing distinct keys.
+		if isIntegerDerived(key.TypeName) {
+			bi := key.BigInt()
+			if bi.IsInt64() {
+				return mapKey{typeName: familyNumeric, value: bi.Int64()}
+			}
+			return mapKey{typeName: familyNumeric, value: new(big.Rat).SetInt(bi).RatString()}
+		}
+		if key.TypeName == TypeDecimal {
+			r := key.BigRat()
+			if r.IsInt() && r.Num().IsInt64() {
+				return mapKey{typeName: familyNumeric, value: r.Num().Int64()}
+			}
+			return mapKey{typeName: familyNumeric, value: new(big.Rat).Set(r).RatString()}
+		}
 		f := key.ToFloat64()
 		if math.IsNaN(f) {
 			return mapKey{typeName: familyNumeric, value: "NaN"}
@@ -550,31 +566,13 @@ func normalizeMapKey(key AtomicValue) mapKey {
 		if math.IsInf(f, -1) {
 			return mapKey{typeName: familyNumeric, value: "-Inf"}
 		}
-		// For non-int64 numerics: check if the value is an exact integer
-		// that fits in int64, so it matches the int64 fast path above.
-		switch key.TypeName {
-		case TypeInteger:
-			bi := key.BigInt()
-			if bi.IsInt64() {
-				return mapKey{typeName: familyNumeric, value: bi.Int64()}
-			}
-			return mapKey{typeName: familyNumeric, value: new(big.Rat).SetInt(bi).RatString()}
-		case TypeDecimal:
-			r := key.BigRat()
-			if r.IsInt() {
-				num := r.Num()
-				if num.IsInt64() {
-					return mapKey{typeName: familyNumeric, value: num.Int64()}
-				}
-			}
-			return mapKey{typeName: familyNumeric, value: new(big.Rat).Set(r).RatString()}
-		default: // float, double
-			// Check if float is an exact integer in int64 range
-			if f == math.Trunc(f) && !math.IsInf(f, 0) && f >= math.MinInt64 && f <= math.MaxInt64 {
-				return mapKey{typeName: familyNumeric, value: int64(f)}
-			}
-			return mapKey{typeName: familyNumeric, value: new(big.Rat).SetFloat64(f).RatString()}
+		// Remaining numerics are xs:float / xs:double (and user-defined types whose
+		// underlying value is a float). Check if the float is an exact integer in
+		// int64 range so it matches the int64 fast path above.
+		if f == math.Trunc(f) && !math.IsInf(f, 0) && f >= math.MinInt64 && f <= math.MaxInt64 {
+			return mapKey{typeName: familyNumeric, value: int64(f)}
 		}
+		return mapKey{typeName: familyNumeric, value: new(big.Rat).SetFloat64(f).RatString()}
 	}
 
 	// Normalize duration types: xs:duration, xs:yearMonthDuration, xs:dayTimeDuration

--- a/xpath3/types.go
+++ b/xpath3/types.go
@@ -542,14 +542,16 @@ func normalizeMapKey(key AtomicValue) mapKey {
 		}
 		// Exact numeric types must normalize with exact arithmetic, never float64:
 		// ToFloat64 overflows values > MaxFloat64 to +Inf, collapsing distinct keys.
-		if isIntegerDerived(key.TypeName) {
+		// Also consult BaseType so a user-defined schema type derived from
+		// xs:integer/xs:decimal is normalized exactly rather than via float64.
+		if isIntegerDerived(key.TypeName) || isIntegerDerived(key.BaseType) {
 			bi := key.BigInt()
 			if bi.IsInt64() {
 				return mapKey{typeName: familyNumeric, value: bi.Int64()}
 			}
 			return mapKey{typeName: familyNumeric, value: new(big.Rat).SetInt(bi).RatString()}
 		}
-		if key.TypeName == TypeDecimal {
+		if key.TypeName == TypeDecimal || key.BaseType == TypeDecimal {
 			r := key.BigRat()
 			if r.IsInt() && r.Num().IsInt64() {
 				return mapKey{typeName: familyNumeric, value: r.Num().Int64()}


### PR DESCRIPTION
- `normalizeMapKey` routed xs:integer/xs:decimal keys through `ToFloat64` before the exact `case TypeInteger`/`case TypeDecimal` handling.
- For integer keys with magnitude > MaxFloat64, `ToFloat64` overflows to +Inf, so two distinct huge keys both landed in the shared "+Inf" bucket — a false XQDY0137 duplicate-key error / wrong lookups.
- Fix hoists exact-numeric normalization (via `BigInt`/`BigRat`, gated on `isIntegerDerived` to also cover xs:long/xs:nonNegativeInteger etc.) above the float/Inf/NaN checks; Inf/NaN handling now only applies to xs:float/xs:double.
- In-range keys still land in the same bucket, so cross-type numeric key equality (e.g. 1 vs 1.0) is unchanged.
- Adds xpath3 regression tests; full `go test ./xpath3/...` passes.
