### PR TITLE
fix runecursor read short-buffer panic

### DIFF
--- a/internal/strcursor/strcursor.go
+++ b/internal/strcursor/strcursor.go
@@ -570,11 +570,13 @@ func (c *RuneCursor) Read(buf []byte) (int, error) {
 	mask := c.ringMask
 	for c.count > 0 && nread < len(buf) {
 		e := c.ring[c.head]
-		w := utf8.EncodeRune(buf[nread:], e.val)
-		if nread+w > len(buf) {
+		// Only encode if the whole rune fits in the remaining space;
+		// EncodeRune would otherwise write past buf and panic. Leaving
+		// the rune buffered yields a valid short read on the next call.
+		if utf8.RuneLen(e.val) > len(buf)-nread {
 			break
 		}
-		nread += w
+		nread += utf8.EncodeRune(buf[nread:], e.val)
 		c.head = (c.head + 1) & mask
 		c.count--
 	}
@@ -584,6 +586,11 @@ func (c *RuneCursor) Read(buf []byte) (int, error) {
 		}
 		n, err := c.in.Read(buf[nread:])
 		return nread + n, err
+	}
+	// A rune is still buffered but did not fit in buf; return a valid short
+	// read rather than pulling from c.in and reordering the buffered rune.
+	if c.count > 0 {
+		return 0, nil
 	}
 	return c.in.Read(buf)
 }

--- a/internal/strcursor/strcursor.go
+++ b/internal/strcursor/strcursor.go
@@ -580,17 +580,16 @@ func (c *RuneCursor) Read(buf []byte) (int, error) {
 		c.head = (c.head + 1) & mask
 		c.count--
 	}
+	// If a rune is still buffered (either buf is full or the next rune did
+	// not fit), return a valid short read. Pulling from c.in here would
+	// reorder bytes ahead of the still-pending buffered rune.
+	if c.count > 0 || nread >= len(buf) {
+		return nread, nil
+	}
+	// Ring fully drained with room left; top up from the underlying reader.
 	if nread > 0 {
-		if nread >= len(buf) {
-			return nread, nil
-		}
 		n, err := c.in.Read(buf[nread:])
 		return nread + n, err
-	}
-	// A rune is still buffered but did not fit in buf; return a valid short
-	// read rather than pulling from c.in and reordering the buffered rune.
-	if c.count > 0 {
-		return 0, nil
 	}
 	return c.in.Read(buf)
 }

--- a/internal/strcursor/utf8cursor_test.go
+++ b/internal/strcursor/utf8cursor_test.go
@@ -128,3 +128,27 @@ func TestRuneCursorReadShortBufferBufferedRune(t *testing.T) {
 	}
 	require.Equal(t, "é", string(got), "rune delivered intact across reads")
 }
+
+func TestRuneCursorReadShortBufferPartialRuneFit(t *testing.T) {
+	cur := NewRuneCursor(strings.NewReader("aé"))
+	// Buffer both runes in the ring.
+	require.Equal(t, 'a', cur.Peek())
+	require.Equal(t, 'é', cur.PeekN(2))
+
+	// A 2-byte buffer fits 'a' (1 byte) but not the following 2-byte 'é'.
+	// Read must emit only 'a' as a short read with no EOF, leaving 'é'
+	// buffered rather than reordering bytes from the underlying reader.
+	buf := make([]byte, 2)
+	n, err := cur.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 1, n, "only the 1-byte rune fits")
+	require.Equal(t, "a", string(buf[:n]))
+
+	// The buffered 'é' is delivered intact on the next read.
+	rest := make([]byte, 8)
+	m, err := cur.Read(rest)
+	require.Equal(t, "é", string(rest[:m]))
+	if err != nil {
+		require.Equal(t, io.EOF, err)
+	}
+}

--- a/internal/strcursor/utf8cursor_test.go
+++ b/internal/strcursor/utf8cursor_test.go
@@ -99,3 +99,32 @@ func TestUTF8CursorScanQNameBytesRejectsSecondColon(t *testing.T) {
 	require.Zero(t, n)
 	require.Equal(t, byte('a'), cur.Peek())
 }
+
+func TestRuneCursorReadShortBufferBufferedRune(t *testing.T) {
+	cur := NewRuneCursor(strings.NewReader("é"))
+	// Buffer the multibyte rune in the ring.
+	require.Equal(t, 'é', cur.Peek())
+
+	// A 1-byte destination cannot hold the 2-byte rune. Read must not panic
+	// and must not corrupt or drop the buffered rune.
+	first := make([]byte, 1)
+	n, err := cur.Read(first)
+	require.NoError(t, err)
+	require.Zero(t, n, "no full rune fits in a 1-byte buffer")
+
+	// The rune must still be deliverable on a subsequent read.
+	rest := make([]byte, 8)
+	var got []byte
+	for {
+		m, rerr := cur.Read(rest)
+		got = append(got, rest[:m]...)
+		if rerr == io.EOF {
+			break
+		}
+		require.NoError(t, rerr)
+		if m == 0 {
+			break
+		}
+	}
+	require.Equal(t, "é", string(got), "rune delivered intact across reads")
+}


### PR DESCRIPTION
- RuneCursor.Read now checks utf8.RuneLen against remaining space before encoding, avoiding an out-of-range panic when buf is too small for a buffered rune
- returns a valid short read and preserves the buffered rune for the next Read instead of reading from the underlying reader and reordering