### PR TITLE
reject duplicate attributes in start tags

### DIFF
--- a/parser_element.go
+++ b/parser_element.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 	"unicode/utf8"
 
@@ -204,6 +205,14 @@ func (pctx *parserCtx) parseStartTag(ctx context.Context) error {
 		pctx.attrBuf = make([]attrData, 0, 8)
 	}
 	attrs := pctx.attrBuf[:0]
+
+	// Prefixes declared by namespace attributes on THIS start tag, used to
+	// detect same-element duplicate declarations. The empty string is the
+	// default xmlns. This is tracked independently of pushNS/nbNs because
+	// parseNsClean may skip pushing a redundant ancestor redeclaration while
+	// still having consumed a same-element declaration that a later
+	// duplicate must conflict with. Reset per element (nsDeclared[:0]).
+	nsDeclared := pctx.nsDeclaredBuf[:0]
 	for pctx.instate != psEOF {
 		pctx.skipBlanks(ctx)
 		if cur.Peek() == '>' {
@@ -227,7 +236,19 @@ func (pctx *parserCtx) parseStartTag(ctx context.Context) error {
 			// during attribute value parsing (replaceEntities forced true in
 			// parseAttribute for namespace attrs), so no post-processing needed.
 
-			// parseNsClean: skip redundant namespace declarations
+			// A start tag may not carry two default namespace declarations.
+			// This is a well-formedness violation regardless of whether the
+			// URIs match and is fatal even with parseNsClean (which only
+			// suppresses redundant ancestor redeclarations, never
+			// same-element duplicates). The check uses nsDeclared, which
+			// records every same-element declaration even one the parseNsClean
+			// skip path would not push onto nsTab.
+			if slices.Contains(nsDeclared, "") {
+				return pctx.error(ctx, errors.New("duplicate attribute is not allowed"))
+			}
+			nsDeclared = append(nsDeclared, "")
+
+			// parseNsClean: skip redundant ancestor redeclarations.
 			if pctx.options.IsSet(parseNsClean) && pctx.nsTab.Lookup("") == attvalue {
 				goto SkipDefaultNS
 			}
@@ -245,7 +266,6 @@ func (pctx *parserCtx) parseStartTag(ctx context.Context) error {
 			continue
 		} else if aprefix == lexicon.PrefixXMLNS {
 			var u *url.URL
-			var existingURI string
 
 			// <elem xmlns:foo="...">
 			// Namespace URI entity/character references are expanded inline
@@ -277,16 +297,18 @@ func (pctx *parserCtx) parseStartTag(ctx context.Context) error {
 				return pctx.namespaceError(ctx, fmt.Errorf("xmlns:%s: URI %s is not absolute", attname, attvalue))
 			}
 
-			// Check only the current element's bindings (top nbNs entries)
-			// to detect true duplicates. A prefix bound in an ancestor
-			// element is valid shadowing, not a duplicate.
-			existingURI = pctx.nsTab.LookupInTopN(attname, nbNs)
-			if existingURI != "" {
-				if pctx.options.IsSet(parseNsClean) && existingURI == attvalue {
-					goto SkipNS
-				}
+			// A same-element duplicate namespace declaration is a
+			// well-formedness violation and is fatal even when the URIs
+			// match and parseNsClean is set: parseNsClean only suppresses
+			// redundant ancestor redeclarations, never same-element dupes.
+			// nsDeclared records every same-element declaration, including
+			// one the parseNsClean skip path would not push onto nsTab, so a
+			// later duplicate is still caught. A prefix bound only in an
+			// ancestor is valid shadowing and is not in nsDeclared.
+			if slices.Contains(nsDeclared, attname) {
 				return pctx.error(ctx, errors.New("duplicate attribute is not allowed"))
 			}
+			nsDeclared = append(nsDeclared, attname)
 			// parseNsClean: skip if an ancestor already binds this prefix
 			// to the same URI (redundant redeclaration).
 			if pctx.options.IsSet(parseNsClean) && pctx.nsTab.Lookup(attname) == attvalue {
@@ -392,6 +414,33 @@ func (pctx *parserCtx) parseStartTag(ctx context.Context) error {
 		}
 	}
 
+	// Namespaces in XML §6.3: no element may have two attributes with the
+	// same expanded name (namespace URI + local name). Literal duplicate
+	// qualified names were already rejected during parsing; here we catch
+	// the case of distinct prefixes bound to the same namespace URI
+	// (e.g. p:a and q:a where xmlns:p and xmlns:q both map to urn:x).
+	// This is done after all namespace declarations on this start tag have
+	// been pushed, so prefixes declared after the attributes still resolve.
+	// Unprefixed attributes are in no namespace (a default xmlns does not
+	// apply to attributes) and are excluded from this check.
+	for i := range attrs {
+		if attrs[i].prefix == "" || attrs[i].prefix == lexicon.PrefixXML {
+			continue
+		}
+		iuri := pctx.lookupNamespace(attrs[i].prefix)
+		for j := i + 1; j < len(attrs); j++ {
+			if attrs[j].prefix == "" || attrs[j].prefix == lexicon.PrefixXML {
+				continue
+			}
+			if attrs[i].localname != attrs[j].localname {
+				continue
+			}
+			if iuri != "" && iuri == pctx.lookupNamespace(attrs[j].prefix) {
+				return pctx.error(ctx, errors.New("duplicate attribute is not allowed"))
+			}
+		}
+	}
+
 	nsuri := pctx.lookupNamespace(prefix)
 	if prefix != "" && nsuri == "" {
 		return pctx.namespaceError(ctx, errors.New("namespace '"+prefix+"' not found"))
@@ -430,6 +479,7 @@ func (pctx *parserCtx) parseStartTag(ctx context.Context) error {
 	pctx.pushNodeEntry(nodeEntry{local: local, prefix: prefix, uri: nsuri, qname: qname})
 	pctx.nsNrTab = append(pctx.nsNrTab, nbNs)
 	pctx.attrBuf = attrs[:0]
+	pctx.nsDeclaredBuf = nsDeclared[:0]
 
 	return nil
 }

--- a/parser_element.go
+++ b/parser_element.go
@@ -307,6 +307,16 @@ func (pctx *parserCtx) parseStartTag(ctx context.Context) error {
 			continue
 		}
 
+		// XML 1.0 §3.1: a start tag may not carry two attributes with the
+		// same qualified name. Reject before appending or invoking any
+		// SAX/DOM callback. (Namespace declarations are duplicate-checked
+		// in their own branches above and never reach here.)
+		for i := range attrs {
+			if attrs[i].localname == attname && attrs[i].prefix == aprefix {
+				return pctx.error(ctx, errors.New("duplicate attribute is not allowed"))
+			}
+		}
+
 		attr := attrData{
 			localname: attname,
 			prefix:    aprefix,

--- a/parser_test.go
+++ b/parser_test.go
@@ -169,6 +169,31 @@ func TestParseRejectsMalformedComment(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestParseRejectsDuplicateAttribute(t *testing.T) {
+	// XML 1.0 §3.1 well-formedness: a start tag may not have two
+	// attributes with the same (qualified) name. These must be rejected
+	// even when not validating.
+	reject := []string{
+		`<root a="1" a="2"/>`,
+		`<root xmlns:p="urn:x" p:a="1" p:a="2"/>`,
+	}
+	for _, input := range reject {
+		_, err := helium.NewParser().Parse(t.Context(), []byte(input))
+		require.Error(t, err, "Parse should reject duplicate attribute in %q", input)
+	}
+
+	// Distinct qualified names must still parse, including the same local
+	// name carried by different prefixes.
+	accept := []string{
+		`<root a="1" b="2"/>`,
+		`<root xmlns:p="urn:x" xmlns:q="urn:y" p:a="1" q:a="2"/>`,
+	}
+	for _, input := range accept {
+		_, err := helium.NewParser().Parse(t.Context(), []byte(input))
+		require.NoError(t, err, "Parse should accept distinct attributes in %q", input)
+	}
+}
+
 func TestParseNamespace(t *testing.T) {
 	const input = `<?xml version="1.0"?>
 <helium:root xmlns:helium="https://github.com/lestrrat-go/helium">

--- a/parser_test.go
+++ b/parser_test.go
@@ -176,21 +176,65 @@ func TestParseRejectsDuplicateAttribute(t *testing.T) {
 	reject := []string{
 		`<root a="1" a="2"/>`,
 		`<root xmlns:p="urn:x" p:a="1" p:a="2"/>`,
+		// Duplicate default namespace declarations on the same element,
+		// including when one or both are empty (xmlns="").
+		`<root xmlns="urn:x" xmlns="urn:y"/>`,
+		`<root xmlns="urn:x" xmlns="urn:x"/>`,
+		`<root xmlns="" xmlns="urn:x"/>`,
+		`<root xmlns="" xmlns=""/>`,
+		// Two attributes with different prefixes but the same expanded
+		// name ({urn:x}a). Forbidden by Namespaces in XML.
+		`<root xmlns:p="urn:x" xmlns:q="urn:x" p:a="1" q:a="2"/>`,
 	}
 	for _, input := range reject {
 		_, err := helium.NewParser().Parse(t.Context(), []byte(input))
 		require.Error(t, err, "Parse should reject duplicate attribute in %q", input)
 	}
 
+	// The same well-formedness violations must remain fatal even with
+	// CleanNamespaces(true) (parseNsClean), which only suppresses redundant
+	// ancestor redeclarations, never same-element duplicates.
+	rejectClean := []string{
+		`<root xmlns:p="urn:x" xmlns:p="urn:x"/>`,
+		`<root xmlns="urn:x" xmlns="urn:x"/>`,
+		`<root xmlns="" xmlns=""/>`,
+		`<root xmlns="" xmlns="urn:x"/>`,
+		// A child re-declaring a prefix already bound by an ancestor to the
+		// same URI is the parseNsClean redundant-redeclaration case; a
+		// SECOND same-element declaration must still be fatal even though the
+		// first one is skipped as redundant (not pushed onto the ns stack).
+		`<root xmlns="urn:x"><child xmlns="urn:x" xmlns="urn:x"/></root>`,
+		`<root xmlns:p="urn:x"><child xmlns:p="urn:x" xmlns:p="urn:x"/></root>`,
+	}
+	for _, input := range rejectClean {
+		_, err := helium.NewParser().CleanNamespaces(true).Parse(t.Context(), []byte(input))
+		require.Error(t, err, "Parse with CleanNamespaces should reject duplicate ns decl in %q", input)
+	}
+
 	// Distinct qualified names must still parse, including the same local
-	// name carried by different prefixes.
+	// name carried by different prefixes mapped to different URIs.
 	accept := []string{
 		`<root a="1" b="2"/>`,
 		`<root xmlns:p="urn:x" xmlns:q="urn:y" p:a="1" q:a="2"/>`,
+		// Unprefixed attributes are in no namespace; a default xmlns does
+		// not put them in a namespace, so distinct local names are fine.
+		`<root xmlns="urn:x" a="1" b="2"/>`,
 	}
 	for _, input := range accept {
 		_, err := helium.NewParser().Parse(t.Context(), []byte(input))
 		require.NoError(t, err, "Parse should accept distinct attributes in %q", input)
+	}
+
+	// A single child redeclaration of an ancestor binding (no same-element
+	// duplicate) is a legitimate parseNsClean redundant redeclaration and
+	// must still parse.
+	acceptClean := []string{
+		`<root xmlns="urn:x"><child xmlns="urn:x"/></root>`,
+		`<root xmlns:p="urn:x"><child xmlns:p="urn:x"/></root>`,
+	}
+	for _, input := range acceptClean {
+		_, err := helium.NewParser().CleanNamespaces(true).Parse(t.Context(), []byte(input))
+		require.NoError(t, err, "Parse with CleanNamespaces should accept redundant redecl in %q", input)
 	}
 }
 

--- a/parserctx.go
+++ b/parserctx.go
@@ -127,6 +127,7 @@ type parserCtx struct {
 	nameCache        map[string]string // per-parse string interning for element/attribute names
 	charBuf          []byte            // reusable buffer for parseCharDataContent
 	attrBuf          []attrData        // reusable attribute scratch buffer for start-tag parsing
+	nsDeclaredBuf    []string          // reusable scratch buffer of ns prefixes declared on the current start tag
 }
 
 type parserCtxKey struct{}

--- a/stack.go
+++ b/stack.go
@@ -1,8 +1,6 @@
 package helium
 
 import (
-	"slices"
-
 	"github.com/lestrrat-go/helium/internal/stack"
 )
 
@@ -76,20 +74,6 @@ func (s *nsStack) Lookup(prefix string) string {
 		return ""
 	}
 	return item.href
-}
-
-// LookupInTopN searches only the top n entries of the stack for prefix.
-// This is used to detect duplicate namespace declarations on the same
-// element without being confused by ancestor bindings (which are valid
-// prefix shadowing, not duplicates).
-func (s *nsStack) LookupInTopN(prefix string, n int) string {
-	entries := s.Peek(n)
-	for _, v := range slices.Backward(entries) {
-		if v.prefix == prefix {
-			return v.href
-		}
-	}
-	return ""
 }
 
 func (s *nodeStack) Push(e nodeEntry) {


### PR DESCRIPTION
- parseStartTag now rejects two attributes with the same qualified name (XML 1.0 §3.1), matching libxml2's "Attribute redefined"
- previously only namespace-declaration attributes were duplicate-checked; regular attributes were appended unchecked
- distinct qualified names (incl. same local name with different prefixes) still parse