### PR TITLE
fix double-counted fractional seconds in duration div

### DIFF
--- a/xpath3/arithmetic_datetime.go
+++ b/xpath3/arithmetic_datetime.go
@@ -352,8 +352,23 @@ func durationToRat(d Duration, isYM bool) *big.Rat {
 	if isYM {
 		r = new(big.Rat).SetInt64(int64(d.Months))
 	} else {
+		// d.Seconds is the total seconds INCLUDING any fractional part, while
+		// d.FracSec (when set) holds the exact fractional component in [0,1).
+		// Building the rational from d.Seconds and then adding d.FracSec would
+		// double-count the fraction. When FracSec is present, derive the
+		// whole-second count and add the exact fraction once.
+		secs := d.Seconds
+		if d.FracSec != nil {
+			// Recover the whole-second count by removing the (possibly rounded)
+			// fractional part from Seconds before truncation. Subtracting FracSec
+			// first prevents float64 rounding from inflating the integer portion
+			// for fractions extremely close to 1 (e.g. PT0.999...9S where Seconds
+			// rounds up to 1.0).
+			fracFloat, _ := d.FracSec.Float64()
+			secs = math.Trunc(d.Seconds - fracFloat + 0.5)
+		}
 		// Use big.Float → big.Rat to handle values exceeding int64 range
-		bf := new(big.Float).SetPrec(256).SetFloat64(d.Seconds)
+		bf := new(big.Float).SetPrec(256).SetFloat64(secs)
 		r, _ = bf.Rat(nil)
 		if d.FracSec != nil {
 			r.Add(r, d.FracSec)

--- a/xpath3/arithmetic_datetime_test.go
+++ b/xpath3/arithmetic_datetime_test.go
@@ -1,0 +1,75 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDurationFractionalSeconds guards against double-counting fractional
+// seconds when a dayTimeDuration carries an exact FracSec component alongside
+// the float64 Seconds total.
+func TestDurationFractionalSeconds(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	tests := []struct {
+		name string
+		expr string
+		want string
+	}{
+		{
+			name: "div fractional by whole",
+			expr: `xs:dayTimeDuration("PT1.5S") div xs:dayTimeDuration("PT1S")`,
+			want: "1.5",
+		},
+		{
+			name: "div fractional by fractional",
+			expr: `xs:dayTimeDuration("PT1.5S") div xs:dayTimeDuration("PT0.5S")`,
+			want: "3",
+		},
+		{
+			// Fraction so close to 1 that float64 Seconds rounds up to the next
+			// integer; the whole-second count must still be 0, not 1.
+			name: "div near-one fraction by whole",
+			expr: `xs:dayTimeDuration("PT0.999999999999999999999999999999S") div xs:dayTimeDuration("PT1S")`,
+			want: "0.999999999999999999999999999999",
+		},
+		{
+			name: "div equal fractional durations",
+			expr: `xs:dayTimeDuration("PT2.25S") div xs:dayTimeDuration("PT2.25S")`,
+			want: "1",
+		},
+		{
+			name: "add fractional durations",
+			expr: `xs:dayTimeDuration("PT1.5S") + xs:dayTimeDuration("PT1S")`,
+			want: "PT2.5S",
+		},
+		{
+			name: "subtract fractional durations",
+			expr: `xs:dayTimeDuration("PT2.5S") - xs:dayTimeDuration("PT1S")`,
+			want: "PT1.5S",
+		},
+		{
+			name: "multiply fractional duration",
+			expr: `xs:dayTimeDuration("PT1.5S") * 2`,
+			want: "PT3S",
+		},
+		{
+			name: "compare fractional durations equal",
+			expr: `xs:dayTimeDuration("PT1.5S") eq xs:dayTimeDuration("PT1.5S")`,
+			want: "true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seq := evalExpr(t, doc, tt.expr)
+			require.Equal(t, 1, seq.Len())
+			av := seq.Get(0).(xpath3.AtomicValue)
+			got, err := xpath3.AtomicToString(av)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
- durationToRat added FracSec on top of the full Seconds total, double-counting the fraction in dayTimeDuration div
- now uses the whole-second portion plus exact FracSec
- adds duration arithmetic tests covering div/add/subtract/multiply/compare with fractional seconds