### PR TITLE
clear node context for atomic xsl:iterate items

### DIFF
--- a/xslt3/execute_streaming.go
+++ b/xslt3/execute_streaming.go
@@ -225,6 +225,8 @@ func (ec *execContext) execIterate(ctx context.Context, inst *iterateInst) error
 			ec.contextItem = nil
 		} else {
 			ec.contextItem = item
+			ec.contextNode = nil
+			ec.currentNode = nil
 		}
 
 		// Push var scope and set iterate param values.

--- a/xslt3/transform_test.go
+++ b/xslt3/transform_test.go
@@ -153,3 +153,26 @@ func TestAnnotateAttrRegistersIDSubtype(t *testing.T) {
 	require.Contains(t, result, "<found>true</found>")
 	require.Contains(t, result, "<name>root</name>")
 }
+
+// TestIterateAtomicClearsNodeContext verifies that xsl:iterate over a
+// sequence of atomic items sets the context item without leaving a stale
+// node context. xsl:copy inside the body must copy the current atomic item
+// as text, not the previous source node.
+func TestIterateAtomicClearsNodeContext(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <out><xsl:iterate select="'x'"><xsl:copy/></xsl:iterate></out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	source, err := helium.NewParser().Parse(t.Context(), []byte(`<doc/>`))
+	require.NoError(t, err)
+
+	result, err := xslt3.TransformString(t.Context(), source, ss)
+	require.NoError(t, err)
+
+	require.Contains(t, result, "<out>x</out>")
+	require.NotContains(t, result, "<doc/>")
+}


### PR DESCRIPTION
- xsl:iterate atomic branch now clears contextNode/currentNode, mirroring xsl:for-each
- fixes xsl:copy (and other node-context instructions) operating on the stale source node instead of the current atomic item