### PR TITLE
xmlenc1: bind aes key size to declared algorithm

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -285,6 +285,7 @@ XML Encryption 1.1 (W3C xmlenc-core1). Encrypt and decrypt XML elements/content.
 - Block encryption: AES-128/256-CBC, AES-128/256-GCM
 - Key transport: RSA-OAEP (1.0 + 1.1 with configurable digest/MGF)
 - Key wrapping: AES-128/256-KeyWrap (RFC 3394)
+- Key sizes are bound to the declared algorithm URI on encrypt and decrypt (incl. after unwrap/key transport); mismatch → `KeySizeError`
 - Files: `xmlenc1.go` (API), `constants.go`, `block.go`, `keytransport.go`, `keywrap.go`, `types.go`, `serialize.go`, `parse.go`, `errors.go`
 - Imports: helium
 

--- a/xmlenc1/block.go
+++ b/xmlenc1/block.go
@@ -20,11 +20,31 @@ func keySizeForAlgorithm(algorithm string) (int, error) {
 	}
 }
 
+// validateKeySize ensures key is exactly the length required by the
+// declared algorithm URI. This binds the wire-declared algorithm to the
+// real key length: requesting, e.g., an AES-256 algorithm with a 16-byte
+// key (which crypto/aes silently accepts as AES-128) is rejected instead
+// of producing data that DECLARES AES-256 but uses AES-128. Enforced on
+// both encrypt and decrypt, including after key unwrap / key transport.
+func validateKeySize(algorithm string, key []byte) error {
+	want, err := keySizeForAlgorithm(algorithm)
+	if err != nil {
+		return err
+	}
+	if len(key) != want {
+		return &KeySizeError{Algorithm: algorithm, Want: want, Got: len(key)}
+	}
+	return nil
+}
+
 // blockEncrypt encrypts plaintext with the given algorithm. For AEAD
 // algorithms (GCM) the algorithm URI is bound into the additional
 // authenticated data so that an attacker cannot substitute a different
 // EncryptionMethod/@Algorithm on the wire.
 func blockEncrypt(algorithm string, key, plaintext []byte) ([]byte, error) {
+	if err := validateKeySize(algorithm, key); err != nil {
+		return nil, err
+	}
 	switch algorithm {
 	case AES128CBC, AES256CBC:
 		return encryptCBC(key, plaintext)
@@ -41,6 +61,13 @@ func blockEncrypt(algorithm string, key, plaintext []byte) ([]byte, error) {
 // padding, or downstream parse) so callers cannot mount a padding
 // oracle by distinguishing the cause.
 func blockDecrypt(algorithm string, key, ciphertext []byte) ([]byte, error) {
+	// Bind the declared algorithm URI to the real key length before
+	// touching the ciphertext. The key length is not attacker-controlled
+	// (it is the recipient's configured / unwrapped key), so reporting a
+	// distinguishable KeySizeError here is not a padding-oracle signal.
+	if err := validateKeySize(algorithm, key); err != nil {
+		return nil, err
+	}
 	switch algorithm {
 	case AES128CBC, AES256CBC:
 		return decryptCBC(key, ciphertext)

--- a/xmlenc1/errors.go
+++ b/xmlenc1/errors.go
@@ -48,3 +48,18 @@ type UnsupportedAlgorithmError struct {
 func (e *UnsupportedAlgorithmError) Error() string {
 	return fmt.Sprintf("xmlenc1: unsupported algorithm %q", e.Algorithm)
 }
+
+// KeySizeError is returned when a key (session key or key-encryption key)
+// does not match the exact length required by its declared algorithm URI.
+// It guards against algorithm/key-size confusion, e.g. declaring AES-256
+// on the wire while supplying a 16-byte key that crypto/aes would silently
+// treat as AES-128.
+type KeySizeError struct {
+	Algorithm string
+	Want      int
+	Got       int
+}
+
+func (e *KeySizeError) Error() string {
+	return fmt.Sprintf("xmlenc1: algorithm %q requires a %d-byte key, got %d bytes", e.Algorithm, e.Want, e.Got)
+}

--- a/xmlenc1/export_test.go
+++ b/xmlenc1/export_test.go
@@ -27,3 +27,11 @@ func MarshalEncryptedDataForTest(doc *helium.Document, ed *EncryptedData) (*heli
 func HardenedParserForTest() helium.Parser {
 	return newHardenedInnerParser()
 }
+
+// AESKeyWrapForTest wraps key material under a KEK using RFC 3394 AES Key
+// Wrap. It exists so security tests can assemble an EncryptedKey whose
+// wrapped session-key length does not match the declared block algorithm,
+// exercising the post-unwrap key-size binding.
+func AESKeyWrapForTest(kek, plaintext []byte) ([]byte, error) {
+	return aesKeyWrap(kek, plaintext)
+}

--- a/xmlenc1/keysize_test.go
+++ b/xmlenc1/keysize_test.go
@@ -1,0 +1,189 @@
+package xmlenc1_test
+
+import (
+	"crypto/rand"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xmlenc1"
+	"github.com/stretchr/testify/require"
+)
+
+func randKey(t *testing.T, n int) []byte {
+	t.Helper()
+	k := make([]byte, n)
+	_, err := rand.Read(k)
+	require.NoError(t, err)
+	return k
+}
+
+// The declared block-algorithm URI must be bound to the session-key
+// length. Supplying a 16-byte key while declaring an AES-256 algorithm
+// would otherwise emit an AES-256 URI but encrypt with AES-128.
+func TestEncrypt_BlockKeySizeMismatch(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		alg  string
+		size int // wrong size
+	}{
+		{"aes256-gcm with 16-byte key", xmlenc1.AES256GCM, 16},
+		{"aes128-gcm with 32-byte key", xmlenc1.AES128GCM, 32},
+		{"aes256-cbc with 16-byte key", xmlenc1.AES256CBC, 16},
+		{"aes128-cbc with 24-byte key", xmlenc1.AES128CBC, 24},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := mustParseXML(t, `<root><a>hi</a></root>`)
+			enc := xmlenc1.NewEncryptor().
+				BlockAlgorithm(tc.alg).
+				SessionKey(randKey(t, tc.size))
+			_, err := enc.EncryptElement(t.Context(), doc.DocumentElement())
+			require.Error(t, err)
+			var kse *xmlenc1.KeySizeError
+			require.ErrorAs(t, err, &kse)
+		})
+	}
+}
+
+// The declared key-wrap URI must be bound to the KEK length on encrypt.
+func TestEncrypt_KeyWrapKEKSizeMismatch(t *testing.T) {
+	doc := mustParseXML(t, `<root><a>hi</a></root>`)
+	enc := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyWrapAlgorithm(xmlenc1.AES256KeyWrap).
+		KeyEncryptionKey(randKey(t, 16)) // AES-128 KEK declared as kw-aes256
+	_, err := enc.EncryptElement(t.Context(), doc.DocumentElement())
+	require.Error(t, err)
+	var kse *xmlenc1.KeySizeError
+	require.ErrorAs(t, err, &kse)
+}
+
+// Correct sizes must still round-trip via key wrap (GCM, no opt-in needed).
+func TestKeyWrap_CorrectSizeRoundTrip(t *testing.T) {
+	kek := randKey(t, 32)
+	doc := mustParseXML(t, samlAssertion)
+	enc := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyWrapAlgorithm(xmlenc1.AES256KeyWrap).
+		KeyEncryptionKey(kek)
+	edElem, err := enc.EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	dec := xmlenc1.NewDecryptor().KeyEncryptionKey(kek)
+	nodes, err := dec.Decrypt(t.Context(), edElem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	s, err := helium.WriteString(nodes[0])
+	require.NoError(t, err)
+	require.Contains(t, s, "user@example.com")
+}
+
+// Decrypt path: a direct SessionKey whose length does not match the
+// declared block algorithm must be rejected.
+func TestDecrypt_SessionKeySizeMismatch(t *testing.T) {
+	// Encrypt legitimately under AES-256-GCM.
+	sessionKey := randKey(t, 32)
+	doc := mustParseXML(t, samlAssertion)
+	enc := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		SessionKey(sessionKey)
+	edElem, err := enc.EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	// Decrypt with a wrong-length session key.
+	dec := xmlenc1.NewDecryptor().SessionKey(randKey(t, 16))
+	_, err = dec.Decrypt(t.Context(), edElem)
+	require.Error(t, err)
+	var kse *xmlenc1.KeySizeError
+	require.ErrorAs(t, err, &kse)
+}
+
+// Decrypt path: a wrong-length KEK against the declared key-wrap URI must
+// be rejected before unwrap.
+func TestDecrypt_KeyWrapKEKSizeMismatch(t *testing.T) {
+	kek := randKey(t, 32)
+	doc := mustParseXML(t, samlAssertion)
+	enc := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyWrapAlgorithm(xmlenc1.AES256KeyWrap).
+		KeyEncryptionKey(kek)
+	edElem, err := enc.EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	// kw-aes256 was declared on the wire; supply a 16-byte KEK.
+	dec := xmlenc1.NewDecryptor().KeyEncryptionKey(randKey(t, 16))
+	_, err = dec.Decrypt(t.Context(), edElem)
+	require.Error(t, err)
+	var kse *xmlenc1.KeySizeError
+	require.ErrorAs(t, err, &kse)
+}
+
+// Decrypt path: an unwrapped session key whose length does not match the
+// data-encryption algorithm must be rejected after unwrap. We craft an
+// EncryptedData that declares AES-256-GCM but whose EncryptedKey wraps a
+// 16-byte session key under a correctly-sized kw-aes128 KEK.
+func TestDecrypt_PostUnwrapSessionKeySizeMismatch(t *testing.T) {
+	kek := randKey(t, 16) // valid AES-128 KEK
+	// Wrap a 16-byte session key (valid for AES-128 algorithms) but
+	// declare the data algorithm as AES-256-GCM.
+	shortSessionKey := randKey(t, 16)
+
+	wrapped, err := xmlenc1.AESKeyWrapForTest(kek, shortSessionKey)
+	require.NoError(t, err)
+
+	doc := mustParseXML(t, `<root/>`)
+	// Plaintext bytes encrypted under the short key as AES-128-GCM.
+	cipher, err := xmlenc1.EncryptBytesForTest(xmlenc1.AES128GCM, shortSessionKey, []byte("<x>secret</x>"))
+	require.NoError(t, err)
+
+	ed := &xmlenc1.EncryptedData{
+		Type:             xmlenc1.TypeElement,
+		EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256GCM}, // declares 256
+		EncryptedKey: &xmlenc1.EncryptedKey{
+			EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES128KeyWrap},
+			CipherValue:      wrapped,
+		},
+		CipherValue: cipher,
+	}
+	edElem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+	require.NoError(t, err)
+
+	dec := xmlenc1.NewDecryptor().KeyEncryptionKey(kek)
+	_, err = dec.Decrypt(t.Context(), edElem)
+	require.Error(t, err)
+	var kse *xmlenc1.KeySizeError
+	require.ErrorAs(t, err, &kse)
+}
+
+// Correct sizes must still round-trip via a pre-shared session key for
+// every supported block algorithm (CBC requires opt-in on decrypt).
+func TestSessionKey_CorrectSizeRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		alg  string
+		size int
+		cbc  bool
+	}{
+		{"aes128-gcm", xmlenc1.AES128GCM, 16, false},
+		{"aes256-gcm", xmlenc1.AES256GCM, 32, false},
+		{"aes128-cbc", xmlenc1.AES128CBC, 16, true},
+		{"aes256-cbc", xmlenc1.AES256CBC, 32, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			key := randKey(t, tc.size)
+			doc := mustParseXML(t, samlAssertion)
+			enc := xmlenc1.NewEncryptor().
+				BlockAlgorithm(tc.alg).
+				SessionKey(key)
+			edElem, err := enc.EncryptElement(t.Context(), doc.DocumentElement())
+			require.NoError(t, err)
+
+			dec := xmlenc1.NewDecryptor().SessionKey(key)
+			if tc.cbc {
+				dec = dec.AllowUnauthenticatedCBC(true)
+			}
+			nodes, err := dec.Decrypt(t.Context(), edElem)
+			require.NoError(t, err)
+			require.Len(t, nodes, 1)
+		})
+	}
+}

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -148,6 +148,13 @@ func encrypt(_ context.Context, cfg *encryptConfig, elem *helium.Element, encTyp
 		}
 	}
 
