### PR TITLE
xpath3: validate args in math/map/json builtins

### DIFF
--- a/.claude/docs/xpath3-api.md
+++ b/.claude/docs/xpath3-api.md
@@ -136,6 +136,6 @@ func (e *XPathError) Error() string
 func (e *XPathError) Is(target error) bool
 ```
 
-Standard codes: `XPTY0004` (type error), `FOER0000` (general), `FOTY0013` (atomization context), `FOAR0001` (array index OOB), `FOAR0002` (array index type), `FOMX0001` (map duplicate key reject).
+Standard codes: `XPTY0004` (type error), `FOER0000` (general), `FOTY0013` (atomization context), `FOAR0001` (division by zero), `FOAR0002` (numeric overflow/underflow, e.g. round precision past the non-terminating cap), `FOAY0001` (array index out of bounds), `FOMX0001` (map duplicate key reject).
 
 `try-catch` matches `*XPathError` by code. Non-`*XPathError` errors propagate through unchanged.

--- a/xpath3/eval_types.go
+++ b/xpath3/eval_types.go
@@ -272,8 +272,11 @@ func resolveAtomicTypeName(tn AtomicTypeName, ec *evalContext) string {
 	if tn.Prefix == "xs" || tn.Prefix == "xsd" {
 		return "xs:" + tn.Name
 	}
-	// Resolve via namespace context
-	if ec.namespaces != nil {
+	// Resolve via namespace context. ec may be nil when a function item's
+	// coercion runs without a captured eval context; in that case the custom
+	// prefix cannot be resolved, so fall through to the unresolved-type form
+	// (Prefix:Name) which fails coercion with XPTY0004 rather than panicking.
+	if ec != nil && ec.namespaces != nil {
 		if uri, ok := ec.namespaces[tn.Prefix]; ok {
 			if uri == lexicon.NamespaceXSD {
 				return "xs:" + tn.Name

--- a/xpath3/function_signatures.go
+++ b/xpath3/function_signatures.go
@@ -144,9 +144,12 @@ func init() {
 		stItem(OccurrenceZeroOrMore),
 		stFunc([]SequenceType{stItem(OccurrenceExactlyOne), stItem(OccurrenceZeroOrMore)}, stItem(OccurrenceZeroOrMore)),
 	}, stItem(OccurrenceZeroOrMore))
+	// fn:sort#2 is sort($input as item()*, $collation as xs:string?); the
+	// second argument is the collation URI, not the key function (that is
+	// sort#3's third argument).
 	registerSig("sort", 2, []SequenceType{
 		stItem(OccurrenceZeroOrMore),
-		stFunc([]SequenceType{stItem(OccurrenceExactlyOne)}, stItem(OccurrenceZeroOrMore)),
+		stAtomic(TypeString, OccurrenceZeroOrOne),
 	}, stItem(OccurrenceZeroOrMore))
 }
 

--- a/xpath3/functions_hof.go
+++ b/xpath3/functions_hof.go
@@ -232,9 +232,11 @@ func lookupFunctionItem(ctx context.Context, qv QNameValue, arity int) (Function
 	}
 
 	capturedCtx := ctx
+	var capturedEC *evalContext
 	if ec := getFnContext(ctx); ec != nil {
 		capturedECValue := *ec
-		capturedCtx = withFnContext(ctx, &capturedECValue)
+		capturedEC = &capturedECValue
+		capturedCtx = withFnContext(ctx, capturedEC)
 	}
 
 	var paramTypes []SequenceType
@@ -266,7 +268,6 @@ func lookupFunctionItem(ctx context.Context, qv QNameValue, arity int) (Function
 			return fn.Call(ctx, callArgs)
 		},
 	}
-	_ = capturedCtx
 	fi.Invoke = func(_ context.Context, callArgs []Sequence) (Sequence, error) {
 		if len(callArgs) != arity {
 			return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("fn:%s requires %d arguments, got %d", qv.Local, arity, len(callArgs))}
@@ -281,7 +282,7 @@ func lookupFunctionItem(ctx context.Context, qv QNameValue, arity int) (Function
 			copy(coerced, callArgs)
 			for i, arg := range callArgs {
 				if i < len(paramTypes) {
-					c, ok := coerceToSequenceType(arg, paramTypes[i], nil)
+					c, ok := coerceToSequenceType(arg, paramTypes[i], capturedEC)
 					if !ok {
 						return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("fn:%s: argument %d does not match required type %v", qv.Local, i+1, paramTypes[i])}
 					}

--- a/xpath3/functions_hof.go
+++ b/xpath3/functions_hof.go
@@ -242,6 +242,15 @@ func lookupFunctionItem(ctx context.Context, qv QNameValue, arity int) (Function
 	if sig := lookupFunctionSignature(qv.URI, qv.Local, arity); sig != nil {
 		paramTypes = sig.ParamTypes
 		returnType = sig.ReturnType
+	} else if tf, ok := fn.(TypedFunction); ok {
+		// User-defined typed functions expose their signature directly;
+		// mirror evalNamedFunctionRef so function-lookup enforces the same
+		// argument-type checks as the named-reference path (f#1).
+		paramTypes = tf.FuncParamTypes()
+		returnType = tf.FuncReturnType()
+	} else if tfa, ok := fn.(TypedFunctionByArity); ok {
+		paramTypes = tfa.FuncParamTypesForArity(arity)
+		returnType = tfa.FuncReturnTypeForArity(arity)
 	}
 
 	fi := FunctionItem{

--- a/xpath3/functions_hof.go
+++ b/xpath3/functions_hof.go
@@ -272,15 +272,23 @@ func lookupFunctionItem(ctx context.Context, qv QNameValue, arity int) (Function
 			return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("fn:%s requires %d arguments, got %d", qv.Local, arity, len(callArgs))}
 		}
 		// Enforce the recorded parameter types, mirroring the named
-		// function-reference path in eval_funcall.go.
+		// function-reference path in eval_funcall.go. Coercion may convert an
+		// argument (e.g. xs:untypedAtomic -> xs:integer); the coerced value must
+		// be what the function observes, so store it back into a copy of the
+		// argument slice rather than discarding it and invoking with the original.
 		if paramTypes != nil {
+			coerced := make([]Sequence, len(callArgs))
+			copy(coerced, callArgs)
 			for i, arg := range callArgs {
 				if i < len(paramTypes) {
-					if _, ok := coerceToSequenceType(arg, paramTypes[i], nil); !ok {
+					c, ok := coerceToSequenceType(arg, paramTypes[i], nil)
+					if !ok {
 						return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("fn:%s: argument %d does not match required type %v", qv.Local, i+1, paramTypes[i])}
 					}
+					coerced[i] = c
 				}
 			}
+			callArgs = coerced
 		}
 		return fn.Call(capturedCtx, callArgs)
 	}

--- a/xpath3/functions_hof.go
+++ b/xpath3/functions_hof.go
@@ -259,6 +259,17 @@ func lookupFunctionItem(ctx context.Context, qv QNameValue, arity int) (Function
 		if len(callArgs) != arity {
 			return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("fn:%s requires %d arguments, got %d", qv.Local, arity, len(callArgs))}
 		}
+		// Enforce the recorded parameter types, mirroring the named
+		// function-reference path in eval_funcall.go.
+		if paramTypes != nil {
+			for i, arg := range callArgs {
+				if i < len(paramTypes) {
+					if _, ok := coerceToSequenceType(arg, paramTypes[i], nil); !ok {
+						return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("fn:%s: argument %d does not match required type %v", qv.Local, i+1, paramTypes[i])}
+					}
+				}
+			}
+		}
 		return fn.Call(capturedCtx, callArgs)
 	}
 	return fi, true

--- a/xpath3/functions_hof.go
+++ b/xpath3/functions_hof.go
@@ -186,10 +186,13 @@ func fnFunctionLookup(ctx context.Context, args []Sequence) (Sequence, error) {
 	if !ok {
 		return validNilSequence, nil
 	}
-	arity := int(arityVal)
-	if arity < 0 {
+	// Reject negative or out-of-int arities (no such function); checking on
+	// int64 first avoids a wrap to a valid-looking arity on 32-bit platforms.
+	const maxInt = int(^uint(0) >> 1)
+	if arityVal < 0 || arityVal > int64(maxInt) {
 		return validNilSequence, nil
 	}
+	arity := int(arityVal)
 
 	fi, ok := lookupFunctionItem(ctx, nameArg.QNameVal(), arity)
 	if !ok {

--- a/xpath3/functions_json.go
+++ b/xpath3/functions_json.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/unparsedtext"
 )
 
@@ -78,9 +79,13 @@ func parseJSONOptions(args []Sequence) (jsonOptions, error) {
 	if len(args) <= 1 || seqLen(args[1]) == 0 {
 		return opts, nil
 	}
+	// options param is map(*)?: at most one item, and it must be a map.
+	if seqLen(args[1]) > 1 {
+		return opts, &XPathError{Code: lexicon.ErrXPTY0004, Message: "options argument must be a single map"}
+	}
 	m, ok := args[1].Get(0).(MapItem)
 	if !ok {
-		return opts, nil
+		return opts, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("options argument must be a map, got %T", args[1].Get(0))}
 	}
 
 	// Parse "liberal" option — must be xs:boolean

--- a/xpath3/functions_map.go
+++ b/xpath3/functions_map.go
@@ -135,10 +135,7 @@ func fnMapPut(_ context.Context, args []Sequence) (Sequence, error) {
 	if err != nil {
 		return nil, err
 	}
-	if seqLen(args[1]) == 0 {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "map:put requires key"}
-	}
-	ka, err := AtomizeItem(args[1].Get(0))
+	ka, err := extractSingleAtomicArg(args[1], "map:put key")
 	if err != nil {
 		return nil, err
 	}
@@ -146,10 +143,7 @@ func fnMapPut(_ context.Context, args []Sequence) (Sequence, error) {
 }
 
 func fnMapEntry(_ context.Context, args []Sequence) (Sequence, error) {
-	if seqLen(args[0]) == 0 {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "map:entry requires key"}
-	}
-	ka, err := AtomizeItem(args[0].Get(0))
+	ka, err := extractSingleAtomicArg(args[0], "map:entry key")
 	if err != nil {
 		return nil, err
 	}
@@ -196,10 +190,7 @@ func fnMapForEach(ctx context.Context, args []Sequence) (Sequence, error) {
 }
 
 func fnMapFind(_ context.Context, args []Sequence) (Sequence, error) {
-	if seqLen(args[1]) == 0 {
-		return ItemSlice{NewArray(nil)}, nil
-	}
-	ka, err := AtomizeItem(args[1].Get(0))
+	ka, err := extractSingleAtomicArg(args[1], "map:find key")
 	if err != nil {
 		return nil, err
 	}

--- a/xpath3/functions_math.go
+++ b/xpath3/functions_math.go
@@ -26,15 +26,30 @@ func fnMathPi(_ context.Context, _ []Sequence) (Sequence, error) {
 	return SingleDouble(math.Pi), nil
 }
 
-func mathUnary(args []Sequence, fn func(float64) float64) (Sequence, error) {
-	if seqLen(args[0]) == 0 {
-		return validNilSequence, nil
+// coerceMathArg coerces an xs:double? math argument. Empty sequences yield
+// (0, false, nil) so the caller can return an empty result; otherwise the
+// argument is required to be a single numeric/untypedAtomic item, rejecting
+// multi-item and non-numeric values with XPTY0004.
+func coerceMathArg(seq Sequence) (float64, bool, error) {
+	if seqLen(seq) == 0 {
+		return 0, false, nil
 	}
-	a, err := AtomizeItem(args[0].Get(0))
+	f, err := coerceArgToDoubleRequired(seq)
+	if err != nil {
+		return 0, false, err
+	}
+	return f, true, nil
+}
+
+func mathUnary(args []Sequence, fn func(float64) float64) (Sequence, error) {
+	a, ok, err := coerceMathArg(args[0])
 	if err != nil {
 		return nil, err
 	}
-	return SingleDouble(fn(a.ToFloat64())), nil
+	if !ok {
+		return validNilSequence, nil
+	}
+	return SingleDouble(fn(a)), nil
 }
 
 func fnMathExp(_ context.Context, args []Sequence) (Sequence, error) {
@@ -54,18 +69,20 @@ func fnMathLog10(_ context.Context, args []Sequence) (Sequence, error) {
 }
 
 func fnMathPow(_ context.Context, args []Sequence) (Sequence, error) {
-	if seqLen(args[0]) == 0 || seqLen(args[1]) == 0 {
+	// math:pow($x as xs:double?, $y as xs:numeric): empty $x yields empty,
+	// regardless of $y. $y is a required single numeric value.
+	a, aOK, err := coerceMathArg(args[0])
+	if err != nil {
+		return nil, err
+	}
+	if !aOK {
 		return validNilSequence, nil
 	}
-	a, err := AtomizeItem(args[0].Get(0))
+	b, err := coerceArgToDoubleRequired(args[1])
 	if err != nil {
 		return nil, err
 	}
-	b, err := AtomizeItem(args[1].Get(0))
-	if err != nil {
-		return nil, err
-	}
-	return SingleDouble(math.Pow(a.ToFloat64(), b.ToFloat64())), nil
+	return SingleDouble(math.Pow(a, b)), nil
 }
 
 func fnMathSqrt(_ context.Context, args []Sequence) (Sequence, error) {
@@ -97,16 +114,15 @@ func fnMathAtan(_ context.Context, args []Sequence) (Sequence, error) {
 }
 
 func fnMathAtan2(_ context.Context, args []Sequence) (Sequence, error) {
-	if seqLen(args[0]) == 0 || seqLen(args[1]) == 0 {
-		return validNilSequence, nil
-	}
-	a, err := AtomizeItem(args[0].Get(0))
+	// math:atan2($y as xs:double, $x as xs:double): both required, exactly one
+	// numeric value each.
+	a, err := coerceArgToDoubleRequired(args[0])
 	if err != nil {
 		return nil, err
 	}
-	b, err := AtomizeItem(args[1].Get(0))
+	b, err := coerceArgToDoubleRequired(args[1])
 	if err != nil {
 		return nil, err
 	}
-	return SingleDouble(math.Atan2(a.ToFloat64(), b.ToFloat64())), nil
+	return SingleDouble(math.Atan2(a, b)), nil
 }

--- a/xpath3/functions_math.go
+++ b/xpath3/functions_math.go
@@ -69,18 +69,20 @@ func fnMathLog10(_ context.Context, args []Sequence) (Sequence, error) {
 }
 
 func fnMathPow(_ context.Context, args []Sequence) (Sequence, error) {
-	// math:pow($x as xs:double?, $y as xs:numeric): empty $x yields empty,
-	// regardless of $y. $y is a required single numeric value.
+	// math:pow($x as xs:double?, $y as xs:numeric): empty $x yields empty, but
+	// only once $y has been validated. $y is a required single numeric value,
+	// so a malformed or empty $y must raise XPTY0004 even when $x is empty —
+	// function-conversion validates each argument independently of the others.
+	b, err := coerceArgToDoubleRequired(args[1])
+	if err != nil {
+		return nil, err
+	}
 	a, aOK, err := coerceMathArg(args[0])
 	if err != nil {
 		return nil, err
 	}
 	if !aOK {
 		return validNilSequence, nil
-	}
-	b, err := coerceArgToDoubleRequired(args[1])
-	if err != nil {
-		return nil, err
 	}
 	return SingleDouble(math.Pow(a, b)), nil
 }

--- a/xpath3/functions_numeric.go
+++ b/xpath3/functions_numeric.go
@@ -776,9 +776,16 @@ func ratRoundPrecision(r *big.Rat, precision int) *big.Rat {
 		rounded := ratFloor(new(big.Rat).Add(shifted, half))
 		return new(big.Rat).Quo(rounded, new(big.Rat).SetInt(scale))
 	}
-	// Negative precision: round to 10^(-precision)
-	result := roundIntegerHalfUp(ratFloorInt(r), -precision)
-	return new(big.Rat).SetInt(result)
+	// Negative precision: round to 10^(-precision). Operate on the rational
+	// directly (divide, round-half-towards-+∞, multiply back) rather than
+	// flooring to an integer first — flooring discards the fractional part and
+	// can push the value past the rounding boundary (e.g. -249.9 floors to -250
+	// or even -251, landing on the wrong multiple of 100).
+	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(-precision)), nil)
+	scaleRat := new(big.Rat).SetInt(scale)
+	divided := new(big.Rat).Quo(r, scaleRat)
+	rounded := ratRound(divided)
+	return new(big.Rat).Mul(rounded, scaleRat)
 }
 
 // ratRoundPrecisionHalfToEven rounds a *big.Rat to the given precision (number

--- a/xpath3/functions_numeric.go
+++ b/xpath3/functions_numeric.go
@@ -730,8 +730,16 @@ func ratRoundPrecisionHalfToEven(r *big.Rat, precision int) *big.Rat {
 		rounded := icu.RatRoundHalfToEvenInt(shifted)
 		return new(big.Rat).SetFrac(rounded, new(big.Int).Set(scale))
 	}
-	// Negative precision: round to 10^(-precision).
-	return new(big.Rat).SetInt(roundIntegerHalfToEven(ratFloorInt(r), -precision))
+	// Negative precision: round to 10^(-precision). Operate on the rational
+	// directly (divide, round-half-to-even, multiply back) rather than flooring
+	// to an integer first — flooring would discard the fractional part that can
+	// break a tie at the rounding boundary (e.g. ...896.5...123 must round up,
+	// not be treated as an exact half that lands on the even digit).
+	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(-precision)), nil)
+	scaleRat := new(big.Rat).SetInt(scale)
+	divided := new(big.Rat).Quo(r, scaleRat)
+	rounded := icu.RatRoundHalfToEvenInt(divided)
+	return new(big.Rat).Mul(new(big.Rat).SetInt(rounded), scaleRat)
 }
 
 // ratFloorInt returns floor of a rational as big.Int.

--- a/xpath3/functions_numeric.go
+++ b/xpath3/functions_numeric.go
@@ -158,7 +158,10 @@ const (
 // avoids the wrap that int(IntegerVal()) would introduce for out-of-int64
 // values.)
 func roundPrecisionArg(arg Sequence) (*big.Int, error) {
-	pa, err := AtomizeItem(arg.Get(0))
+	// $precision is a required singleton xs:integer: a multi-item sequence is a
+	// type error (XPTY0004). The empty case never reaches here — callers only
+	// invoke this when the argument has at least one item.
+	pa, err := extractSingleAtomicArg(arg, "round")
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +329,7 @@ func roundImpl(args []Sequence, halfToEven bool) (Sequence, error) {
 			p = -scale
 		}
 		if halfToEven {
-			return SingleDecimal(icu.RatRoundHalfToEven(r, p)), nil
+			return SingleDecimal(ratRoundPrecisionHalfToEven(r, p)), nil
 		}
 		if p == 0 {
 			return SingleDecimal(ratRound(r)), nil
@@ -712,6 +715,23 @@ func ratRoundPrecision(r *big.Rat, precision int) *big.Rat {
 	// Negative precision: round to 10^(-precision)
 	result := roundIntegerHalfUp(ratFloorInt(r), -precision)
 	return new(big.Rat).SetInt(result)
+}
+
+// ratRoundPrecisionHalfToEven rounds a *big.Rat to the given precision (number
+// of decimal places) using half-to-even rounding. Unlike the icu helper it
+// applies no coarse magnitude clamp: callers pass a precision whose scale has
+// already been bounded by the operand's own digit count (via resolveRoundScale),
+// so 10^|precision| is bounded by the operand and never astronomically large.
+func ratRoundPrecisionHalfToEven(r *big.Rat, precision int) *big.Rat {
+	if precision >= 0 {
+		scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(precision)), nil)
+		scaleRat := new(big.Rat).SetInt(scale)
+		shifted := new(big.Rat).Mul(r, scaleRat)
+		rounded := icu.RatRoundHalfToEvenInt(shifted)
+		return new(big.Rat).SetFrac(rounded, new(big.Int).Set(scale))
+	}
+	// Negative precision: round to 10^(-precision).
+	return new(big.Rat).SetInt(roundIntegerHalfToEven(ratFloorInt(r), -precision))
 }
 
 // ratFloorInt returns floor of a rational as big.Int.

--- a/xpath3/functions_numeric.go
+++ b/xpath3/functions_numeric.go
@@ -186,6 +186,14 @@ func roundPrecisionArg(arg Sequence) (*big.Int, error) {
 // at least the operand's fractional-digit count the operand is already
 // representable and is returned unchanged; otherwise 10^p is bounded by the
 // operand's fractional scale.
+//
+// The one exception is a non-terminating rational, whose fracDigits is the large
+// ratFracDigitNonTerminating sentinel: it never compares as "fully representable"
+// so a finite precision always rounds, but that precision (e.g. 1e9) could still
+// be enormous. To keep 10^p bounded regardless of input, the positive compute
+// scale is capped at roundMaxComputeScale; beyond that cap the operand's value
+// past the cap'th fractional digit is representationally irrelevant, so rounding
+// at the cap yields the same value while keeping Exp cheap (DoS-safe).
 func resolveRoundScale(precision *big.Int, intDigits, fracDigits int) (int, roundDecision) {
 	if precision.Sign() < 0 {
 		// scale = -precision, as a non-negative big.Int
@@ -204,9 +212,27 @@ func resolveRoundScale(precision *big.Int, intDigits, fracDigits int) (int, roun
 	if precision.Cmp(big.NewInt(int64(fracDigits))) >= 0 {
 		return 0, roundUnchanged
 	}
-	// Here precision < fracDigits, which fits in int and bounds 10^precision.
+	// Here precision < fracDigits. For a terminating decimal fracDigits is the
+	// operand's true scale, so 10^precision is bounded by the operand's own size
+	// (the accepted invariant). For a non-terminating rational fracDigits is the
+	// ratFracDigitNonTerminating sentinel and precision may be astronomically
+	// large with no operand bounding it; cap it so 10^p can never trigger a huge
+	// allocation. Only the sentinel case is capped, so a terminating decimal with
+	// a genuinely large scale is still rounded at its requested precision.
+	if fracDigits == ratFracDigitNonTerminating && precision.Cmp(big.NewInt(roundMaxComputeScale)) > 0 {
+		return roundMaxComputeScale, roundCompute
+	}
 	return int(precision.Int64()), roundCompute
 }
+
+// roundMaxComputeScale caps the positive (fine) compute scale handed to Exp so a
+// non-terminating decimal operand (whose fractional-digit count is the
+// ratFracDigitNonTerminating sentinel) cannot drive an astronomically large
+// 10^precision. It comfortably exceeds the fractional precision of any value
+// that can arise from terminating xs:decimal or float operands (a float64 has at
+// most ~324 fractional digits), so it never alters a representable result; it
+// only bounds the otherwise-unbounded non-terminating case.
+const roundMaxComputeScale = 4096
 
 // intDigitCount returns the number of base-10 digits in |n|, with 0 counted as
 // a single digit. Used as the integer-magnitude input to resolveRoundScale.
@@ -226,10 +252,11 @@ func ratIntDigitCount(r *big.Rat) int {
 // ratFracDigitNonTerminating is returned by ratFracDigitCount for a rational
 // whose decimal expansion does not terminate (e.g. 1/3, common when an
 // xs:decimal is produced by integer division). It is large enough that no
-// practical fine precision will be treated as "finer than the operand's
-// scale", so such values always fall through to roundCompute — yet small
-// enough that resolveRoundScale never feeds it to Exp (positive precision is
-// always bounded by the caller's actual precision argument, not this value).
+// practical fine precision will be treated as "finer than the operand's scale",
+// so such values always fall through to roundCompute. Because the operand itself
+// no longer bounds the scale in this case, resolveRoundScale caps the positive
+// compute scale at roundMaxComputeScale so the precision argument can never feed
+// an astronomically large exponent to Exp.
 const ratFracDigitNonTerminating = 1 << 30
 
 // ratFracDigitCount returns the number of fractional decimal digits of r in its

--- a/xpath3/functions_numeric.go
+++ b/xpath3/functions_numeric.go
@@ -40,13 +40,31 @@ func promoteToNumeric(item Item) (AtomicValue, error) {
 	return a, nil
 }
 
-func fnAbs(_ context.Context, args []Sequence) (Sequence, error) {
-	if seqLen(args[0]) == 0 {
-		return validNilSequence, nil
+// promoteSeqToNumeric coerces an xs:numeric? argument. Empty sequences yield
+// (_, false, nil); a single item is promoted via promoteToNumeric; multi-item
+// sequences are rejected with XPTY0004.
+func promoteSeqToNumeric(seq Sequence) (AtomicValue, bool, error) {
+	switch seqLen(seq) {
+	case 0:
+		return AtomicValue{}, false, nil
+	case 1:
+		a, err := promoteToNumeric(seq.Get(0))
+		if err != nil {
+			return AtomicValue{}, false, err
+		}
+		return a, true, nil
+	default:
+		return AtomicValue{}, false, &XPathError{Code: lexicon.ErrXPTY0004, Message: "expected single numeric value, got sequence of length > 1"}
 	}
-	a, err := promoteToNumeric(args[0].Get(0))
+}
+
+func fnAbs(_ context.Context, args []Sequence) (Sequence, error) {
+	a, ok, err := promoteSeqToNumeric(args[0])
 	if err != nil {
 		return nil, err
+	}
+	if !ok {
+		return validNilSequence, nil
 	}
 	if isIntegerDerived(a.TypeName) {
 		if v, ok := a.Value.(int64); ok {
@@ -66,12 +84,12 @@ func fnAbs(_ context.Context, args []Sequence) (Sequence, error) {
 }
 
 func fnCeiling(_ context.Context, args []Sequence) (Sequence, error) {
-	if seqLen(args[0]) == 0 {
-		return validNilSequence, nil
-	}
-	a, err := promoteToNumeric(args[0].Get(0))
+	a, ok, err := promoteSeqToNumeric(args[0])
 	if err != nil {
 		return nil, err
+	}
+	if !ok {
+		return validNilSequence, nil
 	}
 	if isIntegerDerived(a.TypeName) {
 		if v, ok := a.Value.(int64); ok {
@@ -90,12 +108,12 @@ func fnCeiling(_ context.Context, args []Sequence) (Sequence, error) {
 }
 
 func fnFloor(_ context.Context, args []Sequence) (Sequence, error) {
-	if seqLen(args[0]) == 0 {
-		return validNilSequence, nil
-	}
-	a, err := promoteToNumeric(args[0].Get(0))
+	a, ok, err := promoteSeqToNumeric(args[0])
 	if err != nil {
 		return nil, err
+	}
+	if !ok {
+		return validNilSequence, nil
 	}
 	if isIntegerDerived(a.TypeName) {
 		if v, ok := a.Value.(int64); ok {
@@ -114,12 +132,12 @@ func fnFloor(_ context.Context, args []Sequence) (Sequence, error) {
 }
 
 func fnRound(_ context.Context, args []Sequence) (Sequence, error) {
-	if seqLen(args[0]) == 0 {
-		return validNilSequence, nil
-	}
-	a, err := promoteToNumeric(args[0].Get(0))
+	a, ok, err := promoteSeqToNumeric(args[0])
 	if err != nil {
 		return nil, err
+	}
+	if !ok {
+		return validNilSequence, nil
 	}
 	precision := 0
 	if len(args) > 1 && seqLen(args[1]) > 0 {
@@ -164,12 +182,12 @@ func fnRound(_ context.Context, args []Sequence) (Sequence, error) {
 }
 
 func fnRoundHalfToEven(_ context.Context, args []Sequence) (Sequence, error) {
-	if seqLen(args[0]) == 0 {
-		return validNilSequence, nil
-	}
-	a, err := promoteToNumeric(args[0].Get(0))
+	a, ok, err := promoteSeqToNumeric(args[0])
 	if err != nil {
 		return nil, err
+	}
+	if !ok {
+		return validNilSequence, nil
 	}
 	precision := 0
 	if len(args) > 1 && seqLen(args[1]) > 0 {

--- a/xpath3/functions_numeric.go
+++ b/xpath3/functions_numeric.go
@@ -150,22 +150,23 @@ const (
 	roundTrivialZero
 )
 
-// roundPrecisionArg extracts the rounding precision from the second argument,
-// casting to xs:integer. The precision is returned as a *big.Int (XPath
-// integers are arbitrary precision); callers pair it with the operand's scale
-// via resolveRoundScale so an astronomically large 10^|precision| is never
-// materialised for cases whose result is determined trivially. (A *big.Int
-// avoids the wrap that int(IntegerVal()) would introduce for out-of-int64
-// values.)
+// roundPrecisionArg extracts the rounding precision from the second argument
+// under the XPath 3.1 function-conversion rules for a required
+// "$precision as xs:integer" parameter: the argument must be exactly one item;
+// xs:integer (and its subtypes) is accepted as-is, xs:untypedAtomic is cast to
+// xs:integer, and every other type (xs:boolean, xs:decimal, xs:float, xs:double,
+// xs:string, ...) is rejected with XPTY0004 — there is no implicit numeric
+// truncation. An empty sequence violates the exactly-one cardinality and is a
+// type error too. The precision is returned as a *big.Int (XPath integers are
+// arbitrary precision); callers pair it with the operand's scale via
+// resolveRoundScale so an astronomically large 10^|precision| is never
+// materialised for cases whose result is determined trivially.
 func roundPrecisionArg(arg Sequence) (*big.Int, error) {
-	// $precision is a required singleton xs:integer: a multi-item sequence is a
-	// type error (XPTY0004). The empty case never reaches here — callers only
-	// invoke this when the argument has at least one item.
 	pa, err := extractSingleAtomicArg(arg, "round")
 	if err != nil {
 		return nil, err
 	}
-	pa, err = CastAtomic(pa, TypeInteger)
+	pa, err = coerceToInteger(pa)
 	if err != nil {
 		return nil, err
 	}
@@ -190,49 +191,59 @@ func roundPrecisionArg(arg Sequence) (*big.Int, error) {
 // The one exception is a non-terminating rational, whose fracDigits is the large
 // ratFracDigitNonTerminating sentinel: it never compares as "fully representable"
 // so a finite precision always rounds, but that precision (e.g. 1e9) could still
-// be enormous. To keep 10^p bounded regardless of input, the positive compute
-// scale is capped at roundMaxComputeScale; beyond that cap the operand's value
-// past the cap'th fractional digit is representationally irrelevant, so rounding
-// at the cap yields the same value while keeping Exp cheap (DoS-safe).
-func resolveRoundScale(precision *big.Int, intDigits, fracDigits int) (int, roundDecision) {
+// be enormous. Such an operand has no terminating decimal expansion, so its value
+// is well-defined at any requested fractional precision; honour the request up to
+// roundMaxComputeScale (so 10^p stays bounded), and beyond that cap raise an error
+// rather than silently rounding at a lower scale than asked. Silently clamping
+// would return an observably wrong (lower-precision) value; erroring keeps the
+// computation DoS-safe without ever lying about the result.
+func resolveRoundScale(precision *big.Int, intDigits, fracDigits int) (int, roundDecision, error) {
 	if precision.Sign() < 0 {
 		// scale = -precision, as a non-negative big.Int
 		s := new(big.Int).Neg(precision)
 		// If -precision > intDigits, the scale is at least a full decade above
 		// the operand's magnitude, so |operand| < 10^s / 2 and it rounds to 0.
 		if s.Cmp(big.NewInt(int64(intDigits))) > 0 {
-			return 0, roundTrivialZero
+			return 0, roundTrivialZero, nil
 		}
 		// Here s <= intDigits, which fits in int and bounds 10^s.
-		return int(s.Int64()), roundCompute
+		return int(s.Int64()), roundCompute, nil
 	}
 	// Non-negative precision. If it is at least the operand's fractional-digit
 	// count the operand is unchanged; this also covers all integers (fracDigits
 	// == 0) and any precision >= the operand's scale.
 	if precision.Cmp(big.NewInt(int64(fracDigits))) >= 0 {
-		return 0, roundUnchanged
+		return 0, roundUnchanged, nil
 	}
 	// Here precision < fracDigits. For a terminating decimal fracDigits is the
 	// operand's true scale, so 10^precision is bounded by the operand's own size
 	// (the accepted invariant). For a non-terminating rational fracDigits is the
 	// ratFracDigitNonTerminating sentinel and precision may be astronomically
-	// large with no operand bounding it; cap it so 10^p can never trigger a huge
-	// allocation. Only the sentinel case is capped, so a terminating decimal with
-	// a genuinely large scale is still rounded at its requested precision.
+	// large with no operand bounding it. Honour it up to roundMaxComputeScale so
+	// 10^p stays bounded; beyond that, refuse with FOAR0002 rather than silently
+	// returning a lower-precision value than requested.
 	if fracDigits == ratFracDigitNonTerminating && precision.Cmp(big.NewInt(roundMaxComputeScale)) > 0 {
-		return roundMaxComputeScale, roundCompute
+		return 0, roundCompute, &XPathError{
+			Code: errCodeFOAR0002,
+			Message: fmt.Sprintf(
+				"round precision %s exceeds the maximum of %d fractional digits for a non-terminating decimal",
+				precision.String(), roundMaxComputeScale),
+		}
 	}
-	return int(precision.Int64()), roundCompute
+	return int(precision.Int64()), roundCompute, nil
 }
 
-// roundMaxComputeScale caps the positive (fine) compute scale handed to Exp so a
-// non-terminating decimal operand (whose fractional-digit count is the
-// ratFracDigitNonTerminating sentinel) cannot drive an astronomically large
-// 10^precision. It comfortably exceeds the fractional precision of any value
-// that can arise from terminating xs:decimal or float operands (a float64 has at
-// most ~324 fractional digits), so it never alters a representable result; it
-// only bounds the otherwise-unbounded non-terminating case.
-const roundMaxComputeScale = 4096
+// roundMaxComputeScale bounds the positive (fine) compute scale handed to Exp for
+// a non-terminating decimal operand (whose fractional-digit count is the
+// ratFracDigitNonTerminating sentinel). A precision up to this is computed
+// exactly; a larger precision raises FOAR0002 rather than silently rounding at a
+// lower scale. It comfortably exceeds the fractional precision of any value that
+// can arise from terminating xs:decimal or float operands (a float64 has at most
+// ~324 fractional digits), so it never alters a representable result; it only
+// bounds the otherwise-unbounded non-terminating case. 10^(1<<20) is a ~315 KB
+// big.Int — cheap for Exp — while a precision past a million fractional digits on
+// a repeating decimal is far outside any legitimate use.
+const roundMaxComputeScale = 1 << 20
 
 // intDigitCount returns the number of base-10 digits in |n|, with 0 counted as
 // a single digit. Used as the integer-magnitude input to resolveRoundScale.
@@ -310,6 +321,20 @@ func fnRoundHalfToEven(_ context.Context, args []Sequence) (Sequence, error) {
 // large 10^|precision| is never materialised: cases whose result is determined
 // trivially (rounds to 0, or operand unchanged) short-circuit before any Exp.
 func roundImpl(args []Sequence, halfToEven bool) (Sequence, error) {
+	// When the 2-arg form is used, $precision is a required "exactly one
+	// xs:integer" parameter and must be validated whether or not $arg is empty:
+	// the empty first argument does not excuse an absent or ill-typed precision.
+	// round((), "bad") and round(1, ()) both raise XPTY0004; round((), 3) and
+	// round((), 1) are () only because the precision itself is valid.
+	precision := big.NewInt(0)
+	if len(args) > 1 {
+		p, err := roundPrecisionArg(args[1])
+		if err != nil {
+			return nil, err
+		}
+		precision = p
+	}
+
 	a, ok, err := promoteSeqToNumeric(args[0])
 	if err != nil {
 		return nil, err
@@ -317,16 +342,12 @@ func roundImpl(args []Sequence, halfToEven bool) (Sequence, error) {
 	if !ok {
 		return validNilSequence, nil
 	}
-	precision := big.NewInt(0)
-	if len(args) > 1 && seqLen(args[1]) > 0 {
-		precision, err = roundPrecisionArg(args[1])
+
+	if isIntegerDerived(a.TypeName) {
+		scale, decision, err := resolveRoundScale(precision, intDigitCount(a.BigInt()), 0)
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	if isIntegerDerived(a.TypeName) {
-		scale, decision := resolveRoundScale(precision, intDigitCount(a.BigInt()), 0)
 		if decision == roundUnchanged {
 			if v, ok := a.Value.(int64); ok {
 				return SingleInteger(v), nil
@@ -344,7 +365,10 @@ func roundImpl(args []Sequence, halfToEven bool) (Sequence, error) {
 
 	if a.TypeName == TypeDecimal {
 		r := a.BigRat()
-		scale, decision := resolveRoundScale(precision, ratIntDigitCount(r), ratFracDigitCount(r))
+		scale, decision, err := resolveRoundScale(precision, ratIntDigitCount(r), ratFracDigitCount(r))
+		if err != nil {
+			return nil, err
+		}
 		if decision == roundUnchanged {
 			return SingleDecimal(new(big.Rat).Set(r)), nil
 		}
@@ -372,7 +396,10 @@ func roundImpl(args []Sequence, halfToEven bool) (Sequence, error) {
 	// these bounds make resolveRoundScale short-circuit every extreme precision
 	// without ever computing a huge scale.
 	intDigits := floatIntDigitCount(n)
-	scale, decision := resolveRoundScale(precision, intDigits, 324)
+	scale, decision, err := resolveRoundScale(precision, intDigits, 324)
+	if err != nil {
+		return nil, err
+	}
 	if decision == roundUnchanged {
 		return SingleAtomic(a), nil
 	}

--- a/xpath3/functions_numeric.go
+++ b/xpath3/functions_numeric.go
@@ -131,6 +131,46 @@ func fnFloor(_ context.Context, args []Sequence) (Sequence, error) {
 	return SingleAtomic(makeFloatResult(a.TypeName, math.Floor(f))), nil
 }
 
+// maxRoundPrecision bounds the rounding scale used by fn:round and
+// fn:round-half-to-even. The $precision argument is an xs:integer and may be
+// arbitrarily large (e.g. 2^63, stored as a *big.Int). Two problems must be
+// avoided: int(IntegerVal()) wraps out-of-int64 values (turning a huge positive
+// precision into a huge negative one), and computing 10^|precision| via
+// big.Int.Exp for an astronomically large scale exhausts CPU/memory. Per XPath
+// F&O 3.1 a precision far larger than the value's significant digits leaves it
+// unchanged, and a precision far more negative rounds it to 0; no representable
+// number has anywhere near this many significant digits, so clamping preserves
+// semantics while bounding the scale computation.
+const maxRoundPrecision = 4096
+
+// roundPrecisionArg extracts the rounding precision from the second argument,
+// casting to xs:integer and clamping to ±maxRoundPrecision so an out-of-int64
+// value neither wraps nor blows up the scale computation.
+func roundPrecisionArg(arg Sequence) (int, error) {
+	pa, err := AtomizeItem(arg.Get(0))
+	if err != nil {
+		return 0, err
+	}
+	pa, err = CastAtomic(pa, TypeInteger)
+	if err != nil {
+		return 0, err
+	}
+	if v, ok := pa.Int64Val(); ok {
+		if v > maxRoundPrecision {
+			return maxRoundPrecision, nil
+		}
+		if v < -maxRoundPrecision {
+			return -maxRoundPrecision, nil
+		}
+		return int(v), nil
+	}
+	// Out of int64 range: sign decides whether we clamp high or low.
+	if pa.BigInt().Sign() < 0 {
+		return -maxRoundPrecision, nil
+	}
+	return maxRoundPrecision, nil
+}
+
 func fnRound(_ context.Context, args []Sequence) (Sequence, error) {
 	a, ok, err := promoteSeqToNumeric(args[0])
 	if err != nil {
@@ -141,15 +181,10 @@ func fnRound(_ context.Context, args []Sequence) (Sequence, error) {
 	}
 	precision := 0
 	if len(args) > 1 && seqLen(args[1]) > 0 {
-		pa, err := AtomizeItem(args[1].Get(0))
+		precision, err = roundPrecisionArg(args[1])
 		if err != nil {
 			return nil, err
 		}
-		pa, err = CastAtomic(pa, TypeInteger)
-		if err != nil {
-			return nil, err
-		}
-		precision = int(pa.IntegerVal())
 	}
 	if isIntegerDerived(a.TypeName) {
 		if precision >= 0 {
@@ -191,15 +226,10 @@ func fnRoundHalfToEven(_ context.Context, args []Sequence) (Sequence, error) {
 	}
 	precision := 0
 	if len(args) > 1 && seqLen(args[1]) > 0 {
-		pa, err := AtomizeItem(args[1].Get(0))
+		precision, err = roundPrecisionArg(args[1])
 		if err != nil {
 			return nil, err
 		}
-		pa, err = CastAtomic(pa, TypeInteger)
-		if err != nil {
-			return nil, err
-		}
-		precision = int(pa.IntegerVal())
 	}
 	if isIntegerDerived(a.TypeName) {
 		if precision >= 0 {

--- a/xpath3/functions_numeric.go
+++ b/xpath3/functions_numeric.go
@@ -189,14 +189,16 @@ func roundPrecisionArg(arg Sequence) (*big.Int, error) {
 // operand's fractional scale.
 //
 // The one exception is a non-terminating rational, whose fracDigits is the large
-// ratFracDigitNonTerminating sentinel: it never compares as "fully representable"
-// so a finite precision always rounds, but that precision (e.g. 1e9) could still
-// be enormous. Such an operand has no terminating decimal expansion, so its value
-// is well-defined at any requested fractional precision; honour the request up to
-// roundMaxComputeScale (so 10^p stays bounded), and beyond that cap raise an error
-// rather than silently rounding at a lower scale than asked. Silently clamping
-// would return an observably wrong (lower-precision) value; erroring keeps the
-// computation DoS-safe without ever lying about the result.
+// ratFracDigitNonTerminating sentinel. It must never be treated as "fully
+// representable" — that is handled BEFORE the positive-precision unchanged test,
+// so a precision at or above the sentinel (e.g. 1<<30) cannot short-circuit to
+// roundUnchanged and bypass the cap. Such an operand has no terminating decimal
+// expansion, so its value is well-defined at any requested fractional precision;
+// honour the request up to roundMaxComputeScale (so 10^p stays bounded), and
+// beyond that cap raise an error rather than silently rounding at a lower scale
+// than asked. Silently clamping would return an observably wrong (lower-precision)
+// value; erroring keeps the computation DoS-safe without ever lying about the
+// result.
 func resolveRoundScale(precision *big.Int, intDigits, fracDigits int) (int, roundDecision, error) {
 	if precision.Sign() < 0 {
 		// scale = -precision, as a non-negative big.Int
@@ -209,27 +211,35 @@ func resolveRoundScale(precision *big.Int, intDigits, fracDigits int) (int, roun
 		// Here s <= intDigits, which fits in int and bounds 10^s.
 		return int(s.Int64()), roundCompute, nil
 	}
-	// Non-negative precision. If it is at least the operand's fractional-digit
+	// Non-negative precision. A non-terminating rational has no terminating
+	// decimal expansion, so fracDigits is the ratFracDigitNonTerminating
+	// sentinel rather than a true scale: it must NEVER be treated as "fully
+	// representable" (which would short-circuit to roundUnchanged and return the
+	// repeating operand). Handle it first — honour the request up to
+	// roundMaxComputeScale so 10^p stays bounded, and beyond that refuse with
+	// FOAR0002 rather than silently returning a lower-precision value. This must
+	// precede the precision >= fracDigits test below, because a precision at or
+	// above the sentinel (e.g. 1<<30) would otherwise wrongly select
+	// roundUnchanged and bypass the cap entirely.
+	if fracDigits == ratFracDigitNonTerminating {
+		if precision.Cmp(big.NewInt(roundMaxComputeScale)) > 0 {
+			return 0, roundCompute, &XPathError{
+				Code: errCodeFOAR0002,
+				Message: fmt.Sprintf(
+					"round precision %s exceeds the maximum of %d fractional digits for a non-terminating decimal",
+					precision.String(), roundMaxComputeScale),
+			}
+		}
+		return int(precision.Int64()), roundCompute, nil
+	}
+	// Terminating decimal. If precision is at least the operand's fractional-digit
 	// count the operand is unchanged; this also covers all integers (fracDigits
 	// == 0) and any precision >= the operand's scale.
 	if precision.Cmp(big.NewInt(int64(fracDigits))) >= 0 {
 		return 0, roundUnchanged, nil
 	}
-	// Here precision < fracDigits. For a terminating decimal fracDigits is the
-	// operand's true scale, so 10^precision is bounded by the operand's own size
-	// (the accepted invariant). For a non-terminating rational fracDigits is the
-	// ratFracDigitNonTerminating sentinel and precision may be astronomically
-	// large with no operand bounding it. Honour it up to roundMaxComputeScale so
-	// 10^p stays bounded; beyond that, refuse with FOAR0002 rather than silently
-	// returning a lower-precision value than requested.
-	if fracDigits == ratFracDigitNonTerminating && precision.Cmp(big.NewInt(roundMaxComputeScale)) > 0 {
-		return 0, roundCompute, &XPathError{
-			Code: errCodeFOAR0002,
-			Message: fmt.Sprintf(
-				"round precision %s exceeds the maximum of %d fractional digits for a non-terminating decimal",
-				precision.String(), roundMaxComputeScale),
-		}
-	}
+	// Here precision < fracDigits, and fracDigits is the operand's true scale, so
+	// 10^precision is bounded by the operand's own size (the accepted invariant).
 	return int(precision.Int64()), roundCompute, nil
 }
 

--- a/xpath3/functions_numeric.go
+++ b/xpath3/functions_numeric.go
@@ -131,47 +131,155 @@ func fnFloor(_ context.Context, args []Sequence) (Sequence, error) {
 	return SingleAtomic(makeFloatResult(a.TypeName, math.Floor(f))), nil
 }
 
-// maxRoundPrecision bounds the rounding scale used by fn:round and
-// fn:round-half-to-even. The $precision argument is an xs:integer and may be
-// arbitrarily large (e.g. 2^63, stored as a *big.Int). Two problems must be
-// avoided: int(IntegerVal()) wraps out-of-int64 values (turning a huge positive
-// precision into a huge negative one), and computing 10^|precision| via
-// big.Int.Exp for an astronomically large scale exhausts CPU/memory. Per XPath
-// F&O 3.1 a precision far larger than the value's significant digits leaves it
-// unchanged, and a precision far more negative rounds it to 0; no representable
-// number has anywhere near this many significant digits, so clamping preserves
-// semantics while bounding the scale computation.
-const maxRoundPrecision = 4096
+// roundDecision is the scale-aware outcome of resolving a $precision argument
+// against an operand's own base-10 scale. See resolveRoundScale.
+type roundDecision int
+
+const (
+	// roundCompute: the precision is within range of the operand's scale, so
+	// the result must be computed with the (bounded) scale exponent.
+	roundCompute roundDecision = iota
+	// roundUnchanged: the precision is finer than the operand's fractional
+	// scale; the result equals the operand unchanged. No Exp needed.
+	roundUnchanged
+	// roundTrivialZero: the precision is coarser than the operand's magnitude
+	// by more than one decade, so every digit rounds away. The result is 0
+	// (the boundary/tie case s == magnitude is handled by roundCompute, since
+	// its scale exponent is bounded by the operand's own digit count). No Exp
+	// needed.
+	roundTrivialZero
+)
 
 // roundPrecisionArg extracts the rounding precision from the second argument,
-// casting to xs:integer and clamping to ±maxRoundPrecision so an out-of-int64
-// value neither wraps nor blows up the scale computation.
-func roundPrecisionArg(arg Sequence) (int, error) {
+// casting to xs:integer. The precision is returned as a *big.Int (XPath
+// integers are arbitrary precision); callers pair it with the operand's scale
+// via resolveRoundScale so an astronomically large 10^|precision| is never
+// materialised for cases whose result is determined trivially. (A *big.Int
+// avoids the wrap that int(IntegerVal()) would introduce for out-of-int64
+// values.)
+func roundPrecisionArg(arg Sequence) (*big.Int, error) {
 	pa, err := AtomizeItem(arg.Get(0))
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	pa, err = CastAtomic(pa, TypeInteger)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	if v, ok := pa.Int64Val(); ok {
-		if v > maxRoundPrecision {
-			return maxRoundPrecision, nil
+	return new(big.Int).Set(pa.BigInt()), nil
+}
+
+// resolveRoundScale decides, scale-aware, how to round an operand to the given
+// $precision. intDigits is the number of base-10 digits in the operand's
+// integer part (>= 1; use 1 for |operand| < 1). fracDigits is the number of
+// fractional decimal digits the operand actually has (0 for integers). The
+// returned scale is the bounded magnitude of 10 to raise (always >= 0) and is
+// only meaningful when the decision is roundCompute.
+//
+// For coarse (negative) precision the scale is s = -precision: when s exceeds
+// the operand's integer magnitude by more than one decade no tie is possible
+// and the result is 0; otherwise s <= intDigits so 10^s is bounded by the
+// operand. For fine (positive) precision the scale is p = precision: when p is
+// at least the operand's fractional-digit count the operand is already
+// representable and is returned unchanged; otherwise 10^p is bounded by the
+// operand's fractional scale.
+func resolveRoundScale(precision *big.Int, intDigits, fracDigits int) (int, roundDecision) {
+	if precision.Sign() < 0 {
+		// scale = -precision, as a non-negative big.Int
+		s := new(big.Int).Neg(precision)
+		// If -precision > intDigits, the scale is at least a full decade above
+		// the operand's magnitude, so |operand| < 10^s / 2 and it rounds to 0.
+		if s.Cmp(big.NewInt(int64(intDigits))) > 0 {
+			return 0, roundTrivialZero
 		}
-		if v < -maxRoundPrecision {
-			return -maxRoundPrecision, nil
+		// Here s <= intDigits, which fits in int and bounds 10^s.
+		return int(s.Int64()), roundCompute
+	}
+	// Non-negative precision. If it is at least the operand's fractional-digit
+	// count the operand is unchanged; this also covers all integers (fracDigits
+	// == 0) and any precision >= the operand's scale.
+	if precision.Cmp(big.NewInt(int64(fracDigits))) >= 0 {
+		return 0, roundUnchanged
+	}
+	// Here precision < fracDigits, which fits in int and bounds 10^precision.
+	return int(precision.Int64()), roundCompute
+}
+
+// intDigitCount returns the number of base-10 digits in |n|, with 0 counted as
+// a single digit. Used as the integer-magnitude input to resolveRoundScale.
+func intDigitCount(n *big.Int) int {
+	if n.Sign() == 0 {
+		return 1
+	}
+	return len(new(big.Int).Abs(n).Text(10))
+}
+
+// ratIntDigitCount returns the number of base-10 digits in the integer part of
+// |r| (>= 1).
+func ratIntDigitCount(r *big.Rat) int {
+	return intDigitCount(ratFloorInt(new(big.Rat).Abs(r)))
+}
+
+// ratFracDigitNonTerminating is returned by ratFracDigitCount for a rational
+// whose decimal expansion does not terminate (e.g. 1/3, common when an
+// xs:decimal is produced by integer division). It is large enough that no
+// practical fine precision will be treated as "finer than the operand's
+// scale", so such values always fall through to roundCompute — yet small
+// enough that resolveRoundScale never feeds it to Exp (positive precision is
+// always bounded by the caller's actual precision argument, not this value).
+const ratFracDigitNonTerminating = 1 << 30
+
+// ratFracDigitCount returns the number of fractional decimal digits of r in its
+// terminating decimal expansion: when r's reduced denominator is 2^a * 5^b this
+// is max(a, b). For a non-terminating rational (a denominator with other prime
+// factors, which an xs:decimal division result can be) it returns
+// ratFracDigitNonTerminating so any finite precision triggers real rounding.
+func ratFracDigitCount(r *big.Rat) int {
+	d := new(big.Int).Set(r.Denom())
+	two := big.NewInt(2)
+	five := big.NewInt(5)
+	a := 0
+	for d.Cmp(big.NewInt(1)) != 0 {
+		q, rem := new(big.Int).QuoRem(d, two, new(big.Int))
+		if rem.Sign() != 0 {
+			break
 		}
-		return int(v), nil
+		d = q
+		a++
 	}
-	// Out of int64 range: sign decides whether we clamp high or low.
-	if pa.BigInt().Sign() < 0 {
-		return -maxRoundPrecision, nil
+	b := 0
+	for d.Cmp(big.NewInt(1)) != 0 {
+		q, rem := new(big.Int).QuoRem(d, five, new(big.Int))
+		if rem.Sign() != 0 {
+			break
+		}
+		d = q
+		b++
 	}
-	return maxRoundPrecision, nil
+	if d.Cmp(big.NewInt(1)) != 0 {
+		// Residual factor other than 2 or 5: the decimal expansion repeats.
+		return ratFracDigitNonTerminating
+	}
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func fnRound(_ context.Context, args []Sequence) (Sequence, error) {
+	return roundImpl(args, false)
+}
+
+func fnRoundHalfToEven(_ context.Context, args []Sequence) (Sequence, error) {
+	return roundImpl(args, true)
+}
+
+// roundImpl is the shared core of fn:round (halfToEven == false, half towards
+// +infinity) and fn:round-half-to-even (halfToEven == true). The $precision
+// argument is resolved scale-aware against each operand so an astronomically
+// large 10^|precision| is never materialised: cases whose result is determined
+// trivially (rounds to 0, or operand unchanged) short-circuit before any Exp.
+func roundImpl(args []Sequence, halfToEven bool) (Sequence, error) {
 	a, ok, err := promoteSeqToNumeric(args[0])
 	if err != nil {
 		return nil, err
@@ -179,83 +287,98 @@ func fnRound(_ context.Context, args []Sequence) (Sequence, error) {
 	if !ok {
 		return validNilSequence, nil
 	}
-	precision := 0
+	precision := big.NewInt(0)
 	if len(args) > 1 && seqLen(args[1]) > 0 {
 		precision, err = roundPrecisionArg(args[1])
 		if err != nil {
 			return nil, err
 		}
 	}
+
 	if isIntegerDerived(a.TypeName) {
-		if precision >= 0 {
+		scale, decision := resolveRoundScale(precision, intDigitCount(a.BigInt()), 0)
+		if decision == roundUnchanged {
 			if v, ok := a.Value.(int64); ok {
 				return SingleInteger(v), nil
 			}
 			return SingleIntegerBig(new(big.Int).Set(a.BigInt())), nil
 		}
-		return SingleIntegerBig(roundIntegerHalfUp(a.BigInt(), -precision)), nil
-	}
-	if a.TypeName == TypeDecimal {
-		if precision == 0 {
-			return SingleDecimal(ratRound(a.BigRat())), nil
+		if decision == roundTrivialZero {
+			return SingleInteger(0), nil
 		}
-		return SingleDecimal(ratRoundPrecision(a.BigRat(), precision)), nil
+		if halfToEven {
+			return SingleIntegerBig(roundIntegerHalfToEven(a.BigInt(), scale)), nil
+		}
+		return SingleIntegerBig(roundIntegerHalfUp(a.BigInt(), scale)), nil
 	}
+
+	if a.TypeName == TypeDecimal {
+		r := a.BigRat()
+		scale, decision := resolveRoundScale(precision, ratIntDigitCount(r), ratFracDigitCount(r))
+		if decision == roundUnchanged {
+			return SingleDecimal(new(big.Rat).Set(r)), nil
+		}
+		if decision == roundTrivialZero {
+			return SingleDecimal(new(big.Rat)), nil
+		}
+		p := scale
+		if precision.Sign() < 0 {
+			p = -scale
+		}
+		if halfToEven {
+			return SingleDecimal(icu.RatRoundHalfToEven(r, p)), nil
+		}
+		if p == 0 {
+			return SingleDecimal(ratRound(r)), nil
+		}
+		return SingleDecimal(ratRoundPrecision(r, p)), nil
+	}
+
 	n := a.ToFloat64()
 	if math.IsNaN(n) || math.IsInf(n, 0) || n == 0 {
 		return SingleAtomic(a), nil
 	}
-	if precision > 308 {
+	// A float64 has at most ~309 integer digits and ~324 fractional digits, so
+	// these bounds make resolveRoundScale short-circuit every extreme precision
+	// without ever computing a huge scale.
+	intDigits := floatIntDigitCount(n)
+	scale, decision := resolveRoundScale(precision, intDigits, 324)
+	if decision == roundUnchanged {
 		return SingleAtomic(a), nil
 	}
-	// Use big.Float to preserve the exact IEEE 754 value during scaling
-	r := roundHalfUpFloat(n, precision)
+	if decision == roundTrivialZero {
+		r := 0.0
+		if math.Signbit(n) {
+			r = math.Copysign(0, -1)
+		}
+		return SingleAtomic(makeFloatResult(a.TypeName, r)), nil
+	}
+	p := scale
+	if precision.Sign() < 0 {
+		p = -scale
+	}
+	if halfToEven {
+		result := roundHalfToEvenFloat(n, p)
+		return SingleAtomic(makeFloatResult(a.TypeName, result)), nil
+	}
+	r := roundHalfUpFloat(n, p)
 	if r == 0 && math.Signbit(n) {
 		r = math.Copysign(0, -1)
 	}
 	return SingleAtomic(makeFloatResult(a.TypeName, r)), nil
 }
 
-func fnRoundHalfToEven(_ context.Context, args []Sequence) (Sequence, error) {
-	a, ok, err := promoteSeqToNumeric(args[0])
-	if err != nil {
-		return nil, err
+// floatIntDigitCount returns the number of base-10 digits in the integer part
+// of |n| (>= 1), used as the magnitude input to resolveRoundScale. It derives
+// the magnitude from the exact value via big.Float to avoid the off-by-one that
+// math.Log10 exhibits near powers of ten.
+func floatIntDigitCount(n float64) int {
+	m := math.Abs(n)
+	if m < 1 {
+		return 1
 	}
-	if !ok {
-		return validNilSequence, nil
-	}
-	precision := 0
-	if len(args) > 1 && seqLen(args[1]) > 0 {
-		precision, err = roundPrecisionArg(args[1])
-		if err != nil {
-			return nil, err
-		}
-	}
-	if isIntegerDerived(a.TypeName) {
-		if precision >= 0 {
-			if v, ok := a.Value.(int64); ok {
-				return SingleInteger(v), nil
-			}
-			return SingleIntegerBig(new(big.Int).Set(a.BigInt())), nil
-		}
-		// Negative precision: round to 10^(-precision)
-		return SingleIntegerBig(roundIntegerHalfToEven(a.BigInt(), -precision)), nil
-	}
-	if a.TypeName == TypeDecimal {
-		return SingleDecimal(icu.RatRoundHalfToEven(a.BigRat(), precision)), nil
-	}
-	n := a.ToFloat64()
-	if math.IsNaN(n) || math.IsInf(n, 0) || n == 0 {
-		return SingleAtomic(a), nil
-	}
-	// Clamp precision for float64: beyond ~15 significant digits, no rounding effect
-	if precision > 308 {
-		return SingleAtomic(a), nil
-	}
-	// Use big.Float to preserve the exact double value during scaling,
-	// avoiding precision loss that can flip the rounding direction.
-	result := roundHalfToEvenFloat(n, precision)
-	return SingleAtomic(makeFloatResult(a.TypeName, result)), nil
+	intPart, _ := new(big.Float).SetPrec(256).SetFloat64(m).Int(nil)
+	return intDigitCount(intPart)
 }
 
 // roundHalfToEvenFloat rounds a float64 to the given precision using

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -133,6 +133,60 @@ func TestFnNumeric(t *testing.T) {
 	}
 }
 
+// TestFnRoundPrecision exercises fn:round and fn:round-half-to-even at
+// negative, zero, and positive precision over positive and negative operands,
+// including div-derived rationals. fn:round rounds the half toward positive
+// infinity; a regression in the negative-precision path floored the rational to
+// an integer before rounding, pushing values such as -249.9 past the boundary
+// (yielding -300 instead of -200).
+func TestFnRoundPrecision(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	tests := []struct {
+		expr   string
+		expect string
+	}{
+		// Negative precision, half-up (toward +∞).
+		{`round(-249.9, -2)`, "-200"},
+		{`round(-250, -2)`, "-200"}, // tie -2.5 → -2 toward +∞
+		{`round(250.1, -2)`, "300"},
+		{`round(-1234.567, -2)`, "-1200"}, // QT3 fn-round-decimal-11
+		{`round(8452, -2)`, "8500"},       // QT3 fn-round2args-2
+		// Zero precision / no precision arg, half-up (toward +∞).
+		{`round(-0.5)`, "0"},
+		{`round(2.5)`, "3"},
+		{`round(2.4)`, "2"},
+		{`round(-2.5, 0)`, "-2"},
+		// Positive precision, half-up.
+		{`round(2.4567, 2)`, "2.46"},
+		{`round(-2.345, 2)`, "-2.34"}, // tie toward +∞
+		// Div-derived rational input (1 div 3 etc.).
+		{`round((-2499 div 10), -2)`, "-200"},
+		{`round((2501 div 10), -2)`, "300"},
+		// Negative precision, half-to-even.
+		{`round-half-to-even(-250, -2)`, "-200"},
+		{`round-half-to-even(-350, -2)`, "-400"}, // tie → even
+		{`round-half-to-even(-249.9, -2)`, "-200"},
+		{`round-half-to-even(150, -2)`, "200"}, // tie → even
+		{`round-half-to-even(250, -2)`, "200"}, // tie → even
+		// Zero / positive precision, half-to-even.
+		{`round-half-to-even(2.5)`, "2"},
+		{`round-half-to-even(3.5)`, "4"},
+		{`round-half-to-even(-2.5)`, "-2"},
+		{`round-half-to-even(3.567, 2)`, "3.57"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.expr, func(t *testing.T) {
+			compiled, err := xpath3.NewCompiler().Compile(tc.expr)
+			require.NoError(t, err)
+			result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+				Evaluate(t.Context(), compiled, doc)
+			require.NoError(t, err)
+			require.Equal(t, tc.expect, result.StringValue())
+		})
+	}
+}
+
 // --- Aggregate functions ---
 
 func TestFnAggregate(t *testing.T) {

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -1,8 +1,11 @@
 package xpath3_test
 
 import (
+	"context"
 	"math"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/xpath3"
@@ -602,6 +605,131 @@ func TestFnImplicitTimezoneReturnsDuration(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, atomics, 1)
 	require.Equal(t, xpath3.TypeDayTimeDuration, atomics[0].TypeName)
+}
+
+// integerIdentityFn is a custom TypedFunction declaring a single xs:integer
+// parameter. It is used to verify that function-lookup enforces the declared
+// parameter types, mirroring the direct named-reference path (f#1).
+type integerIdentityFn struct{}
+
+func (integerIdentityFn) MinArity() int { return 1 }
+func (integerIdentityFn) MaxArity() int { return 1 }
+
+func (integerIdentityFn) Call(_ context.Context, args []xpath3.Sequence) (xpath3.Sequence, error) {
+	return args[0], nil
+}
+
+func (integerIdentityFn) FuncParamTypes() []xpath3.SequenceType {
+	return []xpath3.SequenceType{{
+		ItemTest:   xpath3.AtomicOrUnionType{Prefix: "xs", Name: "integer"},
+		Occurrence: xpath3.OccurrenceExactlyOne,
+	}}
+}
+
+func (integerIdentityFn) FuncReturnType() *xpath3.SequenceType {
+	return &xpath3.SequenceType{
+		ItemTest:   xpath3.AtomicOrUnionType{Prefix: "xs", Name: "integer"},
+		Occurrence: xpath3.OccurrenceExactlyOne,
+	}
+}
+
+// TestFunctionLookupTypedParamValidation verifies that a function item obtained
+// via function-lookup for a user-defined TypedFunction enforces the declared
+// parameter types — the same XPTY0004 check the direct f#1 reference applies.
+func TestFunctionLookupTypedParamValidation(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	lib := xpath3.NewFunctionLibrary()
+	lib.Set("f", integerIdentityFn{})
+
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Functions(lib)
+
+	t.Run("bad-typed arg raises XPTY0004", func(t *testing.T) {
+		compiled, err := xpath3.NewCompiler().Compile(`function-lookup(QName("","f"), 1)("bad")`)
+		require.NoError(t, err)
+		_, err = eval.Evaluate(t.Context(), compiled, doc)
+		require.Error(t, err)
+		require.ErrorIs(t, err, &xpath3.XPathError{Code: "XPTY0004"})
+	})
+
+	t.Run("good-typed arg works", func(t *testing.T) {
+		compiled, err := xpath3.NewCompiler().Compile(`function-lookup(QName("","f"), 1)(42)`)
+		require.NoError(t, err)
+		result, err := eval.Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, err)
+		seq := result.Sequence()
+		require.Equal(t, 1, seq.Len())
+		require.Equal(t, int64(42), seq.Get(0).(xpath3.AtomicValue).IntegerVal())
+	})
+
+	t.Run("named-reference parity", func(t *testing.T) {
+		// The direct f#1 path must reject the same bad arg.
+		compiled, err := xpath3.NewCompiler().Compile(`f#1("bad")`)
+		require.NoError(t, err)
+		_, err = eval.Evaluate(t.Context(), compiled, doc)
+		require.Error(t, err)
+		require.ErrorIs(t, err, &xpath3.XPathError{Code: "XPTY0004"})
+	})
+}
+
+// TestFnRoundScaleAware verifies that extreme but representable precisions
+// produce the spec-correct result rather than being blindly clamped, and that
+// each case returns promptly (no Exp on an astronomically large exponent). The
+// huge-magnitude cases use integers far beyond float64 range, so results are
+// compared as exact decimal strings.
+func TestFnRoundScaleAware(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	// 5 followed by 4999 zeros — an exact half at precision -5000.
+	bigHalf := "5" + strings.Repeat("0", 4999)
+	// 1 followed by 5000 zeros — the rounded result.
+	bigHalfRounded := "1" + strings.Repeat("0", 5000)
+
+	tests := []struct {
+		name   string
+		expr   string
+		expect string // exact decimal string of the result
+	}{
+		// Huge negative precision AT the magnitude boundary: must round the
+		// half case up, not leave it unchanged (the old fixed clamp returned
+		// the operand untouched).
+		{"int half boundary up", `round(` + bigHalf + `, -5000)`, bigHalfRounded},
+		// Half-to-even: the quotient (0) is already even, so the half rounds
+		// down to 0 — distinct from half-up which rounds the same value up.
+		{"int half boundary even", `round-half-to-even(` + bigHalf + `, -5000)`, "0"},
+		// Huge negative precision PAST the magnitude: rounds to 0.
+		{"int past magnitude", `round(` + bigHalf + `, -6000)`, "0"},
+		// Huge positive precision PAST the operand's (zero) fractional scale:
+		// integer is unchanged.
+		{"int fine unchanged", `round(123, 5000)`, "123"},
+		// Decimal with huge positive precision past its scale: unchanged.
+		{"decimal fine unchanged", `round(1.236, 5000)`, "1.236"},
+		// Decimal with huge negative precision past magnitude: zero.
+		{"decimal past magnitude", `round(1.236, -5000)`, "0"},
+		// Normal cases still correct.
+		{"normal up", `round(2.5, 0)`, "3"},
+		{"normal even", `round-half-to-even(2.5, 0)`, "2"},
+		{"normal neg", `round(12345, -2)`, "12300"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			done := make(chan xpath3.Sequence, 1)
+			go func() {
+				done <- evalExpr(t, doc, tc.expr)
+			}()
+			var seq xpath3.Sequence
+			select {
+			case seq = <-done:
+			case <-time.After(10 * time.Second):
+				t.Fatalf("round(%q) did not return promptly", tc.expr)
+			}
+			require.Equal(t, 1, seq.Len())
+			av := seq.Get(0).(xpath3.AtomicValue)
+			s, err := xpath3.AtomicToString(av)
+			require.NoError(t, err)
+			require.Equal(t, tc.expect, s)
+		})
+	}
 }
 
 // TestFnRoundExtremePrecision guards against the precision argument (an

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -760,6 +760,75 @@ func TestFnRoundExtremePrecision(t *testing.T) {
 	}
 }
 
