### PR TITLE
fix format-integer CJK panic for large values

### DIFF
--- a/xpath3/format_integer.go
+++ b/xpath3/format_integer.go
@@ -316,8 +316,7 @@ func int64ToCJK(n int64) string {
 
 	var parts []string
 	// Emit most-significant group first.
-	for i := len(groups) - 1; i >= 0; i-- {
-		g := groups[i]
+	for i, g := range slices.Backward(groups) {
 		if g == 0 {
 			continue
 		}

--- a/xpath3/format_integer.go
+++ b/xpath3/format_integer.go
@@ -293,6 +293,12 @@ func formatCJK(n *big.Int) string {
 	return int64ToCJK(n.Int64())
 }
 
+// cjkMyriadUnits are the myriad (10^4) grouping separators, ascending.
+// Each successive unit is 10^4 times the previous: 万=10^4, 億=10^8, 兆=10^12,
+// 京=10^16. int64 maxes out below 京×10 (~9.2×10^18), so this table is sufficient
+// for every representable value.
+var cjkMyriadUnits = []string{"", "万", "億", "兆", "京"}
+
 func int64ToCJK(n int64) string {
 	if n == 0 {
 		return "〇"
@@ -301,20 +307,41 @@ func int64ToCJK(n int64) string {
 		return "負" + int64ToCJK(-n)
 	}
 
-	var parts []string
+	// Split into 4-digit (myriad) groups, least-significant first.
+	var groups []int64
+	for n > 0 {
+		groups = append(groups, n%10000)
+		n /= 10000
+	}
 
+	var parts []string
+	// Emit most-significant group first.
+	for i := len(groups) - 1; i >= 0; i-- {
+		g := groups[i]
+		if g == 0 {
+			continue
+		}
+		parts = append(parts, cjkGroupUnder10000(g))
+		parts = append(parts, cjkMyriadUnits[i])
+	}
+
+	return strings.Join(parts, "")
+}
+
+// cjkGroupUnder10000 renders a value in 1..9999 as CJK numerals. The leading
+// "一" is omitted before 十/百/千 (e.g. 10 → 十, 100 → 百) per CJK convention.
+func cjkGroupUnder10000(n int64) string {
 	type cjkUnit struct {
 		value int64
 		char  string
 	}
 	units := []cjkUnit{
-		{100000000, "億"},
-		{10000, "万"},
 		{1000, "千"},
 		{100, "百"},
 		{10, "十"},
 	}
 
+	var parts []string
 	for _, u := range units {
 		if n >= u.value {
 			q := n / u.value

--- a/xpath3/format_integer_test.go
+++ b/xpath3/format_integer_test.go
@@ -86,6 +86,36 @@ func TestStringArgAtomizesBeforeCardinality(t *testing.T) {
 	require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code)
 }
 
+// CJK ideographic formatting (picture "一") must not panic for large values that
+// require a multi-digit quotient on a unit (e.g. 10億 for 1,000,000,000) and must
+// produce correct CJK numerals across magnitudes.
+func TestFormatIntegerCJK(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		value  string
+		expect string
+	}{
+		{"0", "〇"},
+		{"5", "五"},
+		{"10", "十"},
+		{"11", "十一"},
+		{"20", "二十"},
+		{"100", "百"},
+		{"1234", "千二百三十四"},
+		{"10000", "一万"},
+		{"100000000", "一億"},
+		{"1000000000", "十億"},
+		{"1234567890", "十二億三千四百五十六万七千八百九十"},
+		{"1000000000000", "一兆"},
+	}
+	for _, tc := range cases {
+		result, err := evaluate(t.Context(), nil, `format-integer(`+tc.value+`, "一")`)
+		require.NoError(t, err, tc.value)
+		require.Equal(t, tc.expect, result.StringValue(), tc.value)
+	}
+}
+
 // The atomize-first rewrite must not materialize a large sequence just to reject
 // it on cardinality — it stops at the second atomized item.
 func TestStringArgRejectsLongSequencePromptly(t *testing.T) {


### PR DESCRIPTION
- `fn:format-integer(n, "一")` panicked (index out of range) for n ≥ 1,000,000,000 because the 億 quotient could exceed 9 and index past `cjkDigits`
- Rewrote CJK formatting to group by myriad (万/億/兆/京), fixing the panic and the missing leading 一 before 万-and-above (e.g. 10000 → 一万)