### PR TITLE
fail lint when xinclude processing errors

### DIFF
--- a/internal/cli/heliumcmd/lint.go
+++ b/internal/cli/heliumcmd/lint.go
@@ -429,6 +429,7 @@ func (c *command) processInput(ctx context.Context, cfg *config, input namedInpu
 		}
 		if xiErr != nil {
 			_, _ = fmt.Fprintf(c.stderr, "%s\n", xiErr)
+			return ExitErr
 		}
 	}
 

--- a/internal/cli/heliumcmd/lint_test.go
+++ b/internal/cli/heliumcmd/lint_test.go
@@ -414,6 +414,19 @@ func TestXIncludeTextInclusion(t *testing.T) {
 	require.Contains(t, out, "Hello, World!")
 }
 
+func TestXIncludeMissingTargetExitCode(t *testing.T) {
+	dir := t.TempDir()
+	mainXML := `<?xml version="1.0"?>
+<book xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:include href="missing.xml"/>
+</book>`
+	f := writeFile(t, dir, "main.xml", mainXML)
+
+	_, errOut, code := executeLintFile(t, f, "--xinclude", "--noout")
+	require.NotEqual(t, heliumcmd.ExitOK, code, "failed XInclude should yield non-zero exit code")
+	require.NotEmpty(t, errOut, "XInclude error should be reported on stderr")
+}
+
 func TestSchemaValidation(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
- `helium lint --xinclude` now returns ExitErr when XInclude processing fails instead of exiting 0
- previously a failed/missing include was printed but the command still succeeded, especially with --noout