+	// Bind the declared block-algorithm URI to the session-key length so
+	// a user-supplied SessionKey cannot make us emit, e.g., an AES-256
+	// URI while actually encrypting with AES-128.
+	if err := validateKeySize(cfg.blockAlgorithm, sessionKey); err != nil {
+		return nil, err
+	}
+
 	// Serialize the plaintext.
 	var plaintext string
 	if encType == TypeElement {
@@ -182,6 +189,12 @@ func encrypt(_ context.Context, cfg *encryptConfig, elem *helium.Element, encTyp
 			CipherValue: encKeyBytes,
 		}
 	} else if hasKeyWrap {
+		// Bind the declared key-wrap URI to the KEK length so a 16-byte
+		// KEK cannot make us emit a kw-aes256 URI while wrapping with
+		// AES-128.
+		if err := validateKeySize(cfg.keyWrapAlgorithm, cfg.keyEncryptionKey); err != nil {
+			return nil, err
+		}
 		wrappedKey, err := aesKeyWrap(cfg.keyEncryptionKey, sessionKey)
 		if err != nil {
 			return nil, err
@@ -429,6 +442,13 @@ func resolveSessionKey(cfg *decryptConfig, ed *EncryptedData) ([]byte, error) {
 	case AES128KeyWrap, AES256KeyWrap:
 		if len(cfg.keyEncryptionKey) == 0 {
 			return nil, ErrMissingKey
+		}
+		// Bind the declared key-wrap URI to the KEK length so a 16-byte
+		// KEK is not silently accepted as AES-128 against a kw-aes256
+		// declaration. The unwrapped session key is in turn validated
+		// against the data-encryption algorithm in blockDecrypt.
+		if err := validateKeySize(alg, cfg.keyEncryptionKey); err != nil {
+			return nil, err
 		}
 		return aesKeyUnwrap(cfg.keyEncryptionKey, ek.CipherValue)
 	default:


### PR DESCRIPTION
- enforce exact key sizes bound to the declared algorithm URI on encrypt and decrypt
- validate KEK against key-wrap URI and unwrapped session key against block algorithm
- mismatch now returns new `KeySizeError` instead of silently downgrading (e.g. AES-256 URI run as AES-128)
