### PR TITLE
fix self-loop when replacing node with its sibling

### DIFF
--- a/node.go
+++ b/node.go
@@ -409,6 +409,21 @@ func replaceNode(n MutableNode, nodes ...Node) error {
 	cur := nodes[0]
 	cdn := cur.baseDocNode()
 	ndn := n.baseDocNode()
+
+	// A replacement node may already be linked into the tree (e.g. replacing a
+	// node with its own sibling). Detach every replacement node from its current
+	// position before splicing so it cannot remain in n's neighbor chain and
+	// create a self-loop. Skip n itself: when n is among the replacements it
+	// stays live in place (handled below as replacedIsInserted).
+	for _, nn := range nodes {
+		if nn.baseDocNode() == ndn {
+			continue
+		}
+		UnlinkNode(nn.(MutableNode)) //nolint:forcetypeassert
+	}
+
+	// Capture n's following sibling AFTER detaching replacement nodes so it
+	// always points at a node that survives the splice.
 	afterN := ndn.next
 
 	// Patch first replacement into n's position

--- a/tree_test.go
+++ b/tree_test.go
@@ -727,3 +727,69 @@ func TestReplaceSelf(t *testing.T) {
 		require.Equal(t, b, root.LastChild())
 	})
 }
+
+func TestReplaceWithExistingSibling(t *testing.T) {
+	t.Run("replace node with its own next sibling", func(t *testing.T) {
+		// Build <root><a/><b/></root>
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.AddChild(root))
+		a := doc.CreateElement("a")
+		b := doc.CreateElement("b")
+		require.NoError(t, root.AddChild(a))
+		require.NoError(t, root.AddChild(b))
+
+		// Replacing a with its own next sibling b must yield a
+		// well-formed chain with just b as root's only child.
+		require.NoError(t, a.Replace(b))
+
+		require.Equal(t, root, b.Parent())
+		require.Equal(t, b, root.FirstChild())
+		require.Equal(t, b, root.LastChild())
+		require.Nil(t, b.NextSibling(), "b.NextSibling() must be nil (no self-loop)")
+		require.Nil(t, b.PrevSibling(), "b.PrevSibling() must be nil (no self-loop)")
+	})
+
+	t.Run("replace node with its own previous sibling", func(t *testing.T) {
+		// Build <root><a/><b/></root>
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.AddChild(root))
+		a := doc.CreateElement("a")
+		b := doc.CreateElement("b")
+		require.NoError(t, root.AddChild(a))
+		require.NoError(t, root.AddChild(b))
+
+		// Replacing b with its own previous sibling a must yield a
+		// well-formed chain with just a as root's only child.
+		require.NoError(t, b.Replace(a))
+
+		require.Equal(t, root, a.Parent())
+		require.Equal(t, a, root.FirstChild())
+		require.Equal(t, a, root.LastChild())
+		require.Nil(t, a.NextSibling(), "a.NextSibling() must be nil (no self-loop)")
+		require.Nil(t, a.PrevSibling(), "a.PrevSibling() must be nil (no self-loop)")
+	})
+
+	t.Run("replace middle node with its next sibling", func(t *testing.T) {
+		// Build <root><a/><b/><c/></root>
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.AddChild(root))
+		a := doc.CreateElement("a")
+		b := doc.CreateElement("b")
+		c := doc.CreateElement("c")
+		require.NoError(t, root.AddChild(a))
+		require.NoError(t, root.AddChild(b))
+		require.NoError(t, root.AddChild(c))
+
+		// Replace b with c: chain becomes a / c with no self-loop.
+		require.NoError(t, b.Replace(c))
+
+		require.Equal(t, a, root.FirstChild())
+		require.Equal(t, c, a.NextSibling())
+		require.Equal(t, a, c.PrevSibling())
+		require.Nil(t, c.NextSibling(), "c.NextSibling() must be nil")
+		require.Equal(t, c, root.LastChild())
+	})
+}


### PR DESCRIPTION
- `replaceNode` now detaches each replacement node from its current position before splicing, so replacing a node with its own sibling no longer produces a self-linked sibling chain
- add regression tests for replacing a node with its next/prev/middle sibling