### PR TITLE
validate shim encoder token names

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -5,7 +5,7 @@ Arrows show "imports" direction. Indented items are transitive.
 ```
 cmd/helium     → internal/cli/heliumcmd
 internal/cli/heliumcmd → helium, c14n, relaxng, schematron, xsd, xinclude, xpath1, xpath3, catalog, internal/cliutil
-shim           → helium, stream, enum, internal/encoding
+shim           → helium, stream, enum, internal/encoding, internal/xmlchar
 xinclude       → helium, xpointer
                   → xpath1 (via xpointer)
                   → internal/encoding

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -299,7 +299,7 @@ Drop-in replacement for encoding/xml backed by helium parser.
 - API mirrors encoding/xml; strict mode only; undeclared namespace prefixes rejected
 - Known differences: empty elements self-closed, xmlns before regular attrs, InputOffset approximate
 - Files: `decoder.go`, `encoder.go`, `marshal.go`, `unmarshal.go`, `types.go`, `namespace.go`, `escape.go`, `doc.go`
-- Imports: helium, stream/, internal/encoding/
+- Imports: helium, stream/, internal/encoding/, internal/xmlchar/
 
 ## sink/
 

--- a/shim/consts_test.go
+++ b/shim/consts_test.go
@@ -19,4 +19,5 @@ const (
 	testCannotUnmarshalIface = "cannot unmarshal into interface {}"
 	testNs2                  = "ns2"
 	testTag                  = "tag"
+	testRoot                 = "root"
 )

--- a/shim/encoder.go
+++ b/shim/encoder.go
@@ -5,8 +5,10 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 )
 
 var (
@@ -91,9 +93,67 @@ func (enc *Encoder) writeIndent(depth int) error {
 	return nil
 }
 
+// validateNameGrammar checks the XML grammar of a Name about to be serialized.
+// The shim writes Name.Local raw (and, when Name.Space is set, after a
+// generated "prefix:"), so an unvalidated Local would let malformed token names
+// become injected or otherwise invalid XML. This hardens the shim beyond
+// encoding/xml (which writes names raw) and keeps behavior consistent with the
+// helium writer.
+//
+// When Space is set, Local is the local part of a QName and must be a bare
+// NCName: the prefix is generated separately, so a colon in Local would emit a
+// malformed double-prefixed name. When Space is empty, Local is written
+// verbatim and may itself be a prefixed QName (e.g. "foo:bar").
+func validateNameGrammar(kind string, name Name) error {
+	if name.Space != "" {
+		if !xmlchar.IsValidNCName(name.Local) {
+			return fmt.Errorf("xml: invalid %s name %q", kind, name.Local)
+		}
+		return nil
+	}
+	if !xmlchar.IsValidQName(name.Local) {
+		return fmt.Errorf("xml: invalid %s name %q", kind, name.Local)
+	}
+	return nil
+}
+
+// validateElementName validates an element Name. In addition to grammar it
+// rejects the reserved "xmlns" QName prefix: Namespaces-in-XML forbids "xmlns"
+// as an element prefix, so a name like "xmlns:root" (with no Space, so written
+// verbatim) must not be serialized as <xmlns:root>. This mirrors the helium
+// writer. The bare name "xmlns" is a valid element name (<xmlns/> is
+// well-formed) and is allowed.
+func validateElementName(name Name) error {
+	if name.Space == "" && strings.HasPrefix(name.Local, "xmlns:") {
+		return fmt.Errorf("xml: reserved element name %q", name.Local)
+	}
+	return validateNameGrammar("element", name)
+}
+
+// validateAttributeName validates an attribute Name. Only grammar is checked:
+// unlike the helium writer, the shim accepts "xmlns"/"xmlns:foo" attribute
+// names as the encoding/xml way to declare namespaces.
+func validateAttributeName(name Name) error {
+	return validateNameGrammar("attribute", name)
+}
+
 func (enc *Encoder) writeStartElement(se StartElement) error {
 	if se.Name.Local == "" {
 		return fmt.Errorf("xml: start tag with no name")
+	}
+	// Validate the element and all attribute names up front, before any output
+	// is buffered or encoder state is mutated, so a rejected token never leaves
+	// partial markup or a corrupt tag/namespace stack behind.
+	if err := validateElementName(se.Name); err != nil {
+		return err
+	}
+	for _, attr := range se.Attr {
+		if attr.Name.Local == "" {
+			continue
+		}
+		if err := validateAttributeName(attr.Name); err != nil {
+			return err
+		}
 	}
 
 	if enc.indent != "" || enc.prefix != "" {

--- a/shim/shim_test.go
+++ b/shim/shim_test.go
@@ -45,7 +45,7 @@ func TestNewDecoderToken(t *testing.T) {
 	require.NoError(t, err, "Token failed")
 	se, ok := tok.(shim.StartElement)
 	require.True(t, ok, "expected first token StartElement, got %T", tok)
-	require.Equal(t, "root", se.Name.Local, "start element mismatch")
+	require.Equal(t, testRoot, se.Name.Local, "start element mismatch")
 }
 
 func TestNewTokenDecoder(t *testing.T) {
@@ -76,10 +76,75 @@ func requireEncodeTokenSequence(t *testing.T, enc interface {
 	Flush() error
 }) {
 	t.Helper()
-	require.NoError(t, enc.EncodeToken(stdxml.StartElement{Name: stdxml.Name{Local: "root"}}), "EncodeToken(start) failed")
+	require.NoError(t, enc.EncodeToken(stdxml.StartElement{Name: stdxml.Name{Local: testRoot}}), "EncodeToken(start) failed")
 	require.NoError(t, enc.EncodeToken(stdxml.CharData([]byte(testHello))), "EncodeToken(chardata) failed")
-	require.NoError(t, enc.EncodeToken(stdxml.EndElement{Name: stdxml.Name{Local: "root"}}), "EncodeToken(end) failed")
+	require.NoError(t, enc.EncodeToken(stdxml.EndElement{Name: stdxml.Name{Local: testRoot}}), "EncodeToken(end) failed")
 	require.NoError(t, enc.Flush(), "Flush failed")
+}
+
+func TestEncodeTokenRejectsInvalidNames(t *testing.T) {
+	invalidNS := "urn:ns"
+	for _, tc := range []struct {
+		name  string
+		token shim.Token
+	}{
+		{
+			name:  "start element local with injected attribute",
+			token: shim.StartElement{Name: shim.Name{Local: `root injected="1"`}},
+		},
+		{
+			name:  "start element local with angle bracket",
+			token: shim.StartElement{Name: shim.Name{Local: "ro>ot"}},
+		},
+		{
+			name:  "start element local starting with digit",
+			token: shim.StartElement{Name: shim.Name{Local: "1root"}},
+		},
+		{
+			name:  "attribute local with injected markup",
+			token: shim.StartElement{Name: shim.Name{Local: testRoot}, Attr: []shim.Attr{{Name: shim.Name{Local: `a="x" b`}, Value: "v"}}},
+		},
+		{
+			name:  "namespaced element local with colon",
+			token: shim.StartElement{Name: shim.Name{Space: invalidNS, Local: "a:b"}},
+		},
+		{
+			name:  "namespaced attribute local with injected markup",
+			token: shim.StartElement{Name: shim.Name{Local: testRoot}, Attr: []shim.Attr{{Name: shim.Name{Space: invalidNS, Local: `a"/><b`}, Value: "v"}}},
+		},
+		{
+			name:  "reserved xmlns element prefix",
+			token: shim.StartElement{Name: shim.Name{Local: "xmlns:root"}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			enc := shim.NewEncoder(&buf)
+			err := enc.EncodeToken(tc.token)
+			require.Error(t, err, "EncodeToken should reject invalid name")
+			// A rejected token must not leave partial markup behind, even
+			// after a subsequent Flush.
+			require.NoError(t, enc.Flush(), "Flush after rejected token")
+			require.Empty(t, buf.String(), "rejected token must not emit partial markup")
+		})
+	}
+}
+
+func TestEncodeTokenAcceptsValidNames(t *testing.T) {
+	var buf bytes.Buffer
+	enc := shim.NewEncoder(&buf)
+
+	require.NoError(t, enc.EncodeToken(shim.StartElement{
+		Name: shim.Name{Space: "urn:ns", Local: testRoot},
+		Attr: []shim.Attr{
+			{Name: shim.Name{Local: "id"}, Value: "1"},
+			{Name: shim.Name{Space: "urn:other", Local: "ref"}, Value: "2"},
+		},
+	}), "valid namespaced start element should encode")
+	require.NoError(t, enc.EncodeToken(shim.CharData([]byte("hi"))), "char data should encode")
+	require.NoError(t, enc.EncodeToken(shim.EndElement{Name: shim.Name{Space: "urn:ns", Local: testRoot}}), "valid end element should encode")
+	require.NoError(t, enc.Flush(), "Flush failed")
+	require.NotEmpty(t, buf.String(), "expected output for valid tokens")
 }
 
 func TestCopyTokenCopiesCharData(t *testing.T) {


### PR DESCRIPTION
- reject invalid element/attribute local names in shim Encoder.EncodeToken instead of writing them raw, preventing markup injection via malformed token names
- reuse internal/xmlchar validation (NCName for namespaced locals, QName otherwise) for consistency with the helium writer