### PR TITLE
validate element and attribute names on serialize

### DIFF
--- a/internal/xmlchar/xmlchar.go
+++ b/internal/xmlchar/xmlchar.go
@@ -62,6 +62,27 @@ func IsValidPITarget(target string) bool {
 	return IsValidNCName(target)
 }
 
+// IsValidQName checks whether s is a valid XML QName (Namespaces in XML §3):
+//
+//	QName ::= PrefixedName | UnprefixedName
+//	PrefixedName ::= Prefix ':' LocalPart
+//	UnprefixedName ::= LocalPart
+//
+// where Prefix and LocalPart are each an NCName. An unprefixed name is a bare
+// NCName; a prefixed name has exactly one colon separating two NCNames.
+func IsValidQName(s string) bool {
+	if s == "" {
+		return false
+	}
+	if prefix, local, found := strings.Cut(s, ":"); found {
+		// Exactly one colon, splitting two NCNames. A second colon makes
+		// the local part fail IsValidNCName, so no explicit second-colon
+		// check is needed.
+		return IsValidNCName(prefix) && IsValidNCName(local)
+	}
+	return IsValidNCName(s)
+}
+
 // IsValidNCName checks whether s is a valid XML NCName (non-colonized name).
 func IsValidNCName(s string) bool {
 	if s == "" {

--- a/internal/xmlchar/xmlchar_test.go
+++ b/internal/xmlchar/xmlchar_test.go
@@ -39,6 +39,34 @@ func TestIsValidNCName(t *testing.T) {
 	}
 }
 
+func TestIsValidQName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"foo", true},
+		{"p:foo", true},
+		{"xml:space", true},
+		{"_a:_b", true},
+		{"", false},
+		{":foo", false},
+		{"foo:", false},
+		{"p:q:r", false},
+		{"1p:foo", false},
+		{"p:1foo", false},
+		{`root injected="1"`, false},
+		{"foo bar", false},
+		{"x>y", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, xmlchar.IsValidQName(tt.input))
+		})
+	}
+}
+
 func TestIsValidPITarget(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/writer.go
+++ b/writer.go
@@ -115,7 +115,19 @@ func (s *writeSession) checkElementName(name string) bool {
 // checkAttributeName validates an attribute name about to be emitted verbatim.
 // An unvalidated name can inject raw markup (extra attributes, '>') into the
 // start tag. On failure it records a sticky error and returns false.
+//
+// The reserved "xmlns" name is also rejected: a normal attribute named
+// "xmlns" (or one whose QName prefix is "xmlns", e.g. "xmlns:foo") would be
+// emitted as a namespace declaration even though it never went through
+// DeclareNamespace. Namespace declarations are stored as separate Namespace
+// nodes (nsDefs) and serialized by dumpNs; the serializer's own correct
+// xmlns output never reaches this function, so rejecting here only blocks
+// user-supplied misuse.
 func (s *writeSession) checkAttributeName(name string) bool {
+	if name == "xmlns" || strings.HasPrefix(name, "xmlns:") {
+		s.check(fmt.Errorf("helium: reserved attribute name %q: namespace declarations must use DeclareNamespace", name))
+		return false
+	}
 	if xmlchar.IsValidQName(name) {
 		return true
 	}
@@ -127,11 +139,17 @@ func (s *writeSession) checkAttributeName(name string) bool {
 // emitted as "xmlns:"+prefix. An unvalidated prefix (e.g. from
 // DeclareNamespace) can carry whitespace, quotes, or '>' that inject raw markup
 // into the start tag. The empty prefix (default namespace, xmlns="...") is
-// allowed; any non-empty prefix must be a valid NCName (no colon). On failure
-// it records a sticky error (preserving any earlier one) and returns false.
-// Shared by both the generic and XHTML serialization paths so they cannot
-// diverge.
+// allowed; any non-empty prefix must be a valid NCName (no colon). The
+// reserved "xmlns" prefix is rejected: Namespaces-in-XML forbids declaring it,
+// so dumpNs must not emit xmlns:xmlns="...". The "xml" prefix is handled by
+// dumpNs before this function is called. On failure it records a sticky error
+// (preserving any earlier one) and returns false. Shared by both the generic
+// and XHTML serialization paths so they cannot diverge.
 func (s *writeSession) checkNamespacePrefix(prefix string) bool {
+	if prefix == "xmlns" {
+		s.check(fmt.Errorf("helium: reserved namespace prefix %q must not be declared", prefix))
+		return false
+	}
 	if prefix == "" || xmlchar.IsValidNCName(prefix) {
 		return true
 	}

--- a/writer.go
+++ b/writer.go
@@ -99,6 +99,30 @@ func (s *writeSession) check(err error) {
 	}
 }
 
+// checkElementName validates an element name about to be emitted verbatim. An
+// unvalidated name (e.g. from CreateElement) can carry whitespace, quotes, or
+// '>' that inject raw markup into the output. On failure it records a sticky
+// error (preserving any earlier one) and returns false. Shared by both the
+// generic and XHTML serialization paths so they cannot diverge.
+func (s *writeSession) checkElementName(name string) bool {
+	if xmlchar.IsValidQName(name) {
+		return true
+	}
+	s.check(fmt.Errorf("helium: invalid element name %q", name))
+	return false
+}
+
+// checkAttributeName validates an attribute name about to be emitted verbatim.
+// An unvalidated name can inject raw markup (extra attributes, '>') into the
+// start tag. On failure it records a sticky error and returns false.
+func (s *writeSession) checkAttributeName(name string) bool {
+	if xmlchar.IsValidQName(name) {
+		return true
+	}
+	s.check(fmt.Errorf("helium: invalid attribute name %q", name))
+	return false
+}
+
 // NewWriter creates a new Writer with default settings.
 func NewWriter() Writer {
 	return Writer{}
@@ -437,13 +461,10 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 		name = n.Name()
 	}
 
-	// The element name is emitted verbatim below. An unvalidated name (e.g.
-	// from CreateElement) can carry whitespace, quotes, or '>' that inject raw
-	// markup into the output. Reject names that are not well-formed XML QNames.
-	if !xmlchar.IsValidQName(name) {
-		// check() keeps the first sticky error, so an earlier I/O failure is
-		// not clobbered by this validation error.
-		d.check(fmt.Errorf("helium: invalid element name %q", name))
+	// The element name is emitted verbatim below. checkElementName rejects
+	// names that are not well-formed XML QNames (whitespace, quotes, '>') and
+	// records a sticky error without clobbering an earlier I/O failure.
+	if !d.checkElementName(name) {
 		return d.err
 	}
 
@@ -463,10 +484,9 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 	if e, ok := n.(*Element); ok {
 		for attr := e.properties; attr != nil; {
 			g := pdebug.IPrintf("START WriteNode(fallthrough->attribute(%s))", attr.Name())
-			// The attribute name is emitted verbatim. An unvalidated name can
-			// inject raw markup (extra attributes, '>') into the start tag.
-			if attrName := attr.Name(); !xmlchar.IsValidQName(attrName) {
-				d.check(fmt.Errorf("helium: invalid attribute name %q", attrName))
+			// The attribute name is emitted verbatim. checkAttributeName
+			// rejects names that would inject raw markup into the start tag.
+			if !d.checkAttributeName(attr.Name()) {
 				return d.err
 			}
 			d.writeString(out, " "+attr.Name()+`="`)

--- a/writer.go
+++ b/writer.go
@@ -3,6 +3,7 @@ package helium
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 
@@ -436,6 +437,16 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 		name = n.Name()
 	}
 
+	// The element name is emitted verbatim below. An unvalidated name (e.g.
+	// from CreateElement) can carry whitespace, quotes, or '>' that inject raw
+	// markup into the output. Reject names that are not well-formed XML QNames.
+	if !xmlchar.IsValidQName(name) {
+		// check() keeps the first sticky error, so an earlier I/O failure is
+		// not clobbered by this validation error.
+		d.check(fmt.Errorf("helium: invalid element name %q", name))
+		return d.err
+	}
+
 	d.writeString(out, "<")
 	d.writeString(out, name)
 
@@ -452,6 +463,12 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 	if e, ok := n.(*Element); ok {
 		for attr := e.properties; attr != nil; {
 			g := pdebug.IPrintf("START WriteNode(fallthrough->attribute(%s))", attr.Name())
+			// The attribute name is emitted verbatim. An unvalidated name can
+			// inject raw markup (extra attributes, '>') into the start tag.
+			if attrName := attr.Name(); !xmlchar.IsValidQName(attrName) {
+				d.check(fmt.Errorf("helium: invalid attribute name %q", attrName))
+				return d.err
+			}
 			d.writeString(out, " "+attr.Name()+`="`)
 			if d.err != nil {
 				return d.err

--- a/writer.go
+++ b/writer.go
@@ -123,6 +123,22 @@ func (s *writeSession) checkAttributeName(name string) bool {
 	return false
 }
 
+// checkNamespacePrefix validates a namespace declaration prefix about to be
+// emitted as "xmlns:"+prefix. An unvalidated prefix (e.g. from
+// DeclareNamespace) can carry whitespace, quotes, or '>' that inject raw markup
+// into the start tag. The empty prefix (default namespace, xmlns="...") is
+// allowed; any non-empty prefix must be a valid NCName (no colon). On failure
+// it records a sticky error (preserving any earlier one) and returns false.
+// Shared by both the generic and XHTML serialization paths so they cannot
+// diverge.
+func (s *writeSession) checkNamespacePrefix(prefix string) bool {
+	if prefix == "" || xmlchar.IsValidNCName(prefix) {
+		return true
+	}
+	s.check(fmt.Errorf("helium: invalid namespace prefix %q", prefix))
+	return false
+}
+
 // NewWriter creates a new Writer with default settings.
 func NewWriter() Writer {
 	return Writer{}

--- a/writer.go
+++ b/writer.go
@@ -99,13 +99,14 @@ func (s *writeSession) check(err error) {
 	}
 }
 
-// hasReservedXmlnsPrefix reports whether name is the reserved "xmlns" name or
-// carries the reserved "xmlns:" QName prefix. Namespaces-in-XML forbids using
-// "xmlns" as an element/attribute prefix; such a name would be serialized as a
-// (bogus) namespace declaration or as a forbidden prefixed name. Shared by the
-// element and attribute name checks so they stay consistent.
-func hasReservedXmlnsPrefix(name string) bool {
-	return name == "xmlns" || strings.HasPrefix(name, "xmlns:")
+// hasXmlnsPrefix reports whether name carries the reserved "xmlns:" QName
+// prefix. Namespaces-in-XML forbids using "xmlns" as an element/attribute
+// prefix; such a name (e.g. "xmlns:root") would be serialized as a forbidden
+// prefixed name. Note this does NOT match the bare name "xmlns": that name is a
+// valid element name (<xmlns/> is well-formed) and is only reserved as an
+// attribute name, which checkAttributeName handles separately.
+func hasXmlnsPrefix(name string) bool {
+	return strings.HasPrefix(name, "xmlns:")
 }
 
 // checkElementName validates an element name about to be emitted verbatim. An
@@ -114,12 +115,14 @@ func hasReservedXmlnsPrefix(name string) bool {
 // error (preserving any earlier one) and returns false. Shared by both the
 // generic and XHTML serialization paths so they cannot diverge.
 //
-// An element whose QName prefix is the reserved "xmlns" prefix is also rejected:
+// An element whose QName prefix is the reserved "xmlns" prefix is rejected:
 // IsValidQName only checks QName grammar, but Namespaces-in-XML forbids using
 // "xmlns" as a prefix. With an active namespace (which bypasses dumpNs) such a
-// name (e.g. "xmlns:root") could otherwise be serialized as <xmlns:root/>.
+// name (e.g. "xmlns:root") could otherwise be serialized as <xmlns:root/>. The
+// bare name "xmlns" is NOT rejected: it is a valid element name (<xmlns/> is
+// well-formed XML); "xmlns" is reserved only as an attribute name.
 func (s *writeSession) checkElementName(name string) bool {
-	if hasReservedXmlnsPrefix(name) {
+	if hasXmlnsPrefix(name) {
 		s.check(fmt.Errorf("helium: reserved element name %q: namespace declarations must use DeclareNamespace", name))
 		return false
 	}
@@ -142,7 +145,7 @@ func (s *writeSession) checkElementName(name string) bool {
 // xmlns output never reaches this function, so rejecting here only blocks
 // user-supplied misuse.
 func (s *writeSession) checkAttributeName(name string) bool {
-	if hasReservedXmlnsPrefix(name) {
+	if name == "xmlns" || hasXmlnsPrefix(name) {
 		s.check(fmt.Errorf("helium: reserved attribute name %q: namespace declarations must use DeclareNamespace", name))
 		return false
 	}

--- a/writer.go
+++ b/writer.go
@@ -99,12 +99,30 @@ func (s *writeSession) check(err error) {
 	}
 }
 
+// hasReservedXmlnsPrefix reports whether name is the reserved "xmlns" name or
+// carries the reserved "xmlns:" QName prefix. Namespaces-in-XML forbids using
+// "xmlns" as an element/attribute prefix; such a name would be serialized as a
+// (bogus) namespace declaration or as a forbidden prefixed name. Shared by the
+// element and attribute name checks so they stay consistent.
+func hasReservedXmlnsPrefix(name string) bool {
+	return name == "xmlns" || strings.HasPrefix(name, "xmlns:")
+}
+
 // checkElementName validates an element name about to be emitted verbatim. An
 // unvalidated name (e.g. from CreateElement) can carry whitespace, quotes, or
 // '>' that inject raw markup into the output. On failure it records a sticky
 // error (preserving any earlier one) and returns false. Shared by both the
 // generic and XHTML serialization paths so they cannot diverge.
+//
+// An element whose QName prefix is the reserved "xmlns" prefix is also rejected:
+// IsValidQName only checks QName grammar, but Namespaces-in-XML forbids using
+// "xmlns" as a prefix. With an active namespace (which bypasses dumpNs) such a
+// name (e.g. "xmlns:root") could otherwise be serialized as <xmlns:root/>.
 func (s *writeSession) checkElementName(name string) bool {
+	if hasReservedXmlnsPrefix(name) {
+		s.check(fmt.Errorf("helium: reserved element name %q: namespace declarations must use DeclareNamespace", name))
+		return false
+	}
 	if xmlchar.IsValidQName(name) {
 		return true
 	}
@@ -124,7 +142,7 @@ func (s *writeSession) checkElementName(name string) bool {
 // xmlns output never reaches this function, so rejecting here only blocks
 // user-supplied misuse.
 func (s *writeSession) checkAttributeName(name string) bool {
-	if name == "xmlns" || strings.HasPrefix(name, "xmlns:") {
+	if hasReservedXmlnsPrefix(name) {
 		s.check(fmt.Errorf("helium: reserved attribute name %q: namespace declarations must use DeclareNamespace", name))
 		return false
 	}

--- a/writer_dtd.go
+++ b/writer_dtd.go
@@ -415,6 +415,13 @@ func (d *writeSession) dumpNs(out io.Writer, ns *Namespace) error {
 		return nil
 	}
 
+	// The prefix is emitted verbatim as "xmlns:"+prefix below. Reject any
+	// prefix that is not a valid NCName so a crafted prefix (whitespace,
+	// quotes, '>') cannot inject raw markup into the start tag.
+	if !d.checkNamespacePrefix(ns.prefix) {
+		return d.err
+	}
+
 	if _, err := io.WriteString(out, " "); err != nil {
 		return err
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -150,6 +150,70 @@ func TestWriteRejectsInjectedNames(t *testing.T) {
 	})
 }
 
+func TestXHTMLWriteRejectsInjectedNames(t *testing.T) {
+	t.Parallel()
+
+	// newXHTMLDoc builds a document whose internal subset is an XHTML DTD, so
+	// serialization routes through dumpXHTMLNode / dumpXHTMLAttrList rather than
+	// the generic writeNode path.
+	newXHTMLDoc := func(t *testing.T) *helium.Document {
+		t.Helper()
+		doc := helium.NewDefaultDocument()
+		_, err := doc.CreateInternalSubset(
+			"html",
+			"-//W3C//DTD XHTML 1.0 Strict//EN",
+			"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd",
+		)
+		require.NoError(t, err)
+		return doc
+	}
+
+	t.Run("element name injection", func(t *testing.T) {
+		t.Parallel()
+		doc := newXHTMLDoc(t)
+		root := doc.CreateElement(`html injected="1"`)
+		require.NoError(t, doc.SetDocumentElement(root))
+
+		_, err := helium.WriteString(doc)
+		require.Error(t, err, "injected XHTML element name must not serialize")
+	})
+
+	t.Run("attribute name injection", func(t *testing.T) {
+		t.Parallel()
+		doc := newXHTMLDoc(t)
+		root := doc.CreateElement("html")
+		require.NoError(t, doc.SetDocumentElement(root))
+		_, err := root.SetAttribute(`x onmouseover`, "1")
+		require.NoError(t, err)
+
+		_, err = helium.WriteString(doc)
+		require.Error(t, err, "injected XHTML attribute name must not serialize")
+	})
+
+	t.Run("valid element name serializes", func(t *testing.T) {
+		t.Parallel()
+		doc := newXHTMLDoc(t)
+		root := doc.CreateElement("html")
+		require.NoError(t, doc.SetDocumentElement(root))
+
+		str, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.Contains(t, str, "<html")
+	})
+
+	t.Run("valid namespaced name serializes", func(t *testing.T) {
+		t.Parallel()
+		doc := newXHTMLDoc(t)
+		root := doc.CreateElement("html")
+		require.NoError(t, doc.SetDocumentElement(root))
+		require.NoError(t, root.SetActiveNamespace("p", "urn:example"))
+
+		str, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.Contains(t, str, "<p:html")
+	})
+}
+
 // BenchmarkWriteNonASCII serializes a document containing many non-ASCII
 // characters with EscapeNonASCII enabled, exercising the hex char ref path.
 func BenchmarkWriteNonASCII(b *testing.B) {

--- a/writer_test.go
+++ b/writer_test.go
@@ -126,6 +126,37 @@ func TestWriteRejectsInjectedNames(t *testing.T) {
 		require.Error(t, err, "injected attribute name must not serialize")
 	})
 
+	t.Run("reserved xmlns attribute name rejected", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+		// "xmlns" is a valid NCName, but a normal attribute named "xmlns"
+		// would be emitted as a namespace declaration that never went through
+		// DeclareNamespace.
+		_, err := root.SetAttribute("xmlns", "urn:evil")
+		require.NoError(t, err)
+
+		_, err = helium.WriteString(doc)
+		require.Error(t, err, "reserved xmlns attribute name must not serialize")
+	})
+
+	t.Run("reserved xmlns-prefixed attribute name rejected", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+		// An attribute whose QName prefix is "xmlns" (e.g. "xmlns:foo") is a
+		// namespace declaration and must not be emitted as a normal attribute.
+		ns, err := doc.CreateNamespace("xmlns", "urn:x")
+		require.NoError(t, err)
+		_, err = root.SetAttributeNS("foo", "v", ns)
+		require.NoError(t, err)
+
+		_, err = helium.WriteString(doc)
+		require.Error(t, err, "reserved xmlns-prefixed attribute name must not serialize")
+	})
+
 	t.Run("valid element name serializes", func(t *testing.T) {
 		t.Parallel()
 		doc := helium.NewDefaultDocument()
@@ -263,6 +294,19 @@ func TestWriteRejectsInjectedNamespacePrefix(t *testing.T) {
 
 		_, err := helium.WriteString(doc)
 		require.NoError(t, err, "reserved xml prefix must still serialize")
+	})
+
+	t.Run("reserved xmlns prefix rejected", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+		// Namespaces-in-XML forbids declaring the xmlns prefix; the serializer
+		// must not emit xmlns:xmlns="...".
+		require.NoError(t, root.DeclareNamespace("xmlns", "urn"))
+
+		_, err := helium.WriteString(doc)
+		require.Error(t, err, "reserved xmlns prefix must not serialize")
 	})
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -214,6 +214,97 @@ func TestXHTMLWriteRejectsInjectedNames(t *testing.T) {
 	})
 }
 
+func TestWriteRejectsInjectedNamespacePrefix(t *testing.T) {
+	t.Parallel()
+
+	t.Run("namespace prefix injection", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+		// DeclareNamespace does not validate the prefix, so a crafted prefix
+		// would inject raw markup into the start tag on serialization.
+		require.NoError(t, root.DeclareNamespace(`p injected="1`, "urn"))
+
+		_, err := helium.WriteString(doc)
+		require.Error(t, err, "injected namespace prefix must not serialize")
+	})
+
+	t.Run("valid prefix serializes", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+		require.NoError(t, root.DeclareNamespace("p", "urn:example"))
+
+		str, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.Contains(t, str, `xmlns:p="urn:example"`)
+	})
+
+	t.Run("default namespace serializes", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+		require.NoError(t, root.DeclareNamespace("", "urn:default"))
+
+		str, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.Contains(t, str, `xmlns="urn:default"`)
+	})
+
+	t.Run("reserved xml prefix serializes", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+		require.NoError(t, root.DeclareNamespace("xml", lexicon.NamespaceXML))
+
+		_, err := helium.WriteString(doc)
+		require.NoError(t, err, "reserved xml prefix must still serialize")
+	})
+}
+
+func TestXHTMLWriteRejectsInjectedNamespacePrefix(t *testing.T) {
+	t.Parallel()
+
+	newXHTMLDoc := func(t *testing.T) *helium.Document {
+		t.Helper()
+		doc := helium.NewDefaultDocument()
+		_, err := doc.CreateInternalSubset(
+			"html",
+			"-//W3C//DTD XHTML 1.0 Strict//EN",
+			"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd",
+		)
+		require.NoError(t, err)
+		return doc
+	}
+
+	t.Run("namespace prefix injection", func(t *testing.T) {
+		t.Parallel()
+		doc := newXHTMLDoc(t)
+		root := doc.CreateElement("html")
+		require.NoError(t, doc.SetDocumentElement(root))
+		require.NoError(t, root.DeclareNamespace(`p injected="1`, "urn"))
+
+		_, err := helium.WriteString(doc)
+		require.Error(t, err, "injected XHTML namespace prefix must not serialize")
+	})
+
+	t.Run("valid prefix serializes", func(t *testing.T) {
+		t.Parallel()
+		doc := newXHTMLDoc(t)
+		root := doc.CreateElement("html")
+		require.NoError(t, doc.SetDocumentElement(root))
+		require.NoError(t, root.DeclareNamespace("p", "urn:example"))
+
+		str, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.Contains(t, str, `xmlns:p="urn:example"`)
+	})
+}
+
 // BenchmarkWriteNonASCII serializes a document containing many non-ASCII
 // characters with EscapeNonASCII enabled, exercising the hex char ref path.
 func BenchmarkWriteNonASCII(b *testing.B) {

--- a/writer_test.go
+++ b/writer_test.go
@@ -414,6 +414,21 @@ func TestWriteRejectsXmlnsElementName(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, str, "<p:root")
 	})
+
+	t.Run("bare xmlns element name serializes", func(t *testing.T) {
+		t.Parallel()
+		// "xmlns" is a valid element name: <xmlns>...</xmlns> is well-formed XML.
+		// It is reserved only as an attribute name (default-namespace decl), so
+		// an element literally named "xmlns" must serialize without error. This
+		// is the regression case from xslt3 test si-element-261.
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("xmlns")
+		require.NoError(t, doc.SetDocumentElement(root))
+
+		str, err := helium.WriteString(doc)
+		require.NoError(t, err, "bare xmlns element name must serialize")
+		require.Contains(t, str, "<xmlns")
+	})
 }
 
 // BenchmarkWriteNonASCII serializes a document containing many non-ASCII

--- a/writer_test.go
+++ b/writer_test.go
@@ -99,6 +99,57 @@ func TestDOMToXMLString(t *testing.T) {
 	t.Logf("%s", str)
 }
 
+func TestWriteRejectsInjectedNames(t *testing.T) {
+	t.Parallel()
+
+	t.Run("element name injection", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement(`root injected="1"`)
+		require.NoError(t, doc.SetDocumentElement(root))
+
+		_, err := helium.WriteString(doc)
+		require.Error(t, err, "injected element name must not serialize")
+	})
+
+	t.Run("attribute name injection", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+		// SetAttribute only rejects colons, so a space-bearing name slips
+		// through and would inject a second attribute on serialization.
+		_, err := root.SetAttribute(`x onmouseover`, "1")
+		require.NoError(t, err)
+
+		_, err = helium.WriteString(doc)
+		require.Error(t, err, "injected attribute name must not serialize")
+	})
+
+	t.Run("valid element name serializes", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+
+		str, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.Contains(t, str, "<root/>")
+	})
+
+	t.Run("valid namespaced name serializes", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+		require.NoError(t, root.SetActiveNamespace("p", "urn:example"))
+
+		str, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.Contains(t, str, "<p:root")
+	})
+}
+
 // BenchmarkWriteNonASCII serializes a document containing many non-ASCII
 // characters with EscapeNonASCII enabled, exercising the hex char ref path.
 func BenchmarkWriteNonASCII(b *testing.B) {

--- a/writer_test.go
+++ b/writer_test.go
@@ -349,6 +349,73 @@ func TestXHTMLWriteRejectsInjectedNamespacePrefix(t *testing.T) {
 	})
 }
 
+// TestXHTMLAttrErrorEmitsNoPartialChildren reproduces Finding 1: when an XHTML
+// element has an invalid attribute name AND non-element child content, the
+// serializer must abort at the first error and must NOT emit any of the child
+// content before returning the error.
+func TestXHTMLAttrErrorEmitsNoPartialChildren(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDefaultDocument()
+	_, err := doc.CreateInternalSubset(
+		"html",
+		"-//W3C//DTD XHTML 1.0 Strict//EN",
+		"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd",
+	)
+	require.NoError(t, err)
+
+	root := doc.CreateElement("html")
+	require.NoError(t, doc.SetDocumentElement(root))
+
+	// Invalid attribute name on the element: serialization must fail before any
+	// child content is written.
+	_, err = root.SetAttribute(`x onmouseover`, "1")
+	require.NoError(t, err)
+
+	const childMarker = "SECRET_CHILD_TEXT"
+	text := doc.CreateText([]byte(childMarker))
+	require.NoError(t, root.AddChild(text))
+
+	var buf strings.Builder
+	err = helium.NewWriter().WriteTo(&buf, doc)
+	require.Error(t, err, "invalid XHTML attribute name must fail serialization")
+	require.NotContains(t, buf.String(), childMarker,
+		"no child content must be emitted after an attribute-name error")
+}
+
+// TestWriteRejectsXmlnsElementName reproduces Finding 2: an element whose QName
+// prefix is the reserved "xmlns" prefix must not serialize, even when an active
+// namespace bypasses dumpNs.
+func TestWriteRejectsXmlnsElementName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("xmlns-prefixed element name rejected", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+		// SetActiveNamespace sets the node's active namespace directly, so the
+		// "xmlns" prefix is emitted as the element QName prefix (<xmlns:root/>),
+		// which Namespaces-in-XML forbids.
+		require.NoError(t, root.SetActiveNamespace("xmlns", "urn:evil"))
+
+		_, err := helium.WriteString(doc)
+		require.Error(t, err, "xmlns-prefixed element name must not serialize")
+	})
+
+	t.Run("valid namespaced element name serializes", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+		require.NoError(t, root.SetActiveNamespace("p", "urn:example"))
+
+		str, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.Contains(t, str, "<p:root")
+	})
+}
+
 // BenchmarkWriteNonASCII serializes a document containing many non-ASCII
 // characters with EscapeNonASCII enabled, exercising the hex char ref path.
 func BenchmarkWriteNonASCII(b *testing.B) {

--- a/writer_xhtml.go
+++ b/writer_xhtml.go
@@ -67,6 +67,13 @@ func (d *writeSession) dumpXHTMLNode(out io.Writer, n Node) error {
 		name = n.Name()
 	}
 
+	// The element name is emitted verbatim here and on the closing tag below.
+	// Validate it just like writeNode so an injected name (e.g. from
+	// CreateElement) cannot inject raw markup through the XHTML path.
+	if !d.checkElementName(name) {
+		return d.err
+	}
+
 	d.writeString(out, "<")
 	d.writeString(out, name)
 
@@ -181,6 +188,13 @@ func (d *writeSession) dumpXHTMLAttrList(out io.Writer, e *Element) {
 
 	for attr := e.properties; attr != nil; {
 		attrName := attr.Name()
+
+		// The attribute name is emitted verbatim below. Validate it just like
+		// writeNode so an injected name cannot inject raw markup. Stop on the
+		// first invalid name; the sticky error is propagated to the caller.
+		if !d.checkAttributeName(attrName) {
+			return
+		}
 
 		switch attrName {
 		case "id":

--- a/writer_xhtml.go
+++ b/writer_xhtml.go
@@ -95,7 +95,13 @@ func (d *writeSession) dumpXHTMLNode(out io.Writer, n Node) error {
 		d.writeString(out, ` xmlns="http://www.w3.org/1999/xhtml"`)
 	}
 
-	d.dumpXHTMLAttrList(out, e)
+	// dumpXHTMLAttrList returns a non-nil error (e.g. an invalid/reserved
+	// attribute name) when it stopped early. Abort here, mirroring writeNode,
+	// so no element body, child content, or closing tag is emitted past the
+	// error.
+	if err := d.dumpXHTMLAttrList(out, e); err != nil {
+		return err
+	}
 
 	addMeta := false
 	if localName == "head" {
@@ -182,7 +188,7 @@ func (d *writeSession) dumpXHTMLNode(out io.Writer, n Node) error {
 	return d.err
 }
 
-func (d *writeSession) dumpXHTMLAttrList(out io.Writer, e *Element) {
+func (d *writeSession) dumpXHTMLAttrList(out io.Writer, e *Element) error {
 	var langAttr, xmlLangAttr, nameAttr, idAttr *Attribute
 	localName := e.LocalName()
 
@@ -191,9 +197,10 @@ func (d *writeSession) dumpXHTMLAttrList(out io.Writer, e *Element) {
 
 		// The attribute name is emitted verbatim below. Validate it just like
 		// writeNode so an injected name cannot inject raw markup. Stop on the
-		// first invalid name; the sticky error is propagated to the caller.
+		// first invalid name and return the sticky error so the caller aborts
+		// before emitting any element body or child content.
 		if !d.checkAttributeName(attrName) {
-			return
+			return d.err
 		}
 
 		switch attrName {
@@ -247,6 +254,7 @@ func (d *writeSession) dumpXHTMLAttrList(out io.Writer, e *Element) {
 		d.check(escapeAttrValue(out, xmlLangAttr.Content(), d.escapeNonASCII))
 		d.writeString(out, `"`)
 	}
+	return d.err
 }
 
 func (d *writeSession) headHasContentTypeMeta(head *Element) bool {


### PR DESCRIPTION
- reject element/attribute names that are not well-formed XML QNames at serialization, closing a markup-injection hole (e.g. `CreateElement("root injected=\"1\"")`)
- add `xmlchar.IsValidQName`; validation mirrors the existing PI/comment sticky-error checks in the writer (construction-time would break the no-error `CreateElement`/`CreatePI` API)
