### PR TITLE
keep xsl:sequence order in document variables

### DIFF
--- a/xslt3/execute_globals.go
+++ b/xslt3/execute_globals.go
@@ -663,7 +663,7 @@ func (ec *execContext) evaluateBodyAsDocument(ctx context.Context, body []instru
 		tmpDoc.SetURL(baseURI)
 	}
 
-	frame := &outputFrame{doc: tmpDoc, current: tmpDoc, captureItems: true}
+	frame := &outputFrame{doc: tmpDoc, current: tmpDoc, captureItems: true, documentConstructor: true}
 	ec.outputStack = append(ec.outputStack, frame)
 
 	// Temporarily set resultDoc to the temp document so that nodes
@@ -683,11 +683,38 @@ func (ec *execContext) evaluateBodyAsDocument(ctx context.Context, body []instru
 	// Per XSLT spec: in document-node context (variable/param without as),
 	// node items from xsl:sequence are added as children of the document
 	// node, while atomic items are converted to text nodes and added as
-	// space-separated text.
+	// space-separated text. xsl:sequence output was marked in the DOM with
+	// placeholder PIs (see execXSLSequence); resolve each placeholder in
+	// document order so the constructed text/nodes interleave correctly with
+	// the literal result elements already built into the tree.
+	if len(frame.seqPlaceholders) > 0 {
+		// If the body produced exactly one document node (e.g. via xsl:copy
+		// or xsl:copy-of of a document) and there is no other content, use
+		// that document directly. This preserves DTD information (unparsed
+		// entities, notations) that would be lost if we atomized it.
+		if first := tmpDoc.FirstChild(); first != nil && first.NextSibling() == nil {
+			if items, ok := frame.seqPlaceholders[first]; ok && len(items) == 1 {
+				if ni, ok := items[0].(xpath3.NodeItem); ok {
+					if capturedDoc, ok := ni.Node.(*helium.Document); ok {
+						capturedDoc.SetProperties(capturedDoc.Properties() | helium.DocInternal)
+						return xpath3.ItemSlice{xpath3.NodeItem{Node: capturedDoc}}, nil
+					}
+				}
+			}
+		}
+
+		if err := ec.resolveSequencePlaceholders(tmpDoc, frame.seqPlaceholders); err != nil {
+			return nil, err
+		}
+	}
+
+	// Items captured outside xsl:sequence (e.g. xsl:copy / xsl:copy-of of a
+	// document node, or attributes) are buffered in pendingItems and appended
+	// after the DOM content, as before.
 	if len(frame.pendingItems) > 0 {
 		// If the body produced exactly one document node (e.g. via xsl:copy
 		// or xsl:copy-of of a document) and the temporary doc has no DOM
-		// children of its own, use that document directly.  This preserves
+		// children of its own, use that document directly. This preserves
 		// DTD information (unparsed entities, notations) that would be lost
 		// if we atomized the document into text.
 		if len(frame.pendingItems) == 1 && tmpDoc.FirstChild() == nil {
@@ -711,7 +738,6 @@ func (ec *execContext) evaluateBodyAsDocument(ctx context.Context, body []instru
 		}
 		for _, item := range frame.pendingItems {
 			if ni, ok := item.(xpath3.NodeItem); ok {
-				// Flush any accumulated text before adding the node.
 				if err := flushText(); err != nil {
 					return nil, err
 				}
@@ -725,7 +751,6 @@ func (ec *execContext) evaluateBodyAsDocument(ctx context.Context, body []instru
 				}
 				continue
 			}
-			// Atomic item: atomize and join with spaces.
 			if prevAtomic {
 				sb.WriteByte(' ')
 			}
@@ -758,6 +783,124 @@ func (ec *execContext) evaluateBodyAsDocument(ctx context.Context, body []instru
 	}
 
 	return xpath3.ItemSlice{xpath3.NodeItem{Node: tmpDoc}}, nil
+}
+
+// resolveSequencePlaceholders replaces the xsl:sequence placeholder PIs in the
+// document tree (created by execXSLSequence in document-constructor mode) with
+// the nodes/text produced by their buffered items, in document order. Atomic
+// items are converted to text and consecutive atomics — whether from the same
+// or adjacent xsl:sequence outputs — are separated by a single space, while any
+// intervening node from a literal result element resets that adjacency.
+func (ec *execContext) resolveSequencePlaceholders(tmpDoc *helium.Document, placeholders map[helium.Node]xpath3.ItemSlice) error {
+	var sb strings.Builder
+	prevAtomic := false
+
+	// makeText builds a text node from the accumulated atomic run, if any.
+	flushText := func() helium.Node {
+		if sb.Len() == 0 {
+			return nil
+		}
+		text := tmpDoc.CreateText([]byte(sb.String()))
+		sb.Reset()
+		return text
+	}
+
+	for child := tmpDoc.FirstChild(); child != nil; {
+		next := child.NextSibling()
+
+		items, isPlaceholder := placeholders[child]
+		if !isPlaceholder {
+			// A literal result node breaks the atomic adjacency run.
+			prevAtomic = false
+			child = next
+			continue
+		}
+
+		var replacement []helium.Node
+		for _, item := range items {
+			if ni, ok := item.(xpath3.NodeItem); ok {
+				if t := flushText(); t != nil {
+					replacement = append(replacement, t)
+				}
+				prevAtomic = false
+				if ni.Node.Type() == helium.DocumentNode {
+					// A document node in a sequence constructor is replaced by
+					// copies of its children, spliced in document order (mirrors
+					// the document-node branch in execXSLSequence). Copying the
+					// document node itself would nest a document inside the temp
+					// tree instead of splicing the source root element.
+					for child := ni.Node.FirstChild(); child != nil; child = child.NextSibling() {
+						copied, copyErr := helium.CopyNode(child, tmpDoc)
+						if copyErr != nil {
+							return copyErr
+						}
+						replacement = append(replacement, copied)
+					}
+					continue
+				}
+				copied, copyErr := helium.CopyNode(ni.Node, tmpDoc)
+				if copyErr != nil {
+					return copyErr
+				}
+				replacement = append(replacement, copied)
+				continue
+			}
+			// Atomic item: atomize and join consecutive atomics with a space.
+			if prevAtomic {
+				sb.WriteByte(' ')
+			}
+			av, err := xpath3.AtomizeItem(item)
+			if err != nil {
+				_, _ = fmt.Fprint(&sb, item)
+			} else {
+				s, serr := xpath3.AtomicToString(av)
+				if serr != nil {
+					_, _ = fmt.Fprint(&sb, item)
+				} else {
+					sb.WriteString(s)
+				}
+			}
+			prevAtomic = true
+		}
+
+		// If this placeholder ends an atomic run and the following sibling is
+		// not another placeholder, the run is complete: flush the text now so
+		// it is spliced in at this position.
+		if _, nextIsPlaceholder := placeholders[next]; !nextIsPlaceholder {
+			if t := flushText(); t != nil {
+				replacement = append(replacement, t)
+			}
+			prevAtomic = false
+		}
+
+		if len(replacement) == 0 {
+			helium.UnlinkNode(child.(helium.MutableNode)) //nolint:forcetypeassert
+			child = next
+			continue
+		}
+		if err := child.(helium.MutableNode).Replace(replacement...); err != nil { //nolint:forcetypeassert
+			return err
+		}
+		child = next
+	}
+
+	// XSLT result-tree construction merges adjacent text nodes into one. The
+	// Replace splices above do not merge text across the splice boundary
+	// (e.g. xsl:sequence text next to xsl:text output), so coalesce adjacent
+	// text-node siblings now.
+	for child := tmpDoc.FirstChild(); child != nil; {
+		next := child.NextSibling()
+		if child.Type() == helium.TextNode && next != nil && next.Type() == helium.TextNode {
+			if err := child.(helium.MutableNode).AppendText(next.Content()); err != nil { //nolint:forcetypeassert
+				return err
+			}
+			helium.UnlinkNode(next.(helium.MutableNode)) //nolint:forcetypeassert
+			continue
+		}
+		child = next
+	}
+
+	return nil
 }
 
 // evaluateBodyAsSequence executes instructions and captures the result as a

--- a/xslt3/execute_sequence.go
+++ b/xslt3/execute_sequence.go
@@ -23,6 +23,11 @@ func checkAtomizable(seq xpath3.Sequence) error {
 	return nil
 }
 
+// seqPlaceholderTarget is the PI target used to mark, within a
+// document-constructor frame, the position where buffered xsl:sequence output
+// must be inserted so it keeps document order with literal result elements.
+const seqPlaceholderTarget = "helium-xsl-sequence-placeholder"
+
 func (ec *execContext) execValueOf(ctx context.Context, inst *valueOfInst) error {
 	var value string
 
@@ -293,14 +298,34 @@ func (ec *execContext) execXSLSequence(ctx context.Context, inst *xslSequenceIns
 	// as children of that element.
 	// For the principal output with json/adaptive method, the current node
 	// is the Document itself (not a wrapper element), so also match that case.
-	atRootLevel := out.doc != nil && (out.current == out.doc.DocumentElement() || out.current == out.doc)
-	if out.captureItems && atRootLevel {
-		rSeq := result.Sequence()
-		if rSeq != nil && sequence.Len(rSeq) > 0 {
-			out.pendingItems = append(out.pendingItems, sequence.Materialize(rSeq)...)
-			out.noteOutput()
+	// In a document-constructor frame (variable/param body without as), the
+	// document node itself is the insertion point, and a copied element can
+	// legitimately become its document element. xsl:sequence output is then
+	// interleaved with literal result elements via a placeholder PI written
+	// at the document level (resolved by evaluateBodyAsDocument). Content
+	// nested inside such a copied element must be written into that element,
+	// NOT captured — so the document-constructor root is the document node
+	// alone, never the document element.
+	if out.documentConstructor {
+		if out.captureItems && out.current == out.doc {
+			rSeq := result.Sequence()
+			if rSeq != nil && sequence.Len(rSeq) > 0 {
+				out.captureSequenceItems(sequence.Materialize(rSeq))
+			}
+			return nil
 		}
-		return nil
+		// Nested inside a copied/constructed element: fall through to write
+		// items into the current element in document order.
+	} else {
+		atRootLevel := out.doc != nil && (out.current == out.doc.DocumentElement() || out.current == out.doc)
+		if out.captureItems && atRootLevel {
+			rSeq := result.Sequence()
+			if rSeq != nil && sequence.Len(rSeq) > 0 {
+				out.pendingItems = append(out.pendingItems, sequence.Materialize(rSeq)...)
+				out.noteOutput()
+			}
+			return nil
+		}
 	}
 
 	prevWasAtomic := out.prevWasAtomic
@@ -463,8 +488,7 @@ func (ec *execContext) outputSequence(seq xpath3.Sequence) error {
 	// functions, and other non-DOM items that cannot be serialized to a tree).
 	if out.captureItems {
 		if seq != nil && sequence.Len(seq) > 0 {
-			out.pendingItems = append(out.pendingItems, sequence.Materialize(seq)...)
-			out.noteOutput()
+			out.captureSequenceItems(sequence.Materialize(seq))
 		}
 		return nil
 	}

--- a/xslt3/execute_trycatch.go
+++ b/xslt3/execute_trycatch.go
@@ -236,10 +236,12 @@ func (ec *execContext) execTryCatch(ctx context.Context, inst *tryCatchInst) err
 			}
 		}
 		// Transfer captured items (maps, arrays, function items) to parent.
+		// Route through captureSequenceItems so that in a document-constructor
+		// frame the items keep document order (via a placeholder at the current
+		// position) with the DOM children copied just above and any surrounding
+		// literal result elements.
 		if len(tryFrame.pendingItems) > 0 {
-			out := ec.currentOutput()
-			out.pendingItems = append(out.pendingItems, tryFrame.pendingItems...)
-			out.noteOutput()
+			ec.currentOutput().captureSequenceItems(tryFrame.pendingItems)
 		}
 		return nil
 	}

--- a/xslt3/output.go
+++ b/xslt3/output.go
@@ -19,21 +19,23 @@ import (
 
 // outputFrame represents the current output target during transformation.
 type outputFrame struct {
-	doc               *helium.Document   // result document being built
-	current           helium.MutableNode // current insertion point
-	captureItems      bool               // when true, xsl:sequence adds to pendingItems instead of DOM
-	separateTextNodes bool               // when true, text nodes are captured as separate string items (prevents DOM merging)
-	sequenceMode      bool               // when true, all nodes (text, element, attr, comment, PI) are captured as separate items
-	mapConstructor    bool               // when true, xsl:map-entry emits single-entry maps into pendingItems
-	pendingItems      xpath3.ItemSlice   // captured items from xsl:sequence
-	prevWasAtomic     bool               // true when last xsl:sequence output was an atomic value (for inter-call space separation)
-	emptyAtomicGen    uint64             // seqConstructorGen when prevWasAtomic was set by an empty-string atomic
-	wherePopulated    bool               // when true, xsl:document emits document node (not children) so xsl:where-populated can check emptiness
-	itemSeparator     *string            // item-separator serialization parameter; nil means default (" " between adjacent atomics)
-	prevHadOutput     bool               // true when any item (node or atomic) was previously output; used for item-separator between non-atomic items
-	outputSerial      int                // monotonically increases whenever visible output is produced
-	seqConstructorGen uint64             // incremented each time executeSequenceConstructor is called
-	conditionalScopes []conditionalScope
+	doc                 *helium.Document                 // result document being built
+	current             helium.MutableNode               // current insertion point
+	captureItems        bool                             // when true, xsl:sequence adds to pendingItems instead of DOM
+	separateTextNodes   bool                             // when true, text nodes are captured as separate string items (prevents DOM merging)
+	sequenceMode        bool                             // when true, all nodes (text, element, attr, comment, PI) are captured as separate items
+	mapConstructor      bool                             // when true, xsl:map-entry emits single-entry maps into pendingItems
+	documentConstructor bool                             // when true, the frame builds a document node tree; xsl:sequence output is marked with placeholders in the DOM so it interleaves in document order with literal result elements
+	seqPlaceholders     map[helium.Node]xpath3.ItemSlice // placeholder PI node -> buffered xsl:sequence items, resolved by evaluateBodyAsDocument
+	pendingItems        xpath3.ItemSlice                 // captured items from xsl:sequence
+	prevWasAtomic       bool                             // true when last xsl:sequence output was an atomic value (for inter-call space separation)
+	emptyAtomicGen      uint64                           // seqConstructorGen when prevWasAtomic was set by an empty-string atomic
+	wherePopulated      bool                             // when true, xsl:document emits document node (not children) so xsl:where-populated can check emptiness
+	itemSeparator       *string                          // item-separator serialization parameter; nil means default (" " between adjacent atomics)
+	prevHadOutput       bool                             // true when any item (node or atomic) was previously output; used for item-separator between non-atomic items
+	outputSerial        int                              // monotonically increases whenever visible output is produced
+	seqConstructorGen   uint64                           // incremented each time executeSequenceConstructor is called
+	conditionalScopes   []conditionalScope
 }
 
 type conditionalKind int
@@ -58,6 +60,32 @@ type conditionalScope struct {
 
 func (out *outputFrame) noteOutput() {
 	out.outputSerial++
+}
+
+// captureSequenceItems records captured sequence items for later assembly.
+//
+// In a document-constructor frame (variable/param body without as) at the
+// document-node level, the items are recorded behind a placeholder PI inserted
+// at the current position in the DOM, so they keep document order with literal
+// result elements built directly into the tree (evaluateBodyAsDocument resolves
+// the placeholders). In every other case the items are appended to pendingItems
+// as before. Callers should only invoke this with a non-empty item slice.
+func (out *outputFrame) captureSequenceItems(items xpath3.ItemSlice) {
+	if out.documentConstructor && out.current == out.doc {
+		ph := out.doc.CreatePI(seqPlaceholderTarget, "")
+		if err := out.current.AddChild(ph); err == nil {
+			if out.seqPlaceholders == nil {
+				out.seqPlaceholders = make(map[helium.Node]xpath3.ItemSlice)
+			}
+			out.seqPlaceholders[ph] = items
+			out.noteOutput()
+			return
+		}
+		// AddChild on a document node only fails for invalid input; fall back
+		// to buffering so output order is preserved as best-effort.
+	}
+	out.pendingItems = append(out.pendingItems, items...)
+	out.noteOutput()
 }
 
 // SerializeItems writes a sequence of items (maps, arrays, atomics, nodes)

--- a/xslt3/transform_test.go
+++ b/xslt3/transform_test.go
@@ -90,6 +90,175 @@ func TestCommentBodyNoStraySpace(t *testing.T) {
 	require.Contains(t, out, "<!--hello-->")
 }
 
+// TestDocVariableInterleavesSequence verifies that a document-node variable
+// body preserves document order between literal result elements and
+// xsl:sequence outputs (constructed nodes and atomics interleaved).
+func TestDocVariableInterleavesSequence(t *testing.T) {
+	ctx := t.Context()
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "atomic between elements",
+			body: `<a/><xsl:sequence select="'b'"/><c/>`,
+			want: "<out><a/>b<c/></out>",
+		},
+		{
+			name: "node from sequence between elements",
+			body: `<a/><xsl:sequence select="//src"/><c/>`,
+			want: "<out><a/><src/><c/></out>",
+		},
+		{
+			// xsl:sequence select="/" yields a document node; its children
+			// (the source root element) must be spliced in document order,
+			// not the document node itself.
+			name: "document node between elements",
+			body: `<a/><xsl:sequence select="/"/><c/>`,
+			want: "<out><a/><doc><src/></doc><c/></out>",
+		},
+		{
+			name: "multiple atomics interleaved",
+			body: `<xsl:sequence select="1"/><a/><xsl:sequence select="2"/><b/><xsl:sequence select="3"/>`,
+			want: "<out>1<a/>2<b/>3</out>",
+		},
+		{
+			name: "trailing element after sequence",
+			body: `<xsl:sequence select="('x','y')"/><z/>`,
+			want: "<out>x y<z/></out>",
+		},
+		{
+			// xsl:try select also captures into the document; it must keep
+			// document order with surrounding literal result elements, not be
+			// appended after them.
+			name: "try select between elements",
+			body: `<a/><xsl:try select="'b'"><xsl:catch select="'x'"/></xsl:try><c/>`,
+			want: "<out><a/>b<c/></out>",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:variable name="v">` + tc.body + `</xsl:variable>
+    <out><xsl:copy-of select="$v"/></out>
+  </xsl:template>
+</xsl:stylesheet>`
+
+			doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+			require.NoError(t, err)
+			ss, err := xslt3.CompileStylesheet(ctx, doc)
+			require.NoError(t, err)
+			src, _ := helium.NewParser().Parse(ctx, []byte(`<doc><src/></doc>`))
+			out, err := ss.Transform(src).Serialize(ctx)
+			require.NoError(t, err)
+			require.Contains(t, out, tc.want)
+		})
+	}
+}
+
+// TestDocVariableDocumentNodeSequenceSplicesChildren verifies the structural
+// shape of a document variable built with xsl:sequence select="/" interleaved
+// with literal elements. The document node must contribute its children (the
+// source root element) spliced in document order, so $v/node() sees three
+// nodes (a, doc, c) with the source root in the middle — not a nested document
+// node that would collapse $v/node() to two (a, c).
+func TestDocVariableDocumentNodeSequenceSplicesChildren(t *testing.T) {
+	ctx := t.Context()
+	xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:variable name="v"><a/><xsl:sequence select="/"/><c/></xsl:variable>
+    <out count="{count($v/node())}" mid="{local-name($v/node()[2])}"/>
+  </xsl:template>
+</xsl:stylesheet>`
+
+	doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+	require.NoError(t, err)
+	ss, err := xslt3.CompileStylesheet(ctx, doc)
+	require.NoError(t, err)
+	src, _ := helium.NewParser().Parse(ctx, []byte(`<doc><src/></doc>`))
+	out, err := ss.Transform(src).Serialize(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, `count="3"`)
+	require.Contains(t, out, `mid="doc"`)
+}
+
+// TestDocVariableMergesAdjacentText verifies that text produced by xsl:sequence
+// adjacent to text from xsl:text/xsl:value-of is merged into a single text node
+// in the constructed document tree (XSLT result-tree construction merges
+// adjacent text nodes), so node-level XPath sees one text node, not two.
+func TestDocVariableMergesAdjacentText(t *testing.T) {
+	ctx := t.Context()
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "sequence then text", body: `<xsl:sequence select="'a'"/><xsl:text>b</xsl:text>`},
+		{name: "text then sequence", body: `<xsl:text>a</xsl:text><xsl:sequence select="'b'"/>`},
+		{name: "text sequence text", body: `<xsl:text>a</xsl:text><xsl:sequence select="'b'"/><xsl:text>c</xsl:text>`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:variable name="v">` + tc.body + `</xsl:variable>
+    <out count="{count($v/text())}"><xsl:value-of select="string($v)"/></out>
+  </xsl:template>
+</xsl:stylesheet>`
+
+			doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+			require.NoError(t, err)
+			ss, err := xslt3.CompileStylesheet(ctx, doc)
+			require.NoError(t, err)
+			src, _ := helium.NewParser().Parse(ctx, []byte(`<dummy/>`))
+			out, err := ss.Transform(src).Serialize(ctx)
+			require.NoError(t, err)
+			require.Contains(t, out, `count="1"`)
+		})
+	}
+}
+
+// TestDocVariableNestedSequenceNoPlaceholderLeak verifies that an xsl:sequence
+// nested inside an xsl:copy in a document-variable body writes into the copied
+// element directly (not via a document-level placeholder). The copied element
+// becomes the temp tree's document element, so the placeholder capture path
+// must not fire there — otherwise the unresolved placeholder PI leaks into
+// output.
+func TestDocVariableNestedSequenceNoPlaceholderLeak(t *testing.T) {
+	ctx := t.Context()
+	xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:variable name="v">
+      <xsl:for-each select="/doc/src">
+        <xsl:copy><xsl:sequence select="'b'"/></xsl:copy>
+      </xsl:for-each>
+    </xsl:variable>
+    <out><xsl:copy-of select="$v"/></out>
+  </xsl:template>
+</xsl:stylesheet>`
+
+	doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+	require.NoError(t, err)
+	ss, err := xslt3.CompileStylesheet(ctx, doc)
+	require.NoError(t, err)
+	src, _ := helium.NewParser().Parse(ctx, []byte(`<doc><src/></doc>`))
+	out, err := ss.Transform(src).Serialize(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "<out><src>b</src></out>")
+	require.NotContains(t, out, "helium-xsl-sequence-placeholder")
+}
+
 // TestPIBodyNoStraySpace verifies that xsl:processing-instruction body
 // does not produce a stray leading space when an empty TVT precedes text.
 func TestPIBodyNoStraySpace(t *testing.T) {


### PR DESCRIPTION
- preserve document order between literal result elements and xsl:sequence output in document-node variable/param bodies
- mark xsl:sequence output with placeholder PIs resolved in-tree by evaluateBodyAsDocument