### PR TITLE
reject non-date/time args in fn:dateTime

### DIFF
--- a/xpath3/functions_datetime.go
+++ b/xpath3/functions_datetime.go
@@ -137,13 +137,15 @@ func fnDateTime(_ context.Context, args []Sequence) (Sequence, error) {
 		}
 	}
 	// Per XPath F&O fn:dateTime($arg1 as xs:date?, $arg2 as xs:time?): the
-	// first argument must be xs:date and the second xs:time. Checking only for
-	// a time.Time payload is not enough — xs:dateTime (and other temporal
-	// types) also carry one and would be silently reinterpreted.
-	if dateA.TypeName != TypeDate {
+	// first argument must be xs:date and the second xs:time. By XSD subtype
+	// substitution this also accepts any type derived from xs:date / xs:time.
+	// Checking only for a time.Time payload is not enough — xs:dateTime (a
+	// sibling of xs:date, not a subtype) also carries one and would be silently
+	// reinterpreted; it must still be rejected.
+	if !isAtomicSubtypeOf(dateA, TypeDate) {
 		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "first arg must be xs:date, got " + dateA.TypeName}
 	}
-	if timeA.TypeName != TypeTime {
+	if !isAtomicSubtypeOf(timeA, TypeTime) {
 		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "second arg must be xs:time, got " + timeA.TypeName}
 	}
 	d, ok := dateA.Value.(time.Time)

--- a/xpath3/functions_datetime.go
+++ b/xpath3/functions_datetime.go
@@ -136,6 +136,16 @@ func fnDateTime(_ context.Context, args []Sequence) (Sequence, error) {
 			return nil, err
 		}
 	}
+	// Per XPath F&O fn:dateTime($arg1 as xs:date?, $arg2 as xs:time?): the
+	// first argument must be xs:date and the second xs:time. Checking only for
+	// a time.Time payload is not enough — xs:dateTime (and other temporal
+	// types) also carry one and would be silently reinterpreted.
+	if dateA.TypeName != TypeDate {
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "first arg must be xs:date, got " + dateA.TypeName}
+	}
+	if timeA.TypeName != TypeTime {
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "second arg must be xs:time, got " + timeA.TypeName}
+	}
 	d, ok := dateA.Value.(time.Time)
 	if !ok {
 		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "first arg must be xs:date, got " + dateA.TypeName}