+// TestFnRoundPrecisionArgValidation verifies the function-conversion rules for
+// the required "$precision as xs:integer" parameter of fn:round and
+// fn:round-half-to-even. The precision must be validated even when $arg is the
+// empty sequence (the empty first argument does not excuse an absent or
+// ill-typed precision); only xs:integer (and subtypes) and xs:untypedAtomic
+// (cast to integer) are accepted, everything else raises XPTY0004.
+func TestFnRoundPrecisionArgValidation(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	evalErrCode := func(t *testing.T, expr, code string) {
+		t.Helper()
+		compiled, err := xpath3.NewCompiler().Compile(expr)
+		require.NoError(t, err)
+		_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.Error(t, err, "expected error for %q", expr)
+		require.ErrorIs(t, err, &xpath3.XPathError{Code: code}, "expected error code %s for %q", code, expr)
+	}
+
+	evalOK := func(t *testing.T, expr, want string) {
+		t.Helper()
+		seq := evalExpr(t, doc, expr)
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		s, err := xpath3.AtomicToString(av)
+		require.NoError(t, err)
+		require.Equal(t, want, s)
+	}
+
+	t.Run("empty arg does not excuse bad precision", func(t *testing.T) {
+		// An ill-typed precision is a type error even when $arg is ().
+		evalErrCode(t, `round((), "bad")`, "XPTY0004")
+		evalErrCode(t, `round-half-to-even((), "bad")`, "XPTY0004")
+		// An empty precision in the 2-arg form violates exactly-one cardinality.
+		evalErrCode(t, `round((), ())`, "XPTY0004")
+	})
+
+	t.Run("empty precision is a cardinality error", func(t *testing.T) {
+		evalErrCode(t, `round(1, ())`, "XPTY0004")
+		evalErrCode(t, `round-half-to-even(1.5, ())`, "XPTY0004")
+	})
+
+	t.Run("non-integer precision rejected", func(t *testing.T) {
+		// No implicit numeric/boolean truncation to xs:integer.
+		evalErrCode(t, `round(123.45, true())`, "XPTY0004")
+		evalErrCode(t, `round(123.45, 1.9)`, "XPTY0004")
+		evalErrCode(t, `round(123.45, 2.0)`, "XPTY0004")
+		evalErrCode(t, `round(123.45, xs:double(2))`, "XPTY0004")
+		evalErrCode(t, `round(123.45, xs:float(2))`, "XPTY0004")
+		evalErrCode(t, `round(123.45, "2")`, "XPTY0004")
+		evalErrCode(t, `round-half-to-even(123456e-2, "two")`, "XPTY0004")
+	})
+
+	t.Run("integer precision and subtypes accepted", func(t *testing.T) {
+		evalOK(t, `round(123.456, 2)`, "123.46")
+		evalOK(t, `round(123.456, xs:int(2))`, "123.46")
+		evalOK(t, `round(123.456, xs:long(2))`, "123.46")
+		evalOK(t, `round(123.456, xs:short(2))`, "123.46")
+		// xs:untypedAtomic is cast to xs:integer.
+		evalOK(t, `round(123.456, xs:untypedAtomic("2"))`, "123.46")
+	})
+
+	t.Run("empty arg with valid precision is empty", func(t *testing.T) {
+		// A valid precision plus an empty $arg returns () (not an error).
+		evalOK(t, `empty(round((), 3))`, "true")
+		evalOK(t, `empty(round((), 1))`, "true")
+		evalOK(t, `empty(round-half-to-even((), 3))`, "true")
+	})
+}
+
 // TestFnRoundDecimalHugePrecision verifies that the decimal half-to-even path
 // computes huge-but-representable coarse precisions exactly, rather than being
 // silently clamped to zero by a coarse downstream guard. The operand magnitude
