### PR TITLE
return ErrNilNode from WriteTo on nil node

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 
 	henc "github.com/lestrrat-go/helium/internal/encoding"
@@ -259,10 +260,27 @@ func hasOnlyTextChildren(n Node) bool {
 	return true
 }
 
+// isNilNode reports whether node is nil, covering both a literal nil interface
+// and a typed-nil concrete pointer wrapped in a non-nil Node interface
+// (Go's interface nil trap).
+func isNilNode(node Node) bool {
+	if node == nil {
+		return true
+	}
+	v := reflect.ValueOf(node)
+	return v.Kind() == reflect.Pointer && v.IsNil()
+}
+
 // WriteTo serializes a node (document or element) to the given writer.
 // When the node is a Document, document-level setup (encoding, XHTML
 // detection, DTD filtering) is applied automatically.
 func (d Writer) WriteTo(out io.Writer, node Node) error {
+	// Guard against a nil node — both a literal nil interface and a typed-nil
+	// concrete pointer (e.g. a (*Element)(nil) stored in a Node) — so callers
+	// get ErrNilNode instead of a panic from method calls on the nil node.
+	if isNilNode(node) {
+		return ErrNilNode
+	}
 	if doc, ok := node.(*Document); ok {
 		return d.writeDoc(out, doc)
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -1014,3 +1014,40 @@ func TestWriteValidationPreservesStickyIOError(t *testing.T) {
 		})
 	}
 }
+
+func TestWriteNilNode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WriteString interface nil", func(t *testing.T) {
+		t.Parallel()
+		s, err := helium.WriteString(nil)
+		require.ErrorIs(t, err, helium.ErrNilNode, "nil node must return ErrNilNode")
+		require.Empty(t, s)
+	})
+
+	t.Run("Write interface nil", func(t *testing.T) {
+		t.Parallel()
+		err := helium.Write(io.Discard, nil)
+		require.ErrorIs(t, err, helium.ErrNilNode, "nil node must return ErrNilNode")
+	})
+
+	t.Run("WriteTo interface nil", func(t *testing.T) {
+		t.Parallel()
+		err := helium.NewWriter().WriteTo(io.Discard, nil)
+		require.ErrorIs(t, err, helium.ErrNilNode, "nil node must return ErrNilNode")
+	})
+
+	t.Run("WriteTo typed nil", func(t *testing.T) {
+		t.Parallel()
+		var typedNil *helium.Element
+		err := helium.NewWriter().WriteTo(io.Discard, typedNil)
+		require.ErrorIs(t, err, helium.ErrNilNode, "typed-nil node must return ErrNilNode")
+	})
+
+	t.Run("WriteTo typed nil document", func(t *testing.T) {
+		t.Parallel()
+		var typedNil *helium.Document
+		err := helium.NewWriter().WriteTo(io.Discard, typedNil)
+		require.ErrorIs(t, err, helium.ErrNilNode, "typed-nil document must return ErrNilNode")
+	})
+}


### PR DESCRIPTION
- `Writer.WriteTo` now returns `ErrNilNode` for a nil node instead of panicking, covering both literal-nil and typed-nil pointers
- affects `WriteString`/`Write`/`WriteTo` public helpers