### PR TITLE
fix xmlenc1 encrypt element in place

### DIFF
--- a/node.go
+++ b/node.go
@@ -450,6 +450,13 @@ func replaceNode(n MutableNode, nodes ...Node) error {
 		}
 	}
 
+	// The replaced node is logically removed from the tree. Clear its own
+	// parent/sibling links so a stale handle cannot rewrite the spliced-in
+	// replacement (e.g. via a later UnlinkNode or Replace).
+	ndn.parent = nil
+	ndn.prev = nil
+	ndn.next = nil
+
 	return nil
 }
 

--- a/node.go
+++ b/node.go
@@ -452,10 +452,21 @@ func replaceNode(n MutableNode, nodes ...Node) error {
 
 	// The replaced node is logically removed from the tree. Clear its own
 	// parent/sibling links so a stale handle cannot rewrite the spliced-in
-	// replacement (e.g. via a later UnlinkNode or Replace).
-	ndn.parent = nil
-	ndn.prev = nil
-	ndn.next = nil
+	// replacement (e.g. via a later UnlinkNode or Replace). Skip this when the
+	// replaced node is itself one of the inserted nodes (e.g. self-replacement),
+	// since it remains live in the tree and clearing its links would corrupt it.
+	replacedIsInserted := false
+	for _, nn := range nodes {
+		if nn.baseDocNode() == ndn {
+			replacedIsInserted = true
+			break
+		}
+	}
+	if !replacedIsInserted {
+		ndn.parent = nil
+		ndn.prev = nil
+		ndn.next = nil
+	}
 
 	return nil
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -684,3 +684,46 @@ func TestReplaceDetachesOldNode(t *testing.T) {
 	require.Equal(t, b, root.LastChild())
 	require.Equal(t, repl, b.PrevSibling())
 }
+
+func TestReplaceSelf(t *testing.T) {
+	t.Run("exact self-replacement is a no-op", func(t *testing.T) {
+		// Build <root><a/><b/></root>
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.AddChild(root))
+		a := doc.CreateElement("a")
+		b := doc.CreateElement("b")
+		require.NoError(t, root.AddChild(a))
+		require.NoError(t, root.AddChild(b))
+
+		// Replacing a node with itself must leave the tree intact.
+		require.NoError(t, a.Replace(a))
+
+		require.Equal(t, root, a.Parent(), "a.Parent() must remain root")
+		require.Equal(t, b, a.NextSibling(), "a.NextSibling() must remain b")
+		require.Equal(t, a, root.FirstChild(), "root.FirstChild() must remain a")
+		require.Equal(t, b, root.LastChild())
+		require.Equal(t, a, b.PrevSibling())
+	})
+
+	t.Run("replacement list including the replaced node keeps it live", func(t *testing.T) {
+		// Build <root><a/><b/></root>
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.AddChild(root))
+		a := doc.CreateElement("a")
+		b := doc.CreateElement("b")
+		require.NoError(t, root.AddChild(a))
+		require.NoError(t, root.AddChild(b))
+
+		// Replace a with [a, c]: a stays live, c is inserted after it.
+		c := doc.CreateElement("c")
+		require.NoError(t, a.Replace(a, c))
+
+		require.Equal(t, root, a.Parent())
+		require.Equal(t, a, root.FirstChild())
+		require.Equal(t, c, a.NextSibling())
+		require.Equal(t, b, c.NextSibling())
+		require.Equal(t, b, root.LastChild())
+	})
+}

