### PR TITLE
reject malformed utf-16 in unparsed-text

### DIFF
--- a/internal/unparsedtext/unparsedtext.go
+++ b/internal/unparsedtext/unparsedtext.go
@@ -356,6 +356,14 @@ func resolveEncoding(specified, detected string) string {
 		if detected != "" && !EncodingsCompatible(specified, detected) {
 			return ""
 		}
+		// The BOM has already been stripped from the data by this point, so a
+		// generic "utf-16" decoder can no longer recover the endianness and
+		// would fall back to its little-endian default. When the BOM told us
+		// the concrete endianness, prefer the detected endian-specific
+		// encoding so a big-endian payload is decoded as big-endian.
+		if detected != "" && normalizeEncodingName(specified) == "utf16" {
+			return detected
+		}
 		return specified
 	}
 	if detected != "" {

--- a/internal/unparsedtext/unparsedtext.go
+++ b/internal/unparsedtext/unparsedtext.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 
 	iencoding "github.com/lestrrat-go/helium/internal/encoding"
@@ -372,21 +371,14 @@ func decodeBytes(data []byte, encoding string) (string, error) {
 			return "", &Error{Code: ErrCodeEncoding, Message: "invalid UTF-8 data"}
 		}
 		return string(data), nil
-	case "utf16le":
-		decoder := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewDecoder()
-		decoded, err := io.ReadAll(transform.NewReader(bytes.NewReader(data), decoder))
-		if err != nil {
-			return "", &Error{Code: ErrCodeEncoding, Message: fmt.Sprintf("UTF-16LE decode error: %v", err)}
-		}
-		return string(decoded), nil
-	case "utf16be":
-		decoder := unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM).NewDecoder()
-		decoded, err := io.ReadAll(transform.NewReader(bytes.NewReader(data), decoder))
-		if err != nil {
-			return "", &Error{Code: ErrCodeEncoding, Message: fmt.Sprintf("UTF-16BE decode error: %v", err)}
-		}
-		return string(decoded), nil
 	default:
+		// All non-UTF-8 encodings (including utf-16le/be) go through
+		// iencoding.Load, whose Unicode decoders are strict: malformed source
+		// units (e.g. an unpaired UTF-16 surrogate) produce a decode error
+		// rather than silently substituting U+FFFD. The bare x/text UTF-16
+		// decoders would replace such input, after which ValidateXMLChars
+		// accepts U+FFFD and the malformed resource decodes successfully
+		// instead of failing with FOUT1190.
 		enc := iencoding.Load(encoding)
 		if enc == nil {
 			return "", &Error{Code: ErrCodeEncoding, Message: fmt.Sprintf("unsupported encoding: %s", encoding)}

--- a/internal/unparsedtext/unparsedtext_test.go
+++ b/internal/unparsedtext/unparsedtext_test.go
@@ -667,6 +667,17 @@ func TestDecodeTextUTF16Malformed(t *testing.T) {
 		require.ErrorAs(t, err, &ue)
 		require.Equal(t, unparsedtext.ErrCodeEncoding, ue.Code)
 	})
+
+	t.Run("lone high surrogate, explicit generic utf-16 with BE BOM", func(t *testing.T) {
+		// The BOM is stripped before decoding, so generic "utf-16" must honor
+		// the BE endianness from the BOM rather than its LE default; the lone
+		// big-endian high surrogate must be rejected.
+		_, err := unparsedtext.DecodeText([]byte{0xFE, 0xFF, 0xD8, 0x00}, "utf-16")
+		require.Error(t, err)
+		var ue *unparsedtext.Error
+		require.ErrorAs(t, err, &ue)
+		require.Equal(t, unparsedtext.ErrCodeEncoding, ue.Code)
+	})
 }
 
 func TestDecodeTextUTF16ValidSurrogatePair(t *testing.T) {
@@ -693,6 +704,15 @@ func TestDecodeTextUTF16ValidSurrogatePair(t *testing.T) {
 		text, err := unparsedtext.DecodeText(buf, "")
 		require.NoError(t, err)
 		require.Equal(t, emoji, text)
+	})
+
+	t.Run("explicit generic utf-16 with BE BOM", func(t *testing.T) {
+		// FE FF BOM + big-endian 'A'. Generic "utf-16" must decode using the
+		// endianness indicated by the (now stripped) BOM, yielding "A" rather
+		// than a byte-swapped character.
+		text, err := unparsedtext.DecodeText([]byte{0xFE, 0xFF, 0x00, 0x41}, "utf-16")
+		require.NoError(t, err)
+		require.Equal(t, "A", text)
 	})
 }
 