@@ -809,47 +878,78 @@ func TestFnRoundDecimalHugePrecision(t *testing.T) {
 // xs:decimal (e.g. 1 div 3, whose reduced denominator has a prime factor other
 // than 2 or 5) rounded at an astronomically large positive precision must NOT
 // build 10^precision via Exp. Such an operand has an unbounded fractional-digit
-// count, so the precision argument can never be "finer than the operand's scale";
-// the compute scale must still be bounded so the call returns promptly.
+// count, so a precision beyond roundMaxComputeScale (1<<20) is refused with
+// FOAR0002 rather than silently rounding at a lower scale (which would return an
+// observably wrong, lower-precision value). The refusal must be prompt, never a
+// hang or absurd allocation.
 func TestFnRoundNonTerminatingHugePrecision(t *testing.T) {
 	doc := mustParseXML(t, "<root/>")
 
-	tests := []struct {
-		name string
-		expr string
-	}{
+	tests := []string{
 		// 1 div 3 = 0.333... (non-terminating). A billion fractional digits must
-		// not trigger 10^1000000000.
-		{"halfeven 1div3 huge", `round-half-to-even(1 div 3, 1000000000)`},
-		{"halfup 1div3 huge", `round(1 div 3, 1000000000)`},
-		// 2 div 3 = 0.666... rounds up at its last retained digit; still must not
-		// build a billion-digit power.
-		{"halfeven 2div3 huge", `round-half-to-even(2 div 3, 1000000000)`},
-		// A precision just under the non-terminating sentinel (1<<30) — the exact
-		// boundary that previously slipped past the short-circuit.
-		{"halfeven 1div3 near-sentinel", `round-half-to-even(1 div 3, 1073741823)`},
+		// not trigger 10^1000000000; it exceeds the cap, so FOAR0002.
+		`round-half-to-even(1 div 3, 1000000000)`,
+		`round(1 div 3, 1000000000)`,
+		// 2 div 3 = 0.666... rounds up at its last retained digit; still over the
+		// cap, so FOAR0002 (never a billion-digit power).
+		`round-half-to-even(2 div 3, 1000000000)`,
+		// A precision just under the old non-terminating sentinel (1<<30) — well
+		// past the cap, so still refused.
+		`round-half-to-even(1 div 3, 1073741823)`,
+		// One past the cap is the boundary that must error.
+		`round(2 div 3, 1048577)`,
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			done := make(chan xpath3.Sequence, 1)
+	for _, expr := range tests {
+		t.Run(expr, func(t *testing.T) {
+			compiled, err := xpath3.NewCompiler().Compile(expr)
+			require.NoError(t, err)
+			done := make(chan error, 1)
 			go func() {
-				done <- evalExpr(t, doc, tc.expr)
+				_, ferr := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+				done <- ferr
 			}()
 			select {
-			case seq := <-done:
-				require.Equal(t, 1, seq.Len())
-				av := seq.Get(0).(xpath3.AtomicValue)
-				// The result must be a finite decimal near the operand value
-				// (0.333... or 0.666...), not a hang or absurd allocation.
-				f := av.ToFloat64()
-				require.False(t, math.IsNaN(f) || math.IsInf(f, 0))
-				require.GreaterOrEqual(t, f, 0.0)
-				require.Less(t, f, 1.0)
+			case ferr := <-done:
+				require.Error(t, ferr, "expected FOAR0002 for %q", expr)
+				require.ErrorIs(t, ferr, &xpath3.XPathError{Code: "FOAR0002"}, "expected FOAR0002 for %q", expr)
 			case <-time.After(10 * time.Second):
-				t.Fatalf("round(%q) did not return promptly (DoS)", tc.expr)
+				t.Fatalf("round(%q) did not return promptly (DoS)", expr)
 			}
 		})
 	}
+}
+
+// TestFnRoundNonTerminatingAtCap verifies that a non-terminating xs:decimal
+// rounded at exactly roundMaxComputeScale (1<<20) fractional digits computes the
+// exact value (rather than erroring or silently clamping). 2/3 to 1<<20 digits is
+// well-defined: every retained digit is 6 and the value rounds up in the last
+// place, so the result is "0." followed by (1<<20 - 1) sixes and a trailing 7.
+func TestFnRoundNonTerminatingAtCap(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	const maxScale = 1 << 20
+	expr := `round(2 div 3, 1048576)`
+	compiled, err := xpath3.NewCompiler().Compile(expr)
+	require.NoError(t, err)
+
+	done := make(chan xpath3.Sequence, 1)
+	go func() {
+		result, ferr := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, ferr)
+		done <- result.Sequence()
+	}()
+	var seq xpath3.Sequence
+	select {
+	case seq = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("round(%q) did not return promptly", expr)
+	}
+	require.Equal(t, 1, seq.Len())
+	av := seq.Get(0).(xpath3.AtomicValue)
+	s, err := xpath3.AtomicToString(av)
+	require.NoError(t, err)
+	want := "0." + strings.Repeat("6", maxScale-1) + "7"
+	require.Equal(t, want, s)
 }
 
 // TestFnRoundHalfToEvenNegativePrecision verifies negative-precision half-to-even

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -555,7 +555,14 @@ func TestBuiltinArgValidation(t *testing.T) {
 			`math:sin("abc")`,
 			`math:sin((1,2))`,
 			`math:pow(2,"x")`,
+			// An empty $x must not excuse an invalid/empty required $y:
+			// function-conversion validates each argument independently.
+			`math:pow((),"x")`,
+			`math:pow((),())`,
 			`math:atan2(1,(2,3))`,
+			// atan2's $x ($y) is required; an empty other arg is still XPTY0004.
+			`math:atan2((),1)`,
+			`math:atan2(1,())`,
 			`map:put(map{},(1,2),"v")`,
 			`map:entry((1,2),"v")`,
 			`parse-json("{}","bad")`,
@@ -580,6 +587,13 @@ func TestBuiltinArgValidation(t *testing.T) {
 			seq := evalExpr(t, doc, `math:pow(2,3)`)
 			require.Equal(t, 1, seq.Len())
 			require.InDelta(t, 8.0, seq.Get(0).(xpath3.AtomicValue).DoubleVal(), 0.0001)
+		})
+		t.Run("math:pow empty x valid y is empty", func(t *testing.T) {
+			// QT3 math-pow-001: math:pow((), 93.7) is the empty sequence
+			// because $y is a valid number. The empty-$x short-circuit only
+			// fires after $y validates.
+			seq := evalExpr(t, doc, `math:pow((), 93.7)`)
+			require.Nil(t, seq)
 		})
 		t.Run("map:put singleton key", func(t *testing.T) {
 			seq := evalExpr(t, doc, `map:size(map:put(map{},1,"v"))`)

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -759,3 +759,69 @@ func TestFnRoundExtremePrecision(t *testing.T) {
 		})
 	}
 }
+
+// TestFnRoundDecimalHugePrecision verifies that the decimal half-to-even path
+// computes huge-but-representable coarse precisions exactly, rather than being
+// silently clamped to zero by a coarse downstream guard. The operand magnitude
+// bounds the scale, so the result must be the exact large value and return
+// promptly (no hang).
+func TestFnRoundDecimalHugePrecision(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	// 6 followed by 4999 zeros, written as an xs:decimal (trailing ".0") so the
+	// decimal/icu path is exercised. At precision -5000 the magnitude boundary
+	// makes the value round up to 1 followed by 5000 zeros.
+	bigDecimal := "6" + strings.Repeat("0", 4999) + ".0"
+	bigRounded := "1" + strings.Repeat("0", 5000)
+
+	tests := []struct {
+		name   string
+		expr   string
+		expect string
+	}{
+		// Half-to-even decimal path, coarse precision past the clamp threshold.
+		{"halfeven decimal boundary up", `round-half-to-even(` + bigDecimal + `, -5000)`, bigRounded},
+		// Half-up decimal path with the same magnitude/precision.
+		{"halfup decimal boundary up", `round(` + bigDecimal + `, -5000)`, bigRounded},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			done := make(chan xpath3.Sequence, 1)
+			go func() {
+				done <- evalExpr(t, doc, tc.expr)
+			}()
+			var seq xpath3.Sequence
+			select {
+			case seq = <-done:
+			case <-time.After(10 * time.Second):
+				t.Fatalf("round(%q) did not return promptly", tc.expr)
+			}
+			require.Equal(t, 1, seq.Len())
+			av := seq.Get(0).(xpath3.AtomicValue)
+			s, err := xpath3.AtomicToString(av)
+			require.NoError(t, err)
+			require.Equal(t, tc.expect, s)
+		})
+	}
+}
+
+// TestFnRoundPrecisionCardinality verifies that the second ($precision) argument
+// of fn:round / fn:round-half-to-even is a required singleton: a multi-item
+// sequence must raise XPTY0004 rather than silently using its first item.
+func TestFnRoundPrecisionCardinality(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	exprs := []string{
+		`round(1, (1, 2))`,
+		`round-half-to-even(1, (1, 2))`,
+	}
+	for _, expr := range exprs {
+		t.Run(expr, func(t *testing.T) {
+			compiled, err := xpath3.NewCompiler().Compile(expr)
+			require.NoError(t, err)
+			_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+			require.Error(t, err, "expected error for %q", expr)
+			require.ErrorIs(t, err, &xpath3.XPathError{Code: "XPTY0004"})
+		})
+	}
+}

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -479,6 +479,72 @@ func TestFnCodepointsToStringRange(t *testing.T) {
 	})
 }
 
