### PR TITLE
fix key() panic on empty first argument

### DIFF
--- a/xslt3/functions_key.go
+++ b/xslt3/functions_key.go
@@ -15,6 +15,12 @@ func (ec *execContext) fnKey(ctx context.Context, args []xpath3.Sequence) (xpath
 		return nil, dynamicError(errCodeXTDE1170, "key() requires at least 2 arguments")
 	}
 
+	// fn:key($key-name as xs:string, ...): the first argument is required to be
+	// a single string. An empty sequence is a type error, not a panic.
+	if args[0] == nil || sequence.Len(args[0]) == 0 {
+		return nil, dynamicError(errCodeXPTY0004, "key() first argument must be a single xs:string, got empty sequence")
+	}
+
 	nameAV, err := xpath3.AtomizeItem(args[0].Get(0))
 	if err != nil {
 		return nil, err

--- a/xslt3/keys_test.go
+++ b/xslt3/keys_test.go
@@ -127,6 +127,24 @@ func TestCanonicalKeyUsesQNameValueSpace(t *testing.T) {
 	require.Contains(t, result, "<count>2</count>")
 }
 
+func TestKeyEmptyNameArgReturnsError(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:key name="items" match="item" use="@id"/>
+  <xsl:template match="/">
+    <out><xsl:value-of select="key((), 'v')"/></out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	src, err := helium.NewParser().Parse(t.Context(), []byte(`<root><item id="v"/></root>`))
+	require.NoError(t, err)
+
+	// An empty sequence for the key name must produce a dynamic type error,
+	// not an index-out-of-range panic.
+	_, err = xslt3.TransformString(t.Context(), src, ss)
+	require.Error(t, err)
+}
+
 func TestMutuallyRecursiveKeysDoNotOverflow(t *testing.T) {
 	ss := compileStylesheetString(t, `
 <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">


### PR DESCRIPTION
- `fnKey` indexed `args[0].Get(0)` before checking cardinality; `key((), 'v')` panicked with index-out-of-range
- now returns XPTY0004 dynamic error when the key-name argument is an empty sequence