### PR TITLE
xsd: require all xs:key fields to be present

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -73,6 +73,11 @@ expression.`); its `compiledPatterns` entry stays nil and is skipped at validati
   2. For each selected node, evaluate field XPaths → collect key-sequences
   3. Check unique/key: all key-sequences must be unique
   4. Check keyref: all key-sequences must exist in referenced constraint table
+  - Field presence (cvc-identity-constraint.4.2.1): an `xs:key` requires every
+    field to evaluate to a node for each selected node; an absent field is a
+    validity error (`Not all fields of key identity-constraint '…' evaluate to a
+    node.`). `xs:unique` and `xs:keyref` tolerate absent fields — the node drops
+    out of the qualified node-set.
   - XPath uses namespace context from schema, not instance
   - Key comparison is value-space aware (XSD 3.11.4): each field value is
     canonicalized via its declared simple type (`resolveFieldBuiltinLocal` →

--- a/xsd/validate_idc.go
+++ b/xsd/validate_idc.go
@@ -13,8 +13,9 @@ import (
 
 // idcTable holds key-sequences collected during IDC evaluation for a single constraint.
 type idcTable struct {
-	idc  *IDConstraint
-	keys []idcEntry
+	idc        *IDConstraint
+	keys       []idcEntry
+	keyMissing bool // an xs:key selected node had an absent field (cvc-identity-constraint.4.2.1)
 }
 
 // idcEntry holds a single key-sequence value and the node that produced it.
@@ -40,11 +41,17 @@ func (vc *validationContext) validateIDConstraints(ctx context.Context, elem *he
 	for _, idc := range edecl.IDCs {
 		// Use the schema's namespace context for XPath evaluation.
 		ev := xpath1.NewEvaluator().AdditionalNamespaces(idc.Namespaces)
-		table, err := evaluateIDC(ctx, ev, elem, edecl, idc, vc.schema)
+		table, err := vc.evaluateIDC(ctx, ev, elem, edecl, idc)
 		if err != nil {
 			continue
 		}
 		tables[idc.Name] = table
+
+		// A key with an absent field was already reported during
+		// evaluation; surface it as a validation failure.
+		if table.keyMissing {
+			lastErr = fmt.Errorf("missing key field")
+		}
 
 		// Check unique/key constraints immediately.
 		if idc.Kind == IDCUnique || idc.Kind == IDCKey {
@@ -84,7 +91,8 @@ func (vc *validationContext) validateIDConstraints(ctx context.Context, elem *he
 }
 
 // evaluateIDC evaluates the selector and field XPaths for a single IDC.
-func evaluateIDC(ctx context.Context, ev xpath1.Evaluator, elem *helium.Element, edecl *ElementDecl, idc *IDConstraint, schema *Schema) (*idcTable, error) {
+func (vc *validationContext) evaluateIDC(ctx context.Context, ev xpath1.Evaluator, elem *helium.Element, edecl *ElementDecl, idc *IDConstraint) (*idcTable, error) {
+	schema := vc.schema
 	// Evaluate selector XPath using pre-compiled expression when available.
 	var selectorResult *xpath1.Result
 	var err error
@@ -160,6 +168,20 @@ func evaluateIDC(ctx context.Context, ev xpath1.Evaluator, elem *helium.Element,
 
 		if allPresent {
 			table.keys = append(table.keys, entry)
+			continue
+		}
+
+		// A field that resolved to no node leaves the key-sequence
+		// incomplete. Per cvc-identity-constraint 4.2.1, every field of an
+		// xs:key must evaluate to a node for each selected node, so an
+		// absent field is a validity error. xs:unique and xs:keyref
+		// tolerate absent fields (the node simply drops out of the
+		// qualified node-set), so they only skip the entry.
+		if idc.Kind == IDCKey && entry.elem != nil {
+			table.keyMissing = true
+			idcName := idcDisplayName(idc, vc.schema)
+			msg := fmt.Sprintf("Not all fields of key identity-constraint '%s' evaluate to a node.", idcName)
+			vc.reportValidityError(ctx, vc.filename, entry.elem.Line(), elemDisplayName(entry.elem), msg)
 		}
 	}
 

--- a/xsd/validate_idc_key_missing_test.go
+++ b/xsd/validate_idc_key_missing_test.go
@@ -1,0 +1,102 @@
+package xsd_test
+
+import (
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIDCKeyMissingField covers cvc-identity-constraint.4.2.1: every field of an
+// xs:key must evaluate to a node for each selected node. An xs:key with an absent
+// field is a validation error, while xs:unique (and xs:keyref) tolerate absent
+// fields by dropping the node from the qualified node-set.
+func TestIDCKeyMissingField(t *testing.T) {
+	t.Parallel()
+
+	schema := func(kind string) string {
+		return `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="id" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:` + kind + ` name="itemKey">
+      <xs:selector xpath="item"/>
+      <xs:field xpath="@id"/>
+    </xs:` + kind + `>
+  </xs:element>
+</xs:schema>`
+	}
+
+	compile := func(t *testing.T, src string) xsd.Validator {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+		require.NoError(t, err)
+		s, err := xsd.NewCompiler().Compile(t.Context(), doc)
+		require.NoError(t, err)
+		return xsd.NewValidator(s)
+	}
+
+	cases := []struct {
+		name        string
+		schemaKind  string
+		instance    string
+		valid       bool
+		wantMessage string
+	}{
+		{
+			name:        "key with missing field fails",
+			schemaKind:  "key",
+			instance:    `<root><item/></root>`,
+			valid:       false,
+			wantMessage: "Not all fields of key identity-constraint 'itemKey' evaluate to a node.",
+		},
+		{
+			name:       "unique with missing field passes",
+			schemaKind: "unique",
+			instance:   `<root><item/></root>`,
+			valid:      true,
+		},
+		{
+			name:       "key with all fields present and unique passes",
+			schemaKind: "key",
+			instance:   `<root><item id="a"/><item id="b"/></root>`,
+			valid:      true,
+		},
+		{
+			name:        "key with one of several nodes missing field fails",
+			schemaKind:  "key",
+			instance:    `<root><item id="a"/><item/></root>`,
+			valid:       false,
+			wantMessage: "Not all fields of key identity-constraint 'itemKey' evaluate to a node.",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			v := compile(t, schema(tc.schemaKind))
+
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(tc.instance))
+			require.NoError(t, err)
+
+			var errs string
+			err = validateWithOutput(t, v, doc, &errs)
+			if tc.valid {
+				require.NoError(t, err, "expected valid, got errors: %s", errs)
+				return
+			}
+			require.Error(t, err, "expected validation error")
+			require.True(t, strings.Contains(errs, tc.wantMessage),
+				"expected error message %q in %q", tc.wantMessage, errs)
+		})
+	}
+}


### PR DESCRIPTION
- `xs:key` now reports a validity error when a selected node has an absent field (cvc-identity-constraint.4.2.1); `xs:unique` and `xs:keyref` still tolerate absent fields
- message matches libxml2: `Not all fields of key identity-constraint '…' evaluate to a node.`