+// --- argument cardinality/type validation in math/map/json/hof builtins ---
+
+func TestBuiltinArgValidation(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	evalErrCode := func(t *testing.T, expr, code string) {
+		t.Helper()
+		compiled, err := xpath3.NewCompiler().Compile(expr)
+		require.NoError(t, err, "compile %q", expr)
+		_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.Error(t, err, "expected error for %q", expr)
+		require.ErrorIs(t, err, &xpath3.XPathError{Code: code}, "expected error code %s for %q", code, expr)
+	}
+
+	t.Run("type errors", func(t *testing.T) {
+		cases := []string{
+			`math:sin("abc")`,
+			`math:sin((1,2))`,
+			`math:pow(2,"x")`,
+			`math:atan2(1,(2,3))`,
+			`map:put(map{},(1,2),"v")`,
+			`map:entry((1,2),"v")`,
+			`parse-json("{}","bad")`,
+			`parse-json("{}",(map{},map{}))`,
+			`abs((1,2))`,
+			`function-lookup(QName("http://www.w3.org/2005/xpath-functions/math","sin"),1)(("a","b"))`,
+		}
+		for _, expr := range cases {
+			t.Run(expr, func(t *testing.T) {
+				evalErrCode(t, expr, "XPTY0004")
+			})
+		}
+	})
+
+	t.Run("valid controls still work", func(t *testing.T) {
+		t.Run("math:sin(0)", func(t *testing.T) {
+			seq := evalExpr(t, doc, `math:sin(0)`)
+			require.Equal(t, 1, seq.Len())
+			require.InDelta(t, 0.0, seq.Get(0).(xpath3.AtomicValue).DoubleVal(), 0.0001)
+		})
+		t.Run("math:pow(2,3)", func(t *testing.T) {
+			seq := evalExpr(t, doc, `math:pow(2,3)`)
+			require.Equal(t, 1, seq.Len())
+			require.InDelta(t, 8.0, seq.Get(0).(xpath3.AtomicValue).DoubleVal(), 0.0001)
+		})
+		t.Run("map:put singleton key", func(t *testing.T) {
+			seq := evalExpr(t, doc, `map:size(map:put(map{},1,"v"))`)
+			require.Equal(t, 1, seq.Len())
+			require.Equal(t, int64(1), seq.Get(0).(xpath3.AtomicValue).IntegerVal())
+		})
+		t.Run("parse-json no options", func(t *testing.T) {
+			seq := evalExpr(t, doc, `parse-json("{}")`)
+			require.Equal(t, 1, seq.Len())
+		})
+		t.Run("parse-json empty-map options", func(t *testing.T) {
+			seq := evalExpr(t, doc, `parse-json("{}", map{})`)
+			require.Equal(t, 1, seq.Len())
+		})
+		t.Run("abs(-3)", func(t *testing.T) {
+			seq := evalExpr(t, doc, `abs(-3)`)
+			require.Equal(t, 1, seq.Len())
+			require.Equal(t, int64(3), seq.Get(0).(xpath3.AtomicValue).IntegerVal())
+		})
+	})
+}
+
 // --- Error function ---
 
 func TestFnError(t *testing.T) {

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -603,3 +603,31 @@ func TestFnImplicitTimezoneReturnsDuration(t *testing.T) {
 	require.Len(t, atomics, 1)
 	require.Equal(t, xpath3.TypeDayTimeDuration, atomics[0].TypeName)
 }
+
+// TestFnRoundExtremePrecision guards against the precision argument (an
+// xs:integer that may exceed int64 range) wrapping when converted to int, and
+// against an astronomically large 10^|precision| scale hanging the computation.
+func TestFnRoundExtremePrecision(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	tests := []struct {
+		expr   string
+		expect float64
+	}{
+		{`round(1.236, 2)`, 1.24},
+		{`round(123.456, -2)`, 100},
+		{`round(1.23, 9223372036854775808)`, 1.23},
+		{`round-half-to-even(1.23, 9223372036854775808)`, 1.23},
+		{`round(1.23, -9223372036854775809)`, 0},
+		{`round-half-to-even(1.23, -9223372036854775809)`, 0},
+		{`round(125, -9223372036854775809)`, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.expr, func(t *testing.T) {
+			seq := evalExpr(t, doc, tc.expr)
+			require.Equal(t, 1, seq.Len())
+			av := seq.Get(0).(xpath3.AtomicValue)
+			require.InDelta(t, tc.expect, av.ToFloat64(), 0.001)
+		})
+	}
+}

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -717,7 +717,7 @@ func TestFunctionLookupTypedParamValidation(t *testing.T) {
 		require.NoError(t, err)
 		_, err = eval.Evaluate(t.Context(), compiled, doc)
 		require.Error(t, err)
-		require.ErrorIs(t, err, &xpath3.XPathError{Code: "XPTY0004"})
+		require.ErrorIs(t, err, &xpath3.XPathError{Code: lexicon.ErrXPTY0004})
 	})
 
 	t.Run("good-typed arg works", func(t *testing.T) {
@@ -736,7 +736,7 @@ func TestFunctionLookupTypedParamValidation(t *testing.T) {
 		require.NoError(t, err)
 		_, err = eval.Evaluate(t.Context(), compiled, doc)
 		require.Error(t, err)
-		require.ErrorIs(t, err, &xpath3.XPathError{Code: "XPTY0004"})
+		require.ErrorIs(t, err, &xpath3.XPathError{Code: lexicon.ErrXPTY0004})
 	})
 
 	t.Run("untypedAtomic arg is coerced before invocation", func(t *testing.T) {
@@ -760,8 +760,58 @@ func TestFunctionLookupTypedParamValidation(t *testing.T) {
 		require.NoError(t, err)
 		_, err = eval.Evaluate(t.Context(), compiled, doc)
 		require.Error(t, err)
-		require.ErrorIs(t, err, &xpath3.XPathError{Code: "XPTY0004"})
+		require.ErrorIs(t, err, &xpath3.XPathError{Code: lexicon.ErrXPTY0004})
 	})
+}
+
+// customPrefixParamFn is a TypedFunction whose single parameter declares an
+// AtomicOrUnionType with a NON-xs/xsd prefix ("app"). Resolving such a type via
+// function-lookup's Invoke closure formerly passed a nil eval context into
+// coerceToSequenceType, which dereferenced ec.namespaces and panicked. The
+// function must instead surface an XPTY0004 type error with no panic.
+type customPrefixParamFn struct{}
+
+func (customPrefixParamFn) MinArity() int { return 1 }
+func (customPrefixParamFn) MaxArity() int { return 1 }
+
+func (customPrefixParamFn) Call(_ context.Context, args []xpath3.Sequence) (xpath3.Sequence, error) {
+	return args[0], nil
+}
+
+func (customPrefixParamFn) FuncParamTypes() []xpath3.SequenceType {
+	return []xpath3.SequenceType{{
+		ItemTest:   xpath3.AtomicOrUnionType{Prefix: "app", Name: "id"},
+		Occurrence: xpath3.OccurrenceExactlyOne,
+	}}
+}
+
+func (customPrefixParamFn) FuncReturnType() *xpath3.SequenceType {
+	return &xpath3.SequenceType{
+		ItemTest:   xpath3.AtomicOrUnionType{Prefix: "app", Name: "id"},
+		Occurrence: xpath3.OccurrenceExactlyOne,
+	}
+}
+
+// TestFunctionLookupCustomPrefixParamNoPanic verifies that invoking a function
+// item obtained via function-lookup for a TypedFunction whose parameter type has
+// a non-xs prefix does not panic on a nil eval context, but returns an
+// XPathError (XPTY0004) for the unresolvable custom type.
+func TestFunctionLookupCustomPrefixParamNoPanic(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	lib := xpath3.NewFunctionLibrary()
+	lib.Set("f", customPrefixParamFn{})
+
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Functions(lib)
+
+	compiled, err := xpath3.NewCompiler().Compile(`function-lookup(QName("","f"), 1)(1)`)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_, err = eval.Evaluate(t.Context(), compiled, doc)
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, &xpath3.XPathError{Code: lexicon.ErrXPTY0004})
 }
 
 // TestFnRoundScaleAware verifies that extreme but representable precisions