--- a/internal/unparsedtext/unparsedtext_test.go
+++ b/internal/unparsedtext/unparsedtext_test.go
@@ -630,6 +630,72 @@ func TestDecodeTextUTF16WithExplicitEncoding(t *testing.T) {
 	require.Equal(t, "test", text)
 }
 
+func TestDecodeTextUTF16Malformed(t *testing.T) {
+	// A lone high surrogate (D800) is not a valid UTF-16 code unit on its own.
+	// Decoding it must fail with FOUT1190 rather than silently substituting
+	// U+FFFD and succeeding.
+	t.Run("lone high surrogate, explicit utf-16le", func(t *testing.T) {
+		_, err := unparsedtext.DecodeText([]byte{0x00, 0xD8}, "utf-16le")
+		require.Error(t, err)
+		var ue *unparsedtext.Error
+		require.ErrorAs(t, err, &ue)
+		require.Equal(t, unparsedtext.ErrCodeEncoding, ue.Code)
+	})
+
+	t.Run("lone high surrogate, explicit utf-16be", func(t *testing.T) {
+		_, err := unparsedtext.DecodeText([]byte{0xD8, 0x00}, "utf-16be")
+		require.Error(t, err)
+		var ue *unparsedtext.Error
+		require.ErrorAs(t, err, &ue)
+		require.Equal(t, unparsedtext.ErrCodeEncoding, ue.Code)
+	})
+
+	t.Run("lone high surrogate, BOM-detected utf-16le", func(t *testing.T) {
+		// FF FE BOM => utf-16le, followed by a lone high surrogate.
+		_, err := unparsedtext.DecodeText([]byte{0xFF, 0xFE, 0x00, 0xD8}, "")
+		require.Error(t, err)
+		var ue *unparsedtext.Error
+		require.ErrorAs(t, err, &ue)
+		require.Equal(t, unparsedtext.ErrCodeEncoding, ue.Code)
+	})
+
+	t.Run("lone high surrogate, BOM-detected utf-16be", func(t *testing.T) {
+		// FE FF BOM => utf-16be, followed by a lone high surrogate.
+		_, err := unparsedtext.DecodeText([]byte{0xFE, 0xFF, 0xD8, 0x00}, "")
+		require.Error(t, err)
+		var ue *unparsedtext.Error
+		require.ErrorAs(t, err, &ue)
+		require.Equal(t, unparsedtext.ErrCodeEncoding, ue.Code)
+	})
+}
+
+func TestDecodeTextUTF16ValidSurrogatePair(t *testing.T) {
+	// U+1F600 (GRINNING FACE) requires a surrogate pair; well-formed UTF-16
+	// must still decode correctly through the strict path.
+	const emoji = "\U0001F600"
+	runes := utf16.Encode([]rune(emoji))
+
+	t.Run("explicit utf-16le", func(t *testing.T) {
+		var buf []byte
+		for _, r := range runes {
+			buf = binary.LittleEndian.AppendUint16(buf, r)
+		}
+		text, err := unparsedtext.DecodeText(buf, "utf-16le")
+		require.NoError(t, err)
+		require.Equal(t, emoji, text)
+	})
+
+	t.Run("BOM-detected utf-16be", func(t *testing.T) {
+		buf := []byte{0xFE, 0xFF}
+		for _, r := range runes {
+			buf = binary.BigEndian.AppendUint16(buf, r)
+		}
+		text, err := unparsedtext.DecodeText(buf, "")
+		require.NoError(t, err)
+		require.Equal(t, emoji, text)
+	})
+}
+
 func TestLoadTextHTTP(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/hello.txt") {


### PR DESCRIPTION
- route utf-16le/be decoding in DecodeText through the strict iencoding decoder so unpaired surrogates fail with FOUT1190 instead of silent U+FFFD
- covers both explicit utf-16le/be and BOM-detected paths