### PR TITLE
xpath3: fix format-integer picture validation and string arg atomization

### DIFF
--- a/xpath3/format_integer.go
+++ b/xpath3/format_integer.go
@@ -15,9 +15,16 @@ import (
 func fnFormatInteger(ctx context.Context, args []Sequence) (Sequence, error) {
 	// format-integer($value, $picture [, $lang])
 	valSeq := args[0]
-	picSeq := args[1]
 
-	// Empty sequence → empty string
+	// $picture is a required, exactly-one xs:string. Validate it before the
+	// empty-$value short-circuit so an empty or oversized picture raises
+	// XPTY0004 rather than panicking on picSeq.Get(0).
+	picture, err := coerceArgToStringRequired(args[1])
+	if err != nil {
+		return nil, err
+	}
+
+	// Empty $value → empty string (per F&O), once $picture is known valid.
 	if seqLen(valSeq) == 0 {
 		return SingleString(""), nil
 	}
@@ -44,12 +51,6 @@ func fnFormatInteger(ctx context.Context, args []Sequence) (Sequence, error) {
 	default:
 		return nil, fmt.Errorf("xpath3: internal error: expected integer value for %s, got %T", valAtom.TypeName, valAtom.Value)
 	}
-
-	picAtom, err := AtomizeItem(picSeq.Get(0))
-	if err != nil {
-		return nil, err
-	}
-	picture := picAtom.StringVal()
 
 	lang := "en"
 	if ec := getFnContext(ctx); ec != nil {

--- a/xpath3/format_integer_test.go
+++ b/xpath3/format_integer_test.go
@@ -1,0 +1,54 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// fn:format-integer($value as xs:integer?, $picture as xs:string, ...).
+// $picture is a required, exactly-one xs:string. It must be validated
+// regardless of whether $value is empty — an empty or oversized $picture
+// is XPTY0004, never a panic, and an empty $value with a valid $picture
+// yields a zero-length string.
+func TestFormatIntegerPictureValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty picture with non-empty value raises XPTY0004", func(t *testing.T) {
+		_, err := evaluate(t.Context(), nil, `format-integer(1, ())`)
+		require.Error(t, err)
+		var xpErr *xpath3.XPathError
+		require.ErrorAs(t, err, &xpErr)
+		require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code)
+	})
+
+	t.Run("empty picture with empty value raises XPTY0004", func(t *testing.T) {
+		_, err := evaluate(t.Context(), nil, `format-integer((), ())`)
+		require.Error(t, err)
+		var xpErr *xpath3.XPathError
+		require.ErrorAs(t, err, &xpErr)
+		require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code)
+	})
+
+	t.Run("oversized picture raises XPTY0004", func(t *testing.T) {
+		_, err := evaluate(t.Context(), nil, `format-integer(1, ("0", "0"))`)
+		require.Error(t, err)
+		var xpErr *xpath3.XPathError
+		require.ErrorAs(t, err, &xpErr)
+		require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code)
+	})
+
+	t.Run("empty value with valid picture yields empty string", func(t *testing.T) {
+		result, err := evaluate(t.Context(), nil, `format-integer((), "0")`)
+		require.NoError(t, err)
+		require.Equal(t, "", result.StringValue())
+	})
+
+	t.Run("normal value still formats", func(t *testing.T) {
+		result, err := evaluate(t.Context(), nil, `format-integer(123, "0")`)
+		require.NoError(t, err)
+		require.Equal(t, "123", result.StringValue())
+	})
+}

--- a/xpath3/format_integer_test.go
+++ b/xpath3/format_integer_test.go
@@ -2,6 +2,7 @@ package xpath3_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/xpath3"
@@ -51,4 +52,53 @@ func TestFormatIntegerPictureValidation(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "123", result.StringValue())
 	})
+}
+
+// XPath function conversion atomizes an argument before checking cardinality.
+// A picture such as ([], "0") atomizes to the single string "0", so it must be
+// accepted, not rejected as a 2-item sequence. This is handled by the shared
+// xs:string coercion helper, so format-number must behave identically.
+func TestStringArgAtomizesBeforeCardinality(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		expr   string
+		expect string
+	}{
+		{`format-integer(123, ([], "0"))`, "123"},
+		{`format-integer((), ([], "0"))`, ""},
+		{`format-number(123, ([], "0"))`, "123"},
+		{`format-number((), ([], "0.0"))`, "NaN"},
+		{`upper-case(([], "ab"))`, "AB"},
+		{`concat(([], "x"), "y")`, "xy"},
+	}
+	for _, tc := range cases {
+		result, err := evaluate(t.Context(), nil, tc.expr)
+		require.NoError(t, err, tc.expr)
+		require.Equal(t, tc.expect, result.StringValue(), tc.expr)
+	}
+
+	// A genuinely oversized atomized picture is still XPTY0004.
+	_, err := evaluate(t.Context(), nil, `format-integer(1, ("0", "0"))`)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code)
+}
+
+// The atomize-first rewrite must not materialize a large sequence just to reject
+// it on cardinality — it stops at the second atomized item.
+func TestStringArgRejectsLongSequencePromptly(t *testing.T) {
+	t.Parallel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, err := evaluate(t.Context(), nil, `upper-case(1 to 100000000)`)
+		require.Error(t, err)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("coercion materialized a large sequence instead of stopping at the 2nd item")
+	}
 }

