### PR TITLE
xmldsig1: reject out-of-range rsa exponent

### DIFF
--- a/xmldsig1/keyinfo.go
+++ b/xmldsig1/keyinfo.go
@@ -256,7 +256,12 @@ func parseRSAKeyValue(elem *helium.Element, data *KeyInfoData) error {
 		case "Modulus":
 			kv.Modulus = new(big.Int).SetBytes(decoded)
 		case "Exponent":
-			kv.Exponent = int(new(big.Int).SetBytes(decoded).Int64())
+			exp := new(big.Int).SetBytes(decoded)
+			const maxInt = int(^uint(0) >> 1)
+			if exp.Sign() <= 0 || !exp.IsInt64() || exp.Int64() > int64(maxInt) {
+				return fmt.Errorf("%w: RSAKeyValue Exponent out of range", ErrInvalidKeyInfo)
+			}
+			kv.Exponent = int(exp.Int64())
 		}
 	}
 	data.RSAKeyValue = kv

--- a/xmldsig1/keyinfo_rsa_exponent_test.go
+++ b/xmldsig1/keyinfo_rsa_exponent_test.go
@@ -1,0 +1,70 @@
+package xmldsig1
+
+import (
+	"encoding/base64"
+	"fmt"
+	"math/big"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// rsaKeyInfoXML builds a ds:KeyInfo document carrying an RSAKeyValue with the
+// given base64-encoded modulus and exponent.
+func rsaKeyInfoXML(modulus, exponent string) string {
+	return fmt.Sprintf(`<ds:KeyInfo xmlns:ds="%s">`+
+		`<ds:KeyValue><ds:RSAKeyValue>`+
+		`<ds:Modulus>%s</ds:Modulus>`+
+		`<ds:Exponent>%s</ds:Exponent>`+
+		`</ds:RSAKeyValue></ds:KeyValue></ds:KeyInfo>`, NamespaceDSig, modulus, exponent)
+}
+
+func TestParseKeyInfo_RSAExponentRange(t *testing.T) {
+	modulus := base64.StdEncoding.EncodeToString(big.NewInt(3233).Bytes())
+
+	encode := func(n *big.Int) string {
+		return base64.StdEncoding.EncodeToString(n.Bytes())
+	}
+
+	t.Run("valid 65537", func(t *testing.T) {
+		xml := rsaKeyInfoXML(modulus, "AQAB") // 65537
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(xml))
+		require.NoError(t, err)
+
+		data, err := parseKeyInfo(doc.DocumentElement())
+		require.NoError(t, err)
+		require.NotNil(t, data.RSAKeyValue)
+		require.Equal(t, 65537, data.RSAKeyValue.Exponent)
+	})
+
+	oversized := map[string]*big.Int{
+		"2^63": new(big.Int).Lsh(big.NewInt(1), 63),
+	}
+	// 2^64 + 65537
+	bigVal := new(big.Int).Lsh(big.NewInt(1), 64)
+	bigVal.Add(bigVal, big.NewInt(65537))
+	oversized["2^64+65537"] = bigVal
+
+	for name, val := range oversized {
+		t.Run("oversized "+name, func(t *testing.T) {
+			xml := rsaKeyInfoXML(modulus, encode(val))
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(xml))
+			require.NoError(t, err)
+
+			_, err = parseKeyInfo(doc.DocumentElement())
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrInvalidKeyInfo)
+		})
+	}
+
+	t.Run("zero exponent rejected", func(t *testing.T) {
+		xml := rsaKeyInfoXML(modulus, encode(big.NewInt(0)))
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(xml))
+		require.NoError(t, err)
+
+		_, err = parseKeyInfo(doc.DocumentElement())
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidKeyInfo)
+	})
+}


### PR DESCRIPTION
- `parseRSAKeyValue` decoded `<ds:Exponent>` via `big.Int.Int64()`, which silently wraps when the value exceeds int64 range — a crafted/oversized exponent yielded a truncated or negative `RSAKeyValueData.Exponent`.
- Reject non-positive or out-of-int-range exponents with `ErrInvalidKeyInfo` instead of wrapping.
- Adds regression test: valid 65537, oversized `2^63` / `2^64+65537`, and zero all covered.
