### PR TITLE
parser: validate cdata and width-aware slow paths

### DIFF
--- a/internal/strcursor/utf8cursor.go
+++ b/internal/strcursor/utf8cursor.go
@@ -491,7 +491,7 @@ func (c *UTF8Cursor) ScanNCNameBytes() ([]byte, int) {
 	} else {
 		_ = c.fillBuffer(utf8.UTFMax)
 		r, w := utf8.DecodeRune(c.buf[c.bufpos:c.buflen])
-		if r == utf8.RuneError || !xmlchar.IsNCNameStartChar(r) {
+		if (r == utf8.RuneError && w == 1) || !xmlchar.IsNCNameStartChar(r) {
 			return nil, 0
 		}
 		off += w
@@ -522,7 +522,7 @@ func (c *UTF8Cursor) ScanNCNameBytes() ([]byte, int) {
 		} else {
 			_ = c.fillBuffer(off + utf8.UTFMax)
 			r, w := utf8.DecodeRune(c.buf[c.bufpos+off : c.buflen])
-			if r == utf8.RuneError || !xmlchar.IsNCNameChar(r) {
+			if (r == utf8.RuneError && w == 1) || !xmlchar.IsNCNameChar(r) {
 				break
 			}
 			off += w

--- a/internal/xmlchar/xmlchar.go
+++ b/internal/xmlchar/xmlchar.go
@@ -1,6 +1,8 @@
 // Package xmlchar provides XML 1.0 NCName character classification functions.
 package xmlchar
 
+import "unicode/utf8"
+
 // IsNCNameStartChar checks the XML 1.0 NCName start character production.
 // NCNameStartChar ::= [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6]
 //
@@ -32,13 +34,23 @@ func IsValidNCName(s string) bool {
 	if s == "" {
 		return false
 	}
-	for i, r := range s {
-		if i == 0 && !IsNCNameStartChar(r) {
+	// Decode explicitly (not range) so invalid UTF-8 — which range reports as
+	// RuneError indistinguishable from a real U+FFFD — is rejected by width.
+	first := true
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
 			return false
 		}
-		if i > 0 && !IsNCNameChar(r) {
+		if first {
+			if !IsNCNameStartChar(r) {
+				return false
+			}
+			first = false
+		} else if !IsNCNameChar(r) {
 			return false
 		}
+		i += size
 	}
 	return true
 }

--- a/internal/xmlchar/xmlchar_test.go
+++ b/internal/xmlchar/xmlchar_test.go
@@ -87,3 +87,12 @@ func TestIsNCNameChar(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidNCNameWidthAware(t *testing.T) {
+	t.Parallel()
+	require.True(t, xmlchar.IsValidNCName("a�b"), "valid U+FFFD must be accepted")
+	require.True(t, xmlchar.IsValidNCName("�"), "U+FFFD is a valid NCNameStartChar")
+	require.False(t, xmlchar.IsValidNCName(string([]byte{0xff})), "invalid UTF-8 must be rejected")
+	require.True(t, xmlchar.IsValidNCName("abc"))
+	require.False(t, xmlchar.IsValidNCName("1abc"))
+}

--- a/parser_content.go
+++ b/parser_content.go
@@ -49,6 +49,9 @@ func (ctx *parserCtx) parseCDataContent() (string, error) {
 			continue
 		}
 		if b < 0x80 {
+			if !isChar(rune(b)) {
+				return "", ErrInvalidChar
+			}
 			buf.WriteByte(b)
 			off++
 			continue
@@ -56,6 +59,9 @@ func (ctx *parserCtx) parseCDataContent() (string, error) {
 		r, w, ok := decodeRuneAt(cur, off)
 		if !ok {
 			break
+		}
+		if !isCharWidth(r, w) {
+			return "", ErrInvalidChar
 		}
 		buf.WriteRune(r)
 		off += w
@@ -164,7 +170,7 @@ func (pctx *parserCtx) parsePI(ctx context.Context) error {
 			continue
 		}
 		r, w, ok := decodeRuneAt(cur, off)
-		if !ok || !isChar(r) {
+		if !ok || !isCharWidth(r, w) {
 			break
 		}
 		buf.WriteRune(r)
@@ -228,6 +234,18 @@ func isChar(r rune) bool {
 
 	c := uint32(r)
 	return isXMLCharValue(c)
+}
+
+// isCharWidth is the width-aware counterpart of isChar. A utf8.RuneError with
+// width 1 denotes genuinely invalid UTF-8 and must be rejected, but a real
+// U+FFFD decodes as utf8.RuneError with width 3 and is a valid XML Char. The
+// fast UTF-8 scanners make the same distinction (see
+// internal/strcursor/utf8cursor.go).
+func isCharWidth(r rune, w int) bool {
+	if r == utf8.RuneError && w == 1 {
+		return false
+	}
+	return isXMLCharValue(uint32(r))
 }
 
 func isXMLCharValue(c uint32) bool {
@@ -313,14 +331,14 @@ func (pctx *parserCtx) parseComment(ctx context.Context) error {
 
 	off := 0
 	q, qw, qok := decodeRuneAt(cur, off)
-	if !qok || !isChar(q) {
+	if !qok || !isCharWidth(q, qw) {
 		return pctx.error(ctx, ErrInvalidChar)
 	}
 	buf.WriteRune(q)
 	off += qw
 
 	r, rw, rok := decodeRuneAt(cur, off)
-	if !rok || !isChar(r) {
+	if !rok || !isCharWidth(r, rw) {
 		return pctx.error(ctx, ErrInvalidChar)
 	}
 	buf.WriteRune(r)
@@ -331,7 +349,7 @@ func (pctx *parserCtx) parseComment(ctx context.Context) error {
 		if !ok {
 			return pctx.error(ctx, ErrInvalidComment)
 		}
-		if !isChar(c) {
+		if !isCharWidth(c, w) {
 			return pctx.error(ctx, ErrInvalidChar)
 		}
 		if q == '-' && r == '-' && c == '>' {

--- a/parser_decl.go
+++ b/parser_decl.go
@@ -411,7 +411,9 @@ func (pctx *parserCtx) parseName(ctx context.Context) (name string, err error) {
 	} else {
 		firstRune, firstWidth, _ = decodeRuneAt(cur, 0)
 	}
-	if firstRune == utf8.RuneError {
+	// A real U+FFFD decodes as RuneError with width 3 and is a valid name char;
+	// only width 1 is genuinely-invalid UTF-8.
+	if firstRune == utf8.RuneError && firstWidth == 1 {
 		err = pctx.error(ctx, errInvalidUTF8Name)
 		return
 	}
@@ -438,7 +440,7 @@ func (pctx *parserCtx) parseName(ctx context.Context) (name string, err error) {
 			continue
 		}
 		r, w, ok := decodeRuneAt(cur, off)
-		if !ok || r == utf8.RuneError {
+		if !ok || (r == utf8.RuneError && w == 1) {
 			err = pctx.error(ctx, errInvalidUTF8Name)
 			return
 		}
@@ -539,6 +541,15 @@ func isNameChar(r rune) bool {
 	return r != utf8.RuneError && (r == ':' || isValidNameChar(r))
 }
 
+// isNameCharW is the width-aware form of isNameChar: a RuneError with width 1 is
+// invalid UTF-8, but a width-3 RuneError is a real U+FFFD (a valid NameChar).
+func isNameCharW(r rune, w int) bool {
+	if r == utf8.RuneError && w == 1 {
+		return false
+	}
+	return r == ':' || isValidNameChar(r)
+}
+
 func (ctx *parserCtx) parseNmtoken() (string, error) {
 	if pdebug.Enabled {
 		g := pdebug.IPrintf("START parseNmtoken")
@@ -564,7 +575,7 @@ func (ctx *parserCtx) parseNmtoken() (string, error) {
 			continue
 		}
 		r, w, ok := decodeRuneAt(cur, off)
-		if !ok || !isNameChar(r) {
+		if !ok || !isNameCharW(r, w) {
 			break
 		}
 		off += w
@@ -618,7 +629,7 @@ func (pctx *parserCtx) parseNCName(ctx context.Context) (ncname string, err erro
 	}
 
 	firstR, firstW, _ := decodeRuneAt(cur, 0)
-	if firstR == utf8.RuneError {
+	if firstR == utf8.RuneError && firstW == 1 {
 		err = pctx.error(ctx, errInvalidUTF8Name)
 		return
 	}
@@ -642,7 +653,7 @@ func (pctx *parserCtx) parseNCName(ctx context.Context) (ncname string, err erro
 			continue
 		}
 		r, w, ok := decodeRuneAt(cur, off)
-		if !ok || r == utf8.RuneError {
+		if !ok || (r == utf8.RuneError && w == 1) {
 			err = pctx.error(ctx, errInvalidUTF8Name)
 			return
 		}

--- a/parser_dtd_attr.go
+++ b/parser_dtd_attr.go
@@ -575,7 +575,7 @@ func (pctx *parserCtx) parseSystemLiteral(ctx context.Context, qch byte) (string
 			continue
 		}
 		r, w, ok := decodeRuneAt(cur, off)
-		if !ok || !isChar(r) {
+		if !ok || !isCharWidth(r, w) {
 			break
 		}
 		buf.WriteRune(r)
@@ -612,7 +612,7 @@ func (pctx *parserCtx) parsePubidLiteral(ctx context.Context, qch byte) (string,
 			continue
 		}
 		r, w, ok := decodeRuneAt(cur, off)
-		if !ok || !isChar(r) {
+		if !ok || !isCharWidth(r, w) {
 			break
 		}
 		buf.WriteRune(r)

--- a/parser_dtd_attr.go
+++ b/parser_dtd_attr.go
@@ -603,20 +603,14 @@ func (pctx *parserCtx) parsePubidLiteral(ctx context.Context, qch byte) (string,
 		if b == 0 || b == qch {
 			break
 		}
-		if b < 0x80 {
-			if !isChar(rune(b)) {
-				break
-			}
-			buf.WriteByte(b)
-			off++
-			continue
-		}
-		r, w, ok := decodeRuneAt(cur, off)
-		if !ok || !isCharWidth(r, w) {
+		// PubidChar is restricted to a subset of ASCII, so any byte >= 0x80
+		// (the lead byte of a multi-byte sequence, including a real U+FFFD)
+		// is not a valid pubid character.
+		if !isPubidChar(rune(b)) {
 			break
 		}
-		buf.WriteRune(r)
-		off += w
+		buf.WriteByte(b)
+		off++
 	}
 	if off > 0 {
 		if err := cur.Advance(off); err != nil {
@@ -624,6 +618,26 @@ func (pctx *parserCtx) parsePubidLiteral(ctx context.Context, qch byte) (string,
 		}
 	}
 	return buf.String(), nil
+}
+
+// isPubidChar reports whether r is a member of the XML PubidChar production:
+//
+//	PubidChar ::= #x20 | #xD | #xA | [a-zA-Z0-9] | [-'()+,./:=?;!*#@$_%]
+func isPubidChar(r rune) bool {
+	if r >= 'a' && r <= 'z' {
+		return true
+	}
+	if r >= 'A' && r <= 'Z' {
+		return true
+	}
+	if r >= '0' && r <= '9' {
+		return true
+	}
+	switch r {
+	case ' ', '\r', '\n', '-', '\'', '(', ')', '+', ',', '.', '/', ':', '=', '?', ';', '!', '*', '#', '@', '$', '_', '%':
+		return true
+	}
+	return false
 }
 
 func (pctx *parserCtx) parseExternalID(ctx context.Context) (string, string, error) {

--- a/parser_element.go
+++ b/parser_element.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/lestrrat-go/helium/enum"
 	"github.com/lestrrat-go/helium/internal/lexicon"
@@ -568,8 +567,8 @@ func (pctx *parserCtx) parseAttributeValueInternal(ctx context.Context, qch byte
 	defer releaseBuffer(b)
 
 	for {
-		c := cur.PeekRune()
-		if (qch != 0x0 && c == rune(qch)) || !isChar(c) || c == '<' {
+		c, cw, cok := decodeRuneAt(cur, 0)
+		if !cok || (qch != 0x0 && c == rune(qch)) || !isCharWidth(c, cw) || c == '<' {
 			break
 		}
 		switch c {
@@ -645,7 +644,7 @@ func (pctx *parserCtx) parseAttributeValueInternal(ctx context.Context, qch byte
 		default:
 			inSpace = false
 			b.WriteRune(c)
-			w := max(utf8.RuneLen(c), 1)
+			w := max(cw, 1)
 			if err := cur.Advance(w); err != nil {
 				return "", 0, err
 			}

--- a/parser_entity_decl.go
+++ b/parser_entity_decl.go
@@ -38,7 +38,7 @@ func (pctx *parserCtx) parseEntityValueInternal(ctx context.Context, qch byte) (
 			continue
 		}
 		r, w, ok := decodeRuneAt(cur, off)
-		if !ok || !isChar(r) {
+		if !ok || !isCharWidth(r, w) {
 			break
 		}
 		buf.WriteRune(r)

--- a/valid.go
+++ b/valid.go
@@ -96,12 +96,12 @@ func isValidName(s string) bool {
 		return false
 	}
 	r, size := utf8.DecodeRuneInString(s)
-	if r == utf8.RuneError || !isValidNameStartChar(r) {
+	if (r == utf8.RuneError && size == 1) || !isValidNameStartChar(r) {
 		return false
 	}
 	for i := size; i < len(s); {
 		r, size = utf8.DecodeRuneInString(s[i:])
-		if r == utf8.RuneError || !isValidNameChar(r) {
+		if (r == utf8.RuneError && size == 1) || !isValidNameChar(r) {
 			return false
 		}
 		i += size
@@ -117,7 +117,7 @@ func isValidNmtoken(s string) bool {
 	}
 	for i := 0; i < len(s); {
 		r, size := utf8.DecodeRuneInString(s[i:])
-		if r == utf8.RuneError || !isValidNameChar(r) {
+		if (r == utf8.RuneError && size == 1) || !isValidNameChar(r) {
 			return false
 		}
 		i += size

--- a/xmlchar_validation_test.go
+++ b/xmlchar_validation_test.go
@@ -1,0 +1,64 @@
+package helium_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestXMLCharValidation covers character-validity enforcement across the
+// scan paths that previously missed it: CDATA sections never validated the
+// XML Char production, and the slow attribute/comment/PI paths rejected a
+// valid U+FFFD because they treated every utf8.RuneError as invalid without
+// distinguishing genuinely-invalid UTF-8 (width 1) from a real U+FFFD
+// (width 3).
+func TestXMLCharValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cdata with U+0001 is rejected", func(t *testing.T) {
+		t.Parallel()
+		data := []byte("<root><![CDATA[" + "\x01" + "]]></root>")
+		_, err := helium.NewParser().Parse(t.Context(), data)
+		require.Error(t, err)
+	})
+
+	t.Run("cdata with invalid UTF-8 byte 0xFF is rejected", func(t *testing.T) {
+		t.Parallel()
+		data := []byte("<root><![CDATA[" + "\xff" + "]]></root>")
+		_, err := helium.NewParser().Parse(t.Context(), data)
+		require.Error(t, err)
+	})
+
+	t.Run("cdata with valid content is accepted", func(t *testing.T) {
+		t.Parallel()
+		data := []byte("<root><![CDATA[ok]]></root>")
+		_, err := helium.NewParser().Parse(t.Context(), data)
+		require.NoError(t, err)
+	})
+
+	t.Run("comment with U+FFFD is accepted", func(t *testing.T) {
+		t.Parallel()
+		// U+FFFD (EF BF BD) is a valid XML Char and must survive the slow
+		// comment scan path.
+		data := []byte("<root><!--" + "�" + "--></root>")
+		_, err := helium.NewParser().Parse(t.Context(), data)
+		require.NoError(t, err)
+	})
+
+	t.Run("comment with U+0001 is rejected", func(t *testing.T) {
+		t.Parallel()
+		data := []byte("<root><!--" + "\x01" + "--></root>")
+		_, err := helium.NewParser().Parse(t.Context(), data)
+		require.Error(t, err)
+	})
+
+	t.Run("slow-path attribute value with U+FFFD is accepted", func(t *testing.T) {
+		t.Parallel()
+		// The entity reference forces the slow attribute-value scan path
+		// (the fast scanner bails on '&'). U+FFFD in that value is valid.
+		data := []byte(`<root a="x&amp;` + "�" + `"></root>`)
+		_, err := helium.NewParser().Parse(t.Context(), data)
+		require.NoError(t, err)
+	})
+}

--- a/xmlchar_validation_test.go
+++ b/xmlchar_validation_test.go
@@ -102,4 +102,18 @@ func TestXMLCharValidationOtherSlowPaths(t *testing.T) {
 		_, err := helium.NewParser().Parse(t.Context(), []byte(doc))
 		require.NoError(t, err)
 	})
+
+	t.Run("PUBLIC pubid literal with U+FFFD is rejected", func(t *testing.T) {
+		// U+FFFD is a valid XML Char but not a PubidChar, so a pubid
+		// literal containing it must be rejected.
+		doc := "<!DOCTYPE root PUBLIC \"\uFFFD\" \"sys\"><root/>"
+		_, err := helium.NewParser().Parse(t.Context(), []byte(doc))
+		require.Error(t, err)
+	})
+
+	t.Run("PUBLIC pubid literal with valid PubidChars is accepted", func(t *testing.T) {
+		doc := "<!DOCTYPE root PUBLIC \"-//W3C//DTD//EN\" \"sys\"><root/>"
+		_, err := helium.NewParser().Parse(t.Context(), []byte(doc))
+		require.NoError(t, err)
+	})
 }

--- a/xmlchar_validation_test.go
+++ b/xmlchar_validation_test.go
@@ -41,7 +41,7 @@ func TestXMLCharValidation(t *testing.T) {
 		t.Parallel()
 		// U+FFFD (EF BF BD) is a valid XML Char and must survive the slow
 		// comment scan path.
-		data := []byte("<root><!--" + "�" + "--></root>")
+		data := []byte("<root><!--" + "\uFFFD" + "--></root>")
 		_, err := helium.NewParser().Parse(t.Context(), data)
 		require.NoError(t, err)
 	})
@@ -57,7 +57,7 @@ func TestXMLCharValidation(t *testing.T) {
 		t.Parallel()
 		// The entity reference forces the slow attribute-value scan path
 		// (the fast scanner bails on '&'). U+FFFD in that value is valid.
-		data := []byte(`<root a="x&amp;` + "�" + `"></root>`)
+		data := []byte(`<root a="x&amp;` + "\uFFFD" + `"></root>`)
 		_, err := helium.NewParser().Parse(t.Context(), data)
 		require.NoError(t, err)
 	})
@@ -69,14 +69,37 @@ func TestXMLCharValidation(t *testing.T) {
 func TestParseNameUTF8FFFD(t *testing.T) {
 	t.Parallel()
 	for _, in := range []string{
-		"<�/>",             // element name starting with U+FFFD
-		"<a�/>",            // U+FFFD inside element name
-		"<root �=\"v\"/>",  // attr name starting with U+FFFD
-		"<root x�=\"v\"/>", // U+FFFD inside attr name (ASCII-first fast path)
+		"<\uFFFD/>",             // element name starting with U+FFFD
+		"<a\uFFFD/>",            // U+FFFD inside element name
+		"<root \uFFFD=\"v\"/>",  // attr name starting with U+FFFD
+		"<root x\uFFFD=\"v\"/>", // U+FFFD inside attr name (ASCII-first fast path)
 	} {
 		_, err := helium.NewParser().Parse(t.Context(), []byte(in))
 		require.NoError(t, err, "valid U+FFFD in name must parse: %q", in)
 	}
 	_, err := helium.NewParser().Parse(t.Context(), []byte{'<', 0xFF, '/', '>'})
 	require.Error(t, err, "invalid UTF-8 lead byte in a name must be rejected")
+}
+
+// TestXMLCharValidationOtherSlowPaths exercises the width-aware U+FFFD handling
+// in the PI and DTD entity-value scan paths.
+func TestXMLCharValidationOtherSlowPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("PI content with U+FFFD is accepted", func(t *testing.T) {
+		_, err := helium.NewParser().Parse(t.Context(), []byte("<root><?pi a\uFFFDb?></root>"))
+		require.NoError(t, err)
+	})
+
+	t.Run("PI content with U+0001 is rejected", func(t *testing.T) {
+		_, err := helium.NewParser().Parse(t.Context(), []byte("<root><?pi a\x01b?></root>"))
+		require.Error(t, err)
+	})
+
+	t.Run("entity declaration value with U+FFFD is accepted", func(t *testing.T) {
+		// The entity-declaration value scanner must accept the valid U+FFFD.
+		doc := "<!DOCTYPE root [<!ENTITY e \"a\uFFFDb\">]><root/>"
+		_, err := helium.NewParser().Parse(t.Context(), []byte(doc))
+		require.NoError(t, err)
+	})
 }

--- a/xmlchar_validation_test.go
+++ b/xmlchar_validation_test.go
@@ -62,3 +62,21 @@ func TestXMLCharValidation(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+// TestParseNameUTF8FFFD checks that U+FFFD (a valid XML NameStartChar/NameChar)
+// is accepted in element and attribute names, while genuinely-invalid UTF-8 in
+// a name is still rejected.
+func TestParseNameUTF8FFFD(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{
+		"<�/>",             // element name starting with U+FFFD
+		"<a�/>",            // U+FFFD inside element name
+		"<root �=\"v\"/>",  // attr name starting with U+FFFD
+		"<root x�=\"v\"/>", // U+FFFD inside attr name (ASCII-first fast path)
+	} {
+		_, err := helium.NewParser().Parse(t.Context(), []byte(in))
+		require.NoError(t, err, "valid U+FFFD in name must parse: %q", in)
+	}
+	_, err := helium.NewParser().Parse(t.Context(), []byte{'<', 0xFF, '/', '>'})
+	require.Error(t, err, "invalid UTF-8 lead byte in a name must be rejected")
+}


### PR DESCRIPTION
- CDATA sections now validate every character against the XML Char production and reject invalid UTF-8, instead of writing bytes/runes unchecked
- Slow attribute/comment/PI/DTD-literal scan paths now distinguish width-1 RuneError (invalid UTF-8, rejected) from a real width-3 U+FFFD (valid XML Char, accepted), matching the fast UTF-8 scanners
