### PR TITLE
stream: validate comment and pi well-formedness

### DIFF
--- a/internal/xmlchar/xmlchar.go
+++ b/internal/xmlchar/xmlchar.go
@@ -1,6 +1,11 @@
 // Package xmlchar provides XML 1.0 NCName character classification functions.
 package xmlchar
 
+import (
+	"strings"
+	"unicode/utf8"
+)
+
 // IsNCNameStartChar checks the XML 1.0 NCName start character production.
 // NCNameStartChar ::= [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6]
 //
@@ -25,6 +30,37 @@ func IsNCNameChar(r rune) bool {
 	return IsNCNameStartChar(r) ||
 		(r >= '0' && r <= '9') || r == '-' || r == '.' ||
 		r == 0xB7 || (r >= 0x0300 && r <= 0x036F) || (r >= 0x203F && r <= 0x2040)
+}
+
+// IsValidPITarget reports whether target is a valid XML processing
+// instruction target. A PI target is an XML Name (an NCName optionally
+// containing colons) and must not be the reserved name "xml" (any case).
+func IsValidPITarget(target string) bool {
+	if target == "" {
+		return false
+	}
+	if strings.EqualFold(target, "xml") {
+		return false
+	}
+	// Ranging over an invalid byte yields utf8.RuneError (U+FFFD), which is
+	// itself a valid NCName character, so the loop below would accept invalid
+	// UTF-8 and emit raw bytes. Reject invalid encodings up front; a genuinely
+	// encoded U+FFFD is valid UTF-8 and still passes.
+	if !utf8.ValidString(target) {
+		return false
+	}
+	for i, r := range target {
+		if r == ':' {
+			continue
+		}
+		if i == 0 && !IsNCNameStartChar(r) {
+			return false
+		}
+		if i > 0 && !IsNCNameChar(r) {
+			return false
+		}
+	}
+	return true
 }
 
 // IsValidNCName checks whether s is a valid XML NCName (non-colonized name).

--- a/internal/xmlchar/xmlchar.go
+++ b/internal/xmlchar/xmlchar.go
@@ -33,8 +33,9 @@ func IsNCNameChar(r rune) bool {
 }
 
 // IsValidPITarget reports whether target is a valid XML processing
-// instruction target. A PI target is an XML Name (an NCName optionally
-// containing colons) and must not be the reserved name "xml" (any case).
+// instruction target. A PI target is an NCName (colons are forbidden, matching
+// helium's parser, which rejects colons in PI targets) and must not be the
+// reserved name "xml" (any case).
 func IsValidPITarget(target string) bool {
 	if target == "" {
 		return false
@@ -43,24 +44,13 @@ func IsValidPITarget(target string) bool {
 		return false
 	}
 	// Ranging over an invalid byte yields utf8.RuneError (U+FFFD), which is
-	// itself a valid NCName character, so the loop below would accept invalid
+	// itself a valid NCName character, so IsValidNCName would accept invalid
 	// UTF-8 and emit raw bytes. Reject invalid encodings up front; a genuinely
 	// encoded U+FFFD is valid UTF-8 and still passes.
 	if !utf8.ValidString(target) {
 		return false
 	}
-	for i, r := range target {
-		if r == ':' {
-			continue
-		}
-		if i == 0 && !IsNCNameStartChar(r) {
-			return false
-		}
-		if i > 0 && !IsNCNameChar(r) {
-			return false
-		}
-	}
-	return true
+	return IsValidNCName(target)
 }
 
 // IsValidNCName checks whether s is a valid XML NCName (non-colonized name).

--- a/internal/xmlchar/xmlchar_test.go
+++ b/internal/xmlchar/xmlchar_test.go
@@ -38,6 +38,36 @@ func TestIsValidNCName(t *testing.T) {
 	}
 }
 
