### PR TITLE
report invalid schematron value-of select

### DIFF
--- a/schematron/parse.go
+++ b/schematron/parse.go
@@ -250,8 +250,10 @@ func parseMessageElement(compileCtx context.Context, childElem *helium.Element, 
 		}
 		compiled, err := xpath1.Compile(sel)
 		if err != nil {
-			// XPath compile error — record in handler but still add the part
-			// so validation can emit the error at runtime
+			// Report the compile error through the handler (mirroring the
+			// <name path="..."> case and compileTest), then still add the
+			// part so the message structure is preserved.
+			eh.Handle(compileCtx, helium.NewLeveledError(fmt.Sprintf("element value-of: Failed to compile select expression '%s': %s\n", sel, err), helium.ErrorLevelFatal))
 			return append(parts, valueOfPart{sel: sel})
 		}
 		return append(parts, valueOfPart{sel: sel, expr: compiled})

--- a/schematron/schematron_test.go
+++ b/schematron/schematron_test.go
@@ -573,6 +573,21 @@ func TestCompileNonRuleInPattern(t *testing.T) {
 	require.Contains(t, errs, "Expecting a rule element instead of bogus")
 }
 
+func TestCompileInvalidValueOfSelect(t *testing.T) {
+	t.Parallel()
+	// An invalid <value-of select="..."> XPath must be reported through the
+	// error handler, mirroring the <name path="..."> case, instead of being
+	// silently swallowed (which leaves a truncated assertion message).
+	_, errs := compileTestSchema(t, `<schema xmlns="http://purl.oclc.org/dsdl/schematron">
+		<pattern>
+			<rule context="/root">
+				<assert test="false()">val is <value-of select="("/></assert>
+			</rule>
+		</pattern>
+	</schema>`)
+	require.Contains(t, errs, "Failed to compile select expression '('")
+}
+
 func TestCompileValidSchema(t *testing.T) {
 	t.Parallel()
 	_, errs := compileTestSchema(t, `<schema xmlns="http://purl.oclc.org/dsdl/schematron">

--- a/schematron/validate.go
+++ b/schematron/validate.go
@@ -134,7 +134,9 @@ func formatMessage(ctx context.Context, ev xpath1.Evaluator, parts []messagePart
 			}
 		case valueOfPart:
 			if p.expr == nil {
-				// Compile-time error -- should not happen (caught during compilation).
+				// The select expression failed to compile; the error was
+				// already reported through the handler at compile time, so
+				// stop here rather than emitting a bogus value.
 				return string(buf), ""
 			}
 			result, err := ev.Evaluate(ctx, p.expr, node)


### PR DESCRIPTION
- report `<value-of select>` XPath compile errors through the error handler instead of swallowing them
- add failing test for invalid value-of select surfacing a compile error