### PR TITLE
enforce recursion limit in EvaluateReuse

### DIFF
--- a/xpath3/eval_reuse.go
+++ b/xpath3/eval_reuse.go
@@ -161,6 +161,7 @@ func (e Evaluator) NewEvalState(node helium.Node) *EvalState {
 
 	// limits
 	ec.opLimit = cfg.opLimit
+	ec.maxRecursionDepth = DefaultMaxRecursionDepth
 
 	// time
 	if cfg.currentTime != nil {

--- a/xpath3/recursion_depth_test.go
+++ b/xpath3/recursion_depth_test.go
@@ -33,3 +33,26 @@ func TestDefaultMaxRecursionDepth_Tunable(t *testing.T) {
 	require.True(t, errors.Is(evalErr, xpath3.ErrRecursionLimit),
 		"expected ErrRecursionLimit, got %v", evalErr)
 }
+
+// EvaluateReuse must enforce the same recursion limit as Evaluate.
+// NewEvalState previously failed to initialize maxRecursionDepth, so the
+// reuse path treated the limit as zero (unlimited) and never tripped.
+func TestDefaultMaxRecursionDepth_Tunable_Reuse(t *testing.T) {
+	orig := xpath3.DefaultMaxRecursionDepth
+	xpath3.DefaultMaxRecursionDepth = 8
+	t.Cleanup(func() { xpath3.DefaultMaxRecursionDepth = orig })
+
+	const n = 50
+	expr := "1" + strings.Repeat("+1", n-1)
+
+	compiled, err := xpath3.NewCompiler().Compile(expr)
+	require.NoError(t, err)
+
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions)
+	state := eval.NewEvalState(nil)
+
+	_, evalErr := compiled.EvaluateReuse(t.Context(), state, nil)
+	require.Error(t, evalErr, "deeply-nested expression must trip the recursion limit on the reuse path")
+	require.True(t, errors.Is(evalErr, xpath3.ErrRecursionLimit),
+		"expected ErrRecursionLimit, got %v", evalErr)
+}


### PR DESCRIPTION
- NewEvalState never set ec.maxRecursionDepth, so EvaluateReuse treated the limit as zero (unlimited) and could blow the stack on deeply nested expressions
- mirror newEvalCtx: initialize ec.maxRecursionDepth to DefaultMaxRecursionDepth
- add reuse-path test asserting ErrRecursionLimit