### PR TITLE
fix html parser spin on nul byte

### DIFF
--- a/html/nul_loop_test.go
+++ b/html/nul_loop_test.go
@@ -1,0 +1,90 @@
+package html_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/helium/html"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNULCharacterNoHang guards against an infinite loop when a real U+0000
+// (NUL) byte appears in character data. The cursor returns 0 both for EOF and
+// for an actual NUL byte, so the scan loops in parseCharacters,
+// parseRCDATAContent and parsePlaintext broke with no progress and the parse
+// loop spun forever. A watchdog converts a regression into a failure instead of
+// stalling the suite.
+func TestNULCharacterNoHang(t *testing.T) {
+	inputs := map[string][]byte{
+		"lone-nul":      {0x00},
+		"body-nul":      []byte("<html><body>\x00</body></html>"),
+		"text-nul":      []byte("<html><body>a\x00b</body></html>"),
+		"nested-nul":    []byte("<p>x\x00\x00y</p>"),
+		"title-nul":     []byte("<title>a\x00b</title>"),
+		"textarea-nul":  []byte("<textarea>a\x00b</textarea>"),
+		"script-nul":    []byte("<script>a\x00b</script>"),
+		"style-nul":     []byte("<style>a\x00b</style>"),
+		"plaintext-nul": []byte("<plaintext>a\x00b"),
+		// NUL immediately after an end-tag name must not hang either.
+		"end-tag-nul": []byte("</title\x00"),
+	}
+
+	for name, input := range inputs {
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				// We don't care about the result, only that it returns.
+				_, _ = html.NewParser().Parse(ctx, input)
+			}()
+
+			watchdog := time.NewTimer(3 * time.Second)
+			defer watchdog.Stop()
+
+			select {
+			case <-done:
+			case <-watchdog.C:
+				t.Fatal("parse hang detected (NUL byte infinite loop)")
+			}
+		})
+	}
+}
+
+// TestNULCharacterReplaced verifies that a real U+0000 byte is replaced with
+// the U+FFFD replacement character (per HTML5 data/RCDATA/RAWTEXT/PLAINTEXT
+// state handling) across every content mode, rather than being dropped, kept
+// literally, or truncating the surrounding content.
+func TestNULCharacterReplaced(t *testing.T) {
+	const repl = "�"
+
+	cases := map[string]struct {
+		input string
+		want  string // expected serialized substring containing the NUL site
+	}{
+		"data":      {"<html><body>a\x00b</body></html>", "<body>a" + repl + "b</body>"},
+		"rcdata":    {"<title>a\x00b</title>", "<title>a" + repl + "b</title>"},
+		"textarea":  {"<textarea>a\x00b</textarea>", "<textarea>a" + repl + "b</textarea>"},
+		"rawscript": {"<script>a\x00b</script>", "<script>a" + repl + "b</script>"},
+		"rawstyle":  {"<style>a\x00b</style>", "<style>a" + repl + "b</style>"},
+		"plaintext": {"<plaintext>a\x00b", "<plaintext>a" + repl + "b</plaintext>"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			doc, err := html.NewParser().
+				SuppressErrors(true).
+				SuppressWarnings(true).
+				Parse(t.Context(), []byte(tc.input))
+			require.NoError(t, err, "parse must not error")
+
+			out, err := html.WriteString(doc)
+			require.NoError(t, err, "serialize must not error")
+			require.NotContains(t, out, "\x00", "literal NUL must not survive")
+			require.Contains(t, out, tc.want, "NUL must be replaced with U+FFFD")
+			// The bytes surrounding the NUL must be preserved (no truncation).
+			require.True(t, strings.Contains(out, "a"+repl+"b"), "content around NUL must be intact: %q", out)
+		})
+	}
+}