--- a/xpath3/functions_datetime_internal_test.go
+++ b/xpath3/functions_datetime_internal_test.go
@@ -1,0 +1,48 @@
+package xpath3
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFnDateTimeDerivedArgType verifies fn:dateTime accepts xs:date / xs:time
+// and any type derived from them by restriction (carried via BaseType), while
+// still rejecting xs:dateTime, which is a sibling of xs:date (not a subtype).
+func TestFnDateTimeDerivedArgType(t *testing.T) {
+	d := time.Date(1948, time.November, 2, 0, 0, 0, 0, noTZLocation)
+	tm := time.Date(0, time.January, 1, 1, 2, 3, 0, noTZLocation)
+
+	derivedDate := AtomicValue{TypeName: "Q{urn:x}myDate", Value: d, BaseType: TypeDate}
+	derivedTime := AtomicValue{TypeName: "Q{urn:x}myTime", Value: tm, BaseType: TypeTime}
+
+	t.Run("user-derived from xs:date and xs:time are accepted", func(t *testing.T) {
+		seq, err := fnDateTime(t.Context(), []Sequence{
+			SingleAtomic(derivedDate),
+			SingleAtomic(derivedTime),
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, seq.Len())
+		require.Equal(t, TypeDateTime, seq.Get(0).(AtomicValue).TypeName)
+	})
+
+	t.Run("xs:dateTime as first arg is rejected (sibling, not subtype)", func(t *testing.T) {
+		dt := AtomicValue{TypeName: TypeDateTime, Value: d}
+		_, err := fnDateTime(t.Context(), []Sequence{
+			SingleAtomic(dt),
+			SingleAtomic(AtomicValue{TypeName: TypeTime, Value: tm}),
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, &XPathError{Code: "XPTY0004"})
+	})
+
+	t.Run("plain xs:date and xs:time are accepted", func(t *testing.T) {
+		seq, err := fnDateTime(t.Context(), []Sequence{
+			SingleAtomic(AtomicValue{TypeName: TypeDate, Value: d}),
+			SingleAtomic(AtomicValue{TypeName: TypeTime, Value: tm}),
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, seq.Len())
+	})
+}

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -780,6 +780,44 @@ func TestFnDateTime(t *testing.T) {
 		av := seq.Get(0).(xpath3.AtomicValue)
 		require.True(t, av.IntegerVal() >= 2024)
 	})
+
+	t.Run("date and time combine", func(t *testing.T) {
+		// fn:dateTime($arg1 as xs:date?, $arg2 as xs:time?) combines a date
+		// and a time into an xs:dateTime.
+		seq := evalExpr(t, doc, `dateTime(xs:date("2020-01-01"), xs:time("01:02:03"))`)
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.Equal(t, xpath3.TypeDateTime, av.TypeName)
+
+		strSeq := evalExpr(t, doc, `string(dateTime(xs:date("2020-01-01"), xs:time("01:02:03")))`)
+		require.Equal(t, 1, strSeq.Len())
+		require.Equal(t, "2020-01-01T01:02:03", strSeq.Get(0).(xpath3.AtomicValue).Value)
+	})
+
+	t.Run("empty arg yields empty sequence", func(t *testing.T) {
+		require.Nil(t, evalExpr(t, doc, `dateTime((), xs:time("01:02:03"))`))
+		require.Nil(t, evalExpr(t, doc, `dateTime(xs:date("2020-01-01"), ())`))
+	})
+
+	t.Run("dateTime as first arg is a type error", func(t *testing.T) {
+		// $arg1 is declared xs:date?; passing an xs:dateTime must raise
+		// XPTY0004 rather than being reinterpreted as a date.
+		compiled, err := xpath3.NewCompiler().Compile(`dateTime(xs:dateTime("2020-01-01T12:00:00"), xs:time("01:02:03"))`)
+		require.NoError(t, err)
+		_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.Error(t, err)
+		require.ErrorIs(t, err, &xpath3.XPathError{Code: "XPTY0004"})
+	})
+
+	t.Run("dateTime as second arg is a type error", func(t *testing.T) {
+		// $arg2 is declared xs:time?; passing an xs:dateTime must raise
+		// XPTY0004 rather than being reinterpreted as a time.
+		compiled, err := xpath3.NewCompiler().Compile(`dateTime(xs:date("2020-01-01"), xs:dateTime("2020-01-01T12:00:00"))`)
+		require.NoError(t, err)
+		_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.Error(t, err)
+		require.ErrorIs(t, err, &xpath3.XPathError{Code: "XPTY0004"})
+	})
 }
 
 func TestFnAvgLexicalDecimal(t *testing.T) {

--- a/xpath3/types.go
+++ b/xpath3/types.go
@@ -170,6 +170,22 @@ func isSubtypeOf(actualType, targetType string) bool {
 	return result
 }
 
+// isAtomicSubtypeOf reports whether the atomic value's type is targetType or a
+// subtype of it, honoring both the built-in XSD hierarchy and the value's
+// built-in BaseType (set when TypeName is a user-defined schema type derived by
+// restriction). Unlike PromoteSchemaType it never falls back to the Go value's
+// kind, so a sibling type (e.g. xs:dateTime relative to xs:date) is correctly
+// rejected rather than reinterpreted from its time.Time payload.
+func isAtomicSubtypeOf(av AtomicValue, targetType string) bool {
+	if isSubtypeOf(av.TypeName, targetType) {
+		return true
+	}
+	if av.BaseType != "" && IsKnownXSDType(av.BaseType) && isSubtypeOf(av.BaseType, targetType) {
+		return true
+	}
+	return false
+}
+
 // BuiltinIsSubtypeOf reports whether actualType is the same as or a subtype of
 // targetType using only the built-in XSD type hierarchy (no schema lookup).
 // This is exported for use by schema-aware backends (e.g. xslt3) that need to


### PR DESCRIPTION
- fn:dateTime now requires $arg1 to be xs:date and $arg2 to be xs:time, raising XPTY0004 otherwise (previously any time.Time-backed type passed)
- empty-sequence args and valid date+time combination preserved