### PR TITLE
process apply-templates selection in order

### DIFF
--- a/xslt3/apply_templates_order_test.go
+++ b/xslt3/apply_templates_order_test.go
@@ -41,3 +41,111 @@ func TestApplyTemplatesMixedSelectionOrder(t *testing.T) {
 	// all nodes first, producing [node:B][str:a][str:c].
 	require.Contains(t, out, `[str:a][node:B][str:c]`)
 }
+
+// TestApplyTemplatesMixedSortPosition verifies that within an xsl:sort over a
+// mixed atomic+node selection, position()/last() in the sort key reflect the
+// full mixed sequence (size = number of selected items, position = 1-based
+// index in the unsorted sequence) rather than a stale size of 1.
+func TestApplyTemplatesMixedSortPosition(t *testing.T) {
+	ctx := t.Context()
+
+	// Selection is ('x', /root/a, 'y'), three items. Sort key = position()
+	// in descending order, so the processing order must be reversed:
+	// 'y' (pos 3), /root/a (pos 2), 'x' (pos 1).
+	xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out><xsl:apply-templates select="('x', /root/a, 'y')">
+      <xsl:sort select="position()" data-type="number" order="descending"/>
+    </xsl:apply-templates></out>
+  </xsl:template>
+  <xsl:template match=".[. instance of xs:string]">[str:<xsl:value-of select="."/>]</xsl:template>
+  <xsl:template match="a">[node:<xsl:value-of select="."/>]</xsl:template>
+</xsl:stylesheet>`
+
+	doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+	require.NoError(t, err)
+	ss, err := xslt3.CompileStylesheet(ctx, doc)
+	require.NoError(t, err)
+
+	src, err := helium.NewParser().Parse(ctx, []byte(`<root><a>A</a></root>`))
+	require.NoError(t, err)
+
+	out, err := ss.Transform(src).Serialize(ctx)
+	require.NoError(t, err)
+
+	require.Contains(t, out, `[str:y][node:A][str:x]`)
+}
+
+// TestApplyTemplatesMixedSortLast verifies that last() in the sort key over a
+// mixed atomic+node selection reports the full mixed sequence size.
+func TestApplyTemplatesMixedSortLast(t *testing.T) {
+	ctx := t.Context()
+
+	// last() must be 3 for every item. Sort key = (last() - position()) so the
+	// order is reversed: 'y' (3-3=0), /root/a (3-2=1), 'x' (3-1=2) ascending.
+	xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out><xsl:apply-templates select="('x', /root/a, 'y')">
+      <xsl:sort select="last() - position()" data-type="number"/>
+    </xsl:apply-templates></out>
+  </xsl:template>
+  <xsl:template match=".[. instance of xs:string]">[str:<xsl:value-of select="."/>]</xsl:template>
+  <xsl:template match="a">[node:<xsl:value-of select="."/>]</xsl:template>
+</xsl:stylesheet>`
+
+	doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+	require.NoError(t, err)
+	ss, err := xslt3.CompileStylesheet(ctx, doc)
+	require.NoError(t, err)
+
+	src, err := helium.NewParser().Parse(ctx, []byte(`<root><a>A</a></root>`))
+	require.NoError(t, err)
+
+	out, err := ss.Transform(src).Serialize(ctx)
+	require.NoError(t, err)
+
+	require.Contains(t, out, `[str:y][node:A][str:x]`)
+}
+
+// TestApplyTemplatesMixedSortCurrent verifies that current() in the sort key
+// resolves to the node being sorted for NODE items in a mixed selection, while
+// non-node items still atomize via the context item.
+func TestApplyTemplatesMixedSortCurrent(t *testing.T) {
+	ctx := t.Context()
+
+	// Selection mixes nodes and a string. Sort by current() string value so
+	// node items sort by their own value via current(). Nodes a/b/c have
+	// values "3","1","2"; string "0" sorts first. Expected ascending order:
+	// '0', b(1), c(2), a(3).
+	xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out><xsl:apply-templates select="(/root/a, '0', /root/b, /root/c)">
+      <xsl:sort select="current()" data-type="number"/>
+    </xsl:apply-templates></out>
+  </xsl:template>
+  <xsl:template match=".[. instance of xs:string]">[str:<xsl:value-of select="."/>]</xsl:template>
+  <xsl:template match="*">[node:<xsl:value-of select="."/>]</xsl:template>
+</xsl:stylesheet>`
+
+	doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+	require.NoError(t, err)
+	ss, err := xslt3.CompileStylesheet(ctx, doc)
+	require.NoError(t, err)
+
+	src, err := helium.NewParser().Parse(ctx, []byte(`<root><a>3</a><b>1</b><c>2</c></root>`))
+	require.NoError(t, err)
+
+	out, err := ss.Transform(src).Serialize(ctx)
+	require.NoError(t, err)
+
+	require.Contains(t, out, `[str:0][node:1][node:2][node:3]`)
+}

--- a/xslt3/apply_templates_order_test.go
+++ b/xslt3/apply_templates_order_test.go
@@ -1,0 +1,43 @@
+package xslt3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xslt3"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyTemplatesMixedSelectionOrder verifies that xsl:apply-templates
+// processes a mixed sequence of atomic values and nodes in sequence order,
+// not by processing all nodes before all atomic values. Per XSLT 3.0, the
+// selected sequence is processed in order.
+func TestApplyTemplatesMixedSelectionOrder(t *testing.T) {
+	ctx := t.Context()
+
+	xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out><xsl:apply-templates select="('a', /root/b, 'c')"/></out>
+  </xsl:template>
+  <xsl:template match=".[. instance of xs:string]">[str:<xsl:value-of select="."/>]</xsl:template>
+  <xsl:template match="b">[node:<xsl:value-of select="."/>]</xsl:template>
+</xsl:stylesheet>`
+
+	doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+	require.NoError(t, err)
+	ss, err := xslt3.CompileStylesheet(ctx, doc)
+	require.NoError(t, err)
+
+	src, err := helium.NewParser().Parse(ctx, []byte(`<root><b>B</b></root>`))
+	require.NoError(t, err)
+
+	out, err := ss.Transform(src).Serialize(ctx)
+	require.NoError(t, err)
+
+	// Sequence order is: 'a', /root/b, 'c'. The buggy implementation emits
+	// all nodes first, producing [node:B][str:a][str:c].
+	require.Contains(t, out, `[str:a][node:B][str:c]`)
+}

