### PR TITLE
guard nil context node in absolute paths

### DIFF
--- a/xpath1/eval.go
+++ b/xpath1/eval.go
@@ -166,6 +166,12 @@ func evalLocationPath(ctx context.Context, ec *evalContext, lp *LocationPath) (*
 	var nodes []helium.Node
 
 	if lp.Absolute {
+		// DocumentRoot dereferences the context node; guard against a
+		// nil/typed-nil context so a missing context node yields an
+		// evaluation error instead of a panic.
+		if ixpath.IsNilNode(ec.node) {
+			return nil, ErrNoContextNode
+		}
 		root := ixpath.DocumentRoot(ec.node)
 		nodes = []helium.Node{root}
 	} else {

--- a/xpath1/eval_test.go
+++ b/xpath1/eval_test.go
@@ -44,6 +44,15 @@ func TestEvalRootPath(t *testing.T) {
 	require.Equal(t, helium.DocumentNode, r.NodeSet[0].Type())
 }
 
+func TestEvalAbsolutePathNilContextNode(t *testing.T) {
+	expr, err := xpath1.Compile("/")
+	require.NoError(t, err)
+	// A nil context node must produce an evaluation error, not a panic.
+	_, err = expr.Evaluate(t.Context(), nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, xpath1.ErrNoContextNode)
+}
+
 func TestEvalAbsoluteChild(t *testing.T) {
 	doc := parseXML(t, `<root><a/><b/></root>`)
 	r, err := xpath1.Evaluate(t.Context(), doc, "/root/a")

--- a/xpath1/xpath.go
+++ b/xpath1/xpath.go
@@ -59,6 +59,10 @@ var ErrPathNotNodeSet = errors.New("xpath: path expression requires a node-set")
 // ErrInvalidFunctionContext is returned when a function receives an unexpected context type.
 var ErrInvalidFunctionContext = errors.New("xpath: invalid function context type")
 
+// ErrNoContextNode is returned when an expression that requires a context node
+// (such as an absolute location path) is evaluated with a nil context node.
+var ErrNoContextNode = errors.New("xpath: no context node")
+
 // ErrExprTooDeep is returned when expression nesting exceeds the maximum parse depth.
 var ErrExprTooDeep = errors.New("xpath: expression nesting too deep")
 


### PR DESCRIPTION
- xpath1 absolute location paths now return `ErrNoContextNode` instead of panicking when the context node is nil/typed-nil
- guards `DocumentRoot(ec.node)` via existing `ixpath.IsNilNode` helper