### PR TITLE
treat absolute-uri include/import hrefs as absolute

### DIFF
--- a/xslt3/compile_imports.go
+++ b/xslt3/compile_imports.go
@@ -69,6 +69,15 @@ func resolveModuleURI(href, baseURI string) (string, error) {
 	if href == "" || baseURI == "" {
 		return href, nil
 	}
+	// A Windows drive-letter href ("C:/..." or "C:\\...") is a filesystem path,
+	// not a URI: its single-letter "scheme" is rejected by xsd.URIScheme, so
+	// without this branch it would fall through to ResolveSchemaURI and be
+	// lowercased / dot-segment-mangled by RFC 3986 resolution against a URI
+	// base. Address its own location verbatim. This must run BEFORE the URI
+	// branch below.
+	if isWindowsDrivePath(href) {
+		return href, nil
+	}
 	// Absolute-URI href, or any href against a URI base: defer to the shared
 	// canonical resolver (RFC 3986 + OmitHost preservation).
 	if xsd.URIScheme(href) != "" || xsd.URIScheme(baseURI) != "" {
@@ -79,6 +88,21 @@ func resolveModuleURI(href, baseURI string) (string, error) {
 		return href, nil
 	}
 	return filepath.Join(filepath.Dir(baseURI), href), nil
+}
+
+// isWindowsDrivePath reports whether s begins with a Windows drive-letter prefix
+// ("C:/" or "C:\\"). Such paths are local filesystem paths, not URI references:
+// their single-letter "scheme" is deliberately not recognized by xsd.URIScheme,
+// so they must be handled as filesystem paths before any URI resolution.
+func isWindowsDrivePath(s string) bool {
+	if len(s) < 3 {
+		return false
+	}
+	c := s[0]
+	if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+		return false
+	}
+	return s[1] == ':' && (s[2] == '/' || s[2] == '\\')
 }
 
 // collectIncludeImports is the first phase of two-phase include processing.

--- a/xslt3/compile_imports.go
+++ b/xslt3/compile_imports.go
@@ -99,7 +99,7 @@ func isWindowsDrivePath(s string) bool {
 		return false
 	}
 	c := s[0]
-	if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+	if (c < 'A' || c > 'Z') && (c < 'a' || c > 'z') {
 		return false
 	}
 	return s[1] == ':' && (s[2] == '/' || s[2] == '\\')

