### PR TITLE
validate inline attribute simpleType

### DIFF
--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -163,6 +163,9 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 		if au.TypeName == (QName{}) {
 			au.TypeName = ga.TypeName
 		}
+		if au.Type == nil {
+			au.Type = ga.Type
+		}
 	}
 
 	// Topologically order extension types so each base type is merged before

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -160,6 +160,31 @@ func (c *compiler) readAttributeUseDecl(ctx context.Context, elem *helium.Elemen
 	au := &AttrUse{Name: opts.name}
 	if typeRef := getAttr(elem, attrType); typeRef != "" {
 		au.TypeName = c.resolveQName(ctx, elem, typeRef)
+	} else {
+		// No type attribute: look for an inline anonymous <xs:simpleType>.
+		// (type and inline simpleType are mutually exclusive, enforced by
+		// checkAttributeUse.)
+		for child := range helium.Children(elem) {
+			if child.Type() != helium.ElementNode {
+				continue
+			}
+			ce, ok := helium.AsNode[*helium.Element](child)
+			if !ok {
+				continue
+			}
+			if !isXSDElement(ce, elemSimpleType) {
+				continue
+			}
+			td, err := c.parseSimpleType(ctx, ce)
+			if err != nil {
+				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, ce.Line(),
+					ce.LocalName(), "attribute", err.Error()), helium.ErrorLevelFatal))
+				c.errorCount++
+				break
+			}
+			au.Type = td
+			break
+		}
 	}
 	if opts.includeUse {
 		switch getAttr(elem, attrUse) {

--- a/xsd/schema.go
+++ b/xsd/schema.go
@@ -240,6 +240,7 @@ type FacetSet struct {
 type AttrUse struct {
 	Name       QName
 	TypeName   QName
+	Type       *TypeDef // anonymous inline <xs:simpleType>, if any
 	Required   bool
 	Prohibited bool
 	Default    *string // nil = not set

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -425,16 +425,15 @@ func (vc *validationContext) validateAttributes(ctx context.Context, elem *heliu
 				vc.reportValidityErrorAttr(ctx, vc.filename, elem.Line(), elemDisplayName(elem), ad, msg)
 				hasErr = true
 			}
-			// Validate the attribute value against its declared type.
-			if au.TypeName.Local != "" {
-				attrTD, tdOK := vc.schema.LookupType(au.TypeName.Local, au.TypeName.NS)
-				if tdOK && attrTD.ContentType == ContentTypeSimple {
-					if err := attrTD.Validate(ctx, a.Value(), collectNSContext(elem)); err != nil {
-						ad := attrDisplayName(a)
-						msg := fmt.Sprintf("The value '%s' is not valid for the type of attribute '%s'.", a.Value(), ad)
-						vc.reportValidityErrorAttr(ctx, vc.filename, elem.Line(), elemDisplayName(elem), ad, msg)
-						hasErr = true
-					}
+			// Validate the attribute value against its declared type
+			// (inline anonymous simpleType takes precedence over a named type).
+			attrTD, tdOK := vc.attrUseType(au)
+			if tdOK && attrTD.ContentType == ContentTypeSimple {
+				if err := attrTD.Validate(ctx, a.Value(), collectNSContext(elem)); err != nil {
+					ad := attrDisplayName(a)
+					msg := fmt.Sprintf("The value '%s' is not valid for the type of attribute '%s'.", a.Value(), ad)
+					vc.reportValidityErrorAttr(ctx, vc.filename, elem.Line(), elemDisplayName(elem), ad, msg)
+					hasErr = true
 				}
 			}
 			// Annotate the attribute with its declared type.
@@ -750,15 +749,25 @@ func (vc *validationContext) annotateElement(_ context.Context, elem *helium.Ele
 	(*vc.cfg.annotations)[elem] = xsdTypeName(td)
 }
 
+// attrUseType resolves the effective simple type for an attribute use. An inline
+// anonymous <xs:simpleType> (au.Type) takes precedence over a named type
+// reference (au.TypeName).
+func (vc *validationContext) attrUseType(au *AttrUse) (*TypeDef, bool) {
+	if au.Type != nil {
+		return au.Type, true
+	}
+	if au.TypeName.Local == "" {
+		return nil, false
+	}
+	return vc.schema.LookupType(au.TypeName.Local, au.TypeName.NS)
+}
+
 // annotateAttrUse records a type annotation for an attribute node based on its AttrUse declaration.
 func (vc *validationContext) annotateAttrUse(_ context.Context, a *helium.Attribute, au *AttrUse) {
 	if vc.cfg == nil || vc.cfg.annotations == nil {
 		return
 	}
-	if au.TypeName.Local == "" {
-		return
-	}
-	td, ok := vc.schema.types[au.TypeName]
+	td, ok := vc.attrUseType(au)
 	if !ok {
 		return
 	}

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -522,15 +522,15 @@ func (vc *validationContext) validateWildcardAttr(ctx context.Context, a *helium
 
 	// Global attribute found — validate value against its effective type if
 	// known (an inline anonymous simpleType takes precedence over a named type).
+	// TypeDef.Validate handles facets, lists, and unions, not just the builtin
+	// base lexical space.
 	attrTD, ok := vc.attrUseType(globalAttr)
 	if ok && attrTD.ContentType == ContentTypeSimple {
 		value := a.Value()
-		trimmed := strings.TrimSpace(value)
-		builtinLocal := builtinBaseLocal(attrTD)
-		if err := validateBuiltinValue(trimmed, builtinLocal); err != nil {
+		if err := attrTD.Validate(ctx, value, collectNSContext(elem)); err != nil {
 			ad := attrDisplayName(a)
 			typeName := typeDisplayName(attrTD)
-			msg := fmt.Sprintf("'%s' is not a valid value of the atomic type '%s'.", trimmed, typeName)
+			msg := fmt.Sprintf("'%s' is not a valid value of the atomic type '%s'.", strings.TrimSpace(value), typeName)
 			vc.reportValidityErrorAttr(ctx, vc.filename, elem.Line(), elemDisplayName(elem), ad, msg)
 			return err
 		}

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -520,20 +520,19 @@ func (vc *validationContext) validateWildcardAttr(ctx context.Context, a *helium
 		return nil
 	}
 
-	// Global attribute found — validate value against its type if known.
-	if globalAttr.TypeName.Local != "" {
-		attrTD, ok := vc.schema.types[globalAttr.TypeName]
-		if ok {
-			value := a.Value()
-			trimmed := strings.TrimSpace(value)
-			builtinLocal := builtinBaseLocal(attrTD)
-			if err := validateBuiltinValue(trimmed, builtinLocal); err != nil {
-				ad := attrDisplayName(a)
-				typeName := typeDisplayName(attrTD)
-				msg := fmt.Sprintf("'%s' is not a valid value of the atomic type '%s'.", trimmed, typeName)
-				vc.reportValidityErrorAttr(ctx, vc.filename, elem.Line(), elemDisplayName(elem), ad, msg)
-				return err
-			}
+	// Global attribute found — validate value against its effective type if
+	// known (an inline anonymous simpleType takes precedence over a named type).
+	attrTD, ok := vc.attrUseType(globalAttr)
+	if ok && attrTD.ContentType == ContentTypeSimple {
+		value := a.Value()
+		trimmed := strings.TrimSpace(value)
+		builtinLocal := builtinBaseLocal(attrTD)
+		if err := validateBuiltinValue(trimmed, builtinLocal); err != nil {
+			ad := attrDisplayName(a)
+			typeName := typeDisplayName(attrTD)
+			msg := fmt.Sprintf("'%s' is not a valid value of the atomic type '%s'.", trimmed, typeName)
+			vc.reportValidityErrorAttr(ctx, vc.filename, elem.Line(), elemDisplayName(elem), ad, msg)
+			return err
 		}
 	}
 

--- a/xsd/validate_inline_attr_simpletype_test.go
+++ b/xsd/validate_inline_attr_simpletype_test.go
@@ -1,0 +1,37 @@
+package xsd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestInlineAttributeSimpleType checks that an attribute use declared with an
+// inline <xs:simpleType> restriction has its value validated against the
+// anonymous type, rather than the restriction being silently ignored.
+func TestInlineAttributeSimpleType(t *testing.T) {
+	t.Parallel()
+
+	schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="a">
+        <xs:simpleType>
+          <xs:restriction base="xs:int"/>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+	t.Run("accepts valid value", func(t *testing.T) {
+		require.NoError(t, compileAndValidate(t, schemaXML, `<root a="42"/>`, nil))
+	})
+
+	t.Run("rejects invalid value", func(t *testing.T) {
+		var out string
+		err := compileAndValidate(t, schemaXML, `<root a="not-int"/>`, &out)
+		require.Error(t, err)
+		require.Contains(t, out, "is not valid for the type of attribute 'a'")
+	})
+}

--- a/xsd/validate_inline_attr_simpletype_test.go
+++ b/xsd/validate_inline_attr_simpletype_test.go
@@ -8,15 +8,25 @@ import (
 
 // TestInlineAttributeSimpleType checks that an attribute use declared with an
 // inline anonymous <xs:simpleType> restriction has its value validated against
-// the anonymous type, rather than the restriction being silently ignored. This
-// covers all three paths that reach an attribute use:
+// the anonymous type — including its facets — rather than the restriction being
+// silently ignored. This covers all three paths that reach an attribute use:
 //   - a direct local <xs:attribute name="a"> with an inline simpleType
 //   - a local <xs:attribute ref="a"/> referencing a global attribute whose
 //     type is an inline anonymous simpleType
 //   - an <xs:anyAttribute processContents="strict"> matching such a global
 //     attribute
+//
+// Each inline type carries a maxInclusive facet on top of xs:int so the tests
+// fail unless the anonymous type is actually validated (a bare base-type check
+// would accept the out-of-range value).
 func TestInlineAttributeSimpleType(t *testing.T) {
 	t.Parallel()
+
+	const inlineType = `<xs:simpleType>
+      <xs:restriction base="xs:int">
+        <xs:maxInclusive value="10"/>
+      </xs:restriction>
+    </xs:simpleType>`
 
 	t.Run("local inline simpleType", func(t *testing.T) {
 		t.Parallel()
@@ -24,21 +34,26 @@ func TestInlineAttributeSimpleType(t *testing.T) {
   <xs:element name="root">
     <xs:complexType>
       <xs:attribute name="a">
-        <xs:simpleType>
-          <xs:restriction base="xs:int"/>
-        </xs:simpleType>
+        ` + inlineType + `
       </xs:attribute>
     </xs:complexType>
   </xs:element>
 </xs:schema>`
 
 		t.Run("accepts valid value", func(t *testing.T) {
-			require.NoError(t, compileAndValidate(t, schemaXML, `<root a="42"/>`, nil))
+			require.NoError(t, compileAndValidate(t, schemaXML, `<root a="5"/>`, nil))
 		})
 
-		t.Run("rejects invalid value", func(t *testing.T) {
+		t.Run("rejects non-int", func(t *testing.T) {
 			var out string
 			err := compileAndValidate(t, schemaXML, `<root a="not-int"/>`, &out)
+			require.Error(t, err)
+			require.Contains(t, out, "is not valid for the type of attribute 'a'")
+		})
+
+		t.Run("rejects out-of-range value (facet)", func(t *testing.T) {
+			var out string
+			err := compileAndValidate(t, schemaXML, `<root a="42"/>`, &out)
 			require.Error(t, err)
 			require.Contains(t, out, "is not valid for the type of attribute 'a'")
 		})
@@ -48,9 +63,7 @@ func TestInlineAttributeSimpleType(t *testing.T) {
 		t.Parallel()
 		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:attribute name="a">
-    <xs:simpleType>
-      <xs:restriction base="xs:int"/>
-    </xs:simpleType>
+    ` + inlineType + `
   </xs:attribute>
   <xs:element name="root">
     <xs:complexType>
@@ -60,12 +73,19 @@ func TestInlineAttributeSimpleType(t *testing.T) {
 </xs:schema>`
 
 		t.Run("accepts valid value", func(t *testing.T) {
-			require.NoError(t, compileAndValidate(t, schemaXML, `<root a="42"/>`, nil))
+			require.NoError(t, compileAndValidate(t, schemaXML, `<root a="5"/>`, nil))
 		})
 
-		t.Run("rejects invalid value", func(t *testing.T) {
+		t.Run("rejects non-int", func(t *testing.T) {
 			var out string
 			err := compileAndValidate(t, schemaXML, `<root a="not-int"/>`, &out)
+			require.Error(t, err)
+			require.Contains(t, out, "is not valid for the type of attribute 'a'")
+		})
+
+		t.Run("rejects out-of-range value (facet)", func(t *testing.T) {
+			var out string
+			err := compileAndValidate(t, schemaXML, `<root a="42"/>`, &out)
 			require.Error(t, err)
 			require.Contains(t, out, "is not valid for the type of attribute 'a'")
 		})
@@ -75,9 +95,7 @@ func TestInlineAttributeSimpleType(t *testing.T) {
 		t.Parallel()
 		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:attribute name="a">
-    <xs:simpleType>
-      <xs:restriction base="xs:int"/>
-    </xs:simpleType>
+    ` + inlineType + `
   </xs:attribute>
   <xs:element name="root">
     <xs:complexType>
@@ -87,14 +105,21 @@ func TestInlineAttributeSimpleType(t *testing.T) {
 </xs:schema>`
 
 		t.Run("accepts valid value", func(t *testing.T) {
-			require.NoError(t, compileAndValidate(t, schemaXML, `<root a="42"/>`, nil))
+			require.NoError(t, compileAndValidate(t, schemaXML, `<root a="5"/>`, nil))
 		})
 
-		t.Run("rejects invalid value", func(t *testing.T) {
+		t.Run("rejects non-int", func(t *testing.T) {
 			var out string
 			err := compileAndValidate(t, schemaXML, `<root a="not-int"/>`, &out)
 			require.Error(t, err)
-			require.Contains(t, out, "is not a valid value of the atomic type 'xs:int'")
+			require.Contains(t, out, "is not a valid value of the atomic type")
+		})
+
+		t.Run("rejects out-of-range value (facet)", func(t *testing.T) {
+			var out string
+			err := compileAndValidate(t, schemaXML, `<root a="42"/>`, &out)
+			require.Error(t, err)
+			require.Contains(t, out, "is not a valid value of the atomic type")
 		})
 	})
 }

--- a/xsd/validate_inline_attr_simpletype_test.go
+++ b/xsd/validate_inline_attr_simpletype_test.go
@@ -7,12 +7,20 @@ import (
 )
 
 // TestInlineAttributeSimpleType checks that an attribute use declared with an
-// inline <xs:simpleType> restriction has its value validated against the
-// anonymous type, rather than the restriction being silently ignored.
+// inline anonymous <xs:simpleType> restriction has its value validated against
+// the anonymous type, rather than the restriction being silently ignored. This
+// covers all three paths that reach an attribute use:
+//   - a direct local <xs:attribute name="a"> with an inline simpleType
+//   - a local <xs:attribute ref="a"/> referencing a global attribute whose
+//     type is an inline anonymous simpleType
+//   - an <xs:anyAttribute processContents="strict"> matching such a global
+//     attribute
 func TestInlineAttributeSimpleType(t *testing.T) {
 	t.Parallel()
 
-	schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	t.Run("local inline simpleType", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="root">
     <xs:complexType>
       <xs:attribute name="a">
@@ -24,14 +32,69 @@ func TestInlineAttributeSimpleType(t *testing.T) {
   </xs:element>
 </xs:schema>`
 
-	t.Run("accepts valid value", func(t *testing.T) {
-		require.NoError(t, compileAndValidate(t, schemaXML, `<root a="42"/>`, nil))
+		t.Run("accepts valid value", func(t *testing.T) {
+			require.NoError(t, compileAndValidate(t, schemaXML, `<root a="42"/>`, nil))
+		})
+
+		t.Run("rejects invalid value", func(t *testing.T) {
+			var out string
+			err := compileAndValidate(t, schemaXML, `<root a="not-int"/>`, &out)
+			require.Error(t, err)
+			require.Contains(t, out, "is not valid for the type of attribute 'a'")
+		})
 	})
 
-	t.Run("rejects invalid value", func(t *testing.T) {
-		var out string
-		err := compileAndValidate(t, schemaXML, `<root a="not-int"/>`, &out)
-		require.Error(t, err)
-		require.Contains(t, out, "is not valid for the type of attribute 'a'")
+	t.Run("ref to global attr with inline simpleType", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attribute name="a">
+    <xs:simpleType>
+      <xs:restriction base="xs:int"/>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute ref="a"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+		t.Run("accepts valid value", func(t *testing.T) {
+			require.NoError(t, compileAndValidate(t, schemaXML, `<root a="42"/>`, nil))
+		})
+
+		t.Run("rejects invalid value", func(t *testing.T) {
+			var out string
+			err := compileAndValidate(t, schemaXML, `<root a="not-int"/>`, &out)
+			require.Error(t, err)
+			require.Contains(t, out, "is not valid for the type of attribute 'a'")
+		})
+	})
+
+	t.Run("strict wildcard against global attr with inline simpleType", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attribute name="a">
+    <xs:simpleType>
+      <xs:restriction base="xs:int"/>
+    </xs:simpleType>
+  </xs:attribute>
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:anyAttribute processContents="strict"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+		t.Run("accepts valid value", func(t *testing.T) {
+			require.NoError(t, compileAndValidate(t, schemaXML, `<root a="42"/>`, nil))
+		})
+
+		t.Run("rejects invalid value", func(t *testing.T) {
+			var out string
+			err := compileAndValidate(t, schemaXML, `<root a="not-int"/>`, &out)
+			require.Error(t, err)
+			require.Contains(t, out, "is not a valid value of the atomic type 'xs:int'")
+		})
 	})
 }


### PR DESCRIPTION
- parse inline anonymous <xs:simpleType> on attribute uses in readAttributeUseDecl
- validate and annotate attribute values against the inline type (precedence over named type)