### PR TITLE
preserve absolute uri base in c14n 1.1 fixup

### DIFF
--- a/c14n/c14n_test.go
+++ b/c14n/c14n_test.go
@@ -368,3 +368,54 @@ func TestEmptyNamespaceURIAccepted(t *testing.T) {
 	_, err = c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(doc)
 	require.NoError(t, err)
 }
+
+// collectDescendantElements returns the element nodes named `name` and all of
+// their descendant nodes within doc.
+func collectDescendantElements(t *testing.T, doc *helium.Document, name string) []helium.Node {
+	t.Helper()
+	var out []helium.Node
+	var walk func(n helium.Node, inside bool)
+	walk = func(n helium.Node, inside bool) {
+		include := inside
+		if elem, ok := helium.AsNode[*helium.Element](n); ok && elem.LocalName() == name {
+			include = true
+		}
+		if include {
+			out = append(out, n)
+		}
+		for child := range helium.Children(n) {
+			walk(child, include)
+		}
+	}
+	walk(doc, false)
+	return out
+}
+
+// TestC14N11HTTPBaseURIFixup verifies that when the configured base URI is an
+// absolute http(s) URI, C14N 1.1 xml:base fixup produces a proper relative URI
+// reference rather than a filesystem path. The root element carries xml:base
+// but is excluded from the node-set, so its base contribution must be folded
+// into the visible child's xml:base.
+func TestC14N11HTTPBaseURIFixup(t *testing.T) {
+	t.Parallel()
+	xml := `<?xml version="1.0"?><root xml:base="/c/"><child>text</child></root>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(xml))
+	require.NoError(t, err)
+
+	// Visible node-set: the child element subtree only (root excluded).
+	nodes := collectDescendantElements(t, doc, "child")
+
+	got, err := c14n.NewCanonicalizer(c14n.C14N11).
+		NodeSet(nodes).
+		BaseURI("http://example.com/a/b/doc.xml").
+		CanonicalizeTo(doc)
+	require.NoError(t, err)
+
+	// The base URI is an http URI; xml:base fixup must yield a URI reference,
+	// never a filesystem path derived from filepath.Abs.
+	require.NotContains(t, string(got), "file:", "http base URI must not be turned into a file path")
+	// root xml:base "/c/" resolved against http://example.com/a/b/doc.xml is
+	// http://example.com/c/; relative to the visible ancestor base
+	// http://example.com/a/b/doc.xml this is "../../c/".
+	require.Contains(t, string(got), `xml:base="../../c/"`, "expected URI-relative xml:base, got: %s", string(got))
+}

--- a/c14n/c14n_test.go
+++ b/c14n/c14n_test.go
@@ -419,3 +419,26 @@ func TestC14N11HTTPBaseURIFixup(t *testing.T) {
 	// http://example.com/a/b/doc.xml this is "../../c/".
 	require.Contains(t, string(got), `xml:base="../../c/"`, "expected URI-relative xml:base, got: %s", string(got))
 }
+
+// TestC14N11SchemeOnlyBaseURIFixup verifies the fix also covers absolute URIs
+// that carry a scheme but no // authority component (e.g. "mem:/a/b/doc.xml").
+// Such URIs must not be routed through filepath.Abs.
+func TestC14N11SchemeOnlyBaseURIFixup(t *testing.T) {
+	t.Parallel()
+	xml := `<?xml version="1.0"?><root xml:base="/c/"><child>text</child></root>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(xml))
+	require.NoError(t, err)
+
+	nodes := collectDescendantElements(t, doc, "child")
+
+	got, err := c14n.NewCanonicalizer(c14n.C14N11).
+		NodeSet(nodes).
+		BaseURI("mem:/a/b/doc.xml").
+		CanonicalizeTo(doc)
+	require.NoError(t, err)
+
+	require.NotContains(t, string(got), "file:", "scheme-only URI base must not become a file path")
+	// root xml:base "/c/" resolved against mem:/a/b/doc.xml is mem:/c/;
+	// relative to the ancestor base mem:/a/b/doc.xml this is "../../c/".
+	require.Contains(t, string(got), `xml:base="../../c/"`, "expected URI-relative xml:base, got: %s", string(got))
+}

--- a/c14n/canonicalizer.go
+++ b/c14n/canonicalizer.go
@@ -911,12 +911,23 @@ func (c *canonicalizer) effectiveBaseURI(e *helium.Element) string {
 	return base
 }
 
-// documentBaseURI returns the document's base URI as a file:// URL.
+// documentBaseURI returns the document's base URI suitable for RFC 3986
+// relative-reference resolution. If the configured base URI is already an
+// absolute URI (it has a scheme and authority, e.g. "http://example.com/..."),
+// it is preserved as-is so that xml:base fixup uses proper URI semantics. Only
+// plain filesystem paths are converted to a file:// URL.
 func (c *canonicalizer) documentBaseURI() string {
 	if c.baseURI == "" {
 		return ""
 	}
-	// Convert file path to URL for proper URI resolution
+	// An absolute URI with a scheme and authority must not be rewritten as a
+	// filesystem path. url.Parse treats a single-letter Windows drive prefix
+	// (e.g. "c:\dir") as a scheme, so require an authority component to
+	// distinguish genuine URIs from drive-letter paths.
+	if u, err := url.Parse(c.baseURI); err == nil && u.IsAbs() && (u.Host != "" || strings.HasPrefix(c.baseURI, u.Scheme+"://")) {
+		return c.baseURI
+	}
+	// Convert file path to URL for proper URI resolution.
 	absPath, err := filepath.Abs(c.baseURI)
 	if err != nil {
 		return c.baseURI

--- a/c14n/canonicalizer.go
+++ b/c14n/canonicalizer.go
@@ -920,11 +920,12 @@ func (c *canonicalizer) documentBaseURI() string {
 	if c.baseURI == "" {
 		return ""
 	}
-	// An absolute URI with a scheme and authority must not be rewritten as a
-	// filesystem path. url.Parse treats a single-letter Windows drive prefix
-	// (e.g. "c:\dir") as a scheme, so require an authority component to
-	// distinguish genuine URIs from drive-letter paths.
-	if u, err := url.Parse(c.baseURI); err == nil && u.IsAbs() && (u.Host != "" || strings.HasPrefix(c.baseURI, u.Scheme+"://")) {
+	// An absolute URI (one with a scheme, e.g. "http://example.com/...",
+	// "file:/tmp/doc.xml", or "urn:...") must not be rewritten as a filesystem
+	// path. url.Parse treats a single-letter Windows drive prefix (e.g.
+	// "c:\dir") as a scheme, so exclude single-letter schemes to keep treating
+	// drive-letter paths as filesystem paths.
+	if u, err := url.Parse(c.baseURI); err == nil && u.IsAbs() && len(u.Scheme) > 1 {
 		return c.baseURI
 	}
 	// Convert file path to URL for proper URI resolution.


### PR DESCRIPTION
- documentBaseURI no longer runs http(s)/other absolute-scheme base URIs through filepath.Abs, which produced fake file paths and bogus filesystem-relative xml:base values
- only plain filesystem paths are converted to file:// URLs; absolute URIs are preserved for proper RFC 3986 relative-reference resolution