### PR TITLE
strip xml whitespace from xmldsig1 base64

### DIFF
--- a/xmldsig1/base64_whitespace_internal_test.go
+++ b/xmldsig1/base64_whitespace_internal_test.go
@@ -1,0 +1,102 @@
+package xmldsig1
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// findFirstElement returns the first descendant Element matching localName.
+func findFirstElement(t *testing.T, n helium.Node, name string) *helium.Element {
+	t.Helper()
+	for child := n.FirstChild(); child != nil; child = child.NextSibling() {
+		if e, ok := helium.AsNode[*helium.Element](child); ok {
+			if localName(e) == name {
+				return e
+			}
+			if found := findFirstElement(t, e, name); found != nil {
+				return found
+			}
+		}
+	}
+	return nil
+}
+
+// wrapText interleaves XML whitespace (CR, LF, tab, space) into s. Go's base64
+// decoder skips CR/LF but rejects space and tab, so the space/tab variants are
+// what exercise the strip-before-decode fix.
+func wrapText(s string, col int) string {
+	seps := []string{"\n", "  \t", "\r\n\t", " "}
+	var out []byte
+	sepIdx := 0
+	for i := range len(s) {
+		if i > 0 && i%col == 0 {
+			out = append(out, seps[sepIdx%len(seps)]...)
+			sepIdx++
+		}
+		out = append(out, s[i])
+	}
+	return string(out)
+}
+
+// setText removes existing text children and sets a single text node.
+func setText(t *testing.T, e *helium.Element, text string) {
+	t.Helper()
+	for child := e.FirstChild(); child != nil; {
+		next := child.NextSibling()
+		if mn, ok := child.(helium.MutableNode); ok {
+			helium.UnlinkNode(mn)
+		}
+		child = next
+	}
+	doc := e.OwnerDocument()
+	require.NoError(t, e.AddChild(doc.CreateText([]byte(text))))
+}
+
+// TestVerifyLineWrappedDigestValue ensures a DigestValue carrying embedded
+// whitespace (line-wrapped base64) still verifies. Because DigestValue lives
+// inside SignedInfo, the wrapping must be present when SignedInfo is signed —
+// c14n preserves the whitespace in the signed bytes, and the verifier must
+// strip it before base64-decoding to recompute the reference digest.
+func TestVerifyLineWrappedDigestValue(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	const samlAssertion = `<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_abc123" IssueInstant="2024-01-01T00:00:00Z" Version="2.0"><saml:Issuer>https://idp.example.com</saml:Issuer></saml:Assertion>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(samlAssertion))
+	require.NoError(t, err)
+
+	signer := NewSigner().
+		SignatureAlgorithm(AlgRSASHA256).
+		Reference(NewEnvelopedReference())
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+	sigElem := findFirstElement(t, doc, "Signature")
+	require.NotNil(t, sigElem)
+	signedInfo := findFirstElement(t, sigElem, "SignedInfo")
+	require.NotNil(t, signedInfo)
+	digestValue := findFirstElement(t, signedInfo, "DigestValue")
+	require.NotNil(t, digestValue)
+	sigValue := findFirstElement(t, sigElem, "SignatureValue")
+	require.NotNil(t, sigValue)
+
+	// Line-wrap the DigestValue text in place, then re-sign SignedInfo so the
+	// SignatureValue covers the wrapped DigestValue.
+	wrapped := wrapText(textContent(digestValue), 16)
+	require.Contains(t, wrapped, " ")
+	setText(t, digestValue, wrapped)
+
+	canonical, err := canonicalizeSubtree(ExcC14N10, signedInfo, nil)
+	require.NoError(t, err)
+	sigBytes, err := signBytes(AlgRSASHA256, key, canonical)
+	require.NoError(t, err)
+	setText(t, sigValue, base64.StdEncoding.EncodeToString(sigBytes))
+
+	verifier := NewVerifier(StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+}

--- a/xmldsig1/base64_whitespace_test.go
+++ b/xmldsig1/base64_whitespace_test.go
@@ -1,0 +1,121 @@
+package xmldsig1_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xmldsig1"
+	"github.com/stretchr/testify/require"
+)
+
+// wrapElementBase64 line-wraps the text content of the named element at the
+// given column using the full set of XML whitespace separators (CR, LF, tab,
+// space), mimicking real-world signers that pretty-print/indent base64. XSD
+// base64Binary permits interspersed XML whitespace, so a verifier must tolerate
+// all of these. Go's base64 decoder skips CR/LF but rejects space and tab, so
+// spaces/tabs are what actually exercise the strip-before-decode fix.
+func wrapElementBase64(t *testing.T, xml, tag string, col int) string {
+	t.Helper()
+	re := regexp.MustCompile(`(<(?:\w+:)?` + tag + `[^>]*>)([^<]+)(</(?:\w+:)?` + tag + `>)`)
+	loc := re.FindStringSubmatchIndex(xml)
+	require.NotNil(t, loc, "expected to find <%s> element in serialized signature", tag)
+	body := xml[loc[4]:loc[5]]
+	require.NotContains(t, body, " ", "test setup: %s body should be single-line before wrapping", tag)
+
+	// Rotate through all XML whitespace so the fix must handle every variant.
+	seps := []string{"\n", "  \t", "\r\n\t", " "}
+	var sb strings.Builder
+	sepIdx := 0
+	for i, r := range body {
+		if i > 0 && i%col == 0 {
+			sb.WriteString(seps[sepIdx%len(seps)])
+			sepIdx++
+		}
+		sb.WriteRune(r)
+	}
+	wrapped := sb.String()
+	require.Contains(t, wrapped, " ", "test setup: wrapping should introduce a space into %s", tag)
+	return re.ReplaceAllString(xml, "${1}"+wrapped+"${3}")
+}
+
+// TestVerifyLineWrappedSignatureValue ensures that a line-wrapped
+// SignatureValue (valid xs:base64Binary with interspersed whitespace) still
+// verifies rather than failing to base64-decode. SignatureValue lives outside
+// SignedInfo, so wrapping it post-signing does not disturb the signed bytes.
+func TestVerifyLineWrappedSignatureValue(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.NewEnvelopedReference())
+
+	err := signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key)
+	require.NoError(t, err)
+
+	xml, err := helium.WriteString(doc)
+	require.NoError(t, err)
+
+	xml = wrapElementBase64(t, xml, "SignatureValue", 64)
+
+	doc2 := mustParseXML(t, xml)
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(t.Context(), doc2)
+	require.NoError(t, err)
+}
+
+// TestVerifyLineWrappedX509Certificate ensures a line-wrapped
+// X509Certificate in KeyInfo still decodes and resolves the key.
+func TestVerifyLineWrappedX509Certificate(t *testing.T) {
+	key := generateRSAKey(t)
+	cert := generateSelfSignedCert(t, key)
+	doc := mustParseXML(t, samlAssertion)
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.NewEnvelopedReference()).
+		KeyInfo(xmldsig1.X509DataKeyInfo(cert))
+
+	err := signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key)
+	require.NoError(t, err)
+
+	xml, err := helium.WriteString(doc)
+	require.NoError(t, err)
+
+	xml = wrapElementBase64(t, xml, "X509Certificate", 64)
+
+	doc2 := mustParseXML(t, xml)
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.X509CertKeySource(cert))
+	_, err = verifier.Verify(t.Context(), doc2)
+	require.NoError(t, err)
+}
+
+// TestVerifyLineWrappedRSAKeyValue ensures line-wrapped Modulus/Exponent in
+// an RSAKeyValue still decode.
+func TestVerifyLineWrappedRSAKeyValue(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.NewEnvelopedReference()).
+		KeyInfo(xmldsig1.RSAKeyValueKeyInfo())
+
+	err := signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key)
+	require.NoError(t, err)
+
+	xml, err := helium.WriteString(doc)
+	require.NoError(t, err)
+
+	xml = wrapElementBase64(t, xml, "Modulus", 64)
+
+	doc2 := mustParseXML(t, xml)
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(t.Context(), doc2)
+	require.NoError(t, err)
+}

--- a/xmldsig1/dom_helpers.go
+++ b/xmldsig1/dom_helpers.go
@@ -1,8 +1,41 @@
 package xmldsig1
 
 import (
+	"encoding/base64"
+	"strings"
+
 	helium "github.com/lestrrat-go/helium"
 )
+
+// decodeBase64 decodes the base64 text of an XML Signature field. XML Signature
+// base64 fields (SignatureValue, DigestValue, X509Certificate, key-value
+// components, ...) are typed xs:base64Binary, whose lexical space permits
+// interspersed XML whitespace; real-world signers line-wrap and indent base64.
+// Go's base64 decoder happens to skip CR/LF but rejects space and tab, so all
+// four XML whitespace characters (space, tab, CR, LF) are stripped before
+// decoding. No other characters are removed, so invalid base64 still fails.
+func decodeBase64(text string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(stripXMLWhitespace(text))
+}
+
+// stripXMLWhitespace removes the four XML whitespace characters (space 0x20,
+// tab 0x09, CR 0x0D, LF 0x0A) from s.
+func stripXMLWhitespace(s string) string {
+	if !strings.ContainsAny(s, " \t\r\n") {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := range len(s) {
+		switch c := s[i]; c {
+		case ' ', '\t', '\r', '\n':
+			// drop XML whitespace
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
+}
 
 // sigAnchor remembers a Signature element's exact location in its sibling
 // chain so it can be reinserted in the same spot after a temporary detach

--- a/xmldsig1/keyinfo.go
+++ b/xmldsig1/keyinfo.go
@@ -210,8 +210,7 @@ func parseX509Data(elem *helium.Element, data *KeyInfoData) error {
 		if localName(certElem) != "X509Certificate" {
 			continue
 		}
-		text := textContent(certElem)
-		derBytes, err := base64.StdEncoding.DecodeString(text)
+		derBytes, err := decodeBase64(textContent(certElem))
 		if err != nil {
 			return fmt.Errorf("%w: invalid X509Certificate base64: %v", ErrInvalidKeyInfo, err)
 		}
@@ -247,8 +246,7 @@ func parseRSAKeyValue(elem *helium.Element, data *KeyInfoData) error {
 		if !ok {
 			continue
 		}
-		text := textContent(e)
-		decoded, err := base64.StdEncoding.DecodeString(text)
+		decoded, err := decodeBase64(textContent(e))
 		if err != nil {
 			return fmt.Errorf("%w: invalid RSAKeyValue base64: %v", ErrInvalidKeyInfo, err)
 		}
@@ -287,8 +285,7 @@ func parseECKeyValue(elem *helium.Element, data *KeyInfoData) error {
 				return fmt.Errorf("%w: unsupported EC curve: %s", ErrInvalidKeyInfo, uri)
 			}
 		case "PublicKey":
-			text := textContent(e)
-			decoded, err := base64.StdEncoding.DecodeString(text)
+			decoded, err := decodeBase64(textContent(e))
 			if err != nil {
 				return fmt.Errorf("%w: invalid ECKeyValue base64: %v", ErrInvalidKeyInfo, err)
 			}

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -2,7 +2,6 @@ package xmldsig1
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -211,8 +210,7 @@ func parseSignatureElement(sigElem *helium.Element) (*parsedSignature, error) {
 				return nil, fmt.Errorf("%w: multiple SignatureValue elements", ErrInvalidSignature)
 			}
 			signatureValueSeen = true
-			text := strings.TrimSpace(textContent(elem))
-			decoded, err := base64.StdEncoding.DecodeString(text)
+			decoded, err := decodeBase64(textContent(elem))
 			if err != nil {
 				return nil, fmt.Errorf("%w: invalid SignatureValue base64: %v", ErrInvalidSignature, err)
 			}
@@ -308,8 +306,7 @@ func parseReferenceElement(elem *helium.Element) (parsedReference, error) {
 			}
 			ref.digestAlgorithm = alg
 		case "DigestValue":
-			text := strings.TrimSpace(textContent(e))
-			decoded, err := base64.StdEncoding.DecodeString(text)
+			decoded, err := decodeBase64(textContent(e))
 			if err != nil {
 				return ref, fmt.Errorf("%w: invalid DigestValue base64: %v", ErrInvalidSignature, err)
 			}


### PR DESCRIPTION
- xs:base64Binary fields (SignatureValue, DigestValue, X509Certificate, RSA/EC key values) permit interspersed XML whitespace; line-wrapped/indented base64 (spaces, tabs) previously failed to decode
- decode all xmldsig1 base64 fields through a shared helper that strips space/tab/CR/LF before decoding