### PR TITLE
unlink children moved to primary result-document

### DIFF
--- a/xslt3/execute_resultdoc.go
+++ b/xslt3/execute_resultdoc.go
@@ -50,6 +50,24 @@ func validateDocumentStructure(doc *helium.Document) error {
 	return nil
 }
 
+// moveChildren transfers every child of src into dst, preserving order. Each
+// child is unlinked from src before being added to dst so that the source
+// document's sibling/parent links do not remain attached to the moved nodes
+// (which would alias nodes across two trees and can corrupt sibling traversal).
+func moveChildren(src *helium.Document, dst *helium.Document) error {
+	var children []helium.Node
+	for child := range helium.Children(src) {
+		children = append(children, child)
+	}
+	for _, child := range children {
+		helium.UnlinkNode(child.(helium.MutableNode)) //nolint:forcetypeassert
+		if err := dst.AddChild(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // execDocument implements xsl:document: creates a document node wrapping
 // the result of executing the body.
 func (ec *execContext) execDocument(ctx context.Context, inst *documentInst) error {
@@ -419,10 +437,8 @@ func (ec *execContext) execResultDocument(ctx context.Context, inst *resultDocum
 				}
 			}
 			primaryFrame := ec.outputStack[0]
-			for child := tmpDoc.FirstChild(); child != nil; child = child.NextSibling() {
-				if err := primaryFrame.doc.AddChild(child); err != nil {
-					return err
-				}
+			if err := moveChildren(tmpDoc, primaryFrame.doc); err != nil {
+				return err
 			}
 			return nil
 		}
@@ -462,12 +478,10 @@ func (ec *execContext) execResultDocument(ctx context.Context, inst *resultDocum
 					ec.markNilled(elem)
 				}
 			}
-			// Copy validated children into the primary output.
+			// Move validated children into the primary output.
 			primaryFrame := ec.outputStack[0]
-			for child := tmpDoc.FirstChild(); child != nil; child = child.NextSibling() {
-				if err := primaryFrame.doc.AddChild(child); err != nil {
-					return err
-				}
+			if err := moveChildren(tmpDoc, primaryFrame.doc); err != nil {
+				return err
 			}
 			return nil
 		}

--- a/xslt3/resultdoc_unlink_test.go
+++ b/xslt3/resultdoc_unlink_test.go
@@ -1,0 +1,49 @@
+package xslt3_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPrimaryResultDocumentUnlinksChildren guards against a tree-corruption bug
+// where a primary xsl:result-document (validation="strict") moved children from
+// a temporary document into the primary document via AddChild without unlinking
+// them first. The temporary document's sibling links remained attached, which
+// corrupted the result tree (and could hang sibling traversal) when the body
+// produced a comment followed by the root element.
+func TestPrimaryResultDocumentUnlinksChildren(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:result-document href="" validation="strict">
+      <xsl:comment>lead</xsl:comment>
+      <out>body</out>
+    </xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	source := parseTransformSource(t)
+
+	done := make(chan struct{})
+	var result string
+	var err error
+	go func() {
+		result, err = ss.Transform(source).Serialize(t.Context())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Serialize hung: primary result-document corrupted the sibling chain")
+	}
+
+	require.NoError(t, err)
+	require.Contains(t, result, "<!--lead-->")
+	require.Contains(t, result, "<out>body</out>")
+	require.Less(t, strings.Index(result, "<!--lead-->"), strings.Index(result, "<out>body</out>"),
+		"comment must precede the root element")
+}


### PR DESCRIPTION
- Primary xsl:result-document (type/validation paths) moved children into the primary document via AddChild without unlinking them from the temporary document, leaving stale sibling links that corrupted the result tree and could hang sibling traversal
- Snapshot then unlink each child before re-parenting, preserving order
- Add regression test for comment-then-element primary result-document