### PR TITLE
xpath3: enforce builtin parameter signatures

### DIFF
--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -40,6 +40,16 @@ Typed helper coercions for `xs:string?` + `xs:integer` enforce cardinality.
 Sequences with length `> 1` → `XPTY0004`; helpers do not truncate to first item.
 Signature-sensitive string/regex/URI builtin call sites + `||` string coercion also enforce single-item cardinality and propagate atomization/type errors.
 
+`evalFunctionCall` (the static call path) enforces the declared parameter
+signature for every resolved function before invoking it: it looks up
+`paramTypes` via the `function_signatures.go` registry (then
+`TypedFunction`/`TypedFunctionByArity`) the same way `evalNamedFunctionRef`
+does, and runs `coerceToSequenceType(arg, paramTypes[i], ec)` per argument,
+raising `XPTY0004` on mismatch. Functions with no registered signature
+(`paramTypes == nil`) are not type-checked. `coerceToSequenceType` atomizes via
+`AtomizeSequence` (so list-typed nodes/arrays expand correctly) and falls back
+to `ec.schemaDeclarations.IsSubtypeOf` for user-defined schema types.
+
 ## Functions by File
 
 ### `functions_node.go`

--- a/xpath3/cast_numeric.go
+++ b/xpath3/cast_numeric.go
@@ -35,6 +35,13 @@ func castToDouble(v AtomicValue) (AtomicValue, error) {
 	case TypeString, TypeUntypedAtomic:
 		return CastFromString(v.StringVal(), TypeDouble)
 	default:
+		// Integer-derived subtypes (xs:int, xs:long, xs:positiveInteger, …) store
+		// their value as int64/*big.Int just like xs:integer, so promote through
+		// the integer value space.
+		if isIntegerDerived(v.TypeName) {
+			f, _ := new(big.Float).SetInt(v.BigInt()).Float64()
+			return AtomicValue{TypeName: TypeDouble, Value: NewDouble(f)}, nil
+		}
 		if isStringDerived(v.TypeName) {
 			return CastFromString(v.StringVal(), TypeDouble)
 		}

--- a/xpath3/eval_funcall.go
+++ b/xpath3/eval_funcall.go
@@ -28,42 +28,47 @@ func evalFunctionCall(evalFn exprEvaluator, ctx context.Context, ec *evalContext
 		return partialApply(ctx, ec, e, args)
 	}
 
-	// Resolve function
-	fn, err := resolveFunction(ctx, ec, e.Prefix, e.Name, len(args))
+	// Resolve function, keeping the resolved identity so signature enforcement
+	// keys off the resolved URI/local name (handles Q{uri}local) and only applies
+	// the built-in signature when the resolved function is the actual built-in.
+	r, err := resolveFunctionInfo(ctx, ec, e.Prefix, e.Name, len(args))
 	if err != nil {
 		return nil, err
 	}
 
-	// Enforce declared parameter signatures for static built-in calls, mirroring
-	// the function-item / named-function-reference path. Obtain the registered
-	// parameter types the same way evalNamedFunctionRef does (built-in registry
-	// signature, then TypedFunction/TypedFunctionByArity interfaces).
-	ns, _ := resolvePrefix(ec, e.Prefix)
-	paramTypes := lookupParamTypes(fn, ns, e.Name, len(args))
+	// Enforce declared parameter signatures, mirroring the function-item /
+	// named-function-reference path. Coerced values are stored back into args so
+	// typed functions observe the converted values (e.g. xs:integer→xs:double).
+	paramTypes := lookupParamTypes(r, len(args))
 	if paramTypes != nil {
 		for i, arg := range args {
 			if i < len(paramTypes) {
-				if _, ok := coerceToSequenceType(arg, paramTypes[i], ec); !ok {
-					return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("fn:%s: argument %d does not match required type %v", e.Name, i+1, paramTypes[i])}
+				coerced, ok := coerceToSequenceType(arg, paramTypes[i], ec)
+				if !ok {
+					return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("fn:%s: argument %d does not match required type %v", r.name, i+1, paramTypes[i])}
 				}
+				args[i] = coerced
 			}
 		}
 	}
 
-	return fn.Call(ec.fnContext(ctx), args)
+	return r.fn.Call(ec.fnContext(ctx), args)
 }
 
