### PR TITLE
reject trailing tokens in ParseSequenceType

### DIFF
--- a/xpath3/parser.go
+++ b/xpath3/parser.go
@@ -62,6 +62,9 @@ func ParseSequenceType(s string) (SequenceType, error) {
 	if err != nil {
 		return SequenceType{}, err
 	}
+	if tok := p.lexer.Peek(); tok.Type != TokenEOF {
+		return SequenceType{}, fmt.Errorf("%w: %s after sequence type", ErrUnexpectedToken, tok)
+	}
 	return st, nil
 }
 

--- a/xpath3/parser_test.go
+++ b/xpath3/parser_test.go
@@ -374,3 +374,43 @@ func TestParseErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestParseSequenceType(t *testing.T) {
+	valid := []string{
+		"xs:string",
+		"xs:integer?",
+		"xs:double*",
+		"xs:anyAtomicType+",
+		"item()",
+		"item()*",
+		"empty-sequence()",
+		"node()",
+		"element()",
+		"element(e)",
+		"attribute(*, xs:string)",
+		"map(*)",
+		"array(*)",
+		"function(*)",
+		"function(xs:string) as xs:boolean",
+	}
+	for _, in := range valid {
+		t.Run("valid/"+in, func(t *testing.T) {
+			_, err := xpath3.ParseSequenceType(in)
+			require.NoError(t, err, "input: %s", in)
+		})
+	}
+
+	invalid := []string{
+		"xs:string garbage",
+		"xs:integer? extra",
+		"item() ()",
+		"empty-sequence() *",
+		"node() element()",
+	}
+	for _, in := range invalid {
+		t.Run("invalid/"+in, func(t *testing.T) {
+			_, err := xpath3.ParseSequenceType(in)
+			require.Error(t, err, "input: %s", in)
+		})
+	}
+}


### PR DESCRIPTION
- ParseSequenceType now errors on input with valid prefix but unexpected trailing tokens (e.g. `xs:string garbage`)
- requires lexer at EOF after the sequence type, mirroring the main expression parser