@@ -1100,7 +1150,7 @@ func TestFnRoundPrecisionCardinality(t *testing.T) {
 			require.NoError(t, err)
 			_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
 			require.Error(t, err, "expected error for %q", expr)
-			require.ErrorIs(t, err, &xpath3.XPathError{Code: "XPTY0004"})
+			require.ErrorIs(t, err, &xpath3.XPathError{Code: lexicon.ErrXPTY0004})
 		})
 	}
 }

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -670,6 +670,30 @@ func TestFunctionLookupTypedParamValidation(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, &xpath3.XPathError{Code: "XPTY0004"})
 	})
+
+	t.Run("untypedAtomic arg is coerced before invocation", func(t *testing.T) {
+		// xs:untypedAtomic("7") satisfies the xs:integer parameter via the
+		// function-conversion rules. The coerced value (an xs:integer) must be
+		// what the function body observes — integerIdentityFn returns args[0],
+		// so the result type proves whether coercion was applied.
+		compiled, err := xpath3.NewCompiler().Compile(`function-lookup(QName("","f"), 1)(xs:untypedAtomic("7"))`)
+		require.NoError(t, err)
+		result, err := eval.Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, err)
+		seq := result.Sequence()
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.Equal(t, xpath3.TypeInteger, av.TypeName)
+		require.Equal(t, int64(7), av.IntegerVal())
+	})
+
+	t.Run("non-coercible value still raises XPTY0004", func(t *testing.T) {
+		compiled, err := xpath3.NewCompiler().Compile(`function-lookup(QName("","f"), 1)(xs:untypedAtomic("not-an-int"))`)
+		require.NoError(t, err)
+		_, err = eval.Evaluate(t.Context(), compiled, doc)
+		require.Error(t, err)
+		require.ErrorIs(t, err, &xpath3.XPathError{Code: "XPTY0004"})
+	})
 }
 
 // TestFnRoundScaleAware verifies that extreme but representable precisions
