### PR TITLE
fix xs:dateTimeStamp comparisons

### DIFF
--- a/xpath3/compare.go
+++ b/xpath3/compare.go
@@ -631,6 +631,12 @@ func compareAtomicWithImplicitTimezone(op TokenType, a, b AtomicValue, implicitT
 	a = promoteSchemaForCompare(a)
 	b = promoteSchemaForCompare(b)
 
+	// xs:dateTimeStamp (XSD 1.1) is a subtype of xs:dateTime and compares
+	// identically; normalize it so same-type and mixed comparisons share the
+	// xs:dateTime branch below.
+	a = normalizeDateTimeStamp(a)
+	b = normalizeDateTimeStamp(b)
+
 	// String comparison (includes string-derived types and anyURI)
 	aStr := isStringDerived(a.TypeName) || a.TypeName == TypeAnyURI
 	bStr := isStringDerived(b.TypeName) || b.TypeName == TypeAnyURI
@@ -747,6 +753,17 @@ func compareAtomicWithImplicitTimezone(op TokenType, a, b AtomicValue, implicitT
 // base type for comparison purposes.
 func promoteSchemaForCompare(a AtomicValue) AtomicValue {
 	return PromoteSchemaType(a)
+}
+
+// normalizeDateTimeStamp rewrites an xs:dateTimeStamp value to xs:dateTime for
+// comparison. xs:dateTimeStamp (XSD 1.1) is a built-in subtype of xs:dateTime
+// with identical value-space ordering, so comparing it as xs:dateTime is correct
+// for both same-type and mixed dateTime/dateTimeStamp comparisons.
+func normalizeDateTimeStamp(a AtomicValue) AtomicValue {
+	if a.TypeName == TypeDateTimeStamp {
+		a.TypeName = TypeDateTime
+	}
+	return a
 }
 
 // compareAtomicCollation compares two atomic values using the given collation

--- a/xpath3/compare_datetimestamp_test.go
+++ b/xpath3/compare_datetimestamp_test.go
@@ -1,0 +1,44 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEvalDateTimeStampComparison covers comparisons involving xs:dateTimeStamp.
+// xs:dateTimeStamp is a recognized XSD 1.1 type and is a subtype of xs:dateTime,
+// so it must compare like xs:dateTime both against itself and against xs:dateTime.
+func TestEvalDateTimeStampComparison(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	tests := []struct {
+		expr   string
+		expect bool
+	}{
+		// same-type dateTimeStamp comparisons
+		{`xs:dateTimeStamp("2020-01-01T00:00:00Z") eq xs:dateTimeStamp("2020-01-01T00:00:00Z")`, true},
+		{`xs:dateTimeStamp("2020-01-01T00:00:00Z") ne xs:dateTimeStamp("2021-01-01T00:00:00Z")`, true},
+		{`xs:dateTimeStamp("2020-01-01T00:00:00Z") lt xs:dateTimeStamp("2021-01-01T00:00:00Z")`, true},
+		{`xs:dateTimeStamp("2021-01-01T00:00:00Z") gt xs:dateTimeStamp("2020-01-01T00:00:00Z")`, true},
+		{`xs:dateTimeStamp("2020-01-01T00:00:00Z") le xs:dateTimeStamp("2020-01-01T00:00:00Z")`, true},
+		{`xs:dateTimeStamp("2020-01-01T00:00:00Z") ge xs:dateTimeStamp("2020-01-01T00:00:00Z")`, true},
+		// mixed dateTime / dateTimeStamp comparisons
+		{`xs:dateTime("2020-01-01T00:00:00Z") eq xs:dateTimeStamp("2020-01-01T00:00:00Z")`, true},
+		{`xs:dateTimeStamp("2020-01-01T00:00:00Z") eq xs:dateTime("2020-01-01T00:00:00Z")`, true},
+		{`xs:dateTimeStamp("2020-01-01T00:00:00Z") lt xs:dateTime("2021-01-01T00:00:00Z")`, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.expr, func(t *testing.T) {
+			compiled, err := xpath3.NewCompiler().Compile(tc.expr)
+			require.NoError(t, err)
+			result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+			require.NoError(t, err)
+			seq := result.Sequence()
+			require.Equal(t, 1, seq.Len())
+			av := seq.Get(0).(xpath3.AtomicValue)
+			require.Equal(t, tc.expect, av.BooleanVal())
+		})
+	}
+}


### PR DESCRIPTION
- treat xs:dateTimeStamp as xs:dateTime in atomic comparison, fixing XPTY0004 on same-type and mixed dateTime/dateTimeStamp compares