--- a/xslt3/compile_imports.go
+++ b/xslt3/compile_imports.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/lestrrat-go/helium/xsd"
 )
 
 func (c *compiler) compileImport(ctx context.Context, elem *helium.Element) error {
@@ -40,10 +41,9 @@ func (c *compiler) resolveIncludeURI(_ context.Context, elem *helium.Element) (s
 		href = href[:idx]
 	}
 
-	uri := href
-	if baseURI != "" && !strings.Contains(href, "://") && !filepath.IsAbs(href) {
-		baseDir := filepath.Dir(baseURI)
-		uri = filepath.Join(baseDir, href)
+	uri, err := resolveModuleURI(href, baseURI)
+	if err != nil {
+		return "", "", err
 	}
 
 	importKey := uri
@@ -51,6 +51,34 @@ func (c *compiler) resolveIncludeURI(_ context.Context, elem *helium.Element) (s
 		importKey = uri + "#" + fragment
 	}
 	return uri, importKey, nil
+}
+
+// resolveModuleURI resolves an xsl:include / xsl:import href (with any fragment
+// already stripped) against the stylesheet base URI.
+//
+// An absolute-URI href (it carries its own scheme, e.g. "urn:shared",
+// "file:/modules/m.xsl", "mem:/m.xsl") addresses its own location and is
+// returned UNCHANGED — it must never be filepath.Join'ed onto the base, which
+// would corrupt it (e.g. "/styles/urn:shared"). A relative href against a URI
+// base is resolved with RFC 3986 semantics; against a local filesystem base it
+// keeps historical filepath.Join handling. Resolution is delegated to
+// [xsd.ResolveSchemaURI] / [xsd.URIScheme] — the single canonical URI helper
+// shared with the schema loader — so the two layers cannot drift. Windows
+// drive-letter paths (single-letter "scheme") stay filesystem paths.
+func resolveModuleURI(href, baseURI string) (string, error) {
+	if href == "" || baseURI == "" {
+		return href, nil
+	}
+	// Absolute-URI href, or any href against a URI base: defer to the shared
+	// canonical resolver (RFC 3986 + OmitHost preservation).
+	if xsd.URIScheme(href) != "" || xsd.URIScheme(baseURI) != "" {
+		return xsd.ResolveSchemaURI(href, baseURI) //nolint:wrapcheck // static error passthrough
+	}
+	// Local filesystem base (a FILE path): keep historical filepath semantics.
+	if filepath.IsAbs(href) {
+		return href, nil
+	}
+	return filepath.Join(filepath.Dir(baseURI), href), nil
 }
 
 // collectIncludeImports is the first phase of two-phase include processing.
@@ -434,11 +462,11 @@ func (c *compiler) loadExternalStylesheet(ctx context.Context, baseURI, href str
 		href = href[:idx]
 	}
 
-	// Resolve URI relative to base
-	uri := href
-	if baseURI != "" && !strings.Contains(href, "://") && !filepath.IsAbs(href) {
-		baseDir := filepath.Dir(baseURI)
-		uri = filepath.Join(baseDir, href)
+	// Resolve URI relative to base. An absolute-URI href is passed through
+	// uncorrupted; a relative href is resolved against the base.
+	uri, err := resolveModuleURI(href, baseURI)
+	if err != nil {
+		return err
 	}
 
 	// Circular import detection (use uri+fragment for uniqueness)

--- a/xslt3/include_abs_uri_test.go
+++ b/xslt3/include_abs_uri_test.go
@@ -1,0 +1,131 @@
+package xslt3_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xslt3"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingCompileResolver records every URI it is asked to resolve and serves
+// the bytes registered for that URI. It proves an xsl:include / xsl:import href
+// reached the compile-time URIResolver as the intended (uncorrupted) key.
+type recordingCompileResolver struct {
+	mu       sync.Mutex
+	requests []string
+	files    map[string][]byte
+}
+
+func (r *recordingCompileResolver) Resolve(uri string) (io.ReadCloser, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.requests = append(r.requests, uri)
+	data, ok := r.files[uri]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (r *recordingCompileResolver) seen(uri string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Contains(r.requests, uri)
+}
+
+const childModule = `<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <xsl:template match="/data">
+    <out value="{@v}"/>
+  </xsl:template>
+</xsl:stylesheet>`
+
+// TestIncludeAbsoluteURIHrefPassedThrough verifies that an xsl:include /
+// xsl:import href that is an absolute URI reference (with a scheme but no "://"
+// authority, e.g. "urn:shared" or "file:/modules/child.xsl") is handed to the
+// URIResolver unchanged — not filepath.Join'ed onto the stylesheet base.
+func TestIncludeAbsoluteURIHrefPassedThrough(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		decl string // include or import
+		href string
+	}{
+		{"include urn", "include", "urn:shared"},
+		{"import urn", "import", "urn:shared"},
+		{"include file scheme single slash", "include", "file:/modules/child.xsl"},
+		{"import data-ish scheme", "import", "mem:/modules/child.xsl"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			main := `<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <xsl:` + tc.decl + ` href="` + tc.href + `"/>
+</xsl:stylesheet>`
+
+			resolver := &recordingCompileResolver{files: map[string][]byte{
+				tc.href: []byte(childModule),
+			}}
+
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(main))
+			require.NoError(t, err)
+
+			// A non-empty base URI is what triggered the corruption: the
+			// absolute-URI href used to be filepath.Join'ed against it.
+			ss, err := xslt3.NewCompiler().
+				BaseURI("/styles/main.xsl").
+				URIResolver(resolver).
+				Compile(t.Context(), doc)
+			require.NoError(t, err)
+			require.NotNil(t, ss)
+
+			require.True(t, resolver.seen(tc.href),
+				"resolver should have been asked for %q uncorrupted; got %v", tc.href, resolver.requests)
+
+			// Confirm the module actually loaded and its template runs.
+			source, err := helium.NewParser().Parse(t.Context(), []byte(`<data v="hello"/>`))
+			require.NoError(t, err)
+			out, err := xslt3.TransformString(t.Context(), source, ss)
+			require.NoError(t, err)
+			require.Contains(t, out, `value="hello"`)
+		})
+	}
+}
+
+// TestIncludeRelativeHrefResolvedAgainstBase verifies that a relative href is
+// still resolved against the (URI) stylesheet base, not passed through bare.
+func TestIncludeRelativeHrefResolvedAgainstBase(t *testing.T) {
+	t.Parallel()
+
+	main := `<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <xsl:include href="child.xsl"/>
+</xsl:stylesheet>`
+
+	// Base is a URI, so the relative href must resolve via RFC 3986 to a
+	// sibling under the same base directory.
+	resolver := &recordingCompileResolver{files: map[string][]byte{
+		"mem:/styles/child.xsl": []byte(childModule),
+	}}
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(main))
+	require.NoError(t, err)
+
+	_, err = xslt3.NewCompiler().
+		BaseURI("mem:/styles/main.xsl").
+		URIResolver(resolver).
+		Compile(t.Context(), doc)
+	require.NoError(t, err)
+
+	require.True(t, resolver.seen("mem:/styles/child.xsl"),
+		"relative href should resolve against URI base; got %v", resolver.requests)
+}

