### PR TITLE
reject idc field selecting multiple nodes

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -78,6 +78,12 @@ expression.`); its `compiledPatterns` entry stays nil and is skipped at validati
     validity error (`Not all fields of key identity-constraint '…' evaluate to a
     node.`). `xs:unique` and `xs:keyref` tolerate absent fields — the node drops
     out of the qualified node-set.
+  - Field cardinality (cvc-identity-constraint.3): for each selected node every
+    field must evaluate to an empty node-set or a node-set with exactly one
+    member. A field selecting more than one node is a validity error for all IDC
+    kinds (`The XPath '…' of a field of <kind> identity-constraint '…' evaluates
+    to a node-set with more than one member.`) rather than silently using the
+    first node.
   - XPath uses namespace context from schema, not instance
   - Key comparison is value-space aware (XSD 3.11.4): each field value is
     canonicalized via its declared simple type (`resolveFieldBuiltinLocal` →

--- a/xsd/validate_idc.go
+++ b/xsd/validate_idc.go
@@ -16,6 +16,7 @@ type idcTable struct {
 	idc        *IDConstraint
 	keys       []idcEntry
 	keyMissing bool // an xs:key selected node had an absent field (cvc-identity-constraint.4.2.1)
+	fieldError bool // a field XPath selected more than one node (cvc-identity-constraint.3)
 }
 
 // idcEntry holds a single key-sequence value and the node that produced it.
@@ -51,6 +52,12 @@ func (vc *validationContext) validateIDConstraints(ctx context.Context, elem *he
 		// evaluation; surface it as a validation failure.
 		if table.keyMissing {
 			lastErr = fmt.Errorf("missing key field")
+		}
+
+		// A field that selected more than one node was already reported during
+		// evaluation; surface it as a validation failure.
+		if table.fieldError {
+			lastErr = fmt.Errorf("field evaluates to more than one node")
 		}
 
 		// Check unique/key constraints immediately.
@@ -123,7 +130,11 @@ func (vc *validationContext) evaluateIDC(ctx context.Context, ev xpath1.Evaluato
 		}
 
 		// Evaluate each field XPath relative to the selected node.
+		// fieldErr marks that a field already produced a definitive validity
+		// error (e.g. a node-set with more than one member) for this entry, so
+		// the absent-field handling below does not also fire for the same node.
 		allPresent := true
+		fieldErr := false
 		for i, fieldXPath := range idc.Fields {
 			var fieldResult *xpath1.Result
 			if i < len(idc.FieldExprs) && idc.FieldExprs[i] != nil {
@@ -145,6 +156,22 @@ func (vc *validationContext) evaluateIDC(ctx context.Context, ev xpath1.Evaluato
 			var fieldNode helium.Node
 			switch fieldResult.Type {
 			case xpath1.NodeSetResult:
+				if len(fieldResult.NodeSet) > 1 {
+					// cvc-identity-constraint.3: with the selected node as the
+					// context node, each field must evaluate to either an empty
+					// node-set or a node-set with exactly one member. More than
+					// one selected node is a validity error for every IDC kind.
+					if entry.elem != nil {
+						idcName := idcDisplayName(idc, vc.schema)
+						msg := fmt.Sprintf("The XPath '%s' of a field of %s identity-constraint '%s' evaluates to a node-set with more than one member.",
+							fieldXPath, idcKindName(idc.Kind), idcName)
+						vc.reportValidityError(ctx, vc.filename, entry.elem.Line(), elemDisplayName(entry.elem), msg)
+					}
+					table.fieldError = true
+					allPresent = false
+					fieldErr = true
+					break
+				}
 				if len(fieldResult.NodeSet) == 0 {
 					allPresent = false
 				} else {
@@ -177,6 +204,9 @@ func (vc *validationContext) evaluateIDC(ctx context.Context, ev xpath1.Evaluato
 		// absent field is a validity error. xs:unique and xs:keyref
 		// tolerate absent fields (the node simply drops out of the
 		// qualified node-set), so they only skip the entry.
+		if fieldErr {
+			continue
+		}
 		if idc.Kind == IDCKey && entry.elem != nil {
 			table.keyMissing = true
 			idcName := idcDisplayName(idc, vc.schema)
@@ -450,6 +480,19 @@ func entryDisplayName(entry idcEntry) string {
 		return elemDisplayName(entry.elem)
 	}
 	return ""
+}
+
+// idcKindName returns the XSD keyword for an IDC kind ("unique", "key",
+// "keyref"), used in validity-error designations.
+func idcKindName(kind IDCKind) string {
+	switch kind {
+	case IDCKey:
+		return elemKey
+	case IDCKeyRef:
+		return elemKeyRef
+	default:
+		return elemUnique
+	}
 }
 
 // idcDisplayName returns the namespace-qualified display name of an IDC.

--- a/xsd/validate_idc_multi_field_test.go
+++ b/xsd/validate_idc_multi_field_test.go
@@ -1,0 +1,91 @@
+package xsd_test
+
+import (
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIDCFieldMultipleNodes covers cvc-identity-constraint.3: for each selected
+// node, every field XPath must evaluate to either an empty node-set or a
+// node-set with exactly one member. A field that selects more than one node is a
+// validation error rather than being silently reduced to its first node.
+func TestIDCFieldMultipleNodes(t *testing.T) {
+	t.Parallel()
+
+	const schemaSrc = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="row" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="v" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="rowUnique">
+      <xs:selector xpath="row"/>
+      <xs:field xpath="v"/>
+    </xs:unique>
+  </xs:element>
+</xs:schema>`
+
+	compile := func(t *testing.T) xsd.Validator {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaSrc))
+		require.NoError(t, err)
+		s, err := xsd.NewCompiler().Compile(t.Context(), doc)
+		require.NoError(t, err)
+		return xsd.NewValidator(s)
+	}
+
+	cases := []struct {
+		name        string
+		instance    string
+		valid       bool
+		wantMessage string
+	}{
+		{
+			name:        "field selecting two nodes fails",
+			instance:    `<root><row><v>1</v><v>2</v></row></root>`,
+			valid:       false,
+			wantMessage: "The XPath 'v' of a field of unique identity-constraint 'rowUnique' evaluates to a node-set with more than one member.",
+		},
+		{
+			name:     "field selecting one node passes",
+			instance: `<root><row><v>1</v></row><row><v>2</v></row></root>`,
+			valid:    true,
+		},
+		{
+			name:     "field selecting zero nodes passes for unique",
+			instance: `<root><row/></root>`,
+			valid:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			v := compile(t)
+
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(tc.instance))
+			require.NoError(t, err)
+
+			var errs string
+			err = validateWithOutput(t, v, doc, &errs)
+			if tc.valid {
+				require.NoError(t, err, "expected valid, got errors: %s", errs)
+				return
+			}
+			require.Error(t, err, "expected validation error")
+			require.True(t, strings.Contains(errs, tc.wantMessage),
+				"expected error message %q in %q", tc.wantMessage, errs)
+		})
+	}
+}


### PR DESCRIPTION
- xs:unique/key/keyref field XPaths selecting >1 node now raise cvc-identity-constraint.3 validity error instead of silently using the first node
- empty and single-node field results unchanged