@@ -898,6 +922,14 @@ func TestFnRoundNonTerminatingHugePrecision(t *testing.T) {
 		`round-half-to-even(1 div 3, 1073741823)`,
 		// One past the cap is the boundary that must error.
 		`round(2 div 3, 1048577)`,
+		// Precision exactly at the ratFracDigitNonTerminating sentinel (1<<30):
+		// the "precision >= fracDigits" test must NOT short-circuit to
+		// roundUnchanged for a non-terminating decimal; it exceeds the cap so it
+		// must raise FOAR0002, not silently return the repeating operand.
+		`round(1 div 3, 1073741824)`,
+		`round-half-to-even(1 div 3, 1073741824)`,
+		// Precision above the sentinel must also refuse, not return unchanged.
+		`round(1 div 3, 2000000000)`,
 	}
 	for _, expr := range tests {
 		t.Run(expr, func(t *testing.T) {

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -805,6 +805,85 @@ func TestFnRoundDecimalHugePrecision(t *testing.T) {
 	}
 }
 
+// TestFnRoundNonTerminatingHugePrecision guards against a DoS: a non-terminating
+// xs:decimal (e.g. 1 div 3, whose reduced denominator has a prime factor other
+// than 2 or 5) rounded at an astronomically large positive precision must NOT
+// build 10^precision via Exp. Such an operand has an unbounded fractional-digit
+// count, so the precision argument can never be "finer than the operand's scale";
+// the compute scale must still be bounded so the call returns promptly.
+func TestFnRoundNonTerminatingHugePrecision(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	tests := []struct {
+		name string
+		expr string
+	}{
+		// 1 div 3 = 0.333... (non-terminating). A billion fractional digits must
+		// not trigger 10^1000000000.
+		{"halfeven 1div3 huge", `round-half-to-even(1 div 3, 1000000000)`},
+		{"halfup 1div3 huge", `round(1 div 3, 1000000000)`},
+		// 2 div 3 = 0.666... rounds up at its last retained digit; still must not
+		// build a billion-digit power.
+		{"halfeven 2div3 huge", `round-half-to-even(2 div 3, 1000000000)`},
+		// A precision just under the non-terminating sentinel (1<<30) — the exact
+		// boundary that previously slipped past the short-circuit.
+		{"halfeven 1div3 near-sentinel", `round-half-to-even(1 div 3, 1073741823)`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			done := make(chan xpath3.Sequence, 1)
+			go func() {
+				done <- evalExpr(t, doc, tc.expr)
+			}()
+			select {
+			case seq := <-done:
+				require.Equal(t, 1, seq.Len())
+				av := seq.Get(0).(xpath3.AtomicValue)
+				// The result must be a finite decimal near the operand value
+				// (0.333... or 0.666...), not a hang or absurd allocation.
+				f := av.ToFloat64()
+				require.False(t, math.IsNaN(f) || math.IsInf(f, 0))
+				require.GreaterOrEqual(t, f, 0.0)
+				require.Less(t, f, 1.0)
+			case <-time.After(10 * time.Second):
+				t.Fatalf("round(%q) did not return promptly (DoS)", tc.expr)
+			}
+		})
+	}
+}
+
+// TestFnRoundHalfToEvenNegativePrecision verifies negative-precision half-to-even
+// rounding divides the full rational (never floors to an integer first), so a
+// fractional part that breaks a tie is honoured.
+func TestFnRoundHalfToEvenNegativePrecision(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	tests := []struct {
+		expr   string
+		expect string
+	}{
+		// 250.1 at -2: 250.1/100 = 2.501 -> rounds to 3 -> 300 (not 200; the .1
+		// breaks the tie upward, so flooring to 250 first would be wrong).
+		{`round-half-to-even(250.1, -2)`, "300"},
+		// -249.9 at -2: -2.499 -> rounds to -2 -> -200 (not -300).
+		{`round-half-to-even(-249.9, -2)`, "-200"},
+		// Exact even-tie cases at -1.
+		{`round-half-to-even(248, -1)`, "250"},
+		{`round-half-to-even(250, -1)`, "250"},
+		{`round-half-to-even(2.5, -1)`, "0"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.expr, func(t *testing.T) {
+			seq := evalExpr(t, doc, tc.expr)
+			require.Equal(t, 1, seq.Len())
+			av := seq.Get(0).(xpath3.AtomicValue)
+			s, err := xpath3.AtomicToString(av)
+			require.NoError(t, err)
+			require.Equal(t, tc.expect, s)
+		})
+	}
+}
+
 // TestFnRoundPrecisionCardinality verifies that the second ($precision) argument
 // of fn:round / fn:round-half-to-even is a required singleton: a multi-item
 // sequence must raise XPTY0004 rather than silently using its first item.


### PR DESCRIPTION
- math:sin/cos/.../pow/atan2 now route numeric args through single-item coercion (XPTY0004 on multi-item or non-numeric) instead of treating them as 0
- map:put/entry/find and parse-json/json-doc options reject wrong-cardinality/wrong-type args; abs/ceiling/floor/round add a single-item numeric check
- function-lookup invoke wrapper now enforces recorded ParamTypes; fixed the incorrect fn:sort#2 signature (second arg is xs:string? collation, not a key function)
