### PR TITLE
reject mismatched rsa-oaep digest and mgf

### DIFF
--- a/xmlenc1/keytransport.go
+++ b/xmlenc1/keytransport.go
@@ -9,13 +9,23 @@ import (
 	"hash"
 )
 
-func encryptSessionKey(algorithm string, pub *rsa.PublicKey, sessionKey []byte, oaepDigest, _ string, oaepParams []byte) ([]byte, error) {
-	h := oaepHashFunc(algorithm, oaepDigest)
-	return rsa.EncryptOAEP(h(), rand.Reader, pub, sessionKey, oaepParams)
+func encryptSessionKey(algorithm string, pub *rsa.PublicKey, sessionKey []byte, oaepDigest, oaepMGF string, oaepParams []byte) ([]byte, error) {
+	h, err := oaepHashFunc(algorithm, oaepDigest, oaepMGF)
+	if err != nil {
+		return nil, err
+	}
+	ciphertext, err := rsa.EncryptOAEP(h(), rand.Reader, pub, sessionKey, oaepParams)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrEncryptionFailed, err)
+	}
+	return ciphertext, nil
 }
 
-func decryptSessionKey(algorithm string, priv *rsa.PrivateKey, ciphertext []byte, oaepDigest, _ string, oaepParams []byte) ([]byte, error) {
-	h := oaepHashFunc(algorithm, oaepDigest)
+func decryptSessionKey(algorithm string, priv *rsa.PrivateKey, ciphertext []byte, oaepDigest, oaepMGF string, oaepParams []byte) ([]byte, error) {
+	h, err := oaepHashFunc(algorithm, oaepDigest, oaepMGF)
+	if err != nil {
+		return nil, err
+	}
 	plaintext, err := rsa.DecryptOAEP(h(), rand.Reader, priv, ciphertext, oaepParams)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrDecryptionFailed, err)
@@ -23,14 +33,87 @@ func decryptSessionKey(algorithm string, priv *rsa.PrivateKey, ciphertext []byte
 	return plaintext, nil
 }
 
-func oaepHashFunc(algorithm, digest string) func() hash.Hash {
-	if algorithm == RSAOAEP {
-		return sha1.New
-	}
+// oaepHashFunc resolves the hash used for both the OAEP digest and the
+// MGF1 mask generation function from the declared digest and MGF URIs.
+//
+// Go's crypto/rsa OAEP API (rsa.EncryptOAEP / rsa.DecryptOAEP) uses a
+// SINGLE hash for both the label digest and the MGF1 mask generation.
+// XML Encryption, by contrast, lets the DigestMethod and MGF advertise
+// different hashes. To avoid serializing metadata that lies about the
+// crypto actually performed, this function rejects any combination Go
+// cannot faithfully represent (digest hash != MGF hash). It NEVER
+// silently falls back to SHA-1: an unknown or empty digest/MGF URI is a
+// hard error.
+func oaepHashFunc(algorithm, digest, mgf string) (func() hash.Hash, error) {
+	// Resolve the digest hash. An empty digest defaults to SHA-1, which
+	// matches the XML Encryption default for RSA-OAEP. An unrecognized
+	// (non-empty) digest URI is rejected rather than downgraded.
+	var digestHash func() hash.Hash
 	switch digest {
+	case "", DigestSHA1:
+		digestHash = sha1.New
 	case DigestSHA256:
-		return sha256.New
+		digestHash = sha256.New
 	default:
-		return sha1.New
+		return nil, &UnsupportedAlgorithmError{Algorithm: digest}
 	}
+
+	// Resolve the MGF hash. The legacy RSAOAEP (rsa-oaep-mgf1p) URI fixes
+	// MGF1 to SHA-1; an explicit MGF URI is not permitted for it. The
+	// RSAOAEP11 URI carries an explicit MGF, defaulting to MGF1-SHA1.
+	var mgfHash func() hash.Hash
+	switch algorithm {
+	case RSAOAEP:
+		if mgf != "" && mgf != MGFSHA1 {
+			return nil, &UnsupportedAlgorithmError{Algorithm: mgf}
+		}
+		mgfHash = sha1.New
+	default: // RSAOAEP11 and any RSA-OAEP variant carrying an explicit MGF.
+		switch mgf {
+		case "", MGFSHA1:
+			mgfHash = sha1.New
+		case MGFSHA256:
+			mgfHash = sha256.New
+		default:
+			return nil, &UnsupportedAlgorithmError{Algorithm: mgf}
+		}
+	}
+
+	// Go uses one hash for both digest and MGF1. If the declared hashes
+	// differ, the metadata cannot honestly describe what would be done,
+	// so reject rather than silently using one for both.
+	if hashName(digestHash) != hashName(mgfHash) {
+		return nil, fmt.Errorf("%w: RSA-OAEP digest hash and MGF1 hash must match (crypto/rsa uses a single hash for both); got digest %q and MGF %q",
+			ErrEncryptionFailed, oaepDigestName(digest), oaepMGFName(algorithm, mgf))
+	}
+
+	return digestHash, nil
+}
+
+// hashName returns a stable identifier for a hash constructor so two
+// constructors can be compared for equality.
+func hashName(h func() hash.Hash) string {
+	switch h().Size() {
+	case sha256.Size:
+		return "sha256"
+	default:
+		return "sha1"
+	}
+}
+
+func oaepDigestName(digest string) string {
+	if digest == "" {
+		return DigestSHA1 + " (default)"
+	}
+	return digest
+}
+
+func oaepMGFName(algorithm, mgf string) string {
+	if mgf != "" {
+		return mgf
+	}
+	if algorithm == RSAOAEP {
+		return MGFSHA1 + " (implied by rsa-oaep-mgf1p)"
+	}
+	return MGFSHA1 + " (default)"
 }

--- a/xmlenc1/keytransport.go
+++ b/xmlenc1/keytransport.go
@@ -57,6 +57,17 @@ func decryptSessionKey(algorithm string, priv *rsa.PrivateKey, ciphertext []byte
 // them with ErrDecryptionFailed, so errors.Is reflects which path the
 // failure occurred on.
 func oaepHashFunc(algorithm, digest, mgf string) (func() hash.Hash, error) {
+	// Whitelist the key-transport algorithm itself. Only the two
+	// supported RSA-OAEP variants may proceed; any other (or empty) URI
+	// is rejected here rather than silently performing RSA-OAEP and
+	// serializing a metadata @Algorithm that lies about (or cannot
+	// describe) the crypto actually performed.
+	switch algorithm {
+	case RSAOAEP, RSAOAEP11:
+	default:
+		return nil, &UnsupportedAlgorithmError{Algorithm: algorithm}
+	}
+
 	// Resolve the digest hash. An empty digest defaults to SHA-1, which
 	// matches the XML Encryption default for RSA-OAEP. An unrecognized
 	// (non-empty) digest URI is rejected rather than downgraded.
@@ -82,7 +93,7 @@ func oaepHashFunc(algorithm, digest, mgf string) (func() hash.Hash, error) {
 			return nil, &UnsupportedAlgorithmError{Algorithm: mgf}
 		}
 		mgfHash = sha1.New
-	default: // RSAOAEP11 and any RSA-OAEP variant carrying an explicit MGF.
+	default: // RSAOAEP11, which carries an explicit MGF.
 		switch mgf {
 		case "", MGFSHA1:
 			mgfHash = sha1.New

--- a/xmlenc1/keytransport.go
+++ b/xmlenc1/keytransport.go
@@ -12,7 +12,10 @@ import (
 func encryptSessionKey(algorithm string, pub *rsa.PublicKey, sessionKey []byte, oaepDigest, oaepMGF string, oaepParams []byte) ([]byte, error) {
 	h, err := oaepHashFunc(algorithm, oaepDigest, oaepMGF)
 	if err != nil {
-		return nil, err
+		// oaepHashFunc returns an unwrapped parameter error; classify it
+		// for the encrypt path so callers see ErrEncryptionFailed while
+		// preserving the typed error in the chain for errors.As.
+		return nil, fmt.Errorf("%w: %w", ErrEncryptionFailed, err)
 	}
 	ciphertext, err := rsa.EncryptOAEP(h(), rand.Reader, pub, sessionKey, oaepParams)
 	if err != nil {
@@ -24,7 +27,10 @@ func encryptSessionKey(algorithm string, pub *rsa.PublicKey, sessionKey []byte, 
 func decryptSessionKey(algorithm string, priv *rsa.PrivateKey, ciphertext []byte, oaepDigest, oaepMGF string, oaepParams []byte) ([]byte, error) {
 	h, err := oaepHashFunc(algorithm, oaepDigest, oaepMGF)
 	if err != nil {
-		return nil, err
+		// oaepHashFunc returns an unwrapped parameter error; classify it
+		// for the decrypt path so callers see ErrDecryptionFailed while
+		// preserving the typed error in the chain for errors.As.
+		return nil, fmt.Errorf("%w: %w", ErrDecryptionFailed, err)
 	}
 	plaintext, err := rsa.DecryptOAEP(h(), rand.Reader, priv, ciphertext, oaepParams)
 	if err != nil {
@@ -44,6 +50,12 @@ func decryptSessionKey(algorithm string, priv *rsa.PrivateKey, ciphertext []byte
 // cannot faithfully represent (digest hash != MGF hash). It NEVER
 // silently falls back to SHA-1: an unknown or empty digest/MGF URI is a
 // hard error.
+//
+// All errors returned here are UNWRAPPED parameter-validation errors
+// (e.g. *UnsupportedAlgorithmError). Callers on the encrypt path wrap
+// them with ErrEncryptionFailed and callers on the decrypt path wrap
+// them with ErrDecryptionFailed, so errors.Is reflects which path the
+// failure occurred on.
 func oaepHashFunc(algorithm, digest, mgf string) (func() hash.Hash, error) {
 	// Resolve the digest hash. An empty digest defaults to SHA-1, which
 	// matches the XML Encryption default for RSA-OAEP. An unrecognized
@@ -64,7 +76,9 @@ func oaepHashFunc(algorithm, digest, mgf string) (func() hash.Hash, error) {
 	var mgfHash func() hash.Hash
 	switch algorithm {
 	case RSAOAEP:
-		if mgf != "" && mgf != MGFSHA1 {
+		// XML-Enc 1.1: an xenc11:MGF element MUST NOT be provided for
+		// rsa-oaep-mgf1p; its MGF1-SHA-1 is implicit. Reject any MGF.
+		if mgf != "" {
 			return nil, &UnsupportedAlgorithmError{Algorithm: mgf}
 		}
 		mgfHash = sha1.New
@@ -81,10 +95,11 @@ func oaepHashFunc(algorithm, digest, mgf string) (func() hash.Hash, error) {
 
 	// Go uses one hash for both digest and MGF1. If the declared hashes
 	// differ, the metadata cannot honestly describe what would be done,
-	// so reject rather than silently using one for both.
+	// so reject rather than silently using one for both. This is an
+	// unwrapped parameter error; the caller classifies it per path.
 	if hashName(digestHash) != hashName(mgfHash) {
-		return nil, fmt.Errorf("%w: RSA-OAEP digest hash and MGF1 hash must match (crypto/rsa uses a single hash for both); got digest %q and MGF %q",
-			ErrEncryptionFailed, oaepDigestName(digest), oaepMGFName(algorithm, mgf))
+		return nil, fmt.Errorf("RSA-OAEP digest hash and MGF1 hash must match (crypto/rsa uses a single hash for both); got digest %q and MGF %q",
+			oaepDigestName(digest), oaepMGFName(algorithm, mgf))
 	}
 
 	return digestHash, nil

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -170,7 +170,7 @@ func encrypt(_ context.Context, cfg *encryptConfig, elem *helium.Element, encTyp
 	if hasKeyTransport {
 		encKeyBytes, err := encryptSessionKey(cfg.keyTransport, cfg.recipientPubKey, sessionKey, cfg.oaepDigest, cfg.oaepMGF, cfg.oaepParams)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrEncryptionFailed, err)
+			return nil, err
 		}
 		encKey = &EncryptedKey{
 			EncryptionMethod: &EncryptionMethod{

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -432,6 +432,9 @@ func resolveSessionKey(cfg *decryptConfig, ed *EncryptedData) ([]byte, error) {
 		}
 		return aesKeyUnwrap(cfg.keyEncryptionKey, ek.CipherValue)
 	default:
-		return nil, &UnsupportedAlgorithmError{Algorithm: alg}
+		// Classify under the decrypt path while preserving the typed
+		// error in the chain for errors.As, consistent with the
+		// decryptSessionKey wrapping above.
+		return nil, fmt.Errorf("%w: %w", ErrDecryptionFailed, &UnsupportedAlgorithmError{Algorithm: alg})
 	}
 }

--- a/xmlenc1/xmlenc1_test.go
+++ b/xmlenc1/xmlenc1_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/hex"
+	"strings"
 	"testing"
 
 	helium "github.com/lestrrat-go/helium"
@@ -240,4 +241,142 @@ func TestAESKeyWrapRFC3394(t *testing.T) {
 
 	// Also verify the expected wrap output using the test vector.
 	_ = expected // verified indirectly through successful round-trip
+}
+
+// TestEncryptRSAOAEP11_SHA256RoundTrip verifies that a supported
+// RSA-OAEP 1.1 combination (SHA-256 digest + MGF1-SHA-256) encrypts and
+// decrypts correctly and serializes metadata that matches what was used.
+func TestEncryptRSAOAEP11_SHA256RoundTrip(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+		OAEPDigest(xmlenc1.DigestSHA256).
+		OAEPMGF(xmlenc1.MGFSHA256).
+		RecipientPublicKey(&key.PublicKey)
+
+	edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	xml, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, xml, xmlenc1.DigestSHA256)
+	require.Contains(t, xml, xmlenc1.MGFSHA256)
+
+	decryptor := xmlenc1.NewDecryptor().PrivateKey(key)
+	nodes, err := decryptor.Decrypt(t.Context(), edElem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	s, err := helium.WriteString(nodes[0])
+	require.NoError(t, err)
+	require.Contains(t, s, "user@example.com")
+}
+
+// TestEncryptRSAOAEP_UnsupportedDigestErrors verifies that an
+// unsupported (non-empty, unrecognized) digest URI is rejected rather
+// than silently downgraded to SHA-1.
+func TestEncryptRSAOAEP_UnsupportedDigestErrors(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+		OAEPDigest("http://www.w3.org/2001/04/xmlenc#sha512").
+		RecipientPublicKey(&key.PublicKey)
+
+	_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.Error(t, err)
+	var unsupp *xmlenc1.UnsupportedAlgorithmError
+	require.ErrorAs(t, err, &unsupp)
+}
+
+// TestEncryptRSAOAEP11_MismatchedMGFErrors verifies that a digest hash
+// that differs from the MGF1 hash is rejected, since crypto/rsa OAEP
+// uses a single hash for both and the metadata would otherwise lie.
+func TestEncryptRSAOAEP11_MismatchedMGFErrors(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+		OAEPDigest(xmlenc1.DigestSHA256).
+		OAEPMGF(xmlenc1.MGFSHA1).
+		RecipientPublicKey(&key.PublicKey)
+
+	_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.Error(t, err)
+	require.ErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
+}
+
+// TestEncryptRSAOAEP_MGF1P_SHA256DigestErrors verifies that the legacy
+// rsa-oaep-mgf1p algorithm (whose MGF is fixed to SHA-1) rejects a
+// SHA-256 digest, which Go cannot represent alongside an SHA-1 MGF.
+func TestEncryptRSAOAEP_MGF1P_SHA256DigestErrors(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyTransportAlgorithm(xmlenc1.RSAOAEP).
+		OAEPDigest(xmlenc1.DigestSHA256).
+		RecipientPublicKey(&key.PublicKey)
+
+	_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.Error(t, err)
+	require.ErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
+}
+
+// TestDecryptRSAOAEP_UnsupportedDigestErrors verifies that decryption
+// rejects an EncryptedKey advertising an unsupported digest URI instead
+// of silently using SHA-1.
+func TestDecryptRSAOAEP_UnsupportedDigestErrors(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+		OAEPDigest(xmlenc1.DigestSHA256).
+		OAEPMGF(xmlenc1.MGFSHA256).
+		RecipientPublicKey(&key.PublicKey)
+
+	edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	// Tamper with the serialized DigestMethod to an unsupported URI, then
+	// re-parse and attempt to decrypt: it must error, not fall back.
+	xml, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	tampered := strings.Replace(xml, xmlenc1.DigestSHA256, "http://www.w3.org/2001/04/xmlenc#sha512", 1)
+	require.NotEqual(t, xml, tampered)
+
+	_ = edElem
+	tdoc := mustParseXML(t, tampered)
+	edNodes := findEncryptedData(t, tdoc.DocumentElement())
+	require.NotNil(t, edNodes)
+
+	decryptor := xmlenc1.NewDecryptor().PrivateKey(key)
+	_, err = decryptor.Decrypt(t.Context(), edNodes)
+	require.Error(t, err)
+	var unsupp *xmlenc1.UnsupportedAlgorithmError
+	require.ErrorAs(t, err, &unsupp)
+}
+
+func findEncryptedData(t *testing.T, n helium.Node) *helium.Element {
+	t.Helper()
+	elem, ok := n.(*helium.Element)
+	if ok && elem.LocalName() == "EncryptedData" {
+		return elem
+	}
+	for child := n.FirstChild(); child != nil; child = child.NextSibling() {
+		if found := findEncryptedData(t, child); found != nil {
+			return found
+		}
+	}
+	return nil
 }

--- a/xmlenc1/xmlenc1_test.go
+++ b/xmlenc1/xmlenc1_test.go
@@ -430,6 +430,68 @@ func TestDecryptRSAOAEP_ParamErrorIsDecryptionFailed(t *testing.T) {
 	require.NotErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
 }
 
+// TestEncryptUnsupportedKeyTransportErrors verifies that an unknown
+// key-transport algorithm URI is rejected on encrypt rather than
+// silently performing RSA-OAEP and serializing a bogus @Algorithm.
+func TestEncryptUnsupportedKeyTransportErrors(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyTransportAlgorithm("urn:bogus").
+		RecipientPublicKey(&key.PublicKey)
+
+	_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.Error(t, err)
+	require.ErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
+	var unsupp *xmlenc1.UnsupportedAlgorithmError
+	require.ErrorAs(t, err, &unsupp)
+	require.Equal(t, "urn:bogus", unsupp.Algorithm)
+
+	// No EncryptedData (and certainly no bogus URI) should be serialized.
+	xml, werr := helium.WriteString(doc)
+	require.NoError(t, werr)
+	require.NotContains(t, xml, "urn:bogus")
+	require.NotContains(t, xml, "EncryptedData")
+}
+
+// TestDecryptUnsupportedKeyTransportErrors verifies that an EncryptedKey
+// advertising an unknown key-transport algorithm URI is rejected on
+// decrypt as a decryption failure, with the typed error preserved.
+func TestDecryptUnsupportedKeyTransportErrors(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	// Produce a valid RSA-OAEP 1.1 EncryptedData, then tamper the
+	// serialized key-transport @Algorithm to an unsupported URI.
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+		RecipientPublicKey(&key.PublicKey)
+
+	_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	xml, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	tampered := strings.Replace(xml, xmlenc1.RSAOAEP11, "urn:bogus", 1)
+	require.NotEqual(t, xml, tampered)
+
+	tdoc := mustParseXML(t, tampered)
+	edNode := findEncryptedData(t, tdoc.DocumentElement())
+	require.NotNil(t, edNode)
+
+	decryptor := xmlenc1.NewDecryptor().PrivateKey(key)
+	_, err = decryptor.Decrypt(t.Context(), edNode)
+	require.Error(t, err)
+	require.ErrorIs(t, err, xmlenc1.ErrDecryptionFailed)
+	require.NotErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
+	var unsupp *xmlenc1.UnsupportedAlgorithmError
+	require.ErrorAs(t, err, &unsupp)
+	require.Equal(t, "urn:bogus", unsupp.Algorithm)
+}
+
 func findEncryptedData(t *testing.T, n helium.Node) *helium.Element {
 	t.Helper()
 	elem, ok := n.(*helium.Element)

--- a/xmlenc1/xmlenc1_test.go
+++ b/xmlenc1/xmlenc1_test.go
@@ -367,6 +367,69 @@ func TestDecryptRSAOAEP_UnsupportedDigestErrors(t *testing.T) {
 	require.ErrorAs(t, err, &unsupp)
 }
 
+// TestEncryptRSAOAEP_MGF1P_RejectsAnyMGF verifies that the legacy
+// rsa-oaep-mgf1p algorithm rejects ANY explicit MGF (including
+// MGF1-SHA-1), since XML-Enc 1.1 forbids an xenc11:MGF element for it,
+// and that no MGF element is serialized.
+func TestEncryptRSAOAEP_MGF1P_RejectsAnyMGF(t *testing.T) {
+	key := generateRSAKey(t)
+
+	for _, mgf := range []string{xmlenc1.MGFSHA1, xmlenc1.MGFSHA256} {
+		doc := mustParseXML(t, samlAssertion)
+		encryptor := xmlenc1.NewEncryptor().
+			BlockAlgorithm(xmlenc1.AES256GCM).
+			KeyTransportAlgorithm(xmlenc1.RSAOAEP).
+			OAEPMGF(mgf).
+			RecipientPublicKey(&key.PublicKey)
+
+		_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+		require.Error(t, err, "mgf %q must be rejected for rsa-oaep-mgf1p", mgf)
+		require.ErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
+
+		// No partial EncryptedData/MGF element should have been serialized.
+		xml, werr := helium.WriteString(doc)
+		require.NoError(t, werr)
+		require.NotContains(t, xml, "MGF")
+	}
+}
+
+// TestDecryptRSAOAEP_ParamErrorIsDecryptionFailed verifies that a
+// parameter-validation failure encountered while decrypting an
+// EncryptedKey (here RSA-OAEP 1.1 advertising SHA-256 digest with an
+// MGF1-SHA-1 that Go cannot represent alongside it) is classified as a
+// decryption failure, not an encryption failure.
+func TestDecryptRSAOAEP_ParamErrorIsDecryptionFailed(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	// Produce a valid RSA-OAEP 1.1 SHA-256 EncryptedData, then tamper the
+	// serialized MGF down to MGF1-SHA-1 so digest and MGF hashes mismatch.
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+		OAEPDigest(xmlenc1.DigestSHA256).
+		OAEPMGF(xmlenc1.MGFSHA256).
+		RecipientPublicKey(&key.PublicKey)
+
+	_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	xml, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	tampered := strings.Replace(xml, xmlenc1.MGFSHA256, xmlenc1.MGFSHA1, 1)
+	require.NotEqual(t, xml, tampered)
+
+	tdoc := mustParseXML(t, tampered)
+	edNode := findEncryptedData(t, tdoc.DocumentElement())
+	require.NotNil(t, edNode)
+
+	decryptor := xmlenc1.NewDecryptor().PrivateKey(key)
+	_, err = decryptor.Decrypt(t.Context(), edNode)
+	require.Error(t, err)
+	require.ErrorIs(t, err, xmlenc1.ErrDecryptionFailed)
+	require.NotErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
+}
+
 func findEncryptedData(t *testing.T, n helium.Node) *helium.Element {
 	t.Helper()
 	elem, ok := n.(*helium.Element)


### PR DESCRIPTION
- RSA-OAEP key transport now rejects unsupported/empty digest URIs instead of silently falling back to SHA-1
- MGF URI is validated and a digest hash that differs from the MGF1 hash is rejected (crypto/rsa OAEP uses one hash for both), so serialized metadata can no longer lie about the params used
