### PR TITLE
fix catalog nil deref when no loader

### DIFF
--- a/internal/catalog/resolve.go
+++ b/internal/catalog/resolve.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"context"
+	"errors"
 	"strings"
 )
 
@@ -9,6 +10,11 @@ import (
 // tried but all failed" — stops nextCatalog fallback (the libxml2 "cut"
 // algorithm).
 const CatalogBreak = "\x00CATAL_BREAK"
+
+// errNoLoader is returned by lazyLoad when an entry references a catalog that
+// must be loaded but no Loader is configured. Callers treat it like any other
+// load failure and skip the entry.
+var errNoLoader = errors.New("catalog: no loader configured")
 
 // Resolve resolves an external identifier (pubID and/or sysID) to a URI.
 // Returns the resolved URI or "" if not found.
@@ -408,7 +414,10 @@ func (c *Catalog) lazyLoad(ctx context.Context, e *Entry) error {
 		return nil
 	}
 	if c.Loader == nil {
-		return nil
+		// The referenced catalog needs loading but no loader is configured.
+		// Return an error so callers skip this entry instead of dereferencing
+		// the still-nil e.Catalog.
+		return errNoLoader
 	}
 	cat, err := c.Loader.Load(ctx, e.URL)
 	if err != nil {

--- a/internal/catalog/resolve_test.go
+++ b/internal/catalog/resolve_test.go
@@ -11,6 +11,8 @@ import (
 
 const sharedCatalogXML = "shared.xml"
 
+const missingCatalogXML = "missing.xml"
+
 func TestResolveURIUnwrapsURN(t *testing.T) {
 	t.Parallel()
 
@@ -173,4 +175,77 @@ func TestVisitedCachePerQuery(t *testing.T) {
 
 	got = root.Resolve(t.Context(), "", "http://example.com/b.dtd")
 	require.Equal(t, "file:///b.dtd", got)
+}
+
+// An in-memory catalog with nextCatalog/delegate entries but no Loader must
+// skip the unresolvable entries instead of dereferencing a nil sub-catalog.
+func TestNoLoaderDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		entries []catalog.Entry
+		resolve func(*catalog.Catalog) string
+	}{
+		{
+			name:    "nextCatalog ResolveURI",
+			entries: []catalog.Entry{{Type: catalog.EntryNextCatalog, URL: missingCatalogXML}},
+			resolve: func(c *catalog.Catalog) string {
+				return c.ResolveURI(context.Background(), "http://example.com/x")
+			},
+		},
+		{
+			name:    "nextCatalog Resolve system",
+			entries: []catalog.Entry{{Type: catalog.EntryNextCatalog, URL: missingCatalogXML}},
+			resolve: func(c *catalog.Catalog) string {
+				return c.Resolve(context.Background(), "", "http://example.com/x")
+			},
+		},
+		{
+			name:    "nextCatalog Resolve public",
+			entries: []catalog.Entry{{Type: catalog.EntryNextCatalog, URL: missingCatalogXML}},
+			resolve: func(c *catalog.Catalog) string {
+				return c.Resolve(context.Background(), "-//Some//DTD//EN", "")
+			},
+		},
+		{
+			name: "delegateSystem",
+			entries: []catalog.Entry{
+				{Type: catalog.EntryDelegateSystem, Name: "http://example.com/", URL: missingCatalogXML},
+			},
+			resolve: func(c *catalog.Catalog) string {
+				return c.Resolve(context.Background(), "", "http://example.com/x")
+			},
+		},
+		{
+			name: "delegatePublic",
+			entries: []catalog.Entry{
+				{Type: catalog.EntryDelegatePublic, Name: "-//Some//", URL: missingCatalogXML, Prefer: catalog.PreferPublic},
+			},
+			resolve: func(c *catalog.Catalog) string {
+				return c.Resolve(context.Background(), "-//Some//DTD//EN", "")
+			},
+		},
+		{
+			name: "delegateURI",
+			entries: []catalog.Entry{
+				{Type: catalog.EntryDelegateURI, Name: "http://example.com/", URL: missingCatalogXML},
+			},
+			resolve: func(c *catalog.Catalog) string {
+				return c.ResolveURI(context.Background(), "http://example.com/x")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cat := &catalog.Catalog{Entries: tc.entries, Prefer: catalog.PreferPublic}
+			var got string
+			require.NotPanics(t, func() {
+				got = tc.resolve(cat)
+			})
+			require.Equal(t, "", got)
+		})
+	}
 }


### PR DESCRIPTION
- `lazyLoad` now errors instead of returning nil when a nextCatalog/delegate entry needs loading but no Loader is set, so callers skip the entry rather than dereferencing a nil sub-catalog
- add tests covering nextCatalog/delegate{System,Public,URI} resolution with no loader configured