### PR TITLE
restore var scope after xsl:try body

### DIFF
--- a/xslt3/execute_trycatch.go
+++ b/xslt3/execute_trycatch.go
@@ -196,11 +196,15 @@ func (ec *execContext) execTryCatch(ctx context.Context, inst *tryCatchInst) err
 	tryFrame := ec.outputStack[len(ec.outputStack)-1]
 	ec.outputStack = ec.outputStack[:len(ec.outputStack)-1]
 
+	// Restore the variable scope from before the try body on every exit path
+	// (success, control-flow signal, error, and catch). Variables declared
+	// inside the try must not be visible afterward, nor leak into the catch.
+	ec.localVars = savedVarScope
+
 	// XTDE0640: circular reference errors cannot be caught by xsl:try.
 	// Per spec: "the result of any attempt to catch the error using an
 	// xsl:try instruction is implementation-dependent."
 	if tryErr != nil && errors.Is(tryErr, ErrCircularRef) {
-		ec.localVars = savedVarScope
 		return dynamicError(errCodeXTDE0640, "%s", tryErr.Error())
 	}
 
@@ -278,10 +282,6 @@ func (ec *execContext) execTryCatch(ctx context.Context, inst *tryCatchInst) err
 	if errQName.URI != "" {
 		errClark = helium.ClarkName(errQName.URI, errQName.Local)
 	}
-
-	// Restore variable scope to before the try body.
-	// Variables declared inside the try must not be visible in catch.
-	ec.localVars = savedVarScope
 
 	// Find matching catch clause
 	var matchedCatch *catchClause
@@ -374,6 +374,10 @@ func (ec *execContext) execTryCatchNoRollback(ctx context.Context, inst *tryCatc
 		return nil
 	}()
 
+	// Restore the variable scope from before the try body on every exit path.
+	// Variables declared inside the try must not be visible afterward.
+	ec.localVars = savedVarScope
+
 	if tryErr == nil {
 		return nil
 	}
@@ -390,7 +394,6 @@ func (ec *execContext) execTryCatchNoRollback(ctx context.Context, inst *tryCatc
 	}
 
 	// No output was written — safe to execute catch.
-	ec.localVars = savedVarScope
 	ec.pushVarScope()
 	defer ec.popVarScope()
 

--- a/xslt3/trycatch_test.go
+++ b/xslt3/trycatch_test.go
@@ -1,0 +1,62 @@
+package xslt3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Variables declared inside xsl:try (or its xsl:catch) must not leak into the
+// surrounding scope. After the instruction completes, an outer variable of the
+// same name must still resolve to its outer value.
+func TestTryDoesNotLeakVariables(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{
+			// Try body succeeds; inner $x must not shadow outer $x afterward.
+			name: "success",
+			body: `
+      <xsl:try>
+        <xsl:variable name="x" select="'inner'"/>
+        <xsl:catch/>
+      </xsl:try>`,
+		},
+		{
+			// Try body fails; catch runs and declares $x, which must not leak.
+			name: "catch",
+			body: `
+      <xsl:try>
+        <xsl:sequence select="1 div xs:integer('not-a-number')"/>
+        <xsl:catch>
+          <xsl:variable name="x" select="'inner'"/>
+        </xsl:catch>
+      </xsl:try>`,
+		},
+		{
+			// rollback-output="no" with a successful try body.
+			name: "no-rollback-success",
+			body: `
+      <xsl:try rollback-output="no">
+        <xsl:variable name="x" select="'inner'"/>
+        <xsl:catch/>
+      </xsl:try>`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <xsl:variable name="x" select="'outer'"/>
+    <out>`+tc.body+`<xsl:value-of select="$x"/></out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+			result, err := ss.Transform(parseTransformSource(t)).Serialize(t.Context())
+			require.NoError(t, err)
+			require.Contains(t, result, ">outer<")
+			require.NotContains(t, result, ">inner<")
+		})
+	}
+}


### PR DESCRIPTION
- xsl:try pushed a variable scope but only restored it on the error/catch path; the success and control-flow-signal paths leaked try-body variables into the surrounding scope
- restore the saved scope on every exit path for both rollback and rollback-output="no" variants