### PR TITLE
reject non-singleton fn:index-of search value

### DIFF
--- a/xpath3/functions_sequence.go
+++ b/xpath3/functions_sequence.go
@@ -485,13 +485,16 @@ func deepEqualArray(a, b ArrayItem, opts deepEqualOptions) (bool, error) {
 }
 
 func fnIndexOf(ctx context.Context, args []Sequence) (Sequence, error) {
-	if seqLen(args[1]) == 0 {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "index-of: search value must not be empty sequence"}
-	}
-	search, err := AtomizeItem(args[1].Get(0))
+	// $search is declared xs:anyAtomicType (exactly one item): an empty or
+	// multi-item search value is a type error, not a search for the first item.
+	searchAtoms, err := AtomizeSequence(args[1])
 	if err != nil {
 		return nil, err
 	}
+	if len(searchAtoms) != 1 {
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "index-of: search value must be exactly one atomic item"}
+	}
+	search := searchAtoms[0]
 	// Explicit 3rd arg with empty sequence is a type error (xs:string, not xs:string?)
 	if len(args) > 2 && seqLen(args[2]) == 0 {
 		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "collation argument must not be empty"}

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -1435,3 +1435,44 @@ func TestFnSequenceIntegerCardinalityArgs(t *testing.T) {
 		require.Equal(t, []string{"c"}, evalStrings(t, `subsequence(("a","b","c"), 2.6)`))
 	})
 }
+
+// fn:index-of's $search-param is a single atomic item (xs:anyAtomicType), so a
+// non-singleton search value is a type error (XPTY0004) rather than a silent
+// search for just the first item.
+func TestFnIndexOfSearchCardinality(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	evalErrCode := func(t *testing.T, expr, code string) {
+		t.Helper()
+		compiled, err := xpath3.NewCompiler().Compile(expr)
+		require.NoError(t, err)
+		_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.Error(t, err, "expected error for %q", expr)
+		require.ErrorIs(t, err, &xpath3.XPathError{Code: code}, "expected %s for %q", code, expr)
+	}
+
+	t.Run("multi-item search raises XPTY0004", func(t *testing.T) {
+		for _, expr := range []string{
+			`index-of((1, 2, 1), (1, 2))`,
+			`index-of(("a", "b", "a"), ("a", "b"))`,
+		} {
+			t.Run(expr, func(t *testing.T) { evalErrCode(t, expr, "XPTY0004") })
+		}
+	})
+
+	t.Run("empty search raises XPTY0004", func(t *testing.T) {
+		evalErrCode(t, `index-of((1, 2, 1), ())`, "XPTY0004")
+	})
+
+	t.Run("single-item search still works", func(t *testing.T) {
+		seq := evalExpr(t, doc, `index-of((10, 20, 30, 20), 20)`)
+		require.Equal(t, 2, seq.Len())
+		require.Equal(t, int64(2), seq.Get(0).(xpath3.AtomicValue).IntegerVal())
+		require.Equal(t, int64(4), seq.Get(1).(xpath3.AtomicValue).IntegerVal())
+	})
+
+	t.Run("empty sequence with single search returns empty", func(t *testing.T) {
+		seq := evalExpr(t, doc, `index-of((), 5)`)
+		require.Equal(t, 0, seq.Len())
+	})
+}


### PR DESCRIPTION
- fn:index-of $search is exactly one atomic item; a multi-item search value now raises XPTY0004 instead of silently matching only the first item
- atomize the search argument before the cardinality check so arrays/nodes expanding to multiple items are also rejected