### PR TITLE
surface bytecursor error returned with data

### DIFF
--- a/internal/strcursor/bytecursor_test.go
+++ b/internal/strcursor/bytecursor_test.go
@@ -1,0 +1,59 @@
+package strcursor
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// dataThenErrReader returns its payload together with a non-EOF error on the
+// same Read (which io.Reader explicitly permits), then reports EOF. It models a
+// reader that detects corruption/truncation only after emitting the final
+// bytes, e.g. a checksumming or decompressing stream.
+type dataThenErrReader struct {
+	data []byte
+	err  error
+	done bool
+}
+
+func (r *dataThenErrReader) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, io.EOF
+	}
+	r.done = true
+	n := copy(p, r.data)
+	return n, r.err
+}
+
+func TestByteCursorSurfacesErrorReturnedWithData(t *testing.T) {
+	wantErr := errors.New("checksum mismatch")
+	cur := NewByteCursor(&dataThenErrReader{
+		data: []byte("<root/>"),
+		err:  wantErr,
+	})
+
+	// The buffered bytes must remain readable.
+	require.Equal(t, "<root/>", cur.PeekString(7))
+
+	// Consume the buffered bytes.
+	require.NoError(t, cur.Advance(7))
+
+	// Once the buffer drains, the cursor must report the underlying error
+	// rather than silently treating the stream as cleanly terminated.
+	require.True(t, cur.Done(), "Done should be true after buffer drains")
+	require.ErrorIs(t, cur.Err(), wantErr, "the non-EOF read error must be surfaced after the buffered bytes are consumed")
+}
+
+func TestByteCursorTreatsEOFWithDataAsCleanEnd(t *testing.T) {
+	cur := NewByteCursor(&dataThenErrReader{
+		data: []byte("<root/>"),
+		err:  io.EOF,
+	})
+
+	require.Equal(t, "<root/>", cur.PeekString(7))
+	require.NoError(t, cur.Advance(7))
+	require.True(t, cur.Done())
+	require.NoError(t, cur.Err(), "io.EOF must not be reported as an error")
+}

--- a/internal/strcursor/strcursor.go
+++ b/internal/strcursor/strcursor.go
@@ -594,13 +594,14 @@ func (c *RuneCursor) Read(buf []byte) (int, error) {
 
 // ByteCursor reads bytes from an io.Reader.
 type ByteCursor struct {
-	buf    []byte
-	buflen int
-	bufpos int
-	column int
-	in     io.Reader
-	line   []byte
-	lineno int
+	buf     []byte
+	buflen  int
+	bufpos  int
+	column  int
+	in      io.Reader
+	line    []byte
+	lineno  int
+	readErr error // sticky non-EOF read error returned alongside buffered data
 }
 
 func NewByteCursor(r io.Reader, nn ...int) *ByteCursor {
@@ -646,16 +647,38 @@ func (c *ByteCursor) fillBuffer(n int) error {
 
 	nread, err := c.in.Read(c.buf[remaining:])
 	c.buflen = nread + remaining
-	if nread == 0 && err != nil {
-		if remaining >= n {
-			return nil
+	if err != nil {
+		// Remember a genuine read error (anything other than a clean EOF) so
+		// it survives even when this Read also returned data (n > 0), which
+		// io.Reader explicitly permits. A truncated/corrupt stream may deliver
+		// its final bytes and the error together in a single Read; discarding
+		// the error here would let the parser accept the buffered bytes as if
+		// the stream ended cleanly.
+		if err != io.EOF && c.readErr == nil {
+			c.readErr = err
 		}
-		return err
+		if nread == 0 {
+			if remaining >= n {
+				return nil
+			}
+			return err
+		}
 	}
 	if c.buflen < n {
+		if c.readErr != nil {
+			return c.readErr
+		}
 		return errors.New("fillBuffer request exceeds available data")
 	}
 	return nil
+}
+
+// Err returns a sticky non-EOF read error encountered while filling the buffer.
+// A reader is permitted to return data together with an error on the same Read;
+// the buffered bytes are still served, but the error is surfaced here once they
+// have been consumed. It returns nil if the stream ended cleanly.
+func (c *ByteCursor) Err() error {
+	return c.readErr
 }
 
 func (c *ByteCursor) Done() bool {

--- a/internal/strcursor/strcursor.go
+++ b/internal/strcursor/strcursor.go
@@ -853,5 +853,12 @@ func (c *ByteCursor) Read(buf []byte) (int, error) {
 		}
 	}
 	n, err := c.in.Read(buf)
+	// A sticky non-EOF error recorded by fillBuffer (a reader returning data
+	// and an error on the same Read) must still reach a wrapping reader such as
+	// UTF8Cursor. Once the underlying reader stops producing fresh errors,
+	// replay it in place of a clean EOF so the error is never swallowed.
+	if c.readErr != nil && (err == nil || err == io.EOF) {
+		err = c.readErr
+	}
 	return n + nread, err
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -3,7 +3,9 @@ package helium_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -1670,4 +1672,34 @@ func TestParseNCNameReportsInvalidStartRune(t *testing.T) {
 	p := helium.NewParser()
 	_, err := p.Parse(t.Context(), xml)
 	require.Error(t, err)
+}
+
+// dataThenErrReader returns its payload together with a non-EOF error on the
+// same Read (which io.Reader permits), then reports EOF. It models a reader
+// that detects corruption/truncation only after emitting the final bytes,
+// e.g. a checksumming or decompressing stream.
+type dataThenErrReader struct {
+	data []byte
+	err  error
+	done bool
+}
+
+func (r *dataThenErrReader) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, io.EOF
+	}
+	r.done = true
+	n := copy(p, r.data)
+	return n, r.err
+}
+
+func TestParseReaderSurfacesErrorReturnedWithData(t *testing.T) {
+	wantErr := errors.New("checksum mismatch")
+	p := helium.NewParser()
+
+	_, err := p.ParseReader(t.Context(), &dataThenErrReader{
+		data: []byte("<root/>"),
+		err:  wantErr,
+	})
+	require.ErrorIs(t, err, wantErr, "a reader error returned alongside the final bytes must not be swallowed")
 }


### PR DESCRIPTION
- `ByteCursor.fillBuffer` dropped a non-EOF read error when the reader returned it alongside data (n>0); the bytes were buffered and the error lost
- store it as sticky state and expose via new `ByteCursor.Err()`, surfaced once the buffer drains; io.EOF stays a clean end