--- a/xslt3/execute_apply.go
+++ b/xslt3/execute_apply.go
@@ -12,9 +12,11 @@ import (
 )
 
 func (ec *execContext) execApplyTemplates(ctx context.Context, inst *applyTemplatesInst) error {
-	var nodes []helium.Node
-
-	var atomicItems xpath3.ItemSlice // XSLT 3.0: atomic values from select
+	// XSLT 3.0 processes the selected sequence in SEQUENCE ORDER. Keep a
+	// single ordered item list so mixed sequences of nodes and atomic values
+	// (e.g. select="('a', /root/b)") are dispatched in the order they appear,
+	// rather than processing all nodes before all atomic values.
+	var items xpath3.ItemSlice
 	if inst.Select != nil {
 		result, err := ec.evalXPath(ctx, inst.Select, ec.contextNode)
 		if err != nil {
@@ -24,35 +26,47 @@ func (ec *execContext) execApplyTemplates(ctx context.Context, inst *applyTempla
 		// items in apply-templates, matched via pattern rules (e.g.,
 		// match=".[. instance of array(*)]"). Flattening would destroy the
 		// array before template matching can see it.
-		seq := result.Sequence()
-		ns, ok := xpath3.NodesFrom(seq)
-		if ok {
-			nodes = ns
-		} else {
-			// XSLT 3.0: separate nodes from atomic values
-			for item := range sequence.Items(seq) {
-				if ni, ok := item.(xpath3.NodeItem); ok {
-					nodes = append(nodes, ni.Node)
-				} else {
-					atomicItems = append(atomicItems, item)
-				}
-			}
-		}
+		items = xpath3.ItemSlice(sequence.Materialize(result.Sequence()))
 	} else {
 		// Default select is child::node() which requires a node context item.
 		// If the context item is an atomic value (contextNode is nil), raise XTTE0510.
 		if normalizeNode(ec.contextNode) == nil {
 			return dynamicError(errCodeXTTE0510, "apply-templates with default select requires a node context item")
 		}
-		nodes = selectDefaultNodes(ec.contextNode)
+		for _, node := range selectDefaultNodes(ec.contextNode) {
+			items = append(items, xpath3.NodeItem{Node: node})
+		}
 	}
 
-	// Apply sort keys if present
+	// Apply sort keys if present. Sorting reorders the whole selected
+	// sequence per spec. When every selected item is a node, use the
+	// node-only sort path so current() inside the sort key expression
+	// resolves to each sorted node (XSLT 13.1.4); sortItems does not set
+	// currentNode. For mixed/atomic sequences fall back to sortItems, which
+	// handles both node and atomic items.
 	if len(inst.Sort) > 0 {
-		var err error
-		nodes, err = sortNodes(ctx, ec, nodes, inst.Sort)
-		if err != nil {
-			return err
+		if nodes, allNodes := xpath3.NodesFrom(items); allNodes {
+			sorted, err := sortNodes(ctx, ec, nodes, inst.Sort)
+			if err != nil {
+				return err
+			}
+			items = items[:0]
+			for _, node := range sorted {
+				items = append(items, xpath3.NodeItem{Node: node})
+			}
+		} else {
+			// Validate sort key attributes even when the selection is empty
+			// (XTDE0030); sortNodes does this internally, sortItems does not.
+			for _, sk := range inst.Sort {
+				if err := validateSortKeyAttrs(ctx, ec, sk); err != nil {
+					return err
+				}
+			}
+			sorted, err := sortItems(ctx, ec, items, inst.Sort)
+			if err != nil {
+				return err
+			}
+			items = xpath3.ItemSlice(sequence.Materialize(sorted))
 		}
 	}
 
@@ -100,13 +114,14 @@ func (ec *execContext) execApplyTemplates(ctx context.Context, inst *applyTempla
 
 	// Filter whitespace-only text nodes per xsl:strip-space before
 	// setting position/size, so position()/last() reflect the filtered list.
-	filtered := nodes[:0]
-	for _, node := range nodes {
-		if !ec.shouldStripWhitespace(node) {
-			filtered = append(filtered, node)
+	filtered := items[:0]
+	for _, item := range items {
+		if ni, ok := item.(xpath3.NodeItem); ok && ec.shouldStripWhitespace(ni.Node) {
+			continue
 		}
+		filtered = append(filtered, item)
 	}
-	nodes = filtered
+	items = filtered
 
 	savedPos := ec.position
 	savedSize := ec.size
@@ -115,7 +130,7 @@ func (ec *execContext) execApplyTemplates(ctx context.Context, inst *applyTempla
 	savedInGroupCtx := ec.inGroupContext
 	savedGroupHasKey := ec.groupHasKey
 	savedInMerge := ec.inMergeAction
-	ec.size = len(nodes)
+	ec.size = len(items)
 	// Per XSLT 3.0: current-grouping-key() and current-group() are only
 	// available in the body of xsl:for-each-group itself, not in templates
 	// invoked by apply-templates within that body.
@@ -135,89 +150,81 @@ func (ec *execContext) execApplyTemplates(ctx context.Context, inst *applyTempla
 		ec.inMergeAction = savedInMerge
 	}()
 
-	for i, node := range nodes {
+	// Dispatch each selected item in sequence order. Node items go through
+	// template matching for nodes; atomic values, arrays, and maps use the
+	// XSLT 3.0 atomic dispatch rules.
+	for i, item := range items {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		ec.position = i + 1
 
-		if err := ec.applyTemplates(ctx, node, mode, paramValues); err != nil {
-			return err
-		}
-	}
-
-	// XSLT 3.0: sort atomic items if sort keys are present.
-	if len(inst.Sort) > 0 && len(atomicItems) > 0 {
-		sorted, err := sortItems(ctx, ec, atomicItems, inst.Sort)
-		if err != nil {
-			return err
-		}
-		atomicItems = xpath3.ItemSlice(sequence.Materialize(sorted))
-	}
-
-	// XSLT 3.0: process atomic values — try template matching first,
-	// then fall back to built-in text output.
-	// Set position/size so position()/last() work correctly inside templates.
-	ec.size = len(atomicItems)
-	for i, item := range atomicItems {
-		ec.position = i + 1
-		tmpl, err := ec.findAtomicTemplate(ctx, item, mode)
-		if err != nil {
-			return err
-		}
-		if tmpl != nil {
-			if err := ec.executeAtomicTemplate(ctx, tmpl, item, mode); err != nil {
+		if ni, ok := item.(xpath3.NodeItem); ok {
+			if err := ec.applyTemplates(ctx, ni.Node, mode, paramValues); err != nil {
 				return err
 			}
 			continue
 		}
-		// Built-in template rule for arrays: apply-templates to each member.
-		if arr, ok := item.(xpath3.ArrayItem); ok {
-			for j := 1; j <= arr.Size(); j++ {
-				member, err := arr.Get(j)
-				if err != nil {
-					return err
-				}
-				if err := ec.applyTemplatesToSequence(ctx, member, inst, mode); err != nil {
-					return err
-				}
-			}
-			continue
-		}
-		// Built-in template rule for maps: apply-templates to each value.
-		if m, ok := item.(xpath3.MapItem); ok {
-			if err := m.ForEach(func(_ xpath3.AtomicValue, val xpath3.Sequence) error {
-				return ec.applyTemplatesToSequence(ctx, val, inst, mode)
-			}); err != nil {
-				return err
-			}
-			continue
-		}
-		// Check mode's on-no-match: for "deep-skip" and "shallow-skip",
-		// unmatched atomic items are silently skipped.
-		modeKey := mode
-		if modeKey == "" || modeKey == modeUnnamed {
-			modeKey = modeDefault
-		}
-		modeDef := ec.effectiveModeDefs()[modeKey]
-		if modeDef != nil && (modeDef.OnNoMatch == onNoMatchDeepSkip || modeDef.OnNoMatch == onNoMatchShallowSkip) {
-			continue
-		}
-		av, err := xpath3.AtomizeItem(item)
-		if err != nil {
-			return err
-		}
-		s, err := xpath3.AtomicToString(av)
-		if err != nil {
-			return err
-		}
-		text := ec.resultDoc.CreateText([]byte(s))
-		if err := ec.addNode(text); err != nil {
+
+		if err := ec.dispatchApplyTemplatesItem(ctx, item, inst, mode); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// dispatchApplyTemplatesItem applies templates to a single non-node item
+// (atomic value, array, or map) per the XSLT 3.0 rules: try template matching
+// first, then the built-in rules for arrays/maps, then fall back to built-in
+// text output unless the mode's on-no-match skips unmatched atomic items.
+func (ec *execContext) dispatchApplyTemplatesItem(ctx context.Context, item xpath3.Item, inst *applyTemplatesInst, mode string) error {
+	tmpl, err := ec.findAtomicTemplate(ctx, item, mode)
+	if err != nil {
+		return err
+	}
+	if tmpl != nil {
+		return ec.executeAtomicTemplate(ctx, tmpl, item, mode)
+	}
+	// Built-in template rule for arrays: apply-templates to each member.
+	if arr, ok := item.(xpath3.ArrayItem); ok {
+		for j := 1; j <= arr.Size(); j++ {
+			member, err := arr.Get(j)
+			if err != nil {
+				return err
+			}
+			if err := ec.applyTemplatesToSequence(ctx, member, inst, mode); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	// Built-in template rule for maps: apply-templates to each value.
+	if m, ok := item.(xpath3.MapItem); ok {
+		return m.ForEach(func(_ xpath3.AtomicValue, val xpath3.Sequence) error {
+			return ec.applyTemplatesToSequence(ctx, val, inst, mode)
+		})
+	}
+	// Check mode's on-no-match: for "deep-skip" and "shallow-skip",
+	// unmatched atomic items are silently skipped.
+	modeKey := mode
+	if modeKey == "" || modeKey == modeUnnamed {
+		modeKey = modeDefault
+	}
+	modeDef := ec.effectiveModeDefs()[modeKey]
+	if modeDef != nil && (modeDef.OnNoMatch == onNoMatchDeepSkip || modeDef.OnNoMatch == onNoMatchShallowSkip) {
+		return nil
+	}
+	av, err := xpath3.AtomizeItem(item)
+	if err != nil {
+		return err
+	}
+	s, err := xpath3.AtomicToString(av)
+	if err != nil {
+		return err
+	}
+	text := ec.resultDoc.CreateText([]byte(s))
+	return ec.addNode(text)
 }
 
 // applyTemplatesToSequence applies templates to each item in a sequence,

--- a/xslt3/sort.go
+++ b/xslt3/sort.go
@@ -804,18 +804,32 @@ func sortItems1(ctx context.Context, ec *execContext, items xpath3.Sequence, sk 
 	}
 
 	evalState := ec.sortXPathEvalState(ctx)
+	// Set size/position/current() context for the FULL mixed sequence so
+	// sort keys referencing position()/last()/current() compute correctly
+	// (XSLT spec 13.1.4). Mirror the node-only path (sortNodes1).
+	evalState.SetSize(sequence.Len(items))
 	entries := make([]keyed1[xpath3.Item], sequence.Len(items))
 
 	savedItem := ec.contextItem
-	defer func() { ec.contextItem = savedItem }()
+	savedCurrent := ec.currentNode
+	defer func() {
+		ec.contextItem = savedItem
+		ec.currentNode = savedCurrent
+	}()
 
 	for i := range sequence.Len(items) {
+		evalState.SetPosition(i + 1)
 		item := items.Get(i)
 		ec.contextItem = item
 		var node helium.Node
 		if ni, ok := item.(xpath3.NodeItem); ok {
 			node = ni.Node
 			ec.contextItem = nil
+			// current() resolves via ec.currentNode for node items.
+			ec.currentNode = node
+		} else {
+			// current() resolves via ec.contextItem for non-node items.
+			ec.currentNode = nil
 		}
 		sv, err := evaluateSortKey(ctx, ec, sk, node, &dtMode, evalState)
 		if err != nil {
@@ -897,18 +911,32 @@ func sortItemsN(ctx context.Context, ec *execContext, items xpath3.Sequence, sor
 	}
 
 	evalState := ec.sortXPathEvalState(ctx)
+	// Set size/position/current() context for the FULL mixed sequence so
+	// sort keys referencing position()/last()/current() compute correctly
+	// (XSLT spec 13.1.4). Mirror the node-only path (sortNodesN).
+	evalState.SetSize(sequence.Len(items))
 	entries := make(keyedSlice[xpath3.Item], sequence.Len(items))
 
 	savedItem := ec.contextItem
-	defer func() { ec.contextItem = savedItem }()
+	savedCurrent := ec.currentNode
+	defer func() {
+		ec.contextItem = savedItem
+		ec.currentNode = savedCurrent
+	}()
 
 	for i := range sequence.Len(items) {
+		evalState.SetPosition(i + 1)
 		item := items.Get(i)
 		ec.contextItem = item
 		var node helium.Node
 		if ni, ok := item.(xpath3.NodeItem); ok {
 			node = ni.Node
 			ec.contextItem = nil
+			// current() resolves via ec.currentNode for node items.
+			ec.currentNode = node
+		} else {
+			// current() resolves via ec.contextItem for non-node items.
+			ec.currentNode = nil
 		}
 		keys, err := extractSortValues(ctx, ec, sortKeys, node, dtModes, evalState)
 		if err != nil {


### PR DESCRIPTION
- xsl:apply-templates now dispatches the selected sequence in document/sequence order instead of processing all nodes before all atomic values
- node-only selections keep the existing sortNodes path so current() resolves inside xsl:sort; mixed/atomic selections use sortItems