--- a/tree_test.go
+++ b/tree_test.go
@@ -649,3 +649,38 @@ func TestCopyDoc(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestReplaceDetachesOldNode(t *testing.T) {
+	// Build <root><a/><secret/><b/></root>
+	doc := helium.NewDefaultDocument()
+	root := doc.CreateElement("root")
+	require.NoError(t, doc.AddChild(root))
+	a := doc.CreateElement("a")
+	secret := doc.CreateElement("secret")
+	b := doc.CreateElement("b")
+	require.NoError(t, root.AddChild(a))
+	require.NoError(t, root.AddChild(secret))
+	require.NoError(t, root.AddChild(b))
+
+	repl := doc.CreateElement("EncryptedData")
+	require.NoError(t, secret.Replace(repl))
+
+	// After replacement the old node must be fully detached.
+	require.Nil(t, secret.Parent(), "replaced node parent must be cleared")
+	require.Nil(t, secret.PrevSibling(), "replaced node prev must be cleared")
+	require.Nil(t, secret.NextSibling(), "replaced node next must be cleared")
+
+	// Tree must read a / EncryptedData / b.
+	require.Equal(t, a, root.FirstChild())
+	require.Equal(t, repl, a.NextSibling())
+	require.Equal(t, b, repl.NextSibling())
+	require.Equal(t, b, root.LastChild())
+
+	// A stale UnlinkNode on the old handle must NOT corrupt the tree.
+	helium.UnlinkNode(secret)
+	require.Equal(t, a, root.FirstChild())
+	require.Equal(t, repl, a.NextSibling())
+	require.Equal(t, b, repl.NextSibling())
+	require.Equal(t, b, root.LastChild())
+	require.Equal(t, repl, b.PrevSibling())
+}

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -208,17 +208,10 @@ func encrypt(_ context.Context, cfg *encryptConfig, elem *helium.Element, encTyp
 
 	// Replace in tree.
 	if encType == TypeElement {
-		// Replace the element with EncryptedData.
-		if pe, ok := helium.AsNode[*helium.Element](elem.Parent()); ok {
-			if err := pe.AddChild(edElem); err != nil {
-				return nil, err
-			}
-			helium.UnlinkNode(elem)
-		} else if pd, ok := helium.AsNode[*helium.Document](elem.Parent()); ok {
-			if err := pd.AddChild(edElem); err != nil {
-				return nil, err
-			}
-			helium.UnlinkNode(elem)
+		// Replace the element with EncryptedData in place, preserving the
+		// original element's position among its siblings.
+		if err := elem.Replace(edElem); err != nil {
+			return nil, err
 		}
 	} else {
 		// Replace children with EncryptedData.

--- a/xmlenc1/xmlenc1_test.go
+++ b/xmlenc1/xmlenc1_test.go
@@ -241,3 +241,97 @@ func TestAESKeyWrapRFC3394(t *testing.T) {
 	// Also verify the expected wrap output using the test vector.
 	_ = expected // verified indirectly through successful round-trip
 }
+
+// childNames returns the local names of the direct element children of n,
+// in document order.
+func childNames(n helium.Node) []string {
+	var names []string
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		e, ok := c.(*helium.Element)
+		if !ok {
+			continue
+		}
+		names = append(names, e.LocalName())
+	}
+	return names
+}
+
+func TestEncryptElementPreservesSiblingOrder(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		xml    string
+		target string // local name of element to encrypt
+		want   []string
+	}{
+		{
+			name:   "middle",
+			xml:    `<root><a/><secret/><b/></root>`,
+			target: "secret",
+			want:   []string{"a", "EncryptedData", "b"},
+		},
+		{
+			name:   "first",
+			xml:    `<root><secret/><a/><b/></root>`,
+			target: "secret",
+			want:   []string{"EncryptedData", "a", "b"},
+		},
+		{
+			name:   "last",
+			xml:    `<root><a/><b/><secret/></root>`,
+			target: "secret",
+			want:   []string{"a", "b", "EncryptedData"},
+		},
+		{
+			name:   "only",
+			xml:    `<root><secret/></root>`,
+			target: "secret",
+			want:   []string{"EncryptedData"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			key := generateRSAKey(t)
+			doc := mustParseXML(t, tc.xml)
+
+			var target *helium.Element
+			for c := doc.DocumentElement().FirstChild(); c != nil; c = c.NextSibling() {
+				if e, ok := c.(*helium.Element); ok && e.LocalName() == tc.target {
+					target = e
+					break
+				}
+			}
+			require.NotNil(t, target, "target element %q not found", tc.target)
+
+			encryptor := xmlenc1.NewEncryptor().
+				BlockAlgorithm(xmlenc1.AES128CBC).
+				KeyTransportAlgorithm(xmlenc1.RSAOAEP).
+				RecipientPublicKey(&key.PublicKey)
+
+			_, err := encryptor.EncryptElement(t.Context(), target)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.want, childNames(doc.DocumentElement()))
+		})
+	}
+}
+
+func TestEncryptElementRootInPlace(t *testing.T) {
+	// Encrypting the document root element should replace it in place,
+	// leaving EncryptedData as the new document element.
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, `<secret>hidden</secret>`)
+
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES128CBC).
+		KeyTransportAlgorithm(xmlenc1.RSAOAEP).
+		RecipientPublicKey(&key.PublicKey)
+
+	edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+	require.NotNil(t, edElem)
+
+	require.Equal(t, "EncryptedData", doc.DocumentElement().LocalName())
+
+	xml, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.NotContains(t, xml, "hidden")
+}


### PR DESCRIPTION
- `EncryptElement` appended `EncryptedData` then unlinked the original, reordering siblings
- replace the element in place via `Element.Replace` to preserve document order
- tests cover middle/first/last/only-child and root encryption
