### PR TITLE
include namespace nodes in signed subtree c14n

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -16,7 +16,7 @@ relaxng        → helium
 schematron     → helium, xpath1
 xpointer       → helium, xpath1
 c14n           → helium
-xmldsig1       → helium, c14n
+xmldsig1       → helium, c14n, internal/lexicon
 xmlenc1        → helium
 html           → helium, sax, push
 catalog        → helium, internal/catalog, internal/lexicon
@@ -47,7 +47,7 @@ helium (root) → sax, enum, internal/*
 c14n, xpath1, xpath3, html, catalog, relaxng, stream, xmlenc1
 
 ## Security layer (depends on processing)
-xmldsig1 (root + c14n)
+xmldsig1 (root + c14n + internal/lexicon)
 
 ## Composition layer (depends on processing)
 xsd (root + xpath1 + internal/lexicon), xpointer (root + xpath1), schematron (root + xpath1), xinclude (root + xpointer), xslt3 (root + xpath3 + xsd + html + internal/elements), shim (root + stream)

--- a/xmldsig1/subtree_c14n_ns_internal_test.go
+++ b/xmldsig1/subtree_c14n_ns_internal_test.go
@@ -1,0 +1,50 @@
+package xmldsig1
+
+import (
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCanonicalizeSubtreeKeepsNamespaceDecls is the load-bearing regression
+// guard. A namespace-qualified signed subtree must canonicalize WITH its
+// in-scope xmlns declarations. c14n node-set mode only emits namespaces that
+// are explicitly present in the node set, so collectSubtreeNodes must include
+// the in-scope namespace axis for every element. Without it the prefixed
+// element names are emitted WITHOUT their xmlns:p declaration, producing
+// non-W3C canonical bytes that break cross-implementation signature interop.
+func TestCanonicalizeSubtreeKeepsNamespaceDecls(t *testing.T) {
+	const xml = `<doc xmlns:p="urn:p"><p:target Id="x"><p:child>v</p:child></p:target></doc>`
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(xml))
+	require.NoError(t, err)
+
+	target, err := resolveReference(doc, "#x")
+	require.NoError(t, err)
+
+	t.Run("inclusive C14N 1.0", func(t *testing.T) {
+		out, err := canonicalizeSubtree(C14N10, target, nil)
+		require.NoError(t, err)
+		require.Contains(t, string(out), `xmlns:p="urn:p"`,
+			"canonical subtree must carry the in-scope xmlns:p declaration")
+		// The prefixed element name and its namespace decl must coexist.
+		require.True(t, strings.HasPrefix(string(out), `<p:target xmlns:p="urn:p"`),
+			"got: %s", out)
+	})
+
+	t.Run("exclusive C14N 1.0", func(t *testing.T) {
+		out, err := canonicalizeSubtree(ExcC14N10, target, nil)
+		require.NoError(t, err)
+		require.Contains(t, string(out), `xmlns:p="urn:p"`,
+			"exclusive canonical subtree must carry the visibly-utilized xmlns:p declaration")
+	})
+
+	t.Run("C14N 1.1", func(t *testing.T) {
+		out, err := canonicalizeSubtree(C14N11URI, target, nil)
+		require.NoError(t, err)
+		require.Contains(t, string(out), `xmlns:p="urn:p"`,
+			"C14N 1.1 canonical subtree must carry the in-scope xmlns:p declaration")
+	})
+}

--- a/xmldsig1/subtree_c14n_ns_test.go
+++ b/xmldsig1/subtree_c14n_ns_test.go
@@ -1,0 +1,65 @@
+package xmldsig1_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xmldsig1"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSignVerifyNamespacedSubtree exercises a fragment reference into a
+// namespace-qualified subtree. The canonicalized subtree must retain its
+// xmlns declarations so the digest matches a W3C-conformant canonicalization.
+func TestSignVerifyNamespacedSubtree(t *testing.T) {
+	const xml = `<doc xmlns:p="urn:p"><p:target Id="x"><p:child>v</p:child></p:target></doc>`
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, xml)
+
+	ref := xmldsig1.ReferenceConfig{
+		URI:             "#x",
+		DigestAlgorithm: xmldsig1.DigestSHA256,
+		Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+	}
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(ref)
+
+	sigElem, err := signer.SignDetached(t.Context(), doc, key)
+	require.NoError(t, err)
+	require.NotNil(t, sigElem)
+
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+}
+
+// TestSignVerifyNamespacedSubtreeInclusiveC14N covers the inclusive C14N 1.0
+// path for a namespaced subtree.
+func TestSignVerifyNamespacedSubtreeInclusiveC14N(t *testing.T) {
+	const xml = `<doc xmlns:p="urn:p"><p:target Id="x"><p:child>v</p:child></p:target></doc>`
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, xml)
+
+	ref := xmldsig1.ReferenceConfig{
+		URI:             "#x",
+		DigestAlgorithm: xmldsig1.DigestSHA256,
+		Transforms:      []xmldsig1.Transform{xmldsig1.C14NTransform(xmldsig1.C14N10)},
+	}
+
+	signer := xmldsig1.NewSigner().
+		CanonicalizationMethod(xmldsig1.C14N10).
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(ref)
+
+	sigElem, err := signer.SignDetached(t.Context(), doc, key)
+	require.NoError(t, err)
+
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+}

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -2,10 +2,12 @@ package xmldsig1
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/lestrrat-go/helium/c14n"
 	"github.com/lestrrat-go/helium/enum"
+	"github.com/lestrrat-go/helium/internal/lexicon"
 
 	helium "github.com/lestrrat-go/helium"
 )
@@ -108,14 +110,24 @@ func resolveC14NMode(method string) (c14n.Mode, bool, error) {
 
 // collectSubtreeNodes returns all nodes in the subtree rooted at n
 // (including n itself) in document order.
+//
+// For each element it also emits one namespace node per in-scope namespace
+// (walking ancestors so that bindings declared above the subtree root are
+// carried in). The c14n package in node-set mode only renders namespaces that
+// are explicitly present in the node set, so without these the canonical bytes
+// of a namespace-qualified subtree would drop their xmlns declarations,
+// producing non-W3C output that breaks signature interop.
 func collectSubtreeNodes(n helium.Node) []helium.Node {
 	var nodes []helium.Node
 	var walk func(helium.Node)
 	walk = func(cur helium.Node) {
 		nodes = append(nodes, cur)
-		// Include attribute nodes for elements.
-		// Namespace nodes are handled internally by the c14n package.
 		if elem, ok := helium.AsNode[*helium.Element](cur); ok {
+			// In-scope namespace axis. c14n keys namespace nodes by their
+			// parent element, so each wrapper is parented to this element.
+			for _, ns := range inScopeNamespaces(elem) {
+				nodes = append(nodes, helium.NewNamespaceNodeWrapper(ns, elem))
+			}
 			for _, attr := range elem.Attributes() {
 				nodes = append(nodes, attr)
 			}
@@ -126,6 +138,41 @@ func collectSubtreeNodes(n helium.Node) []helium.Node {
 	}
 	walk(n)
 	return nodes
+}
+
+// inScopeNamespaces returns the namespaces in scope for elem, walking from the
+// document root down so that closer (inner) declarations override outer ones.
+// The implicit xml namespace is excluded — C14N never declares it explicitly.
+func inScopeNamespaces(elem *helium.Element) []*helium.Namespace {
+	byPrefix := make(map[string]*helium.Namespace)
+
+	var chain []*helium.Element
+	for n := helium.Node(elem); n != nil; n = n.Parent() {
+		if anc, ok := helium.AsNode[*helium.Element](n); ok {
+			chain = append(chain, anc)
+		}
+	}
+
+	// Outermost to innermost so the innermost binding wins.
+	for _, anc := range slices.Backward(chain) {
+		for _, ns := range anc.Namespaces() {
+			byPrefix[ns.Prefix()] = ns
+		}
+		if ns := anc.Namespace(); ns != nil {
+			if _, ok := byPrefix[ns.Prefix()]; !ok {
+				byPrefix[ns.Prefix()] = ns
+			}
+		}
+	}
+
+	var result []*helium.Namespace
+	for prefix, ns := range byPrefix {
+		if prefix == lexicon.PrefixXML {
+			continue
+		}
+		result = append(result, ns)
+	}
+	return result
 }
 
 // resolveReference resolves a Reference URI to the target node.


### PR DESCRIPTION
- subtree node-set for fragment references now carries the in-scope namespace axis per element, so c14n node-set mode emits the required xmlns declarations
- without it a namespace-qualified signed subtree dropped its xmlns decls, producing non-W3C canonical bytes that break signature interop
- covers inclusive C14N 1.0/1.1 (all in-scope) and exclusive C14N (visibly-utilized only)