--- a/html/parser.go
+++ b/html/parser.go
@@ -766,6 +766,19 @@ func (p *parser) parseCharacters() {
 	// triggers head-close + body-open.
 	inHead := p.currentName() == elemHead
 
+	// A real U+0000 (NUL) byte is indistinguishable from EOF via Peek/PeekAt
+	// (both return 0), so the scan loops below would break with no progress and
+	// the outer parse loop would spin forever. Per HTML5 the data state treats
+	// U+0000 as a parse error and replaces it with U+FFFD. Consume the NUL and
+	// emit the replacement character, guaranteeing forward progress. EOF is
+	// distinguished by Done().
+	if !p.cur.Done() && p.cur.Peek() == 0 {
+		_ = p.cur.Advance(1)
+		p.htmlStartCharData()
+		_ = p.emitCharacters([]byte("�"))
+		return
+	}
+
 	n := 0
 	for {
 		b := p.cur.PeekAt(n)
@@ -1032,9 +1045,16 @@ func (p *parser) parseRawContent(tagName string) {
 			if p.hasPrefixFold(endTag) {
 				afterTag := len(endTag)
 				validEnd := false
-				switch p.cur.PeekAt(afterTag) {
-				case 0, '>', ' ', '\t', '\n', '\r':
+				switch {
+				case !p.cur.HasByteAt(afterTag):
+					// True EOF after the matched tag terminates the element.
+					// A real NUL byte (HasByteAt true, PeekAt 0) does not.
 					validEnd = true
+				default:
+					switch p.cur.PeekAt(afterTag) {
+					case '>', ' ', '\t', '\n', '\r':
+						validEnd = true
+					}
 				}
 				if validEnd {
 					if state == scriptDoubleEscaped {
@@ -1056,6 +1076,14 @@ func (p *parser) parseRawContent(tagName string) {
 				}
 			}
 		}
+		// Per HTML5 the RAWTEXT/script-data states replace U+0000 with U+FFFD.
+		// The loop already advances on every byte (so no spin), but emit the
+		// replacement character instead of a literal NUL for correctness.
+		if p.cur.Peek() == 0 {
+			content.WriteString("�")
+			_ = p.cur.Advance(1)
+			continue
+		}
 		content.WriteByte(p.cur.Peek())
 		_ = p.cur.Advance(1)
 	}
@@ -1075,14 +1103,26 @@ func (p *parser) parseRCDATAContent(tagName string) {
 		if p.cur.Peek() == '<' && p.cur.PeekAt(1) == '/' {
 			if p.hasPrefixFold(endTag) {
 				afterTag := len(endTag)
-				ch := p.cur.PeekAt(afterTag)
-				if ch == 0 {
+				// True EOF after the matched tag terminates the element; a real
+				// NUL byte (HasByteAt true, PeekAt 0) does not.
+				if !p.cur.HasByteAt(afterTag) {
 					return
 				}
-				if ch == '>' || ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' {
+				switch p.cur.PeekAt(afterTag) {
+				case '>', ' ', '\t', '\n', '\r':
 					return
 				}
 			}
+		}
+
+		// A real U+0000 (NUL) byte reads as 0, the same sentinel used to stop
+		// the text scan below, so without this guard the scan makes no progress
+		// and the loop spins forever. Per HTML5 the RCDATA state replaces U+0000
+		// with U+FFFD. EOF is distinguished by Done() in the loop condition.
+		if p.cur.Peek() == 0 {
+			_ = p.cur.Advance(1)
+			_ = p.emitCharacters([]byte("�"))
+			continue
 		}
 
 		if p.cur.Peek() == '&' {
@@ -1112,9 +1152,16 @@ func (p *parser) parseRCDATAContent(tagName string) {
 				// tag so the cursor is guaranteed to progress.
 				validEnd := false
 				if p.cur.PeekAt(1) == '/' && p.hasPrefixFold(endTag) {
-					switch p.cur.PeekAt(len(endTag)) {
-					case 0, '>', ' ', '\t', '\n', '\r':
+					switch {
+					case !p.cur.HasByteAt(len(endTag)):
+						// True EOF after the matched tag; a real NUL does not
+						// count as a valid end-tag terminator.
 						validEnd = true
+					default:
+						switch p.cur.PeekAt(len(endTag)) {
+						case '>', ' ', '\t', '\n', '\r':
+							validEnd = true
+						}
 					}
 				}
 				if !validEnd {
@@ -1128,14 +1175,23 @@ func (p *parser) parseRCDATAContent(tagName string) {
 
 // parsePlaintext parses plaintext content — everything until EOF.
 func (p *parser) parsePlaintext() {
-	n := 0
-	for p.cur.PeekAt(n) != 0 {
-		n++
+	var content bytes.Buffer
+	for !p.cur.Done() {
+		// A real U+0000 (NUL) byte reads as 0, which the previous PeekAt-based
+		// scan treated as EOF, truncating plaintext early. Per HTML5 the
+		// PLAINTEXT state replaces U+0000 with U+FFFD; consume the rest of the
+		// input verbatim, distinguishing genuine EOF via Done().
+		b := p.cur.Peek()
+		if b == 0 {
+			content.WriteString("�")
+			_ = p.cur.Advance(1)
+			continue
+		}
+		content.WriteByte(b)
+		_ = p.cur.Advance(1)
 	}
-	if n > 0 {
-		text := p.cur.PeekString(n)
-		_ = p.cur.Advance(n)
-		p.handleSAXErr(p.sax.Characters([]byte(text)))
+	if content.Len() > 0 {
+		p.handleSAXErr(p.sax.Characters(content.Bytes()))
 	}
 }
 

--- a/html/parser.go
+++ b/html/parser.go
@@ -850,6 +850,18 @@ func (p *parser) htmlStartCharData() {
 	p.htmlCheckImplied("p")
 }
 
+// normalizeNumericCharRef applies the HTML5 numeric-character-reference fixups
+// relevant to NUL handling. A U+0000 reference is a parse error that maps to the
+// replacement character U+FFFD rather than being dropped. Out-of-range and
+// surrogate code points likewise map to U+FFFD instead of producing an invalid
+// rune.
+func normalizeNumericCharRef(cp int) rune {
+	if cp == 0 || cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF) {
+		return '�'
+	}
+	return rune(cp)
+}
+
 // parseCharRef handles entity references (&name; or &#num; or &#xhex;).
 // Emits the resolved value as a Characters SAX event (entity splitting behavior).
 func (p *parser) parseCharRef() {
@@ -861,26 +873,33 @@ func (p *parser) parseCharRef() {
 	if p.cur.Peek() == '#' {
 		_ = p.cur.Advance(1) // skip '#'
 		var codepoint int
+		var haveDigits bool
 		if p.cur.Peek() == 'x' || p.cur.Peek() == 'X' {
 			_ = p.cur.Advance(1) // skip 'x'
 			hexStr := p.parseWhile(isHexDigit)
 			codepoint64, err := strconv.ParseInt(hexStr, 16, 32)
 			if err == nil {
 				codepoint = int(codepoint64)
+				haveDigits = true
 			}
 		} else {
 			numStr := p.parseWhile(isDigit)
 			codepoint64, err := strconv.ParseInt(numStr, 10, 32)
 			if err == nil {
 				codepoint = int(codepoint64)
+				haveDigits = true
 			}
 		}
 		if p.cur.Peek() == ';' {
 			_ = p.cur.Advance(1)
 		}
-		if codepoint > 0 {
+		// Per HTML5, a U+0000 numeric character reference (&#0; / &#x0;) is a
+		// parse error that maps to U+FFFD rather than being dropped. Only emit
+		// nothing when no digits were present at all (a bare "&#" / "&#x").
+		if haveDigits {
+			cp := normalizeNumericCharRef(codepoint)
 			var buf [4]byte
-			n := utf8.EncodeRune(buf[:], rune(codepoint))
+			n := utf8.EncodeRune(buf[:], cp)
 			_ = p.emitCharacters(buf[:n])
 		}
 		return
@@ -1340,25 +1359,30 @@ func (p *parser) resolveEntityInAttr() string {
 	if p.cur.Peek() == '#' {
 		_ = p.cur.Advance(1)
 		var codepoint int
+		var haveDigits bool
 		if p.cur.Peek() == 'x' || p.cur.Peek() == 'X' {
 			_ = p.cur.Advance(1)
 			hexStr := p.parseWhile(isHexDigit)
 			cp, err := strconv.ParseInt(hexStr, 16, 32)
 			if err == nil {
 				codepoint = int(cp)
+				haveDigits = true
 			}
 		} else {
 			numStr := p.parseWhile(isDigit)
 			cp, err := strconv.ParseInt(numStr, 10, 32)
 			if err == nil {
 				codepoint = int(cp)
+				haveDigits = true
 			}
 		}
 		if p.cur.Peek() == ';' {
 			_ = p.cur.Advance(1)
 		}
-		if codepoint > 0 {
-			return string(rune(codepoint))
+		// Per HTML5, &#0; / &#x0; in an attribute value maps to U+FFFD rather
+		// than being dropped. Emit nothing only for a bare "&#" with no digits.
+		if haveDigits {
+			return string(normalizeNumericCharRef(codepoint))
 		}
 		return ""
 	}

--- a/internal/strcursor/utf8cursor.go
+++ b/internal/strcursor/utf8cursor.go
@@ -219,6 +219,24 @@ func (c *UTF8Cursor) PeekAt(offset int) byte {
 	return c.buf[pos]
 }
 
+// HasByteAt reports whether a byte is available at offset bytes from the
+// current position. Unlike PeekAt (which returns 0 both for a genuine NUL byte
+// and for a position past EOF), this lets callers distinguish a real U+0000 in
+// the input from end-of-stream.
+func (c *UTF8Cursor) HasByteAt(offset int) bool {
+	pos := c.bufpos + offset
+	if pos >= c.buflen {
+		if c.fillBuffer(offset+1) != nil {
+			return false
+		}
+		pos = c.bufpos + offset
+		if pos >= c.buflen {
+			return false
+		}
+	}
+	return true
+}
+
 // PeekRune decodes and returns the rune at the current position.
 func (c *UTF8Cursor) PeekRune() rune {
 	if c.bufpos >= c.buflen {


### PR DESCRIPTION
- HTML parseCharacters spun forever on a real U+0000 byte (Peek returns 0 for both NUL and EOF, so the char scan made no progress)
- consume the NUL and emit U+FFFD per HTML5 data-state handling, guaranteeing forward progress
- add watchdog regression test for lone and embedded NUL bytes