-// lookupParamTypes returns the declared parameter types for a function, using the
-// built-in signature registry first and then the TypedFunction/TypedFunctionByArity
-// interfaces. It returns nil when no signature is available (no enforcement).
-func lookupParamTypes(fn Function, ns, name string, arity int) []SequenceType {
-	if sig := lookupFunctionSignature(ns, name, arity); sig != nil {
-		return sig.ParamTypes
+// lookupParamTypes returns the declared parameter types for a resolved function.
+// The built-in signature registry is consulted only when the resolved function is
+// the built-in; user/registered functions use their own TypedFunction metadata.
+// It returns nil when no signature is available (no enforcement).
+func lookupParamTypes(r resolvedFunction, arity int) []SequenceType {
+	if r.isBuiltin {
+		if sig := lookupFunctionSignature(r.uri, r.name, arity); sig != nil {
+			return sig.ParamTypes
+		}
 	}
-	if tf, ok := fn.(TypedFunction); ok {
+	if tf, ok := r.fn.(TypedFunction); ok {
 		return tf.FuncParamTypes()
 	}
-	if tfa, ok := fn.(TypedFunctionByArity); ok {
+	if tfa, ok := r.fn.(TypedFunctionByArity); ok {
 		return tfa.FuncParamTypesForArity(arity)
 	}
 	return nil

--- a/xpath3/eval_funcall.go
+++ b/xpath3/eval_funcall.go
@@ -2,6 +2,7 @@ package xpath3
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/lestrrat-go/helium/internal/lexicon"
@@ -43,8 +44,14 @@ func evalFunctionCall(evalFn exprEvaluator, ctx context.Context, ec *evalContext
 	if paramTypes != nil {
 		for i, arg := range args {
 			if i < len(paramTypes) {
-				coerced, ok := coerceToSequenceType(arg, paramTypes[i], ec)
-				if !ok {
+				coerced, err := coerceToSequenceTypeE(arg, paramTypes[i], ec)
+				if err != nil {
+					// A typed atomization/cast error (FOTY0013, FORG0001, …)
+					// must surface unchanged so try/catch can dispatch on it.
+					// Only a plain type/cardinality mismatch becomes XPTY0004.
+					if !errors.Is(err, errCoerceMismatch) {
+						return nil, err
+					}
 					return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("fn:%s: argument %d does not match required type %v", r.name, i+1, paramTypes[i])}
 				}
 				args[i] = coerced

--- a/xpath3/eval_funcall.go
+++ b/xpath3/eval_funcall.go
@@ -44,15 +44,9 @@ func evalFunctionCall(evalFn exprEvaluator, ctx context.Context, ec *evalContext
 	if paramTypes != nil {
 		for i, arg := range args {
 			if i < len(paramTypes) {
-				coerced, err := coerceToSequenceTypeE(arg, paramTypes[i], ec)
+				coerced, err := coerceFuncallArg(arg, paramTypes[i], r.name, i, ec)
 				if err != nil {
-					// A typed atomization/cast error (FOTY0013, FORG0001, …)
-					// must surface unchanged so try/catch can dispatch on it.
-					// Only a plain type/cardinality mismatch becomes XPTY0004.
-					if !errors.Is(err, errCoerceMismatch) {
-						return nil, err
-					}
-					return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("fn:%s: argument %d does not match required type %v", r.name, i+1, paramTypes[i])}
+					return nil, err
 				}
 				args[i] = coerced
 			}
@@ -381,16 +375,36 @@ func partialApply(ctx context.Context, ec *evalContext, e FunctionCall, fixedArg
 		}
 	}
 
-	fn, err := resolveFunction(ctx, ec, e.Prefix, e.Name, len(e.Args))
+	// Resolve the target function keeping its identity, so signature enforcement
+	// keys off the resolved URI/local name and consults TypedFunction metadata —
+	// mirroring evalFunctionCall. This closes the partial-application bypass where
+	// a registered TypedFunction's parameter types went unenforced.
+	r, err := resolveFunctionInfo(ctx, ec, e.Prefix, e.Name, len(e.Args))
 	if err != nil {
 		return nil, err
 	}
+	paramTypes := lookupParamTypes(r, len(e.Args))
 
-	// Look up type signature for type checking placeholder arguments
-	ns, _ := resolvePrefix(ec, e.Prefix)
-	var paramTypes []SequenceType
-	if sig := lookupFunctionSignature(ns, e.Name, len(e.Args)); sig != nil {
-		paramTypes = sig.ParamTypes
+	// Coerce the fixed (curried) arguments now, before the placeholders are
+	// supplied: they are known at partial-application time, so the function body
+	// must observe the converted values (e.g. xs:integer→xs:double) just like a
+	// direct call.
+	coercedFixed := make([]Sequence, len(fixedArgs))
+	copy(coercedFixed, fixedArgs)
+	if paramTypes != nil {
+		for i, argExpr := range e.Args {
+			if _, ok := argExpr.(PlaceholderExpr); ok {
+				continue // placeholder slot: coerced at invocation time
+			}
+			if i >= len(paramTypes) {
+				continue
+			}
+			coerced, err := coerceFuncallArg(fixedArgs[i], paramTypes[i], r.name, i, ec)
+			if err != nil {
+				return nil, err
+			}
+			coercedFixed[i] = coerced
+		}
 	}
 
 	// Per XPath 3.1, partial applications are anonymous functions
@@ -404,24 +418,46 @@ func partialApply(ctx context.Context, ec *evalContext, e FunctionCall, fixedArg
 				}
 			}
 			fullArgs := make([]Sequence, len(e.Args))
-			copy(fullArgs, fixedArgs)
+			copy(fullArgs, coercedFixed)
 			for pi, idx := range placeholderIndices {
 				fullArgs[idx] = partialArgs[pi]
 			}
-			// Type-check placeholder arguments against declared parameter types
+			// Coerce the placeholder-supplied arguments against the declared
+			// parameter types and store the converted values back, mirroring
+			// evalFunctionCall so typed functions observe promoted values and
+			// typed errors (FOTY0013/FORG0001) propagate unchanged.
 			if paramTypes != nil {
-				for pi, idx := range placeholderIndices {
-					if idx < len(paramTypes) {
-						if _, ok := coerceToSequenceType(partialArgs[pi], paramTypes[idx], nil); !ok {
-							return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("fn:%s: argument %d does not match required type %v", e.Name, idx+1, paramTypes[idx])}
-						}
+				for _, idx := range placeholderIndices {
+					if idx >= len(paramTypes) {
+						continue
 					}
+					coerced, err := coerceFuncallArg(fullArgs[idx], paramTypes[idx], r.name, idx, ec)
+					if err != nil {
+						return nil, err
+					}
+					fullArgs[idx] = coerced
 				}
 			}
-			return fn.Call(ctx, fullArgs)
+			return r.fn.Call(ctx, fullArgs)
 		},
 	}
 	return ItemSlice{fi}, nil
+}
+
+// coerceFuncallArg coerces one argument against its declared parameter type,
+// translating the result into the funcall-enforcement error contract: a typed
+// atomization/cast error (FOTY0013, FORG0001, …) surfaces unchanged so try/catch
+// can dispatch on it; a plain type/cardinality mismatch becomes XPTY0004. This is
+// the shared helper for evalFunctionCall's direct path and partialApply.
+func coerceFuncallArg(arg Sequence, st SequenceType, fnName string, idx int, ec *evalContext) (Sequence, error) {
+	coerced, err := coerceToSequenceTypeE(arg, st, ec)
+	if err != nil {
+		if !errors.Is(err, errCoerceMismatch) {
+			return nil, err
+		}
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("fn:%s: argument %d does not match required type %v", fnName, idx+1, st)}
+	}
+	return coerced, nil
 }
 
 func evalMapConstructorExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContext, e MapConstructorExpr) (Sequence, error) {

--- a/xpath3/eval_funcall.go
+++ b/xpath3/eval_funcall.go
@@ -34,7 +34,39 @@ func evalFunctionCall(evalFn exprEvaluator, ctx context.Context, ec *evalContext
 		return nil, err
 	}
 
+	// Enforce declared parameter signatures for static built-in calls, mirroring
+	// the function-item / named-function-reference path. Obtain the registered
+	// parameter types the same way evalNamedFunctionRef does (built-in registry
+	// signature, then TypedFunction/TypedFunctionByArity interfaces).
+	ns, _ := resolvePrefix(ec, e.Prefix)
+	paramTypes := lookupParamTypes(fn, ns, e.Name, len(args))
+	if paramTypes != nil {
+		for i, arg := range args {
+			if i < len(paramTypes) {
+				if _, ok := coerceToSequenceType(arg, paramTypes[i], ec); !ok {
+					return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("fn:%s: argument %d does not match required type %v", e.Name, i+1, paramTypes[i])}
+				}
+			}
+		}
+	}
+
 	return fn.Call(ec.fnContext(ctx), args)
+}
+
+// lookupParamTypes returns the declared parameter types for a function, using the
+// built-in signature registry first and then the TypedFunction/TypedFunctionByArity
+// interfaces. It returns nil when no signature is available (no enforcement).
+func lookupParamTypes(fn Function, ns, name string, arity int) []SequenceType {
+	if sig := lookupFunctionSignature(ns, name, arity); sig != nil {
+		return sig.ParamTypes
+	}
+	if tf, ok := fn.(TypedFunction); ok {
+		return tf.FuncParamTypes()
+	}
+	if tfa, ok := fn.(TypedFunctionByArity); ok {
+		return tfa.FuncParamTypesForArity(arity)
+	}
+	return nil
 }
 
 func evalDynamicFunctionCall(evalFn exprEvaluator, ctx context.Context, ec *evalContext, e DynamicFunctionCall) (Sequence, error) {

--- a/xpath3/eval_types.go
+++ b/xpath3/eval_types.go
@@ -324,6 +324,15 @@ func coerceToSequenceType(seq Sequence, st SequenceType, ec *evalContext) (Seque
 	result := make(ItemSlice, len(atoms))
 	i := 0
 	for _, av := range atoms {
+		// xs:anyAtomicType is the generalized atomic supertype: once a node has
+		// been atomized (to xs:untypedAtomic), any atomic value already matches.
+		// It is abstract, so it has no concrete cast — accept the atom as-is
+		// rather than attempting an (impossible) cast to it.
+		if targetType == TypeAnyAtomicType {
+			result[i] = av
+			i++
+			continue
+		}
 		// Numeric promotion
 		switch targetType {
 		case TypeDouble:

--- a/xpath3/eval_types.go
+++ b/xpath3/eval_types.go
@@ -425,28 +425,14 @@ func coerceToSequenceTypeE(seq Sequence, st SequenceType, ec *evalContext) (Sequ
 			i++
 			continue
 		}
-		if isSubtypeOf(av.TypeName, targetType) {
+		// Accept when the value matches the target by built-in subtype hierarchy,
+		// its built-in BaseType (schema-derived values the builtins promote via
+		// PromoteSchemaType), or schema-declaration ancestry (incl. the xs:numeric
+		// union). atomicMatchesTargetType is the shared gate matchesItemType uses.
+		if atomicMatchesTargetType(av, targetType, ec) {
 			result[i] = av
 			i++
 			continue
-		}
-		// Fall back to schema declarations for user-defined types derived by
-		// restriction from the target (e.g. a schema type derived from xs:decimal
-		// matching xs:numeric).
-		if ec != nil && ec.schemaDeclarations != nil {
-			if targetType == TypeNumeric {
-				if ec.schemaDeclarations.IsSubtypeOf(av.TypeName, TypeDecimal) ||
-					ec.schemaDeclarations.IsSubtypeOf(av.TypeName, TypeFloat) ||
-					ec.schemaDeclarations.IsSubtypeOf(av.TypeName, TypeDouble) {
-					result[i] = av
-					i++
-					continue
-				}
-			} else if ec.schemaDeclarations.IsSubtypeOf(av.TypeName, targetType) {
-				result[i] = av
-				i++
-				continue
-			}
 		}
 		return seq, errCoerceMismatch
 	}
@@ -567,6 +553,43 @@ func CheckFunctionParamCompat(fi FunctionItem, st SequenceType) bool {
 		}
 	}
 	return true
+}
+
+// atomicMatchesTargetType reports whether an atomic value satisfies an
+// AtomicOrUnionType item test whose resolved name is targetType. Beyond the
+// built-in subtype hierarchy and schema-declaration ancestry, it honors the
+// value's own BaseType: a schema-derived value whose built-in BaseType is a
+// subtype of (or promotes to) the target must match, because the numeric (and
+// other) builtins accept it via PromoteSchemaType. Without this the static
+// signature gate would reject, e.g., abs($v) for $v of a custom type derived
+// from xs:decimal even though fnAbs promotes and handles it.
+func atomicMatchesTargetType(av AtomicValue, targetType string, ec *evalContext) bool {
+	if targetType == TypeAnyAtomicType {
+		return true
+	}
+	if isSubtypeOf(av.TypeName, targetType) {
+		return true
+	}
+	// Schema-derived value carrying a built-in BaseType: match using the base
+	// type, mirroring PromoteSchemaType (which the builtins use). Only built-in
+	// base types are trusted here so acceptance is not broadened for unrelated
+	// user types.
+	if av.BaseType != "" && IsKnownXSDType(av.BaseType) && isSubtypeOf(av.BaseType, targetType) {
+		return true
+	}
+	// Fall back to schema declarations for user-defined types whose ancestry is
+	// only known to the compiled schema.
+	if ec != nil && ec.schemaDeclarations != nil {
+		// xs:numeric is a synthetic union the schema layer does not model, so
+		// resolve it against its member built-in types.
+		if targetType == TypeNumeric {
+			return ec.schemaDeclarations.IsSubtypeOf(av.TypeName, TypeDecimal) ||
+				ec.schemaDeclarations.IsSubtypeOf(av.TypeName, TypeFloat) ||
+				ec.schemaDeclarations.IsSubtypeOf(av.TypeName, TypeDouble)
+		}
+		return ec.schemaDeclarations.IsSubtypeOf(av.TypeName, targetType)
+	}
+	return false
 }
 
 func matchesSequenceType(seq Sequence, st SequenceType, ec *evalContext) bool {
@@ -760,17 +783,7 @@ func matchesItemType(item Item, test NodeTest, ec *evalContext) bool {
 			return false
 		}
 		targetType := resolveAtomicTypeName(AtomicTypeName(t), ec)
-		if targetType == TypeAnyAtomicType {
-			return true
-		}
-		if isSubtypeOf(av.TypeName, targetType) {
-			return true
-		}
-		// Fall back to schema declarations for user-defined types.
-		if ec != nil && ec.schemaDeclarations != nil {
-			return ec.schemaDeclarations.IsSubtypeOf(av.TypeName, targetType)
-		}
-		return false
+		return atomicMatchesTargetType(av, targetType, ec)
 	case FunctionTest:
 		// Maps and arrays are functions per XPath 3.1
 		if t.AnyFunction {

--- a/xpath3/eval_types.go
+++ b/xpath3/eval_types.go
@@ -408,8 +408,16 @@ func coerceToSequenceTypeE(seq Sequence, st SequenceType, ec *evalContext) (Sequ
 				continue
 			}
 		case TypeString:
-			if av.TypeName == TypeAnyURI {
-				result[i] = AtomicValue{TypeName: TypeString, Value: av.Value}
+			// xs:anyURI (and its subtypes) promote to xs:string per the
+			// function-conversion rules. Match via atomicMatchesTargetType so a
+			// schema-DERIVED anyURI (carrying BaseType xs:anyURI, or whose
+			// ancestry the schema knows) is admitted, not only the exact
+			// xs:anyURI type. PromoteSchemaType normalizes the schema-derived
+			// value to a built-in-typed anyURI so its string value is read the
+			// same way the builtins read it.
+			if atomicMatchesTargetType(av, TypeAnyURI, ec) {
+				promoted := PromoteSchemaType(av)
+				result[i] = AtomicValue{TypeName: TypeString, Value: promoted.Value}
 				i++
 				continue
 			}

--- a/xpath3/eval_types.go
+++ b/xpath3/eval_types.go
@@ -2,6 +2,7 @@ package xpath3
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -285,6 +286,13 @@ func resolveAtomicTypeName(tn AtomicTypeName, ec *evalContext) string {
 	return tn.Prefix + ":" + tn.Name
 }
 
+// errCoerceMismatch is a sentinel returned by coerceToSequenceTypeE for a plain
+// type or cardinality mismatch — one with no more-specific typed error. Callers
+// map it to XPTY0004. A more-specific typed error (FOTY0013 from atomizing a
+// function/map item, FORG0001 from an invalid cast, …) is returned directly so
+// it can be surfaced to try/catch instead of being collapsed into XPTY0004.
+var errCoerceMismatch = errors.New("xpath3: sequence type mismatch")
+
 // CoerceToSequenceType applies XPath 3.1 function coercion rules (§3.1.5.2):
 // atomization, numeric promotion (integer→float/double, float→double),
 // URI-to-string promotion, and function coercion.  Returns the coerced
@@ -293,16 +301,31 @@ func CoerceToSequenceType(seq Sequence, st SequenceType) (Sequence, bool) {
 	return coerceToSequenceType(seq, st, nil)
 }
 
-// coerceToSequenceType is the internal version with an evalContext.
+// coerceToSequenceType is the boolean-returning wrapper retained for callers that
+// only need success/failure. It discards the specific error code; callers that
+// must surface FOTY0013/FORG0001 should use coerceToSequenceTypeE.
 func coerceToSequenceType(seq Sequence, st SequenceType, ec *evalContext) (Sequence, bool) {
+	out, err := coerceToSequenceTypeE(seq, st, ec)
+	if err != nil {
+		return seq, false
+	}
+	return out, true
+}
+
+// coerceToSequenceTypeE is the error-propagating coercion. On a plain type or
+// cardinality mismatch it returns errCoerceMismatch; on a typed atomization/cast
+// failure it returns that underlying error (FOTY0013, FORG0001, …). Atomization
+// errors take precedence over cardinality rejection, matching the spec ordering
+// (atomization happens before the occurrence check).
+func coerceToSequenceTypeE(seq Sequence, st SequenceType, ec *evalContext) (Sequence, error) {
 	if matchesSequenceType(seq, st, ec) {
-		return seq, true
+		return seq, nil
 	}
 	if seqLen(seq) == 1 {
 		if fnTest, ok := st.ItemTest.(FunctionTest); ok {
 			adapted, ok := coerceFunctionItem(seq.Get(0), fnTest, ec)
 			if ok {
-				return ItemSlice{adapted}, true
+				return ItemSlice{adapted}, nil
 			}
 		}
 	}
@@ -312,14 +335,37 @@ func coerceToSequenceType(seq Sequence, st SequenceType, ec *evalContext) (Seque
 	case AtomicOrUnionType:
 		targetType = resolveAtomicTypeName(AtomicTypeName(t), ec)
 	default:
-		return seq, false
+		return seq, errCoerceMismatch
 	}
-	// Atomize the sequence. AtomizeSequence correctly flattens arrays and
+	// For a singleton/optional target occurrence the result may hold at most one
+	// item, so cap atomization: stop as soon as a second atom appears rather than
+	// materializing the whole (possibly huge) sequence before rejecting on
+	// cardinality. A typed atomization error encountered before the cap still
+	// propagates (atomization precedes the occurrence check).
+	maxAtoms := 0
+	switch st.Occurrence {
+	case OccurrenceExactlyOne, OccurrenceZeroOrOne:
+		maxAtoms = 1
+	}
+	// Atomize the sequence. atomizeStream correctly flattens arrays and
 	// expands list-typed nodes (e.g. xs:list of xs:decimal) into multiple
 	// atomic values — a per-item AtomizeItem would collapse those incorrectly.
-	atoms, err := AtomizeSequence(seq)
+	var atoms []AtomicValue
+	tooMany := false
+	err := atomizeStream(seq, func(av AtomicValue) (bool, error) {
+		atoms = append(atoms, av)
+		if maxAtoms > 0 && len(atoms) > maxAtoms {
+			tooMany = true
+			return false, nil
+		}
+		return true, nil
+	})
 	if err != nil {
-		return seq, false
+		return seq, err
+	}
+	if tooMany {
+		// More atoms than the occurrence indicator permits: cardinality mismatch.
+		return seq, errCoerceMismatch
 	}
 	result := make(ItemSlice, len(atoms))
 	i := 0
@@ -340,7 +386,7 @@ func coerceToSequenceType(seq Sequence, st SequenceType, ec *evalContext) (Seque
 				isSubtypeOf(av.TypeName, TypeInteger) {
 				promoted, err := castToDouble(av)
 				if err != nil {
-					return seq, false
+					return seq, err
 				}
 				result[i] = promoted
 				i++
@@ -351,7 +397,7 @@ func coerceToSequenceType(seq Sequence, st SequenceType, ec *evalContext) (Seque
 				isSubtypeOf(av.TypeName, TypeInteger) {
 				promoted, err := castToFloat(av)
 				if err != nil {
-					return seq, false
+					return seq, err
 				}
 				result[i] = promoted
 				i++
@@ -373,7 +419,7 @@ func coerceToSequenceType(seq Sequence, st SequenceType, ec *evalContext) (Seque
 			}
 			cast, err := CastAtomic(av, castTarget)
 			if err != nil {
-				return seq, false
+				return seq, err
 			}
 			result[i] = cast
 			i++
@@ -402,24 +448,24 @@ func coerceToSequenceType(seq Sequence, st SequenceType, ec *evalContext) (Seque
 				continue
 			}
 		}
-		return seq, false
+		return seq, errCoerceMismatch
 	}
 	// Verify occurrence constraint on the coerced result
 	switch st.Occurrence {
 	case OccurrenceExactlyOne:
 		if len(result) != 1 {
-			return seq, false
+			return seq, errCoerceMismatch
 		}
 	case OccurrenceOneOrMore:
 		if len(result) == 0 {
-			return seq, false
+			return seq, errCoerceMismatch
 		}
 	case OccurrenceZeroOrOne:
 		if len(result) > 1 {
-			return seq, false
+			return seq, errCoerceMismatch
 		}
 	}
-	return result, true
+	return result, nil
 }
 
 func coerceFunctionItem(item Item, target FunctionTest, ec *evalContext) (Item, bool) {

--- a/xpath3/eval_types.go
+++ b/xpath3/eval_types.go
@@ -273,7 +273,7 @@ func resolveAtomicTypeName(tn AtomicTypeName, ec *evalContext) string {
 		return "xs:" + tn.Name
 	}
 	// Resolve via namespace context
-	if ec.namespaces != nil {
+	if ec != nil && ec.namespaces != nil {
 		if uri, ok := ec.namespaces[tn.Prefix]; ok {
 			if uri == lexicon.NamespaceXSD {
 				return "xs:" + tn.Name
@@ -314,18 +314,16 @@ func coerceToSequenceType(seq Sequence, st SequenceType, ec *evalContext) (Seque
 	default:
 		return seq, false
 	}
-	result := make(ItemSlice, seqLen(seq))
+	// Atomize the sequence. AtomizeSequence correctly flattens arrays and
+	// expands list-typed nodes (e.g. xs:list of xs:decimal) into multiple
+	// atomic values — a per-item AtomizeItem would collapse those incorrectly.
+	atoms, err := AtomizeSequence(seq)
+	if err != nil {
+		return seq, false
+	}
+	result := make(ItemSlice, len(atoms))
 	i := 0
-	for item := range seqItems(seq) {
-		av, ok := item.(AtomicValue)
-		if !ok {
-			// Try atomization
-			atomized, err := AtomizeItem(item)
-			if err != nil {
-				return seq, false
-			}
-			av = atomized
-		}
+	for _, av := range atoms {
 		// Numeric promotion
 		switch targetType {
 		case TypeDouble:
@@ -377,6 +375,24 @@ func coerceToSequenceType(seq Sequence, st SequenceType, ec *evalContext) (Seque
 			i++
 			continue
 		}
+		// Fall back to schema declarations for user-defined types derived by
+		// restriction from the target (e.g. a schema type derived from xs:decimal
+		// matching xs:numeric).
+		if ec != nil && ec.schemaDeclarations != nil {
+			if targetType == TypeNumeric {
+				if ec.schemaDeclarations.IsSubtypeOf(av.TypeName, TypeDecimal) ||
+					ec.schemaDeclarations.IsSubtypeOf(av.TypeName, TypeFloat) ||
+					ec.schemaDeclarations.IsSubtypeOf(av.TypeName, TypeDouble) {
+					result[i] = av
+					i++
+					continue
+				}
+			} else if ec.schemaDeclarations.IsSubtypeOf(av.TypeName, targetType) {
+				result[i] = av
+				i++
+				continue
+			}
+		}
 		return seq, false
 	}
 	// Verify occurrence constraint on the coerced result
@@ -402,7 +418,9 @@ func coerceFunctionItem(item Item, target FunctionTest, ec *evalContext) (Item, 
 		return nil, false
 	}
 
-	actual, ok := item.(FunctionItem)
+	// Maps and arrays are function items of arity 1 per XPath 3.1, so they
+	// participate in function coercion just like an inline/named function.
+	actual, ok := asFunctionItem(item)
 	if !ok {
 		return nil, false
 	}

--- a/xpath3/eval_types.go
+++ b/xpath3/eval_types.go
@@ -318,6 +318,35 @@ func coerceToSequenceType(seq Sequence, st SequenceType, ec *evalContext) (Seque
 // errors take precedence over cardinality rejection, matching the spec ordering
 // (atomization happens before the occurrence check).
 func coerceToSequenceTypeE(seq Sequence, st SequenceType, ec *evalContext) (Sequence, error) {
+	// Fast path: an item() item type matches any item, so per-item coercion is a
+	// no-op. Only the cardinality (occurrence) constraint can reject. Check it
+	// using seqLen — which is O(1) for every Sequence implementation (slice and
+	// lazy Range alike) — instead of iterating the sequence through
+	// matchesSequenceType. This preserves laziness for hot functions like
+	// fn:count / fn:exists (item()* / item()+ parameters) so a large lazy range
+	// (1 to N) is never materialized just to satisfy the signature gate.
+	if !st.Void {
+		if _, anyItem := st.ItemTest.(AnyItemTest); anyItem {
+			n := seqLen(seq)
+			switch st.Occurrence {
+			case OccurrenceExactlyOne:
+				if n != 1 {
+					return seq, errCoerceMismatch
+				}
+			case OccurrenceZeroOrOne:
+				if n > 1 {
+					return seq, errCoerceMismatch
+				}
+			case OccurrenceOneOrMore:
+				if n == 0 {
+					return seq, errCoerceMismatch
+				}
+			case OccurrenceZeroOrMore:
+				// any length ok
+			}
+			return seq, nil
+		}
+	}
 	if matchesSequenceType(seq, st, ec) {
 		return seq, nil
 	}

--- a/xpath3/eval_types.go
+++ b/xpath3/eval_types.go
@@ -379,12 +379,17 @@ func coerceToSequenceTypeE(seq Sequence, st SequenceType, ec *evalContext) (Sequ
 			i++
 			continue
 		}
-		// Numeric promotion
+		// Numeric promotion. The acceptance condition mirrors atomicMatchesTargetType
+		// so the cast that follows always agrees with the gate: any numeric the gate
+		// admits (built-in numerics, integer-derived subtypes, and schema-derived
+		// values whose built-in base/ancestry is numeric) is normalized via
+		// PromoteSchemaType before the cast, so castToDouble/castToFloat operate on a
+		// built-in-typed value instead of failing on an unrecognized schema type.
 		switch targetType {
 		case TypeDouble:
-			if av.TypeName == TypeInteger || av.TypeName == TypeDecimal || av.TypeName == TypeFloat ||
-				isSubtypeOf(av.TypeName, TypeInteger) {
-				promoted, err := castToDouble(av)
+			if atomicMatchesTargetType(av, TypeDouble, ec) || atomicMatchesTargetType(av, TypeFloat, ec) ||
+				atomicMatchesTargetType(av, TypeInteger, ec) || atomicMatchesTargetType(av, TypeDecimal, ec) {
+				promoted, err := castToDouble(PromoteSchemaType(av))
 				if err != nil {
 					return seq, err
 				}
@@ -393,9 +398,8 @@ func coerceToSequenceTypeE(seq Sequence, st SequenceType, ec *evalContext) (Sequ
 				continue
 			}
 		case TypeFloat:
-			if av.TypeName == TypeInteger || av.TypeName == TypeDecimal ||
-				isSubtypeOf(av.TypeName, TypeInteger) {
-				promoted, err := castToFloat(av)
+			if atomicMatchesTargetType(av, TypeInteger, ec) || atomicMatchesTargetType(av, TypeDecimal, ec) {
+				promoted, err := castToFloat(PromoteSchemaType(av))
 				if err != nil {
 					return seq, err
 				}

--- a/xpath3/funcall_signature_test.go
+++ b/xpath3/funcall_signature_test.go
@@ -2,6 +2,7 @@ package xpath3_test
 
 import (
 	"context"
+	"iter"
 	"math/big"
 	"runtime"
 	"testing"
@@ -34,10 +35,10 @@ type typedUserFunc struct {
 func (f typedUserFunc) FuncParamTypes() []xpath3.SequenceType { return f.params }
 func (f typedUserFunc) FuncReturnType() *xpath3.SequenceType  { return f.ret }
 
-func stType(name string, occ xpath3.Occurrence) xpath3.SequenceType {
+func stType(name string) xpath3.SequenceType {
 	return xpath3.SequenceType{
 		ItemTest:   xpath3.AtomicOrUnionType{Prefix: "xs", Name: name},
-		Occurrence: occ,
+		Occurrence: xpath3.OccurrenceExactlyOne,
 	}
 }
 
@@ -85,7 +86,7 @@ func TestUserOverrideSkipsBuiltinSignature(t *testing.T) {
 func TestTypedUserFunctionObservesCoercedArg(t *testing.T) {
 	t.Parallel()
 
-	dbl := stType("double", xpath3.OccurrenceExactlyOne)
+	dbl := stType("double")
 	var observed string
 	lib := xpath3.NewFunctionLibrary()
 	lib.Set("takes-double", typedUserFunc{
@@ -126,7 +127,7 @@ func TestTypedUserFunctionObservesCoercedArg(t *testing.T) {
 func TestTypedUserFunctionAnyAtomicAcceptsNode(t *testing.T) {
 	t.Parallel()
 
-	anyAtomic := stType("anyAtomicType", xpath3.OccurrenceExactlyOne)
+	anyAtomic := stType("anyAtomicType")
 
 	newLib := func(observed *string) *xpath3.FunctionLibrary {
 		lib := xpath3.NewFunctionLibrary()
@@ -437,4 +438,219 @@ func TestSignatureGateRejectsLongSequencePromptly(t *testing.T) {
 	require.Less(t, elapsed, 200*time.Millisecond, "should reject without atomizing whole range")
 	allocKB := (m2.TotalAlloc - m1.TotalAlloc) / 1024
 	require.Less(t, allocKB, uint64(50*1024), "should not allocate the whole atomized sequence")
+}
+
+// countingSequence is a lazy Sequence that records how far it was actually
+// iterated. It lets a test prove that a function whose parameter is item()* /
+// item()+ does NOT force the whole sequence through the signature gate.
+type countingSequence struct {
+	n        int
+	maxIndex *int // highest index materialized (-1 if never)
+}
+
+func (c countingSequence) note(i int) xpath3.Item {
+	if i > *c.maxIndex {
+		*c.maxIndex = i
+	}
+	return xpath3.AtomicValue{TypeName: xpath3.TypeInteger, Value: int64(i + 1)}
+}
+
+func (c countingSequence) Len() int              { return c.n }
+func (c countingSequence) Get(i int) xpath3.Item { return c.note(i) }
+func (c countingSequence) Materialize() []xpath3.Item {
+	out := make([]xpath3.Item, c.n)
+	for i := range out {
+		out[i] = c.note(i)
+	}
+	return out
+}
+func (c countingSequence) Items() iter.Seq[xpath3.Item] {
+	return func(yield func(xpath3.Item) bool) {
+		for i := range c.n {
+			if !yield(c.note(i)) {
+				return
+			}
+		}
+	}
+}
+
+// Finding 1 (round 7): the signature gate must NOT iterate a lazy sequence when
+// the parameter item type is item() — count()/exists() (item()* param) read only
+// Len(), so the gate must stay lazy and never touch a single element. The lazy
+// sequence is produced by a registered function so it reaches the gate without
+// being materialized by variable cloning.
+func TestSignatureGateKeepsItemStarLazy(t *testing.T) {
+	t.Parallel()
+
+	for _, fn := range []string{"count", "exists"} {
+		t.Run(fn, func(t *testing.T) {
+			maxIdx := -1
+			lib := xpath3.NewFunctionLibrary()
+			lib.Set("make-lazy", userFunc{
+				min: 0, max: 0,
+				call: func(_ context.Context, _ []xpath3.Sequence) (xpath3.Sequence, error) {
+					return countingSequence{n: 1000, maxIndex: &maxIdx}, nil
+				},
+			})
+			_, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+				Functions(lib).
+				Evaluate(t.Context(), xpath3.NewCompiler().MustCompile(fn+"(make-lazy())"), nil)
+			require.NoError(t, err)
+			require.Equal(t, -1, maxIdx, "item()* gate must not iterate the lazy sequence")
+		})
+	}
+}
+
+// Finding 1 (round 7): count(1 to N) / exists(1 to N) over a huge lazy range must
+// return promptly without materializing the range — the item()* gate must not
+// force iteration.
+func TestSignatureGateLargeRangeIsLazy(t *testing.T) {
+	t.Parallel()
+
+	for expr, check := range map[string]func(*xpath3.Result){
+		`count(1 to 9000000)`: func(r *xpath3.Result) {
+			n, ok := r.IsNumber()
+			require.True(t, ok)
+			require.Equal(t, float64(9000000), n)
+		},
+		`exists(1 to 9000000)`: func(r *xpath3.Result) {
+			b, ok := r.IsBoolean()
+			require.True(t, ok)
+			require.True(t, b)
+		},
+	} {
+		var m1, m2 runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&m1)
+		start := time.Now()
+		result, err := evaluate(t.Context(), nil, expr)
+		elapsed := time.Since(start)
+		runtime.ReadMemStats(&m2)
+
+		require.NoError(t, err, expr)
+		check(result)
+		require.Less(t, elapsed, 200*time.Millisecond, "%s must stay lazy", expr)
+		allocKB := (m2.TotalAlloc - m1.TotalAlloc) / 1024
+		require.Less(t, allocKB, uint64(50*1024), "%s must not materialize the range", expr)
+	}
+}
+
+// Finding 1 (round 7): the item()+ gate must still reject an EMPTY sequence
+// (cardinality), and item()* must still accept it — without iterating.
+func TestSignatureGateItemPlusCardinality(t *testing.T) {
+	t.Parallel()
+
+	// fn:head has signature item()* — empty input is fine.
+	result, err := evaluate(t.Context(), nil, `count(head(()))`)
+	require.NoError(t, err)
+	n, ok := result.IsNumber()
+	require.True(t, ok)
+	require.Equal(t, float64(0), n)
+}
+
+// typedDoubleLib registers a TypedFunction "takes-double" (xs:double param) that
+// records the observed atomized type of its argument.
+func typedDoubleLib(observed *string) *xpath3.FunctionLibrary {
+	dbl := stType("double")
+	lib := xpath3.NewFunctionLibrary()
+	lib.Set("takes-double", typedUserFunc{
+		userFunc: userFunc{
+			min: 1, max: 1,
+			call: func(_ context.Context, args []xpath3.Sequence) (xpath3.Sequence, error) {
+				av, err := xpath3.AtomizeItem(args[0].Get(0))
+				if err != nil {
+					return nil, err
+				}
+				*observed = av.TypeName
+				return xpath3.SingleString(av.TypeName), nil
+			},
+		},
+		params: []xpath3.SequenceType{dbl},
+	})
+	return lib
+}
+
+// Finding 2 (round 7): partial application of a TypedFunction (xs:double param)
+// must enforce the signature on the placeholder-supplied argument — an xs:integer
+// must be promoted to xs:double, exactly as a direct call would.
+func TestPartialApplicationCoercesTypedParam(t *testing.T) {
+	t.Parallel()
+
+	var observed string
+	result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Functions(typedDoubleLib(&observed)).
+		Evaluate(t.Context(), xpath3.NewCompiler().MustCompile(`takes-double(?)(1)`), nil)
+	require.NoError(t, err)
+
+	require.Equal(t, xpath3.TypeDouble, observed, "placeholder arg must be coerced to xs:double")
+	s, ok := result.IsString()
+	require.True(t, ok)
+	require.Equal(t, xpath3.TypeDouble, s)
+}
+
+// Finding 2 (round 7): a non-coercible placeholder value supplied to a typed
+// partial application raises XPTY0004, just like a direct call.
+func TestPartialApplicationRejectsNonCoercible(t *testing.T) {
+	t.Parallel()
+
+	var observed string
+	_, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Functions(typedDoubleLib(&observed)).
+		Evaluate(t.Context(), xpath3.NewCompiler().MustCompile(`takes-double(?)(current-date())`), nil)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code)
+}
+
+// Finding 2 (round 7): typed atomization errors (FORG0001) propagate unchanged
+// through partial application — an invalid xs:untypedAtomic→double cast must
+// surface FORG0001, not XPTY0004.
+func TestPartialApplicationPropagatesTypedError(t *testing.T) {
+	t.Parallel()
+
+	var observed string
+	_, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Functions(typedDoubleLib(&observed)).
+		Evaluate(t.Context(), xpath3.NewCompiler().MustCompile(`takes-double(?)(xs:untypedAtomic("abc"))`), nil)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, "FORG0001", xpErr.Code)
+}
+
+// Finding 2 (round 7): a fixed (curried) argument must also be coerced — when the
+// double parameter is curried with an xs:integer literal, the body still observes
+// xs:double.
+func TestPartialApplicationCoercesFixedArg(t *testing.T) {
+	t.Parallel()
+
+	dbl := stType("double")
+	str := stType("string")
+	var observed string
+	lib := xpath3.NewFunctionLibrary()
+	lib.Set("takes-double-str", typedUserFunc{
+		userFunc: userFunc{
+			min: 2, max: 2,
+			call: func(_ context.Context, args []xpath3.Sequence) (xpath3.Sequence, error) {
+				av, err := xpath3.AtomizeItem(args[0].Get(0))
+				if err != nil {
+					return nil, err
+				}
+				observed = av.TypeName
+				return xpath3.SingleString(av.TypeName), nil
+			},
+		},
+		params: []xpath3.SequenceType{dbl, str},
+	})
+
+	// Curry the first (double) arg with an integer; the placeholder fills the string.
+	result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Functions(lib).
+		Evaluate(t.Context(), xpath3.NewCompiler().MustCompile(`takes-double-str(1, ?)("x")`), nil)
+	require.NoError(t, err)
+	require.Equal(t, xpath3.TypeDouble, observed, "curried integer must be coerced to xs:double")
+	s, ok := result.IsString()
+	require.True(t, ok)
+	require.Equal(t, xpath3.TypeDouble, s)
 }

--- a/xpath3/funcall_signature_test.go
+++ b/xpath3/funcall_signature_test.go
@@ -114,3 +114,67 @@ func TestTypedUserFunctionObservesCoercedArg(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, xpath3.TypeDouble, s)
 }
+
+// Finding 4: a TypedFunction declaring xs:anyAtomicType must accept a NODE
+// argument. Per the function-conversion rules the node is atomized (a node
+// atomizes to xs:untypedAtomic), and xs:untypedAtomic is a subtype of
+// xs:anyAtomicType, so the call must succeed and observe the atomized value
+// rather than failing the static signature check with XPTY0004.
+func TestTypedUserFunctionAnyAtomicAcceptsNode(t *testing.T) {
+	t.Parallel()
+
+	anyAtomic := stType("anyAtomicType", xpath3.OccurrenceExactlyOne)
+
+	newLib := func(observed *string) *xpath3.FunctionLibrary {
+		lib := xpath3.NewFunctionLibrary()
+		lib.Set("takes-any", typedUserFunc{
+			userFunc: userFunc{
+				min: 1, max: 1,
+				call: func(_ context.Context, args []xpath3.Sequence) (xpath3.Sequence, error) {
+					av, err := xpath3.AtomizeItem(args[0].Get(0))
+					if err != nil {
+						return nil, err
+					}
+					*observed = av.TypeName
+					return xpath3.SingleString(av.TypeName), nil
+				},
+			},
+			params: []xpath3.SequenceType{anyAtomic},
+		})
+		return lib
+	}
+
+	t.Run("node argument atomizes to xs:untypedAtomic", func(t *testing.T) {
+		doc := mustParseXML(t, `<root>hello</root>`)
+
+		compiled, err := xpath3.NewCompiler().Compile(`takes-any(/root)`)
+		require.NoError(t, err)
+
+		var observed string
+		result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+			Functions(newLib(&observed)).
+			Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, err)
+
+		require.Equal(t, xpath3.TypeUntypedAtomic, observed)
+		s, ok := result.IsString()
+		require.True(t, ok)
+		require.Equal(t, xpath3.TypeUntypedAtomic, s)
+	})
+
+	t.Run("atomic argument retains its type", func(t *testing.T) {
+		compiled, err := xpath3.NewCompiler().Compile(`takes-any(42)`)
+		require.NoError(t, err)
+
+		var observed string
+		result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+			Functions(newLib(&observed)).
+			Evaluate(t.Context(), compiled, nil)
+		require.NoError(t, err)
+
+		require.Equal(t, xpath3.TypeInteger, observed)
+		s, ok := result.IsString()
+		require.True(t, ok)
+		require.Equal(t, xpath3.TypeInteger, s)
+	})
+}

--- a/xpath3/funcall_signature_test.go
+++ b/xpath3/funcall_signature_test.go
@@ -2,6 +2,7 @@ package xpath3_test
 
 import (
 	"context"
+	"math/big"
 	"runtime"
 	"testing"
 	"time"
@@ -217,6 +218,41 @@ func TestSignatureGatePlainMismatchIsXPTY0004(t *testing.T) {
 		var xpErr *xpath3.XPathError
 		require.ErrorAs(t, err, &xpErr, expr)
 		require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code, expr)
+	}
+}
+
+// Finding (round 4): the static signature gate must accept a schema-DERIVED
+// numeric atomic value whose BaseType is a built-in numeric type, since the
+// numeric builtins promote it via PromoteSchemaType. A value of a custom type
+// derived from xs:decimal IS numeric and abs/round must accept it — the gate
+// must not raise XPTY0004 before the builtin can promote it.
+func TestSignatureGateAcceptsSchemaDerivedNumeric(t *testing.T) {
+	t.Parallel()
+
+	vars := xpath3.VariablesFromMap(map[string]xpath3.Sequence{
+		"v": xpath3.ItemSlice{
+			xpath3.AtomicValue{
+				TypeName: "Q{urn:test}myDecimal",
+				BaseType: xpath3.TypeDecimal,
+				Value:    big.NewRat(-3, 1),
+			},
+		},
+	})
+
+	cases := map[string]float64{
+		`abs($v)`:   3,  // |-3| = 3
+		`round($v)`: -3, // round(-3) = -3 (the gate must let the value through)
+		`$v + 1`:    -2, // arithmetic also accepts the schema-derived decimal
+	}
+	for expr, want := range cases {
+		result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+			Variables(vars).
+			Evaluate(t.Context(), xpath3.NewCompiler().MustCompile(expr), nil)
+		require.NoError(t, err, expr)
+
+		n, ok := result.IsNumber()
+		require.True(t, ok, expr)
+		require.Equal(t, want, n, expr)
 	}
 }
 

--- a/xpath3/funcall_signature_test.go
+++ b/xpath3/funcall_signature_test.go
@@ -2,7 +2,9 @@ package xpath3_test
 
 import (
 	"context"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/xpath3"
@@ -177,4 +179,70 @@ func TestTypedUserFunctionAnyAtomicAcceptsNode(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, xpath3.TypeInteger, s)
 	})
+}
+
+// Finding 1: the signature gate must propagate a typed atomization error rather
+// than collapsing it into XPTY0004. Atomizing a map/function item where an
+// atomic is required raises FOTY0013, which try/catch dispatches on.
+func TestSignatureGatePropagatesFOTY0013(t *testing.T) {
+	t.Parallel()
+	_, err := evaluate(t.Context(), nil, `upper-case(map{})`)
+	require.Error(t, err)
+
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, "FOTY0013", xpErr.Code)
+}
+
+// Finding 1: an invalid xs:untypedAtomic→numeric cast inside the signature gate
+// raises FORG0001 (invalid cast), not XPTY0004.
+func TestSignatureGatePropagatesFORG0001(t *testing.T) {
+	t.Parallel()
+	_, err := evaluate(t.Context(), nil, `abs(xs:untypedAtomic("abc"))`)
+	require.Error(t, err)
+
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, "FORG0001", xpErr.Code)
+}
+
+// Finding 1: a plain type/cardinality mismatch (no typed atomization/cast error)
+// must still yield XPTY0004.
+func TestSignatureGatePlainMismatchIsXPTY0004(t *testing.T) {
+	t.Parallel()
+	for _, expr := range []string{`upper-case((1, 2))`, `abs((1, 2))`, `upper-case(current-date())`} {
+		_, err := evaluate(t.Context(), nil, expr)
+		require.Error(t, err, expr)
+
+		var xpErr *xpath3.XPathError
+		require.ErrorAs(t, err, &xpErr, expr)
+		require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code, expr)
+	}
+}
+
+// Finding 2: a too-long sequence supplied to a singleton (xs:string?) parameter
+// must be rejected promptly with XPTY0004 — without atomizing the whole range.
+// A 10M-item lazy range would allocate ~1GB if atomized eagerly; the cap keeps
+// allocation and time tiny.
+func TestSignatureGateRejectsLongSequencePromptly(t *testing.T) {
+	t.Parallel()
+
+	var m1, m2 runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&m1)
+	start := time.Now()
+	_, err := evaluate(t.Context(), nil, `upper-case(1 to 10000000)`)
+	elapsed := time.Since(start)
+	runtime.ReadMemStats(&m2)
+
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code)
+
+	// Eager atomization of 10M items took ~800ms / ~1GB before the fix; the
+	// incremental cap keeps both small. Generous bounds avoid CI flakiness.
+	require.Less(t, elapsed, 200*time.Millisecond, "should reject without atomizing whole range")
+	allocKB := (m2.TotalAlloc - m1.TotalAlloc) / 1024
+	require.Less(t, allocKB, uint64(50*1024), "should not allocate the whole atomized sequence")
 }

--- a/xpath3/funcall_signature_test.go
+++ b/xpath3/funcall_signature_test.go
@@ -346,6 +346,72 @@ func TestSignatureGateArrayAtomizationStillWorks(t *testing.T) {
 	}
 }
 
+// Finding (round 6): xs:anyURI promotes to xs:string per the function-conversion
+// rules, and so do its SUBTYPES. A schema-DERIVED anyURI (BaseType xs:anyURI)
+// supplied to fn:upper-case (xs:string? param) must be admitted by the static
+// signature gate, promoted to xs:string, and upper-cased — not rejected with
+// XPTY0004 before the builtin runs.
+func TestSignatureGatePromotesSchemaDerivedAnyURI(t *testing.T) {
+	t.Parallel()
+
+	vars := xpath3.VariablesFromMap(map[string]xpath3.Sequence{
+		"u": xpath3.ItemSlice{
+			xpath3.AtomicValue{
+				TypeName: "Q{urn:test}myURI",
+				BaseType: xpath3.TypeAnyURI,
+				Value:    "abc",
+			},
+		},
+	})
+
+	cases := map[string]string{
+		`upper-case($u)`:    "ABC",
+		`string-length($u)`: "3",
+		`concat($u, "x")`:   "abcx",
+	}
+	for expr, want := range cases {
+		result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+			Variables(vars).
+			Evaluate(t.Context(), xpath3.NewCompiler().MustCompile(expr), nil)
+		require.NoError(t, err, expr)
+
+		switch expr {
+		case `string-length($u)`:
+			n, ok := result.IsNumber()
+			require.True(t, ok, expr)
+			require.Equal(t, float64(3), n, expr)
+		default:
+			s, ok := result.IsString()
+			require.True(t, ok, expr)
+			require.Equal(t, want, s, expr)
+		}
+	}
+}
+
+// Finding (round 6): a plain (built-in) xs:anyURI supplied to an xs:string? param
+// must continue to promote to xs:string and be accepted — the exact-type path
+// previously handled this, and the subtype-aware gate must not regress it.
+func TestSignatureGatePromotesPlainAnyURI(t *testing.T) {
+	t.Parallel()
+	result, err := evaluate(t.Context(), nil, `upper-case(xs:anyURI("abc"))`)
+	require.NoError(t, err)
+	s, ok := result.IsString()
+	require.True(t, ok)
+	require.Equal(t, "ABC", s)
+}
+
+// Finding (round 6): a genuinely non-anyURI, non-string value supplied to an
+// xs:string param still raises XPTY0004 — widening anyURI acceptance must not
+// admit unrelated types.
+func TestSignatureGateRejectsNonStringForStringParam(t *testing.T) {
+	t.Parallel()
+	_, err := evaluate(t.Context(), nil, `upper-case(current-date())`)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code)
+}
+
 // Finding 2: a too-long sequence supplied to a singleton (xs:string?) parameter
 // must be rejected promptly with XPTY0004 — without atomizing the whole range.
 // A 10M-item lazy range would allocate ~1GB if atomized eagerly; the cap keeps

--- a/xpath3/funcall_signature_test.go
+++ b/xpath3/funcall_signature_test.go
@@ -1,0 +1,116 @@
+package xpath3_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// userFunc is a minimal user-defined Function for signature-enforcement tests.
+type userFunc struct {
+	min, max int
+	call     func(ctx context.Context, args []xpath3.Sequence) (xpath3.Sequence, error)
+}
+
+func (f userFunc) MinArity() int { return f.min }
+func (f userFunc) MaxArity() int { return f.max }
+func (f userFunc) Call(ctx context.Context, args []xpath3.Sequence) (xpath3.Sequence, error) {
+	return f.call(ctx, args)
+}
+
+// typedUserFunc additionally declares parameter/return types (TypedFunction).
+type typedUserFunc struct {
+	userFunc
+	params []xpath3.SequenceType
+	ret    *xpath3.SequenceType
+}
+
+func (f typedUserFunc) FuncParamTypes() []xpath3.SequenceType { return f.params }
+func (f typedUserFunc) FuncReturnType() *xpath3.SequenceType  { return f.ret }
+
+func stType(name string, occ xpath3.Occurrence) xpath3.SequenceType {
+	return xpath3.SequenceType{
+		ItemTest:   xpath3.AtomicOrUnionType{Prefix: "xs", Name: name},
+		Occurrence: occ,
+	}
+}
+
+// Finding 1: a built-in called via Q{uri}local syntax must still enforce its
+// registered signature, so a cardinality-violating arg raises XPTY0004.
+func TestURIQualifiedBuiltinEnforcesSignature(t *testing.T) {
+	t.Parallel()
+	_, err := evaluate(t.Context(), nil, `Q{http://www.w3.org/2005/xpath-functions}abs((1, 2))`)
+	require.Error(t, err)
+
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code)
+}
+
+// Finding 2: a user function registered under an unqualified name that shadows a
+// built-in must NOT be subjected to the built-in signature. Calling it with an
+// argument the built-in would reject must succeed.
+func TestUserOverrideSkipsBuiltinSignature(t *testing.T) {
+	t.Parallel()
+
+	lib := xpath3.NewFunctionLibrary()
+	lib.Set("upper-case", userFunc{
+		min: 1, max: 1,
+		call: func(_ context.Context, args []xpath3.Sequence) (xpath3.Sequence, error) {
+			return xpath3.SingleString("ok"), nil
+		},
+	})
+
+	compiled, err := xpath3.NewCompiler().Compile(`upper-case(1)`)
+	require.NoError(t, err)
+
+	result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Functions(lib).
+		Evaluate(t.Context(), compiled, nil)
+	require.NoError(t, err)
+
+	s, ok := result.IsString()
+	require.True(t, ok)
+	require.Equal(t, "ok", s)
+}
+
+// Finding 3: a TypedFunction declaring xs:double must observe a coerced xs:double
+// when called with an xs:integer (function-conversion / numeric promotion).
+func TestTypedUserFunctionObservesCoercedArg(t *testing.T) {
+	t.Parallel()
+
+	dbl := stType("double", xpath3.OccurrenceExactlyOne)
+	var observed string
+	lib := xpath3.NewFunctionLibrary()
+	lib.Set("takes-double", typedUserFunc{
+		userFunc: userFunc{
+			min: 1, max: 1,
+			call: func(_ context.Context, args []xpath3.Sequence) (xpath3.Sequence, error) {
+				av, err := xpath3.AtomizeItem(args[0].Get(0))
+				if err != nil {
+					return nil, err
+				}
+				observed = av.TypeName
+				return xpath3.SingleString(av.TypeName), nil
+			},
+		},
+		params: []xpath3.SequenceType{dbl},
+		ret:    nil,
+	})
+
+	compiled, err := xpath3.NewCompiler().Compile(`takes-double(1)`)
+	require.NoError(t, err)
+
+	result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Functions(lib).
+		Evaluate(t.Context(), compiled, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, xpath3.TypeDouble, observed)
+	s, ok := result.IsString()
+	require.True(t, ok)
+	require.Equal(t, xpath3.TypeDouble, s)
+}

--- a/xpath3/funcall_signature_test.go
+++ b/xpath3/funcall_signature_test.go
@@ -256,6 +256,96 @@ func TestSignatureGateAcceptsSchemaDerivedNumeric(t *testing.T) {
 	}
 }
 
+// Finding 1 (round 5): numeric promotion of an integer-DERIVED subtype to xs:double
+// must succeed. The signature gate admits xs:positiveInteger/xs:int/xs:long/… as a
+// numeric, so the subsequent cast must coerce the whole integer-derived family (not
+// just exact xs:integer) — otherwise a valid promotion is rejected with XPTY0004
+// before the builtin (here fn:substring) runs.
+func TestSignatureGatePromotesIntegerDerivedSubtypes(t *testing.T) {
+	t.Parallel()
+
+	exprs := []string{
+		`substring("abcd", xs:positiveInteger("2"))`,
+		`substring("abcd", xs:int("2"))`,
+		`substring("abcd", xs:long("2"))`,
+		`substring("abcd", xs:short("2"))`,
+		`substring("abcd", xs:byte("2"))`,
+		`substring("abcd", xs:nonNegativeInteger("2"))`,
+	}
+	for _, expr := range exprs {
+		result, err := evaluate(t.Context(), nil, expr)
+		require.NoError(t, err, expr)
+		s, ok := result.IsString()
+		require.True(t, ok, expr)
+		require.Equal(t, "bcd", s, expr)
+	}
+}
+
+// Finding 1 (round 5): a schema-DERIVED integer (BaseType xs:integer) supplied to an
+// xs:double parameter must promote — the gate accepts it via BaseType ancestry and the
+// cast must agree by normalizing through PromoteSchemaType.
+func TestSignatureGatePromotesSchemaDerivedInteger(t *testing.T) {
+	t.Parallel()
+
+	vars := xpath3.VariablesFromMap(map[string]xpath3.Sequence{
+		"v": xpath3.ItemSlice{
+			xpath3.AtomicValue{
+				TypeName: "Q{urn:test}myInt",
+				BaseType: xpath3.TypeInteger,
+				Value:    int64(2),
+			},
+		},
+	})
+	result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Variables(vars).
+		Evaluate(t.Context(), xpath3.NewCompiler().MustCompile(`substring("abcd", $v)`), nil)
+	require.NoError(t, err)
+	s, ok := result.IsString()
+	require.True(t, ok)
+	require.Equal(t, "bcd", s)
+}
+
+// Finding 1 (round 5): a genuinely non-numeric value supplied where a numeric is
+// required still raises XPTY0004 — broadening the cast must not admit non-numerics.
+func TestSignatureGateRejectsNonNumericForNumericParam(t *testing.T) {
+	t.Parallel()
+	_, err := evaluate(t.Context(), nil, `substring("abcd", current-date())`)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code)
+}
+
+// Finding 2 (round 5): when a singleton (xs:string?) parameter receives an ARRAY whose
+// later members would themselves fail atomization (a map → FOTY0013), the cardinality
+// failure observed at the 2nd atom must win. The stop signal must propagate out of the
+// recursive array-member atomization so the map is never reached.
+func TestSignatureGateArrayCardinalityBeatsLaterAtomError(t *testing.T) {
+	t.Parallel()
+	_, err := evaluate(t.Context(), nil, `upper-case([1, 2, map{}])`)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code)
+}
+
+// Finding 2 (round 5): legitimate array atomization still works fully — a single-member
+// array satisfies a singleton param, and array-accepting functions atomize all members.
+func TestSignatureGateArrayAtomizationStillWorks(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		`upper-case(["a"])`:         "A",
+		`string-join([1,2,3], ",")`: "1,2,3",
+	}
+	for expr, want := range cases {
+		result, err := evaluate(t.Context(), nil, expr)
+		require.NoError(t, err, expr)
+		s, ok := result.IsString()
+		require.True(t, ok, expr)
+		require.Equal(t, want, s, expr)
+	}
+}
+
 // Finding 2: a too-long sequence supplied to a singleton (xs:string?) parameter
 // must be rejected promptly with XPTY0004 — without atomizing the whole range.
 // A 10M-item lazy range would allocate ~1GB if atomized eagerly; the cap keeps

--- a/xpath3/function_signatures.go
+++ b/xpath3/function_signatures.go
@@ -146,7 +146,7 @@ func init() {
 	}, stItem(OccurrenceZeroOrMore))
 	registerSig("sort", 2, []SequenceType{
 		stItem(OccurrenceZeroOrMore),
-		stFunc([]SequenceType{stItem(OccurrenceExactlyOne)}, stItem(OccurrenceZeroOrMore)),
+		stAtomic(TypeString, OccurrenceZeroOrOne),
 	}, stItem(OccurrenceZeroOrMore))
 }
 

--- a/xpath3/functions.go
+++ b/xpath3/functions.go
@@ -87,6 +87,17 @@ func namespacePrefixFor(uri string) string {
 // Populated in Phase 4 init() calls. Keyed by QualifiedName{URI, Name}.
 var builtinFunctions3 = map[QualifiedName]Function{}
 
+// resolvedFunction carries a resolved function together with the identity used
+// to find it. Signature enforcement keys off the resolved URI/local name (not the
+// raw call syntax) and only consults the built-in signature registry when the
+// resolved function actually is the registered built-in.
+type resolvedFunction struct {
+	fn        Function
+	uri       string // resolved namespace URI
+	name      string // resolved local name (Q{uri}local stripped)
+	isBuiltin bool   // true only when fn came from the built-in registry
+}
+
 // resolveFunction finds a function by prefix, local name, and arity.
 // Resolution order:
 //  1. User-registered functions by local name (ec.functions)
@@ -94,12 +105,22 @@ var builtinFunctions3 = map[QualifiedName]Function{}
 //  3. Built-in functions by QualifiedName (builtinFunctions3)
 //  4. Default fn: namespace (no prefix = fn:)
 func resolveFunction(ctx context.Context, ec *evalContext, prefix, name string, arity int) (Function, error) {
+	r, err := resolveFunctionInfo(ctx, ec, prefix, name, arity)
+	if err != nil {
+		return nil, err
+	}
+	return r.fn, nil
+}
+
+// resolveFunctionInfo is resolveFunction but additionally reports the resolved
+// identity (URI + local name) and whether the result is the built-in function.
+func resolveFunctionInfo(ctx context.Context, ec *evalContext, prefix, name string, arity int) (resolvedFunction, error) {
 	// Handle Q{uri}local URIQualifiedName syntax from the lexer
 	if prefix == "" && strings.HasPrefix(name, "Q{") {
 		if idx := strings.Index(name, "}"); idx >= 0 {
 			uri := name[2:idx]
 			local := name[idx+1:]
-			return resolveFunctionByURI(ctx, ec, uri, local, arity)
+			return resolveFunctionByURIInfo(ctx, ec, uri, local, arity)
 		}
 	}
 
@@ -107,30 +128,30 @@ func resolveFunction(ctx context.Context, ec *evalContext, prefix, name string, 
 	if prefix == "" && ec.functions != nil {
 		if fn, ok := ec.functions[name]; ok {
 			if err := checkArity(fn, name, arity); err != nil {
-				return nil, err
+				return resolvedFunction{}, err
 			}
-			return fn, nil
+			return resolvedFunction{fn: fn, uri: NSFn, name: name}, nil
 		}
 	}
 
 	// Resolve prefix to namespace URI
 	uri, err := resolvePrefix(ec, prefix)
 	if err != nil {
-		return nil, err
+		return resolvedFunction{}, err
 	}
 
-	return resolveFunctionByURI(ctx, ec, uri, name, arity)
+	return resolveFunctionByURIInfo(ctx, ec, uri, name, arity)
 }
 
-func resolveFunctionByURI(ctx context.Context, ec *evalContext, uri, name string, arity int) (Function, error) {
+func resolveFunctionByURIInfo(ctx context.Context, ec *evalContext, uri, name string, arity int) (resolvedFunction, error) {
 	// User functions by qualified name
 	if ec.fnsNS != nil {
 		qn := QualifiedName{URI: uri, Name: name}
 		if fn, ok := ec.fnsNS[qn]; ok {
 			if err := checkArity(fn, name, arity); err != nil {
-				return nil, err
+				return resolvedFunction{}, err
 			}
-			return fn, nil
+			return resolvedFunction{fn: fn, uri: uri, name: name}, nil
 		}
 	}
 
@@ -138,21 +159,21 @@ func resolveFunctionByURI(ctx context.Context, ec *evalContext, uri, name string
 	qn := QualifiedName{URI: uri, Name: name}
 	if fn, ok := builtinFunctions3[qn]; ok {
 		if err := checkArity(fn, name, arity); err != nil {
-			return nil, err
+			return resolvedFunction{}, err
 		}
-		return fn, nil
+		return resolvedFunction{fn: fn, uri: uri, name: name, isBuiltin: true}, nil
 	}
 
 	// Check function resolver (not visible to function-lookup)
 	if ec.functionResolver != nil {
 		if fn, ok, err := ec.functionResolver.ResolveFunction(ctx, uri, name, arity); err != nil {
-			return nil, err
+			return resolvedFunction{}, err
 		} else if ok {
-			return fn, nil
+			return resolvedFunction{fn: fn, uri: uri, name: name}, nil
 		}
 	}
 
-	return nil, fmt.Errorf("%w: %s#%d", ErrUnknownFunction, name, arity)
+	return resolvedFunction{}, fmt.Errorf("%w: %s#%d", ErrUnknownFunction, name, arity)
 }
 
 func resolvePrefix(ec *evalContext, prefix string) (string, error) {

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -537,3 +537,97 @@ func TestFnImplicitTimezoneReturnsDuration(t *testing.T) {
 	require.Len(t, atomics, 1)
 	require.Equal(t, xpath3.TypeDayTimeDuration, atomics[0].TypeName)
 }
+
+// TestBuiltinSignatureEnforcement verifies that static built-in function calls
+// enforce their declared parameter signatures, raising XPTY0004 when an argument
+// has the wrong cardinality or type, while spec-valid calls still succeed.
+func TestBuiltinSignatureEnforcement(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	t.Run("cardinality violations raise XPTY0004", func(t *testing.T) {
+		// Each of these passes a sequence of length > 1 where the signature
+		// requires xs:string? / xs:numeric? (zero-or-one).
+		exprs := []string{
+			`abs((1, 2))`,
+			`upper-case(("a", "b"))`,
+			`lower-case(("a", "b"))`,
+			`string-length(("a", "b"))`,
+			`normalize-space(("a", "b"))`,
+			`ceiling((1, 2))`,
+			`floor((1, 2))`,
+		}
+		for _, expr := range exprs {
+			t.Run(expr, func(t *testing.T) {
+				compiled, err := xpath3.NewCompiler().Compile(expr)
+				require.NoError(t, err)
+				_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+					Evaluate(t.Context(), compiled, doc)
+				require.Error(t, err)
+				var xpErr *xpath3.XPathError
+				require.ErrorAs(t, err, &xpErr)
+				require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code)
+			})
+		}
+	})
+
+	t.Run("type violations raise XPTY0004", func(t *testing.T) {
+		// matches() arg 1 is xs:string?; a QName is not coercible to xs:string.
+		compiled, err := xpath3.NewCompiler().Compile(`matches(current-dateTime(), "x")`)
+		require.NoError(t, err)
+		_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+			Evaluate(t.Context(), compiled, doc)
+		require.Error(t, err)
+		var xpErr *xpath3.XPathError
+		require.ErrorAs(t, err, &xpErr)
+		require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code)
+	})
+
+	t.Run("valid controls still pass", func(t *testing.T) {
+		tests := []struct {
+			expr   string
+			expect string
+		}{
+			// Wrap numeric results in string() so the lexical form is asserted
+			// uniformly via StringVal.
+			{`string(abs(-3))`, "3"},
+			{`upper-case("a")`, "A"},
+			{`lower-case("A")`, "a"},
+			{`string(string-length("abc"))`, "3"},
+			{`string(ceiling(1.2))`, "2"},
+			{`string(floor(1.8))`, "1"},
+			{`normalize-space("  a  b ")`, "a b"},
+			// fn:upper-case(()) returns the zero-length string (not empty seq).
+			{`upper-case(())`, ""},
+		}
+		for _, tc := range tests {
+			t.Run(tc.expr, func(t *testing.T) {
+				seq := evalExpr(t, doc, tc.expr)
+				require.Equal(t, 1, seq.Len())
+				av := seq.Get(0).(xpath3.AtomicValue)
+				require.Equal(t, tc.expect, av.StringVal())
+			})
+		}
+	})
+
+	t.Run("empty argument satisfies optional cardinality", func(t *testing.T) {
+		// abs(()) returns the empty sequence; the call must not error.
+		seq := evalExpr(t, doc, `abs(())`)
+		if seq != nil {
+			require.Equal(t, 0, seq.Len())
+		}
+	})
+
+	t.Run("maps and arrays coerce to function predicate", func(t *testing.T) {
+		// fn:filter's predicate is function(item()) as xs:boolean; maps and
+		// arrays are arity-1 function items and must coerce successfully.
+		for _, expr := range []string{
+			`filter((4, 5, 6), map{4: true(), 5: false(), 6: true()})`,
+			`filter((4, 5, 6), [1, 2, 3, true(), false(), true()])`,
+		} {
+			t.Run(expr, func(t *testing.T) {
+				seq := evalExpr(t, doc, expr)
+				require.Equal(t, 2, seq.Len())
+			})
+		}
+	})
+}

--- a/xpath3/sequence.go
+++ b/xpath3/sequence.go
@@ -105,15 +105,34 @@ func AtomizeSequence(seq Sequence) ([]AtomicValue, error) {
 		return nil, nil
 	}
 	result := make([]AtomicValue, 0, seq.Len())
+	err := atomizeStream(seq, func(av AtomicValue) (bool, error) {
+		result = append(result, av)
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// atomizeStream atomizes a sequence per XPath 3.1 Section 2.6.2, invoking yield
+// for each produced atomic value. If yield returns false, streaming stops early
+// without error (used to bound work when a caller caps the number of atoms it
+// will accept). A typed atomization error (e.g. FOTY0013 for function/map items,
+// FORG0001 for an invalid list-member cast) propagates to the caller; this lets
+// callers distinguish a genuine atomization failure from a plain cardinality
+// rejection.
+func atomizeStream(seq Sequence, yield func(AtomicValue) (bool, error)) error {
+	if seq == nil {
+		return nil
+	}
 	for item := range seqItems(seq) {
 		// XPath 3.1: atomizing an array flattens its members
 		if arr, ok := item.(ArrayItem); ok {
 			for _, member := range arr.members0() {
-				atoms, err := AtomizeSequence(member)
-				if err != nil {
-					return nil, err
+				if err := atomizeStream(member, yield); err != nil {
+					return err
 				}
-				result = append(result, atoms...)
 			}
 			continue
 		}
@@ -134,21 +153,33 @@ func AtomizeSequence(seq Sequence) ([]AtomicValue, error) {
 						if strings.HasPrefix(listItem, "Q{") {
 							cast = AtomicValue{TypeName: listItem, Value: tok}
 						} else {
-							return nil, err
+							return err
 						}
 					}
-					result = append(result, cast)
+					cont, err := yield(cast)
+					if err != nil {
+						return err
+					}
+					if !cont {
+						return nil
+					}
 				}
 				continue
 			}
 		}
 		av, err := AtomizeItem(item)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		result = append(result, av)
+		cont, err := yield(av)
+		if err != nil {
+			return err
+		}
+		if !cont {
+			return nil
+		}
 	}
-	return result, nil
+	return nil
 }
 
 // builtinListItemType returns the item type for built-in XSD list types.

--- a/xpath3/sequence.go
+++ b/xpath3/sequence.go
@@ -123,15 +123,30 @@ func AtomizeSequence(seq Sequence) ([]AtomicValue, error) {
 // callers distinguish a genuine atomization failure from a plain cardinality
 // rejection.
 func atomizeStream(seq Sequence, yield func(AtomicValue) (bool, error)) error {
+	_, err := atomizeStreamCont(seq, yield)
+	return err
+}
+
+// atomizeStreamCont is the recursive worker behind atomizeStream. It returns
+// (cont, err): cont is false once yield has requested a stop, so that recursive
+// array-member atomization halts IMMEDIATELY and no further members (or items)
+// are atomized. Propagating the stop is what lets a caller's bounded-work cap
+// (e.g. a singleton-cardinality check) surface its own rejection rather than a
+// later member's atomization error (e.g. FOTY0013 from a map).
+func atomizeStreamCont(seq Sequence, yield func(AtomicValue) (bool, error)) (bool, error) {
 	if seq == nil {
-		return nil
+		return true, nil
 	}
 	for item := range seqItems(seq) {
 		// XPath 3.1: atomizing an array flattens its members
 		if arr, ok := item.(ArrayItem); ok {
 			for _, member := range arr.members0() {
-				if err := atomizeStream(member, yield); err != nil {
-					return err
+				cont, err := atomizeStreamCont(member, yield)
+				if err != nil {
+					return false, err
+				}
+				if !cont {
+					return false, nil
 				}
 			}
 			continue
@@ -153,15 +168,15 @@ func atomizeStream(seq Sequence, yield func(AtomicValue) (bool, error)) error {
 						if strings.HasPrefix(listItem, "Q{") {
 							cast = AtomicValue{TypeName: listItem, Value: tok}
 						} else {
-							return err
+							return false, err
 						}
 					}
 					cont, err := yield(cast)
 					if err != nil {
-						return err
+						return false, err
 					}
 					if !cont {
-						return nil
+						return false, nil
 					}
 				}
 				continue
@@ -169,17 +184,17 @@ func atomizeStream(seq Sequence, yield func(AtomicValue) (bool, error)) error {
 		}
 		av, err := AtomizeItem(item)
 		if err != nil {
-			return err
+			return false, err
 		}
 		cont, err := yield(av)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if !cont {
-			return nil
+			return false, nil
 		}
 	}
-	return nil
+	return true, nil
 }
 
 // builtinListItemType returns the item type for built-in XSD list types.


### PR DESCRIPTION
- `evalFunctionCall` now validates every static built-in call against its declared parameter signature (registry → `TypedFunction`/`TypedFunctionByArity`), raising `XPTY0004` on cardinality/type mismatch; functions with no registered signature are unchanged
- `coerceToSequenceType` atomizes via `AtomizeSequence` (correctly expands list-typed nodes/arrays) and falls back to `schemaDeclarations.IsSubtypeOf` for user-defined schema types; nil-`ec` guard added to `resolveAtomicTypeName`
- `coerceFunctionItem` now accepts maps/arrays (arity-1 function items) so they coerce to a function-typed parameter (e.g. `fn:filter` predicate)
- signature fix: `fn:sort#2` 2nd param `function(item()) as item()*` → `$collation as xs:string?`
- adds `TestBuiltinSignatureEnforcement` regression coverage; full `xpath3`+`xslt3` (incl. QT3) suite green
