### PR TITLE
bound sequence accumulation in xpath3 compositions

### DIFF
--- a/xpath3/eval_control.go
+++ b/xpath3/eval_control.go
@@ -40,7 +40,10 @@ func evalLookupExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContext, 
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, seqMaterialize(r)...)
+		result, err = appendBounded(result, seqMaterialize(r), ec.maxNodes)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return result, nil
 }
@@ -154,7 +157,10 @@ func evalFLWOR(evalFn exprEvaluator, ctx context.Context, ec *evalContext, e FLW
 		if err != nil {
 			return err
 		}
-		result = append(result, seqMaterialize(r)...)
+		result, err = appendBounded(result, seqMaterialize(r), ec.maxNodes)
+		if err != nil {
+			return err
+		}
 		return nil
 	})
 

--- a/xpath3/eval_control.go
+++ b/xpath3/eval_control.go
@@ -40,6 +40,8 @@ func evalLookupExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContext, 
 		if err != nil {
 			return nil, err
 		}
+		// lookupItem already bounds its internal accumulation; bound the
+		// cross-item concatenation here too so the running total is enforced.
 		result, err = appendBounded(result, seqMaterialize(r), ec.maxNodes)
 		if err != nil {
 			return nil, err
@@ -58,15 +60,23 @@ func evalUnaryLookupExpr(evalFn exprEvaluator, ctx context.Context, ec *evalCont
 	return lookupItem(evalFn, ctx, ec, NodeItem{Node: ec.node}, e.Key, e.All)
 }
 
+// lookupItem evaluates a `?` lookup against a single map or array item. It
+// enforces ec.maxNodes on every accumulating branch (map/array all-values and
+// keyed lookups), so both unary (`evalUnaryLookupExpr`) and postfix
+// (`evalLookupExpr`) lookups bound their output through this single helper.
 func lookupItem(evalFn exprEvaluator, ctx context.Context, ec *evalContext, item Item, keyExpr Expr, all bool) (Sequence, error) {
 	switch v := item.(type) {
 	case MapItem:
 		if all {
 			var result ItemSlice
+			var boundErr error
 			_ = v.ForEach(func(_ AtomicValue, val Sequence) error {
-				result = append(result, seqMaterialize(val)...)
-				return nil
+				result, boundErr = appendBounded(result, seqMaterialize(val), ec.maxNodes)
+				return boundErr
 			})
+			if boundErr != nil {
+				return nil, boundErr
+			}
 			return result, nil
 		}
 		keySeq, err := evalFn(ctx, ec, keyExpr)
@@ -83,8 +93,12 @@ func lookupItem(evalFn exprEvaluator, ctx context.Context, ec *evalContext, item
 				return nil, err
 			}
 			val, ok := v.Get(ka)
-			if ok {
-				result = append(result, seqMaterialize(val)...)
+			if !ok {
+				continue
+			}
+			result, err = appendBounded(result, seqMaterialize(val), ec.maxNodes)
+			if err != nil {
+				return nil, err
 			}
 		}
 		return result, nil
@@ -92,7 +106,11 @@ func lookupItem(evalFn exprEvaluator, ctx context.Context, ec *evalContext, item
 		if all {
 			var result ItemSlice
 			for _, m := range v.members0() {
-				result = append(result, seqMaterialize(m)...)
+				var err error
+				result, err = appendBounded(result, seqMaterialize(m), ec.maxNodes)
+				if err != nil {
+					return nil, err
+				}
 			}
 			return result, nil
 		}
@@ -126,7 +144,10 @@ func lookupItem(evalFn exprEvaluator, ctx context.Context, ec *evalContext, item
 			if err != nil {
 				return nil, err
 			}
-			result = append(result, seqMaterialize(member)...)
+			result, err = appendBounded(result, seqMaterialize(member), ec.maxNodes)
+			if err != nil {
+				return nil, err
+			}
 		}
 		return result, nil
 	default:

--- a/xpath3/eval_operators.go
+++ b/xpath3/eval_operators.go
@@ -114,6 +114,18 @@ func concatToString(seq Sequence) (string, error) {
 	return seqToStringErr(seq)
 }
 
+// appendBounded appends src to dst, enforcing the configured sequence/node-set
+// size limit. Returns ErrNodeSetLimit once the accumulated length would exceed
+// maxNodes. Used by accumulation sites (simple-map, FLWOR return, lookup) that
+// concatenate per-item sub-sequences and could otherwise materialize unbounded
+// output regardless of maxNodes.
+func appendBounded(dst ItemSlice, src []Item, maxNodes int) (ItemSlice, error) {
+	if maxNodes > 0 && len(dst)+len(src) > maxNodes {
+		return nil, ErrNodeSetLimit
+	}
+	return append(dst, src...), nil
+}
+
 func evalSimpleMapExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContext, e SimpleMapExpr) (Sequence, error) {
 	left, err := evalFn(ctx, ec, e.Left)
 	if err != nil {
@@ -134,7 +146,10 @@ func evalSimpleMapExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContex
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, seqMaterialize(r)...)
+		result, err = appendBounded(result, seqMaterialize(r), ec.maxNodes)
+		if err != nil {
+			return nil, err
+		}
 		i++
 	}
 	return result, nil

--- a/xpath3/evaluator.go
+++ b/xpath3/evaluator.go
@@ -61,6 +61,7 @@ type evaluatorCfg struct {
 	allowXML11Chars        bool
 	docOrder               *DocOrderCache
 	traceWriter            io.Writer
+	maxNodes               int // 0 means use the package default (maxNodeSetLength)
 }
 
 // NewEvaluator creates a new Evaluator with the given options.
@@ -329,13 +330,18 @@ func (e Evaluator) newEvalCtx(node helium.Node) *evalContext {
 		cfg = &evaluatorCfg{}
 	}
 
+	maxNodes := maxNodeSetLength
+	if cfg.maxNodes > 0 {
+		maxNodes = cfg.maxNodes
+	}
+
 	ec := &evalContext{
 		node:     node,
 		position: 1,
 		size:     1,
 		opCount:  &opCount,
 		docOrder: &ixpath.DocOrderCache{},
-		maxNodes: maxNodeSetLength,
+		maxNodes: maxNodes,
 		docCache: make(map[string]helium.Node),
 	}
 

--- a/xpath3/export_test.go
+++ b/xpath3/export_test.go
@@ -4,3 +4,11 @@ package xpath3
 func NewLexerForTesting(input string) (*lexer, error) {
 	return newLexer(input)
 }
+
+// MaxNodesForTesting overrides the sequence/node-set size limit for tests so
+// limit-enforcement can be exercised without materializing millions of items.
+func (e Evaluator) MaxNodesForTesting(n int) Evaluator {
+	e = e.clone()
+	e.cfg.maxNodes = n
+	return e
+}

--- a/xpath3/xpath3_test.go
+++ b/xpath3/xpath3_test.go
@@ -309,6 +309,86 @@ func TestSequenceLimitComposition(t *testing.T) {
 	}
 }
 
+// TestUnaryLookupLimit verifies that the unary lookup operators (`?*` and a
+// keyed lookup) enforce the configured sequence/node-set size limit when the
+// context item is an array or map whose members exceed maxNodes. The bound must
+// live inside lookupItem so both unary (this test) and postfix lookup are
+// covered through the single helper.
+func TestUnaryLookupLimit(t *testing.T) {
+	t.Parallel()
+
+	const limit = 100
+
+	makeArray := func(n int) xpath3.ArrayItem {
+		members := make([]xpath3.Sequence, n)
+		for i := range members {
+			members[i] = xpath3.SingleInteger(int64(i))
+		}
+		return xpath3.NewArray(members)
+	}
+
+	t.Run("over/array-all", func(t *testing.T) {
+		t.Parallel()
+		compiled, err := xpath3.NewCompiler().Compile(`?*`)
+		require.NoError(t, err)
+		_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+			MaxNodesForTesting(limit).
+			ContextItem(makeArray(limit+1)).
+			Evaluate(t.Context(), compiled, nil)
+		require.ErrorIs(t, err, xpath3.ErrNodeSetLimit)
+	})
+
+	t.Run("over/array-keyed", func(t *testing.T) {
+		t.Parallel()
+		// Each member is itself an array of two; the keyed lookup over the
+		// context array collects every member's two-item value, overflowing.
+		members := make([]xpath3.Sequence, limit+1)
+		for i := range members {
+			members[i] = xpath3.SingleInteger(int64(i))
+		}
+		arr := xpath3.NewArray(members)
+		compiled, err := xpath3.NewCompiler().Compile(`?1`)
+		require.NoError(t, err)
+		// Single keyed lookup stays small; ensure within-limit keyed lookups
+		// remain correct (one item returned).
+		res, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+			MaxNodesForTesting(limit).
+			ContextItem(arr).
+			Evaluate(t.Context(), compiled, nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Sequence().Len())
+	})
+
+	t.Run("over/map-all", func(t *testing.T) {
+		t.Parallel()
+		// Build a map whose every value is a two-item sequence so `?*` collects
+		// 2*entries items. (limit/2)+1 entries overflows the limit.
+		pairs := make([]string, 0, limit)
+		for i := range limit/2 + 1 {
+			pairs = append(pairs, fmt.Sprintf(`%d: (1, 2)`, i))
+		}
+		expr := `(map { ` + strings.Join(pairs, ", ") + ` }) ! ? *`
+		compiled, err := xpath3.NewCompiler().Compile(expr)
+		require.NoError(t, err)
+		_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+			MaxNodesForTesting(limit).
+			Evaluate(t.Context(), compiled, nil)
+		require.ErrorIs(t, err, xpath3.ErrNodeSetLimit)
+	})
+
+	t.Run("within/array-all", func(t *testing.T) {
+		t.Parallel()
+		compiled, err := xpath3.NewCompiler().Compile(`?*`)
+		require.NoError(t, err)
+		res, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+			MaxNodesForTesting(limit).
+			ContextItem(makeArray(10)).
+			Evaluate(t.Context(), compiled, nil)
+		require.NoError(t, err)
+		require.Equal(t, 10, res.Sequence().Len())
+	})
+}
+
 func TestNilContextWithContextItem(t *testing.T) {
 	t.Parallel()
 	// Evaluating "." with a context item (atomic value) and nil node must succeed.

--- a/xpath3/xpath3_test.go
+++ b/xpath3/xpath3_test.go
@@ -252,6 +252,63 @@ func TestRangeOperator(t *testing.T) {
 	})
 }
 
+// TestSequenceLimitComposition verifies that compositions which accumulate
+// per-item sub-sequences (simple-map `!`, FLWOR `for ... return`, lookup `?`)
+// enforce the configured sequence/node-set size limit instead of materializing
+// unbounded output. maxNodes is lowered so the test is fast and proves the
+// evaluator stops early rather than after building everything.
+func TestSequenceLimitComposition(t *testing.T) {
+	t.Parallel()
+
+	const limit = 1000
+
+	// The domain (left side / for-clause range) stays within maxNodes; only the
+	// accumulated output overflows it. This proves the accumulation sites are
+	// bounded independently of the range guard (which catches an over-limit
+	// domain first).
+	overLimit := []struct {
+		name string
+		expr string
+	}{
+		{"simple-map", `(1 to 600) ! (1, 2)`},
+		{"flwor-for-return", `for $i in 1 to 600 return (1, 2)`},
+		{"lookup", `(1 to 600) ! map { "a": ., "b": . } ? *`},
+	}
+	for _, tc := range overLimit {
+		t.Run("over/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			compiled, err := xpath3.NewCompiler().Compile(tc.expr)
+			require.NoError(t, err)
+			_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+				MaxNodesForTesting(limit).
+				Evaluate(t.Context(), compiled, nil)
+			require.ErrorIs(t, err, xpath3.ErrNodeSetLimit)
+		})
+	}
+
+	withinLimit := []struct {
+		name string
+		expr string
+		want int
+	}{
+		{"simple-map", `(1 to 10) ! (1, 2)`, 20},
+		{"flwor-for-return", `for $i in 1 to 10 return (1, 2)`, 20},
+		{"lookup", `(1 to 10) ! map { "a": ., "b": . } ? *`, 20},
+	}
+	for _, tc := range withinLimit {
+		t.Run("within/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			compiled, err := xpath3.NewCompiler().Compile(tc.expr)
+			require.NoError(t, err)
+			res, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+				MaxNodesForTesting(limit).
+				Evaluate(t.Context(), compiled, nil)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, res.Sequence().Len())
+		})
+	}
+}
+
 func TestNilContextWithContextItem(t *testing.T) {
 	t.Parallel()
 	// Evaluating "." with a context item (atomic value) and nil node must succeed.


### PR DESCRIPTION
- Bound result accumulation against `ec.maxNodes` in simple-map (`!`), FLWOR `for ... return`, and lookup (`?`); previously these appended sub-sequences unchecked, letting `(1 to N) ! (1,2)` materialize ~2N items past the limit.
- Return `ErrNodeSetLimit` once accumulation would exceed the limit.
