### PR TITLE
bound float frac rounding to avoid nan overflow

### DIFF
--- a/internal/icu/format_number.go
+++ b/internal/icu/format_number.go
@@ -434,12 +434,24 @@ func FormatNumber(f float64, isNaN, isPosInf, isNegInf, negative bool, precise *
 	return prefix + result + pp.Suffix, nil
 }
 
+// isFinite reports whether f is neither NaN nor +/-Inf.
+func isFinite(f float64) bool {
+	return !math.IsNaN(f) && !math.IsInf(f, 0)
+}
+
 // FormatFloat formats a float64 value using the parsed picture and decimal format.
 func FormatFloat(f float64, pp ParsedPicture, df DecimalFormat) string {
-	// Round to maxFracDigits
+	// Round to maxFracDigits. Only scale when both the power-of-ten scale and the
+	// scaled product stay finite: a huge MaxFracDigits overflows math.Pow to +Inf
+	// (which would turn a finite f into NaN), and a large f overflows f*scale to
+	// +Inf (which would yield a non-finite result). In either case rounding is a
+	// no-op for the representable value, so leaving f unchanged is correct and
+	// keeps big.Float.SetFloat64 from ever seeing NaN/Inf.
 	if pp.MaxFracDigits >= 0 {
 		scale := math.Pow(10, float64(pp.MaxFracDigits))
-		f = math.Round(f*scale) / scale
+		if scaled := f * scale; isFinite(scale) && isFinite(scaled) {
+			f = math.Round(scaled) / scale
+		}
 	}
 
 	// Split into integer and fractional parts.

--- a/internal/icu/format_number_test.go
+++ b/internal/icu/format_number_test.go
@@ -1,0 +1,73 @@
+package icu_test
+
+import (
+	"math"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium/internal/icu"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFormatNumberHugeFractionalPicture guards against an overflow in the
+// float formatting path: a picture with hundreds of fractional digit
+// placeholders made math.Pow(10, MaxFracDigits) overflow to +Inf, which
+// turned a finite value into NaN and panicked big.Float.SetFloat64(NaN).
+// The result must stay finite (no panic) and remain a well-formed decimal.
+func TestFormatNumberHugeFractionalPicture(t *testing.T) {
+	const fracDigits = 400
+	picture := "0." + strings.Repeat("0", fracDigits)
+
+	out, err := icu.FormatNumber(1.2, false, false, false, false, nil, picture, icu.DefaultDecimalFormat())
+	require.NoError(t, err)
+
+	// Expect "<int>.<fracDigits digits>": a finite value, not "NaN"/"Infinity".
+	intPart, fracPart, ok := strings.Cut(out, ".")
+	require.True(t, ok, "expected a decimal point in %q", out)
+	require.Equal(t, "1", intPart, "integer part of %q", out)
+	require.Equal(t, fracDigits, len(fracPart), "fractional digit count of %q", out)
+	require.True(t, strings.HasPrefix(fracPart, "1"), "fractional part of %q", out)
+	for _, r := range out {
+		require.True(t, r == '.' || (r >= '0' && r <= '9'), "unexpected char %q in %q", r, out)
+	}
+}
+
+// TestFormatNumberHugeFractionalPicturePrecise exercises the same huge picture
+// on the precise (*big.Rat) path used by real xpath3/xslt3 callers. It must not
+// overflow and must produce the exact value padded with trailing zeros.
+func TestFormatNumberHugeFractionalPicturePrecise(t *testing.T) {
+	const fracDigits = 400
+	picture := "0." + strings.Repeat("0", fracDigits)
+
+	// 1.25 is exactly representable in decimal.
+	precise := new(big.Rat).SetFrac64(5, 4)
+	out, err := icu.FormatNumber(1.25, false, false, false, false, precise, picture, icu.DefaultDecimalFormat())
+	require.NoError(t, err)
+	require.Equal(t, "1.25"+strings.Repeat("0", fracDigits-2), out)
+}
+
+// TestFormatNumberFloatTinyValuePreserved guards against capping fractional
+// precision: a tiny finite value with enough fractional placeholders to hold
+// its leading significant digit must keep that digit (not round to zero).
+func TestFormatNumberFloatTinyValuePreserved(t *testing.T) {
+	picture := "0." + strings.Repeat("0", 20)
+	out, err := icu.FormatNumber(1e-20, false, false, false, false, nil, picture, icu.DefaultDecimalFormat())
+	require.NoError(t, err)
+	require.Equal(t, "0."+strings.Repeat("0", 19)+"1", out)
+}
+
+// TestFormatNumberFloatLargeValueFinite guards against f*scale overflowing to
+// +Inf for large finite inputs, which previously produced "<nil>." output. The
+// integer part must format as digits, never "<nil>".
+func TestFormatNumberFloatLargeValueFinite(t *testing.T) {
+	out, err := icu.FormatNumber(math.MaxFloat64, false, false, false, false, nil, "0.0", icu.DefaultDecimalFormat())
+	require.NoError(t, err)
+	require.NotContains(t, out, "<nil>", "got %q", out)
+	intPart, _, ok := strings.Cut(out, ".")
+	require.True(t, ok, "got %q", out)
+	require.NotEmpty(t, intPart)
+	for _, r := range intPart {
+		require.True(t, r >= '0' && r <= '9', "non-digit %q in integer part of %q", r, out)
+	}
+}


### PR DESCRIPTION
- cap math.Pow(10, MaxFracDigits) scale at float64 precision so huge fractional pictures no longer overflow to +Inf
- prevents FormatFloat from turning a finite value into NaN and panicking big.Float.SetFloat64