### PR TITLE
validate element and attribute names in stream writer

### DIFF
--- a/stream/stream.go
+++ b/stream/stream.go
@@ -346,6 +346,21 @@ func (w *Writer) declareNS(prefix, uri string) {
 	scope.decls = append(scope.decls, nsEntry{prefix: prefix, uri: uri})
 }
 
+// validateNSParts validates the prefix and local name supplied to a
+// namespace-aware method. The local name must be a valid NCName; the prefix,
+// if non-empty, must also be a valid NCName (no colon). This prevents an
+// untrusted prefix or local name from injecting markup into the start tag.
+// kind is "element" or "attribute" and only shapes the error message.
+func validateNSParts(kind, prefix, localName string) error {
+	if prefix != "" && !xmlchar.IsValidNCName(prefix) {
+		return fmt.Errorf("stream: invalid %s prefix %q", kind, prefix)
+	}
+	if !xmlchar.IsValidNCName(localName) {
+		return fmt.Errorf("stream: invalid %s local name %q", kind, localName)
+	}
+	return nil
+}
+
 // qualifiedName returns prefix:localName or just localName if prefix is empty.
 func qualifiedName(prefix, localName string) string {
 	if prefix == "" {
@@ -453,6 +468,13 @@ func (w *Writer) StartElement(name string) error {
 	if w.err != nil {
 		return w.err
 	}
+	// Validate the name before touching any writer state or output, so an
+	// untrusted name cannot inject markup (extra attributes, '>') or produce
+	// malformed XML. Namespaced names (prefix:local) and the xml:/xmlns
+	// idioms are valid QNames and remain accepted.
+	if !xmlchar.IsValidQName(name) {
+		return fmt.Errorf("stream: invalid element name %q", name)
+	}
 	switch w.state {
 	case stateNone, stateDocument, stateText, stateDTD:
 		// ok — stateNone allows fragment writing without StartDocument
@@ -483,6 +505,12 @@ func (w *Writer) StartElement(name string) error {
 // StartElementNS opens a new element with namespace. prefix and
 // namespaceURI may be empty.
 func (w *Writer) StartElementNS(prefix, localName, namespaceURI string) error {
+	if w.err != nil {
+		return w.err
+	}
+	if err := validateNSParts("element", prefix, localName); err != nil {
+		return err
+	}
 	qname := qualifiedName(prefix, localName)
 	if err := w.StartElement(qname); err != nil {
 		return err
@@ -622,6 +650,13 @@ func (w *Writer) StartAttribute(name string) error {
 	if w.err != nil {
 		return w.err
 	}
+	// Validate the name before writing, so an untrusted name cannot inject
+	// markup (extra attributes, '>') into the start tag. The xmlns/xmlns:
+	// declaration idiom and namespaced names are valid QNames and remain
+	// accepted (this is a low-level xmlTextWriter-style API).
+	if !xmlchar.IsValidQName(name) {
+		return fmt.Errorf("stream: invalid attribute name %q", name)
+	}
 	if w.state != stateName {
 		return errors.New("stream: StartAttribute called outside element opening tag")
 	}
@@ -636,6 +671,14 @@ func (w *Writer) StartAttribute(name string) error {
 
 // StartAttributeNS opens a namespace-qualified attribute.
 func (w *Writer) StartAttributeNS(prefix, localName, namespaceURI string) error {
+	if w.err != nil {
+		return w.err
+	}
+	// Validate parts before declareNS mutates the namespace scope, so an
+	// invalid prefix/local name never leaks a declaration or markup.
+	if err := validateNSParts("attribute", prefix, localName); err != nil {
+		return err
+	}
 	if namespaceURI != "" && prefix != "" {
 		w.declareNS(prefix, namespaceURI)
 	}

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -178,6 +178,107 @@ func TestAttribute(t *testing.T) {
 	require.Equal(t, `<root key="value"/>`, buf.String())
 }
 
+func TestStartElementRejectsInvalidName(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		arg  string
+	}{
+		{"injected attribute", `root injected="1"`},
+		{"close bracket", "root>"},
+		{"leading digit", "1root"},
+		{"whitespace", "ro ot"},
+		{"quote", `root"`},
+		{"two colons", "a:b:c"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := stream.NewWriter(&buf)
+			require.Error(t, w.StartElement(tc.arg), "StartElement(%q) must reject invalid name", tc.arg)
+			require.Empty(t, buf.String(), "no markup must be emitted for an invalid name")
+		})
+	}
+}
+
+func TestStartElementAcceptsValidName(t *testing.T) {
+	t.Parallel()
+	cases := []string{"root", "a:b", "xml:lang", "_x", "ns0:elem", "名前"}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := stream.NewWriter(&buf)
+			require.NoError(t, w.StartElement(name))
+			require.NoError(t, w.EndElement())
+			require.Equal(t, "<"+name+"/>", buf.String())
+		})
+	}
+}
+
+func TestStartAttributeRejectsInvalidName(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		arg  string
+	}{
+		{"injected attribute", `key="1" injected`},
+		{"close bracket", "key>"},
+		{"whitespace", "k ey"},
+		{"quote", `key"`},
+		{"leading digit", "1key"},
+		{"two colons", "a:b:c"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := stream.NewWriter(&buf)
+			require.NoError(t, w.StartElement("root"))
+			require.Error(t, w.StartAttribute(tc.arg), "StartAttribute(%q) must reject invalid name", tc.arg)
+		})
+	}
+}
+
+func TestStartAttributeAcceptsValidName(t *testing.T) {
+	t.Parallel()
+	cases := []string{"key", "a:b", "xml:lang", "_x", "名前", "xmlns", "xmlns:foo"}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := stream.NewWriter(&buf)
+			require.NoError(t, w.StartElement("root"))
+			require.NoError(t, w.WriteAttribute(name, "v"))
+			require.NoError(t, w.EndElement())
+			require.Equal(t, `<root `+name+`="v"/>`, buf.String())
+		})
+	}
+}
+
+func TestStartElementNSRejectsInvalidParts(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.Error(t, w.StartElementNS("bad prefix", "local", "urn:x"))
+	require.Empty(t, buf.String())
+
+	buf.Reset()
+	w = stream.NewWriter(&buf)
+	require.Error(t, w.StartElementNS("p", "bad local", "urn:x"))
+	require.Empty(t, buf.String())
+}
+
+func TestStartAttributeNSRejectsInvalidParts(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("root"))
+	require.Error(t, w.StartAttributeNS("bad prefix", "local", "urn:x"))
+
+	buf.Reset()
+	w = stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("root"))
+	require.Error(t, w.StartAttributeNS("p", "bad local", "urn:x"))
+}
+
 func TestAttributeEscaping(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer


### PR DESCRIPTION
- StartElement/StartAttribute reject names that are not valid XML QNames, preventing markup injection via untrusted names
- StartElementNS/StartAttributeNS validate prefix and local name as NCNames
- reuses internal/xmlchar validators (same helpers as serializer commit #492)