### PR TITLE
fix cdata detection in xml normalization

### DIFF
--- a/xslt3/output_charmap.go
+++ b/xslt3/output_charmap.go
@@ -107,7 +107,7 @@ func normalizeXMLContent(data []byte, nf norm.Form) []byte {
 					i += end + 3
 					continue
 				}
-				if j+7 < len(data) && string(data[j:j+7]) == "[CDATA[" {
+				if bytes.HasPrefix(data[i:], []byte("<![CDATA[")) {
 					// CDATA: normalize content inside
 					end := bytes.Index(data[i:], []byte("]]>"))
 					if end < 0 {

--- a/xslt3/output_charmap_cdata_test.go
+++ b/xslt3/output_charmap_cdata_test.go
@@ -1,0 +1,24 @@
+package xslt3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/unicode/norm"
+)
+
+// TestNormalizeXMLContentCDATA verifies that Unicode normalization is applied
+// to the contents of a CDATA section while the surrounding markup is preserved
+// verbatim. The decomposed form of "e" + combining acute accent
+// (U+0065 U+0301) inside a CDATA section must be normalized to the composed
+// form "é" (U+00E9) under NFC.
+func TestNormalizeXMLContentCDATA(t *testing.T) {
+	decomposed := "é" // "e" + combining acute accent
+	composed := "é"    // precomposed "é"
+
+	input := []byte("<e><![CDATA[" + decomposed + "]]></e>")
+	want := "<e><![CDATA[" + composed + "]]></e>"
+
+	got := string(normalizeXMLContent(input, norm.NFC))
+	require.Equal(t, want, got, "CDATA section content should be normalized")
+}


### PR DESCRIPTION
- normalizeXMLContent compared data[j:j+7] (starting at '!') to "[CDATA[", so the CDATA branch never matched and section contents were skipped by Unicode normalization
- detect CDATA via bytes.HasPrefix(data[i:], "<![CDATA[") so normalization-form now applies inside CDATA sections