### PR TITLE
order typed template results in document variables

### DIFF
--- a/xslt3/execute_templates.go
+++ b/xslt3/execute_templates.go
@@ -613,6 +613,19 @@ func (ec *execContext) executeTemplateBodyWithAs(ctx context.Context, tmpl *temp
 	// variable evaluation), preserve atomic values directly so that
 	// their XSD type is retained for typed comparisons.
 	out := ec.currentOutput()
+
+	// In a document-constructor frame at the document node, capture the whole
+	// typed result as one ordered unit (behind a placeholder) so it keeps
+	// document order with literal result elements; otherwise the nodes would
+	// go to the DOM while atomics buffered to pendingItems, splitting the
+	// stream and losing interleaving order.
+	if out.captureItems && out.documentConstructor && out.current == out.doc {
+		if sequence.Len(checked) > 0 {
+			out.captureSequenceItems(sequence.Materialize(checked))
+		}
+		return nil
+	}
+
 	for i := range sequence.Len(checked) {
 		item := checked.Get(i)
 		switch v := item.(type) {

--- a/xslt3/transform_test.go
+++ b/xslt3/transform_test.go
@@ -227,6 +227,33 @@ func TestDocVariableMergesAdjacentText(t *testing.T) {
 	}
 }
 
+// TestDocVariableTypedTemplateResultOrder verifies that the result of a typed
+// (as="...") template invoked via xsl:call-template inside a document-variable
+// body keeps document order with surrounding literal result elements, rather
+// than being appended after them.
+func TestDocVariableTypedTemplateResultOrder(t *testing.T) {
+	ctx := t.Context()
+	xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <xsl:variable name="v"><a/><xsl:call-template name="emit"/><c/></xsl:variable>
+    <out><xsl:copy-of select="$v"/></out>
+  </xsl:template>
+  <xsl:template name="emit" as="xs:string"><xsl:sequence select="'b'"/></xsl:template>
+</xsl:stylesheet>`
+
+	doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+	require.NoError(t, err)
+	ss, err := xslt3.CompileStylesheet(ctx, doc)
+	require.NoError(t, err)
+	src, _ := helium.NewParser().Parse(ctx, []byte(`<dummy/>`))
+	out, err := ss.Transform(src).Serialize(ctx)
+	require.NoError(t, err)
+	require.Regexp(t, `<a[^>]*/>b<c[^>]*/>`, out)
+}
+
 // TestDocVariableNestedSequenceNoPlaceholderLeak verifies that an xsl:sequence
 // nested inside an xsl:copy in a document-variable body writes into the copied
 // element directly (not via a document-level placeholder). The copied element


### PR DESCRIPTION
- route typed (as=...) template results through captureSequenceItems at the document-constructor root so they keep document order with literal result elements
- follow-up to #544 (xsl:call-template/xsl:apply-templates to an as-typed template still appended its result after later DOM children)