### PR TITLE
apply arg coercion in named function references

### DIFF
--- a/xpath3/eval_funcall.go
+++ b/xpath3/eval_funcall.go
@@ -285,15 +285,24 @@ func evalNamedFunctionRef(ctx context.Context, ec *evalContext, e NamedFunctionR
 			if len(args) < minArity {
 				return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("fn:%s requires at least %d arguments, got %d", e.Name, minArity, len(args))}
 			}
-			// Type-check arguments against declared parameter types
+			// Type-check arguments against declared parameter types. Coercion may
+			// convert an argument (e.g. xs:integer -> xs:double); the coerced value
+			// must be what the function observes, so store it back into a copy of the
+			// argument slice rather than discarding it and invoking with the original
+			// — mirroring the direct call path and fn:function-lookup.
 			if paramTypes != nil {
+				coerced := make([]Sequence, len(args))
+				copy(coerced, args)
 				for i, arg := range args {
 					if i < len(paramTypes) {
-						if _, ok := coerceToSequenceType(arg, paramTypes[i], nil); !ok {
+						c, ok := coerceToSequenceType(arg, paramTypes[i], capturedEC)
+						if !ok {
 							return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("fn:%s: argument %d does not match required type %v", e.Name, i+1, paramTypes[i])}
 						}
+						coerced[i] = c
 					}
 				}
+				args = coerced
 			}
 			// Use caller's ctx for cancellation, captured ec for focus/eval state
 			return fn.Call(withFnContext(ctx, capturedEC), args)

--- a/xpath3/funcall_signature_test.go
+++ b/xpath3/funcall_signature_test.go
@@ -619,6 +619,58 @@ func TestPartialApplicationPropagatesTypedError(t *testing.T) {
 	require.Equal(t, "FORG0001", xpErr.Code)
 }
 
+// Finding (named function ref): a named function reference (f#N) to a
+// TypedFunction must coerce its arguments exactly like a direct call. A
+// TypedFunction declaring xs:double invoked via (takes-double#1)(1) must observe a
+// coerced xs:double, not the original xs:integer — mirroring takes-double(1).
+func TestNamedFunctionRefCoercesTypedParam(t *testing.T) {
+	t.Parallel()
+
+	var observed string
+	result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Functions(typedDoubleLib(&observed)).
+		Evaluate(t.Context(), xpath3.NewCompiler().MustCompile(`(takes-double#1)(1)`), nil)
+	require.NoError(t, err)
+
+	require.Equal(t, xpath3.TypeDouble, observed, "named-ref arg must be coerced to xs:double")
+	s, ok := result.IsString()
+	require.True(t, ok)
+	require.Equal(t, xpath3.TypeDouble, s)
+}
+
+// Finding (named function ref): a non-coercible argument supplied through a named
+// function reference raises XPTY0004, just like a direct call.
+func TestNamedFunctionRefRejectsNonCoercible(t *testing.T) {
+	t.Parallel()
+
+	var observed string
+	_, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Functions(typedDoubleLib(&observed)).
+		Evaluate(t.Context(), xpath3.NewCompiler().MustCompile(`(takes-double#1)(current-date())`), nil)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code)
+}
+
+// Finding (function-lookup): fn:function-lookup resolves a TypedFunction and the
+// returned function item must coerce its arguments like a direct call — an
+// xs:integer supplied to an xs:double parameter must be observed as xs:double.
+func TestFunctionLookupCoercesTypedParam(t *testing.T) {
+	t.Parallel()
+
+	var observed string
+	result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Functions(typedDoubleLib(&observed)).
+		Evaluate(t.Context(), xpath3.NewCompiler().MustCompile(`function-lookup(QName("", "takes-double"), 1)(1)`), nil)
+	require.NoError(t, err)
+
+	require.Equal(t, xpath3.TypeDouble, observed, "function-lookup arg must be coerced to xs:double")
+	s, ok := result.IsString()
+	require.True(t, ok)
+	require.Equal(t, xpath3.TypeDouble, s)
+}
+
 // Finding 2 (round 7): a fixed (curried) argument must also be coerced — when the
 // double parameter is curried with an xs:integer literal, the body still observes
 // xs:double.


### PR DESCRIPTION
- Named function references (f#N) now store coerced arguments back before invoking, so typed functions reached via f#N observe promoted values like direct calls and fn:function-lookup.
- Adds tests covering (f#1)(1) coercion, non-coercible rejection, and function-lookup coercion.