--- a/xpath3/functions.go
+++ b/xpath3/functions.go
@@ -276,54 +276,71 @@ func seqToStringErr(seq Sequence) (string, error) {
 }
 
 // coerceArgToStringRequired applies XPath 3.1 function coercion rules for xs:string params.
-// Like coerceArgToString but rejects empty sequences (for non-optional string parameters).
+// Like coerceArgToString but rejects an empty *atomized* sequence (for non-optional
+// string parameters). Cardinality is checked after atomization, so a value such as
+// an empty array — which atomizes to the empty sequence — is rejected, while
+// ([], "x") (which atomizes to the single string "x") is accepted.
 func coerceArgToStringRequired(seq Sequence) (string, error) {
-	if seqLen(seq) == 0 {
+	s, empty, err := coerceAtomizedString(seq)
+	if err != nil {
+		return "", err
+	}
+	if empty {
 		return "", &XPathError{Code: lexicon.ErrXPTY0004, Message: "expected xs:string, got empty sequence"}
 	}
-	return coerceArgToString(seq)
+	return s, nil
 }
 
 // coerceArgToString applies XPath 3.1 function coercion rules for xs:string? params.
 // Accepts: empty sequence → "", xs:string/xs:anyURI → as-is, xs:untypedAtomic → cast.
 // Rejects all other types with XPTY0004.
 func coerceArgToString(seq Sequence) (string, error) {
-	switch seqLen(seq) {
-	case 0:
-		return "", nil
-	case 1:
-	default:
-		return "", &XPathError{Code: lexicon.ErrXPTY0004, Message: "expected xs:string?, got sequence of length > 1"}
+	s, _, err := coerceAtomizedString(seq)
+	return s, err
+}
+
+// coerceAtomizedString performs XPath function conversion to xs:string?: it
+// atomizes the argument FIRST (arrays flatten to their members, list-typed nodes
+// expand to their tokens), THEN checks cardinality. Atomization is streamed and
+// stops as soon as a second item appears, so a too-long sequence is rejected
+// without materializing it. Returns empty=true when the atomized sequence is
+// empty (the caller decides whether that is "" or an error).
+func coerceAtomizedString(seq Sequence) (value string, empty bool, err error) {
+	var first AtomicValue
+	var count int
+	if serr := atomizeStream(seq, func(av AtomicValue) (bool, error) {
+		count++
+		if count == 1 {
+			first = av
+			return true, nil
+		}
+		// A second atomized item: too many for xs:string?. Stop here rather
+		// than atomizing the rest of a potentially huge sequence.
+		return false, nil
+	}); serr != nil {
+		return "", false, serr
 	}
-	// Use AtomizeSequence (not AtomizeItem) to properly expand list types.
-	// For nodes with list type annotations, atomization produces multiple
-	// items which must raise XPTY0004 for xs:string? parameters.
-	atoms, err := AtomizeSequence(seq)
-	if err != nil {
-		return "", err
+	if count == 0 {
+		return "", true, nil
 	}
-	if len(atoms) == 0 {
-		return "", nil
+	if count > 1 {
+		return "", false, &XPathError{Code: lexicon.ErrXPTY0004, Message: "expected xs:string?, got sequence of length > 1"}
 	}
-	if len(atoms) > 1 {
-		return "", &XPathError{Code: lexicon.ErrXPTY0004, Message: "expected xs:string?, got sequence of length > 1"}
-	}
-	a := atoms[0]
-	switch a.TypeName {
+	switch first.TypeName {
 	case TypeString, TypeAnyURI, TypeUntypedAtomic,
 		TypeNormalizedString, TypeToken, TypeLanguage, TypeName, TypeNCName,
 		TypeNMTOKEN, TypeNMTOKENS, TypeENTITY, TypeID, TypeIDREF, TypeIDREFS:
-		s, ok := a.Value.(string)
+		s, ok := first.Value.(string)
 		if !ok {
-			return "", fmt.Errorf("xpath3: internal error: expected string for %s", a.TypeName)
+			return "", false, fmt.Errorf("xpath3: internal error: expected string for %s", first.TypeName)
 		}
-		return s, nil
+		return s, false, nil
 	default:
 		// User-defined types: check if the underlying value is a string.
-		if s, ok := a.Value.(string); ok {
-			return s, nil
+		if s, ok := first.Value.(string); ok {
+			return s, false, nil
 		}
-		return "", &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("expected xs:string?, got %s", a.TypeName)}
+		return "", false, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("expected xs:string?, got %s", first.TypeName)}
 	}
 }
 


### PR DESCRIPTION
Two related fixes to `fn:format-integer` and the shared xs:string argument coercion.

**1. format-integer picture validation.** `format-integer($value, $picture)` returned early on an empty `$value` without validating the required `$picture`, so `format-integer(1, ())` panicked on an empty-sequence index and `format-integer((), ())` silently returned `""` instead of `XPTY0004`. The `$picture` validation now runs before the empty-`$value` short-circuit.

**2. Atomize string args before cardinality.** `coerceArgToString`/`coerceArgToStringRequired` (used by ~60 builtins incl. `format-number`, `format-dateTime`, and most string functions) checked raw sequence length *before* atomization, so `format-integer((), ([], "0"))` was wrongly rejected — per XPath function conversion the empty array atomizes away, leaving the single string `"0"`. Coercion now atomizes first (streaming, stopping at the 2nd item so large sequences aren't materialized), then checks cardinality. `coerceArgToStringRequired` likewise now rejects an empty *atomized* sequence.

Full xpath3 (incl. QT3) + xslt3 suites pass.