+func TestIsValidPITarget(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"target", true},
+		{"xml-stylesheet", true},
+		{"_pi", true},
+		{"café", true},
+		{"�", true}, // genuinely encoded U+FFFD is a valid NCName char
+		{"", false},
+		{"xml", false},                // reserved (any case)
+		{"XML", false},                // reserved (any case)
+		{"Xml", false},                // reserved (any case)
+		{"a:b", false},                // colons forbidden, matching the parser
+		{":", false},                  // colons forbidden
+		{"a:", false},                 // colons forbidden
+		{":a", false},                 // colons forbidden
+		{"1bad", false},               // must start with NCNameStartChar
+		{string([]byte{0xff}), false}, // invalid UTF-8
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, xmlchar.IsValidPITarget(tt.input))
+		})
+	}
+}
+
 func TestIsNCNameStartChar(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -846,6 +846,14 @@ func (w *Writer) StartPI(target string) error {
 	if w.err != nil {
 		return w.err
 	}
+	// Validate the target before touching any writer state or output, so a bad
+	// target never closes an open start tag or otherwise mutates the writer.
+	if strings.EqualFold(target, "xml") {
+		return errors.New("stream: PI target cannot be 'xml'")
+	}
+	if !isValidPITarget(target) {
+		return fmt.Errorf("stream: invalid PI target %q", target)
+	}
 	switch w.state {
 	case stateNone, stateDocument, stateText:
 		// ok
@@ -853,12 +861,6 @@ func (w *Writer) StartPI(target string) error {
 		w.closeTagIfOpen()
 	default:
 		return errors.New("stream: StartPI called in invalid state")
-	}
-	if strings.EqualFold(target, "xml") {
-		return errors.New("stream: PI target cannot be 'xml'")
-	}
-	if !isValidPITarget(target) {
-		return fmt.Errorf("stream: invalid PI target %q", target)
 	}
 	if len(w.elemStack) > 0 {
 		w.elemStack[len(w.elemStack)-1].empty = false

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"slices"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/lestrrat-go/helium/internal/encoding"
 	"github.com/lestrrat-go/helium/internal/xmlchar"
@@ -16,30 +15,11 @@ var errNilOutputWriter = errors.New("stream: output writer is nil")
 
 // isValidPITarget reports whether target is a valid XML processing
 // instruction target. A PI target is an XML Name, which is an NCName
-// optionally containing colons.
+// optionally containing colons. The reserved "xml" target is rejected by
+// StartPI separately (with a dedicated error) before this is reached, so the
+// shared predicate's "xml" rejection is harmless here.
 func isValidPITarget(target string) bool {
-	if target == "" {
-		return false
-	}
-	// Ranging over an invalid byte yields utf8.RuneError (U+FFFD), which is
-	// itself a valid NCName character, so the loop below would accept invalid
-	// UTF-8 and emit raw bytes. Reject invalid encodings up front; a genuinely
-	// encoded U+FFFD is valid UTF-8 and still passes.
-	if !utf8.ValidString(target) {
-		return false
-	}
-	for i, r := range target {
-		if r == ':' {
-			continue
-		}
-		if i == 0 && !xmlchar.IsNCNameStartChar(r) {
-			return false
-		}
-		if i > 0 && !xmlchar.IsNCNameChar(r) {
-			return false
-		}
-	}
-	return true
+	return xmlchar.IsValidPITarget(target)
 }
 
 // writerState tracks what context the writer is currently in.
@@ -837,6 +817,10 @@ func (w *Writer) EndComment() error {
 
 // WriteComment is a convenience for StartComment + WriteString + EndComment.
 func (w *Writer) WriteComment(content string) error {
+	// A prior sticky I/O error must win over the new content validation below.
+	if w.err != nil {
+		return w.err
+	}
 	if strings.Contains(content, "--") {
 		return errors.New("stream: comment content must not contain '--'")
 	}
@@ -912,6 +896,10 @@ func (w *Writer) EndPI() error {
 
 // WritePI is a convenience for StartPI + WriteString + EndPI.
 func (w *Writer) WritePI(target, content string) error {
+	// A prior sticky I/O error must win over the new content validation below.
+	if w.err != nil {
+		return w.err
+	}
 	if strings.Contains(content, "?>") {
 		return errors.New("stream: processing instruction content must not contain '?>'")
 	}

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"slices"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/lestrrat-go/helium/internal/encoding"
 	"github.com/lestrrat-go/helium/internal/xmlchar"
@@ -18,6 +19,13 @@ var errNilOutputWriter = errors.New("stream: output writer is nil")
 // optionally containing colons.
 func isValidPITarget(target string) bool {
 	if target == "" {
+		return false
+	}
+	// Ranging over an invalid byte yields utf8.RuneError (U+FFFD), which is
+	// itself a valid NCName character, so the loop below would accept invalid
+	// UTF-8 and emit raw bytes. Reject invalid encodings up front; a genuinely
+	// encoded U+FFFD is valid UTF-8 and still passes.
+	if !utf8.ValidString(target) {
 		return false
 	}
 	for i, r := range target {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -93,6 +93,7 @@ type Writer struct {
 	hasOutput   bool          // true after first output has been written
 	wroteNL     bool          // true after EndComment/EndPI wrote trailing \n (suppresses writeIndent's \n)
 	commentDash bool          // true if the current comment body ends with '-' (would form '--->' on close)
+	piQuestion  bool          // true if the current PI body ends with '?' (would form '?>' across writes)
 }
 
 // NewWriter creates a Writer that writes to w. Configure the Writer
@@ -717,6 +718,9 @@ func (w *Writer) WriteString(content string) error {
 	case stateAttribute:
 		w.writeAttrEscaped(content)
 	case stateComment:
+		if w.commentDash && strings.HasPrefix(content, "-") {
+			return errors.New("stream: comment content must not contain '--'")
+		}
 		if strings.Contains(content, "--") {
 			return errors.New("stream: comment content must not contain '--'")
 		}
@@ -725,10 +729,16 @@ func (w *Writer) WriteString(content string) error {
 			w.commentDash = strings.HasSuffix(content, "-")
 		}
 	case statePI, statePIText:
+		if w.piQuestion && strings.HasPrefix(content, ">") {
+			return errors.New("stream: processing instruction content must not contain '?>'")
+		}
 		if strings.Contains(content, "?>") {
 			return errors.New("stream: processing instruction content must not contain '?>'")
 		}
 		w.writeStr(content)
+		if content != "" {
+			w.piQuestion = strings.HasSuffix(content, "?")
+		}
 		w.state = statePIText
 	case stateCDATA:
 		w.writeStr(content)
@@ -864,6 +874,7 @@ func (w *Writer) StartPI(target string) error {
 	}
 	w.writeStr("<?")
 	w.writeStr(target)
+	w.piQuestion = false
 	w.stateStack = append(w.stateStack, w.state)
 	w.state = statePI
 	return w.err

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -8,9 +8,31 @@ import (
 	"strings"
 
 	"github.com/lestrrat-go/helium/internal/encoding"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 )
 
 var errNilOutputWriter = errors.New("stream: output writer is nil")
+
+// isValidPITarget reports whether target is a valid XML processing
+// instruction target. A PI target is an XML Name, which is an NCName
+// optionally containing colons.
+func isValidPITarget(target string) bool {
+	if target == "" {
+		return false
+	}
+	for i, r := range target {
+		if r == ':' {
+			continue
+		}
+		if i == 0 && !xmlchar.IsNCNameStartChar(r) {
+			return false
+		}
+		if i > 0 && !xmlchar.IsNCNameChar(r) {
+			return false
+		}
+	}
+	return true
+}
 
 // writerState tracks what context the writer is currently in.
 type writerState int
@@ -58,18 +80,19 @@ type nsScope struct {
 //
 // (libxml2: xmlTextWriter)
 type Writer struct {
-	out        io.Writer
-	indent     string // indent string per level; empty = no indentation
-	quoteChar  byte   // attribute quote character ('"' or '\'')
-	singleByte [1]byte
-	state      writerState
-	elemStack  []elementEntry
-	nsStack    []nsScope
-	stateStack []writerState // for comment/PI/CDATA nesting
-	err        error         // sticky error
-	depth      int           // current element nesting depth (for indentation)
-	hasOutput  bool          // true after first output has been written
-	wroteNL    bool          // true after EndComment/EndPI wrote trailing \n (suppresses writeIndent's \n)
+	out         io.Writer
+	indent      string // indent string per level; empty = no indentation
+	quoteChar   byte   // attribute quote character ('"' or '\'')
+	singleByte  [1]byte
+	state       writerState
+	elemStack   []elementEntry
+	nsStack     []nsScope
+	stateStack  []writerState // for comment/PI/CDATA nesting
+	err         error         // sticky error
+	depth       int           // current element nesting depth (for indentation)
+	hasOutput   bool          // true after first output has been written
+	wroteNL     bool          // true after EndComment/EndPI wrote trailing \n (suppresses writeIndent's \n)
+	commentDash bool          // true if the current comment body ends with '-' (would form '--->' on close)
 }
 
 // NewWriter creates a Writer that writes to w. Configure the Writer
@@ -694,8 +717,17 @@ func (w *Writer) WriteString(content string) error {
 	case stateAttribute:
 		w.writeAttrEscaped(content)
 	case stateComment:
+		if strings.Contains(content, "--") {
+			return errors.New("stream: comment content must not contain '--'")
+		}
 		w.writeStr(content)
+		if content != "" {
+			w.commentDash = strings.HasSuffix(content, "-")
+		}
 	case statePI, statePIText:
+		if strings.Contains(content, "?>") {
+			return errors.New("stream: processing instruction content must not contain '?>'")
+		}
 		w.writeStr(content)
 		w.state = statePIText
 	case stateCDATA:
@@ -754,6 +786,7 @@ func (w *Writer) StartComment() error {
 		w.elemStack[len(w.elemStack)-1].hasChild = true
 	}
 	w.writeStr("<!--")
+	w.commentDash = false
 	w.stateStack = append(w.stateStack, w.state)
 	w.state = stateComment
 	return w.err
@@ -766,6 +799,9 @@ func (w *Writer) EndComment() error {
 	}
 	if w.state != stateComment {
 		return errors.New("stream: EndComment called outside comment")
+	}
+	if w.commentDash {
+		return errors.New("stream: comment content must not end with '-'")
 	}
 	w.writeStr("-->")
 	if w.indent != "" {
@@ -783,6 +819,12 @@ func (w *Writer) EndComment() error {
 
 // WriteComment is a convenience for StartComment + WriteString + EndComment.
 func (w *Writer) WriteComment(content string) error {
+	if strings.Contains(content, "--") {
+		return errors.New("stream: comment content must not contain '--'")
+	}
+	if strings.HasSuffix(content, "-") {
+		return errors.New("stream: comment content must not end with '-'")
+	}
 	if err := w.StartComment(); err != nil {
 		return err
 	}
@@ -812,6 +854,9 @@ func (w *Writer) StartPI(target string) error {
 	}
 	if strings.EqualFold(target, "xml") {
 		return errors.New("stream: PI target cannot be 'xml'")
+	}
+	if !isValidPITarget(target) {
+		return fmt.Errorf("stream: invalid PI target %q", target)
 	}
 	if len(w.elemStack) > 0 {
 		w.elemStack[len(w.elemStack)-1].empty = false
@@ -848,6 +893,9 @@ func (w *Writer) EndPI() error {
 
 // WritePI is a convenience for StartPI + WriteString + EndPI.
 func (w *Writer) WritePI(target, content string) error {
+	if strings.Contains(content, "?>") {
+		return errors.New("stream: processing instruction content must not contain '?>'")
+	}
 	if err := w.StartPI(target); err != nil {
 		return err
 	}

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -347,6 +347,37 @@ func TestCommentWellFormednessRejected(t *testing.T) {
 	}
 }
 
+func TestCommentDashSplitAcrossWrites(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartComment())
+	require.NoError(t, w.WriteString("a-"))
+	require.Error(t, w.WriteString("-b"))
+}
+
+func TestCommentTrailingDashSplitAtEnd(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartComment())
+	require.NoError(t, w.WriteString("a-"))
+	require.Error(t, w.EndComment())
+}
+
+func TestCommentDashChunksNoFalsePositive(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("root"))
+	require.NoError(t, w.StartComment())
+	require.NoError(t, w.WriteString("a-"))
+	require.NoError(t, w.WriteString("b"))
+	require.NoError(t, w.EndComment())
+	require.NoError(t, w.EndElement())
+	require.Equal(t, `<root><!--a-b--></root>`, buf.String())
+}
+
 func TestCommentValidStillSucceeds(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
@@ -375,6 +406,28 @@ func TestPIWellFormednessRejected(t *testing.T) {
 			require.Error(t, w.WritePI(tc.target, tc.content))
 		})
 	}
+}
+
+func TestPIDelimSplitAcrossWrites(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartPI("t"))
+	require.NoError(t, w.WriteString(" a?"))
+	require.Error(t, w.WriteString(">b"))
+}
+
+func TestPIQuestionChunksNoFalsePositive(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("root"))
+	require.NoError(t, w.StartPI("t"))
+	require.NoError(t, w.WriteString(" a?"))
+	require.NoError(t, w.WriteString("x"))
+	require.NoError(t, w.EndPI())
+	require.NoError(t, w.EndElement())
+	require.Equal(t, `<root><?t a?x?></root>`, buf.String())
 }
 
 func TestPIValidStillSucceeds(t *testing.T) {

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -329,6 +329,28 @@ func TestPIXmlCaseForbidden(t *testing.T) {
 	require.Contains(t, err.Error(), "cannot be 'xml'")
 }
 
+func TestPIInvalidUTF8TargetRejected(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	// An invalid UTF-8 byte decodes to U+FFFD, which is a valid NCName char,
+	// so the target must be rejected on the encoding check, not accepted.
+	err := w.StartPI(string([]byte{0xff}))
+	require.Error(t, err)
+	require.Empty(t, buf.String(), "no PI bytes must be emitted for an invalid target")
+}
+
+func TestPINormalTargetAccepted(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("root"))
+	require.NoError(t, w.StartPI("target"))
+	require.NoError(t, w.EndPI())
+	require.NoError(t, w.EndElement())
+	require.Equal(t, `<root><?target?></root>`, buf.String())
+}
+
 func TestCommentWellFormednessRejected(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -351,6 +351,46 @@ func TestPINormalTargetAccepted(t *testing.T) {
 	require.Equal(t, `<root><?target?></root>`, buf.String())
 }
 
+func TestPIColonTargetRejected(t *testing.T) {
+	t.Parallel()
+	for _, target := range []string{"a:b", ":", "a:", ":a"} {
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			w := stream.NewWriter(&buf)
+			err := w.StartPI(target)
+			require.Error(t, err)
+			require.Empty(t, buf.String(), "no PI bytes must be emitted for a colon target")
+		})
+	}
+}
+
+func TestPIReplacementCharTargetAccepted(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	// A genuinely encoded U+FFFD is valid UTF-8 and a valid NCName char.
+	require.NoError(t, w.StartPI("�"))
+	require.NoError(t, w.EndPI())
+	require.Equal(t, "<?�?>", buf.String())
+}
+
+func TestPIBadTargetInOpenStartTagDoesNotMutate(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("r"))
+	// StartElement writes "<r" and leaves the tag open (state stateName) so it
+	// can still self-close. A rejected PI must NOT call closeTagIfOpen (which
+	// would emit ">" and force "<r></r>"); the element must remain self-closeable.
+	require.Equal(t, "<r", buf.String())
+	err := w.StartPI("1bad")
+	require.Error(t, err)
+	require.Equal(t, "<r", buf.String(), "the open start tag must not be flushed by a rejected PI")
+	require.NoError(t, w.EndElement())
+	require.Equal(t, "<r/>", buf.String())
+}
+
 func TestCommentWellFormednessRejected(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -989,6 +989,31 @@ func TestStickyError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestStickyErrorPreservedInConvenienceHelpers(t *testing.T) {
+	t.Parallel()
+	// With an underlying writer that fails immediately, the sticky I/O error
+	// must win over the new content/target validation error in the one-shot
+	// convenience helpers.
+	t.Run("WriteComment", func(t *testing.T) {
+		t.Parallel()
+		fw := &failWriter{failAfter: 0}
+		w := stream.NewWriter(fw)
+		require.Error(t, w.StartElement("root"))
+		err := w.WriteComment("a--b")
+		require.Error(t, err)
+		require.Equal(t, "write failed", err.Error())
+	})
+	t.Run("WritePI", func(t *testing.T) {
+		t.Parallel()
+		fw := &failWriter{failAfter: 0}
+		w := stream.NewWriter(fw)
+		require.Error(t, w.StartElement("root"))
+		err := w.WritePI("t", "a?>b")
+		require.Error(t, err)
+		require.Equal(t, "write failed", err.Error())
+	})
+}
+
 func TestFlush(t *testing.T) {
 	t.Parallel()
 	fb := &flushableBuffer{}

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/stream"
 	"github.com/stretchr/testify/require"
 )
@@ -326,6 +327,80 @@ func TestPIXmlCaseForbidden(t *testing.T) {
 	err := w.StartPI("XML")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot be 'xml'")
+}
+
+func TestCommentWellFormednessRejected(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		content string
+	}{
+		{name: "double-dash", content: "a--b"},
+		{name: "trailing-dash", content: "a-"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			w := stream.NewWriter(&buf)
+			require.Error(t, w.WriteComment(tc.content))
+		})
+	}
+}
+
+func TestCommentValidStillSucceeds(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("root"))
+	require.NoError(t, w.WriteComment(" ok "))
+	require.NoError(t, w.EndElement())
+	require.Equal(t, `<root><!-- ok --></root>`, buf.String())
+}
+
+func TestPIWellFormednessRejected(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		target  string
+		content string
+	}{
+		{name: "content-end-delim", target: "t", content: "a?>b"},
+		{name: "target-starts-digit", target: "123bad", content: "x"},
+		{name: "target-has-space", target: "a b", content: "x"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			w := stream.NewWriter(&buf)
+			require.Error(t, w.WritePI(tc.target, tc.content))
+		})
+	}
+}
+
+func TestPIValidStillSucceeds(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("root"))
+	require.NoError(t, w.WritePI("php", "echo 1"))
+	require.NoError(t, w.EndElement())
+	require.Equal(t, `<root><?php echo 1?></root>`, buf.String())
+}
+
+func TestCommentPIRoundTripsThroughParser(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartDocument("", "", ""))
+	require.NoError(t, w.WritePI("php", "echo 1"))
+	require.NoError(t, w.StartElement("root"))
+	require.NoError(t, w.WriteComment(" a comment "))
+	require.NoError(t, w.WriteString("text"))
+	require.NoError(t, w.EndElement())
+	require.NoError(t, w.EndDocument())
+
+	_, err := helium.NewParser().Parse(t.Context(), buf.Bytes())
+	require.NoError(t, err)
 }
 
 func TestCDATA(t *testing.T) {

--- a/writer.go
+++ b/writer.go
@@ -1,6 +1,7 @@
 package helium
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"strings"
@@ -299,8 +300,11 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 	case CommentNode:
 		// A comment must not contain "--" or end with "-" (that would form
 		// "--->" with the closing delimiter), else the output is not well-formed.
-		content := string(n.Content())
-		if strings.Contains(content, "--") || strings.HasSuffix(content, "-") {
+		// Validate the byte slice directly: a string() copy here would double the
+		// peak memory for a large (attacker-controlled) comment before the same
+		// bytes are written below.
+		content := n.Content()
+		if bytes.Contains(content, []byte("--")) || (len(content) > 0 && content[len(content)-1] == '-') {
 			// check() keeps the first sticky error, so an earlier I/O failure is
 			// not clobbered by this validation error.
 			d.check(errors.New("helium: comment content must not contain \"--\" or end with \"-\""))

--- a/writer.go
+++ b/writer.go
@@ -300,7 +300,9 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 		// "--->" with the closing delimiter), else the output is not well-formed.
 		content := string(n.Content())
 		if strings.Contains(content, "--") || strings.HasSuffix(content, "-") {
-			d.err = errors.New("helium: comment content must not contain \"--\" or end with \"-\"")
+			// check() keeps the first sticky error, so an earlier I/O failure is
+			// not clobbered by this validation error.
+			d.check(errors.New("helium: comment content must not contain \"--\" or end with \"-\""))
 			return d.err
 		}
 		d.writeString(out, "<!--")
@@ -312,7 +314,9 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 		if pi, ok := AsNode[*ProcessingInstruction](n); ok {
 			// PI data must not contain "?>", which would terminate the PI early.
 			if strings.Contains(pi.data, "?>") {
-				d.err = errors.New("helium: PI content must not contain \"?>\"")
+				// check() keeps the first sticky error, so an earlier I/O failure
+				// is not clobbered by this validation error.
+				d.check(errors.New("helium: PI content must not contain \"?>\""))
 				return d.err
 			}
 			d.writeString(out, "<?")

--- a/writer.go
+++ b/writer.go
@@ -1,6 +1,7 @@
 package helium
 
 import (
+	"errors"
 	"io"
 	"strings"
 
@@ -295,6 +296,13 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 		}
 		return nil
 	case CommentNode:
+		// A comment must not contain "--" or end with "-" (that would form
+		// "--->" with the closing delimiter), else the output is not well-formed.
+		content := string(n.Content())
+		if strings.Contains(content, "--") || strings.HasSuffix(content, "-") {
+			d.err = errors.New("helium: comment content must not contain \"--\" or end with \"-\"")
+			return d.err
+		}
 		d.writeString(out, "<!--")
 		d.writeBytes(out, n.Content())
 		d.writeString(out, "-->")
@@ -302,6 +310,11 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 	case ProcessingInstructionNode:
 		// Mirrors xmlsave.c XML_PI_NODE handling.
 		if pi, ok := AsNode[*ProcessingInstruction](n); ok {
+			// PI data must not contain "?>", which would terminate the PI early.
+			if strings.Contains(pi.data, "?>") {
+				d.err = errors.New("helium: PI content must not contain \"?>\"")
+				return d.err
+			}
 			d.writeString(out, "<?")
 			d.writeString(out, pi.target)
 			if pi.data != "" {

--- a/writer.go
+++ b/writer.go
@@ -7,6 +7,7 @@ import (
 
 	henc "github.com/lestrrat-go/helium/internal/encoding"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 	"github.com/lestrrat-go/pdebug"
 )
 
@@ -312,6 +313,15 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 	case ProcessingInstructionNode:
 		// Mirrors xmlsave.c XML_PI_NODE handling.
 		if pi, ok := AsNode[*ProcessingInstruction](n); ok {
+			// The PI target must be a valid XML Name (and not the reserved
+			// "xml"); otherwise an invalid/crafted target injects raw markup
+			// into the output (it is emitted verbatim below).
+			if !xmlchar.IsValidPITarget(pi.target) {
+				// check() keeps the first sticky error, so an earlier I/O failure
+				// is not clobbered by this validation error.
+				d.check(errors.New("helium: invalid PI target"))
+				return d.err
+			}
 			// PI data must not contain "?>", which would terminate the PI early.
 			if strings.Contains(pi.data, "?>") {
 				// check() keeps the first sticky error, so an earlier I/O failure

--- a/writer_test.go
+++ b/writer_test.go
@@ -552,3 +552,22 @@ func TestDumpQuotingViaPublicAPI(t *testing.T) {
 		})
 	}
 }
+func TestWriteRejectsMalformedCommentPI(t *testing.T) {
+	doc := helium.NewDocument("1.0", "", helium.StandaloneImplicitNo)
+
+	var sb strings.Builder
+	require.Error(t, helium.Write(&sb, doc.CreateComment([]byte("a--b"))),
+		"comment containing -- must be rejected")
+	sb.Reset()
+	require.Error(t, helium.Write(&sb, doc.CreateComment([]byte("a-"))),
+		"comment ending in - must be rejected")
+	sb.Reset()
+	require.Error(t, helium.Write(&sb, doc.CreatePI("t", "a?>b")),
+		"PI content containing ?> must be rejected")
+
+	// Valid comment/PI still serialize.
+	sb.Reset()
+	require.NoError(t, helium.Write(&sb, doc.CreateComment([]byte(" ok "))))
+	sb.Reset()
+	require.NoError(t, helium.Write(&sb, doc.CreatePI("php", "echo 1")))
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -562,12 +562,18 @@ func TestWriteRejectsMalformedCommentPI(t *testing.T) {
 	require.Error(t, helium.Write(&sb, doc.CreateComment([]byte("a-"))),
 		"comment ending in - must be rejected")
 	sb.Reset()
+	require.Error(t, helium.Write(&sb, doc.CreateComment([]byte("-"))),
+		"single-dash comment must be rejected")
+	sb.Reset()
 	require.Error(t, helium.Write(&sb, doc.CreatePI("t", "a?>b")),
 		"PI content containing ?> must be rejected")
 
 	// Valid comment/PI still serialize.
 	sb.Reset()
 	require.NoError(t, helium.Write(&sb, doc.CreateComment([]byte(" ok "))))
+	sb.Reset()
+	require.NoError(t, helium.Write(&sb, doc.CreateComment([]byte(""))),
+		"empty comment must serialize without an out-of-range panic")
 	sb.Reset()
 	require.NoError(t, helium.Write(&sb, doc.CreatePI("php", "echo 1")))
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -571,3 +571,66 @@ func TestWriteRejectsMalformedCommentPI(t *testing.T) {
 	sb.Reset()
 	require.NoError(t, helium.Write(&sb, doc.CreatePI("php", "echo 1")))
 }
+
+// failOnSubstringWriter fails the first Write whose accumulated tail+payload
+// contains trigger, and accepts everything else. It is used to make a specific
+// serialization step fail while earlier steps succeed.
+type failOnSubstringWriter struct {
+	trigger string
+	tail    string
+}
+
+func (w *failOnSubstringWriter) Write(p []byte) (int, error) {
+	window := w.tail + string(p)
+	if strings.Contains(window, w.trigger) {
+		return 0, errShortWrite
+	}
+	if keep := len(w.trigger) - 1; keep > 0 {
+		if len(window) > keep {
+			w.tail = window[len(window)-keep:]
+		} else {
+			w.tail = window
+		}
+	}
+	return len(p), nil
+}
+
+// TestWriteValidationPreservesStickyIOError ensures that when an earlier
+// io.Writer failure has already set the sticky error, a subsequent malformed
+// comment/PI sibling does not clobber it: WriteTo must surface the original I/O
+// error, not the validation error.
+func TestWriteValidationPreservesStickyIOError(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		sibling func(*helium.Document) helium.Node
+	}{
+		{
+			name:    "comment",
+			sibling: func(d *helium.Document) helium.Node { return d.CreateComment([]byte("a--b")) },
+		},
+		{
+			name:    "pi",
+			sibling: func(d *helium.Document) helium.Node { return d.CreatePI("t", "a?>b") },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			doc := helium.NewDefaultDocument()
+			root := doc.CreateElement("r")
+			require.NoError(t, doc.SetDocumentElement(root))
+			// A malformed top-level sibling serialized after the root element.
+			// The newline separator written between top-level nodes is forced
+			// to fail, setting the sticky I/O error before the malformed
+			// sibling's validation runs. (Unlike a failed element write, the
+			// separator failure does not short-circuit the child loop, so the
+			// sibling is still reached.)
+			require.NoError(t, doc.AddChild(tc.sibling(doc)))
+
+			err := helium.NewWriter().XMLDeclaration(false).WriteTo(&failOnSubstringWriter{trigger: "\n"}, doc)
+			require.ErrorIs(t, err, errShortWrite,
+				"original I/O error must win over the sibling validation error")
+		})
+	}
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -572,6 +572,48 @@ func TestWriteRejectsMalformedCommentPI(t *testing.T) {
 	require.NoError(t, helium.Write(&sb, doc.CreatePI("php", "echo 1")))
 }
 
+// TestWriteRejectsMalformedPITarget ensures that an invalid PI target — in
+// particular one that injects markup — is rejected before being emitted, so
+// the serialized output never contains the injection.
+func TestWriteRejectsMalformedPITarget(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		target string
+	}{
+		{name: "injection", target: "x?><evil/><?x"},
+		{name: "empty", target: ""},
+		{name: "starts-digit", target: "1bad"},
+		{name: "has-space", target: "a b"},
+		{name: "reserved-xml", target: "xml"},
+		{name: "invalid-utf8", target: "\xff\xfe"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			doc := helium.NewDefaultDocument()
+			root := doc.CreateElement("r")
+			require.NoError(t, doc.SetDocumentElement(root))
+			require.NoError(t, root.AddChild(doc.CreatePI(tc.target, "")))
+
+			var sb strings.Builder
+			err := helium.Write(&sb, doc)
+			require.Error(t, err, "invalid PI target must be rejected")
+			require.NotContains(t, sb.String(), "<evil/>",
+				"injection must not be emitted")
+		})
+	}
+
+	// A valid target still serializes.
+	doc := helium.NewDefaultDocument()
+	root := doc.CreateElement("r")
+	require.NoError(t, doc.SetDocumentElement(root))
+	require.NoError(t, root.AddChild(doc.CreatePI("php", "echo 1")))
+	var sb strings.Builder
+	require.NoError(t, helium.Write(&sb, doc))
+	require.Contains(t, sb.String(), "<?php echo 1?>")
+}
+
 // failOnSubstringWriter fails the first Write whose accumulated tail+payload
 // contains trigger, and accepts everything else. It is used to make a specific
 // serialization step fail while earlier steps succeed.


### PR DESCRIPTION
The `stream` package's comment/PI writers emitted non-well-formed XML while returning nil. This adds validation:

- Comment content rejected if it contains `--` or ends with `-` (would form `--->` with the close delimiter); enforced in `WriteComment`, the `WriteString` streaming path, and `EndComment`.
- PI content rejected if it contains `?>`; enforced in `WritePI` and the `WriteString` streaming path.
- PI target validated as an XML Name (NCName + colons) in `StartPI`, beyond the existing empty/`xml` checks.

Errors use the existing `errors.New("stream: ...")` style. Regression tests cover the rejected cases plus positive controls and a parser round-trip. `go test ./...` clean (33 packages ok).

Scope: `stream` package only; `writer.go` has the same gap but is intentionally out of scope.
