### PR TITLE
reject duplicate dtd enumeration tokens

### DIFF
--- a/parser_dtd_attr.go
+++ b/parser_dtd_attr.go
@@ -40,6 +40,7 @@ func (pctx *parserCtx) parseNotationType(ctx context.Context) (Enumeration, erro
 		if _, ok := names[name]; ok {
 			return nil, pctx.error(ctx, DTDDupTokenError{Name: name})
 		}
+		names[name] = struct{}{}
 
 		enumv = append(enumv, name)
 		pctx.skipBlanks(ctx)
@@ -91,6 +92,7 @@ func (pctx *parserCtx) parseEnumerationType(ctx context.Context) (Enumeration, e
 		if _, ok := names[name]; ok {
 			return nil, pctx.error(ctx, DTDDupTokenError{Name: name})
 		}
+		names[name] = struct{}{}
 
 		enumv = append(enumv, name)
 		pctx.skipBlanks(ctx)

--- a/parser_test.go
+++ b/parser_test.go
@@ -3,6 +3,7 @@ package helium_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -784,6 +785,57 @@ func TestValidateDTD(t *testing.T) {
 
 		require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
 		require.True(t, containsError(collector.Errors(), "unknown ID"))
+	})
+}
+
+func TestDTDDuplicateEnumerationTokens(t *testing.T) {
+	t.Parallel()
+
+	t.Run("enumeration with duplicate token", func(t *testing.T) {
+		t.Parallel()
+
+		const input = `<?xml version="1.0"?>
+<!DOCTYPE r [<!ATTLIST r color (red|red) "red">]>
+<r/>`
+
+		p := helium.NewParser()
+		_, err := p.Parse(t.Context(), []byte(input))
+
+		require.Error(t, err, "duplicate enumeration token should be rejected")
+		var dup helium.DTDDupTokenError
+		require.True(t, errors.As(err, &dup), "error should be DTDDupTokenError")
+		require.Equal(t, "red", dup.Name)
+	})
+
+	t.Run("notation with duplicate token", func(t *testing.T) {
+		t.Parallel()
+
+		const input = `<?xml version="1.0"?>
+<!DOCTYPE r [
+  <!NOTATION n PUBLIC "pub-n">
+  <!ATTLIST r kind NOTATION (n|n) #IMPLIED>
+]>
+<r/>`
+
+		p := helium.NewParser()
+		_, err := p.Parse(t.Context(), []byte(input))
+
+		require.Error(t, err, "duplicate notation token should be rejected")
+		var dup helium.DTDDupTokenError
+		require.True(t, errors.As(err, &dup), "error should be DTDDupTokenError")
+		require.Equal(t, "n", dup.Name)
+	})
+
+	t.Run("enumeration with distinct tokens", func(t *testing.T) {
+		t.Parallel()
+
+		const input = `<?xml version="1.0"?>
+<!DOCTYPE r [<!ATTLIST r color (red|green) "red">]>
+<r/>`
+
+		p := helium.NewParser()
+		_, err := p.Parse(t.Context(), []byte(input))
+		require.NoError(t, err, "distinct enumeration tokens should parse")
 	})
 }
 


### PR DESCRIPTION
- populate the seen-token set in parseEnumerationType/parseNotationType so duplicate enumeration and NOTATION tokens now return DTDDupTokenError
- the dedup map was allocated and checked but never written, so duplicates were silently accepted