--- a/xslt3/include_abs_uri_test.go
+++ b/xslt3/include_abs_uri_test.go
@@ -56,12 +56,20 @@ func TestIncludeAbsoluteURIHrefPassedThrough(t *testing.T) {
 	cases := []struct {
 		name string
 		decl string // include or import
+		base string // compiler base URI
 		href string
 	}{
-		{"include urn", "include", "urn:shared"},
-		{"import urn", "import", "urn:shared"},
-		{"include file scheme single slash", "include", "file:/modules/child.xsl"},
-		{"import data-ish scheme", "import", "mem:/modules/child.xsl"},
+		{"include urn", "include", "/styles/main.xsl", "urn:shared"},
+		{"import urn", "import", "/styles/main.xsl", "urn:shared"},
+		{"include file scheme single slash", "include", "/styles/main.xsl", "file:/modules/child.xsl"},
+		{"import data scheme", "import", "/styles/main.xsl", "data:application/xslt+xml,child"},
+		{"include http scheme", "include", "/styles/main.xsl", "http://example.com/modules/child.xsl"},
+		// Windows drive-letter paths are filesystem paths, not URIs. With a URI
+		// base they used to fall through to RFC 3986 resolution and be
+		// lowercased / dot-segment-mangled; they must reach the resolver
+		// verbatim. A URI base is what triggers the corruption, so use one here.
+		{"include windows drive forward slash", "include", "mem:/styles/main.xsl", "C:/modules/child.xsl"},
+		{"import windows drive back slash", "import", "mem:/styles/main.xsl", `C:\modules\child.xsl`},
 	}
 
 	for _, tc := range cases {
@@ -79,10 +87,10 @@ func TestIncludeAbsoluteURIHrefPassedThrough(t *testing.T) {
 			doc, err := helium.NewParser().Parse(t.Context(), []byte(main))
 			require.NoError(t, err)
 
-			// A non-empty base URI is what triggered the corruption: the
-			// absolute-URI href used to be filepath.Join'ed against it.
+			// A non-empty base is what triggered the corruption: the
+			// absolute href used to be joined/resolved against it.
 			ss, err := xslt3.NewCompiler().
-				BaseURI("/styles/main.xsl").
+				BaseURI(tc.base).
 				URIResolver(resolver).
 				Compile(t.Context(), doc)
 			require.NoError(t, err)

--- a/xslt3/include_abs_uri_test.go
+++ b/xslt3/include_abs_uri_test.go
@@ -39,6 +39,12 @@ func (r *recordingCompileResolver) seen(uri string) bool {
 	return slices.Contains(r.requests, uri)
 }
 
+const (
+	declInclude   = "include"
+	declImport    = "import"
+	stylesMainXSL = "/styles/main.xsl"
+)
+
 const childModule = `<?xml version="1.0"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
   <xsl:template match="/data">
@@ -59,17 +65,17 @@ func TestIncludeAbsoluteURIHrefPassedThrough(t *testing.T) {
 		base string // compiler base URI
 		href string
 	}{
-		{"include urn", "include", "/styles/main.xsl", "urn:shared"},
-		{"import urn", "import", "/styles/main.xsl", "urn:shared"},
-		{"include file scheme single slash", "include", "/styles/main.xsl", "file:/modules/child.xsl"},
-		{"import data scheme", "import", "/styles/main.xsl", "data:application/xslt+xml,child"},
-		{"include http scheme", "include", "/styles/main.xsl", "http://example.com/modules/child.xsl"},
+		{"include urn", declInclude, stylesMainXSL, "urn:shared"},
+		{"import urn", declImport, stylesMainXSL, "urn:shared"},
+		{"include file scheme single slash", declInclude, stylesMainXSL, "file:/modules/child.xsl"},
+		{"import data scheme", declImport, stylesMainXSL, "data:application/xslt+xml,child"},
+		{"include http scheme", declInclude, stylesMainXSL, "http://example.com/modules/child.xsl"},
 		// Windows drive-letter paths are filesystem paths, not URIs. With a URI
 		// base they used to fall through to RFC 3986 resolution and be
 		// lowercased / dot-segment-mangled; they must reach the resolver
 		// verbatim. A URI base is what triggers the corruption, so use one here.
-		{"include windows drive forward slash", "include", "mem:/styles/main.xsl", "C:/modules/child.xsl"},
-		{"import windows drive back slash", "import", "mem:/styles/main.xsl", `C:\modules\child.xsl`},
+		{"include windows drive forward slash", declInclude, "mem:/styles/main.xsl", "C:/modules/child.xsl"},
+		{"import windows drive back slash", declImport, "mem:/styles/main.xsl", `C:\modules\child.xsl`},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
- xsl:include / xsl:import hrefs that are absolute URI references (urn:, file:/, mem:/) are now passed to the URIResolver uncorrupted instead of being filepath.Join'ed onto the stylesheet base
- relative hrefs still resolve against the base via the shared xsd.ResolveSchemaURI helper (RFC 3986 for URI bases, filepath for local bases)