### PR TITLE
error on unsupported xinclude text encoding

### DIFF
--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -669,9 +669,12 @@ func (p *processor) includeText(inc *helium.Element, uri string, incBase string)
 		return err
 	}
 
-	// Handle encoding attribute
-	encName := getAttr(inc, "encoding")
-	if encName != "" {
+	// Handle encoding attribute. Distinguish a missing encoding attribute
+	// (process the bytes as UTF-8) from one that is present but names an
+	// encoding we cannot honour. A present-but-empty encoding="" is treated
+	// as an unsupported encoding rather than as absent, so the raw bytes are
+	// not silently consumed as UTF-8.
+	if encName, ok := findAttr(inc, "encoding"); ok {
 		enc := encoding.Load(encName)
 		// An unsupported requested encoding is a resource error: the raw bytes
 		// must not be silently treated as UTF-8. Returning an error here lets
@@ -884,6 +887,14 @@ func getNamespaceURI(n helium.Node) string {
 // 2. Try attribute with the other XInclude namespace URI
 // 3. Try unqualified attribute (no namespace)
 func getAttr(elem *helium.Element, name string) string {
+	val, _ := findAttr(elem, name)
+	return val
+}
+
+// findAttr performs the same 3-pass lookup as getAttr but also reports whether
+// the attribute was present. This distinguishes a missing attribute from one
+// that is present with an empty value, which getAttr alone cannot do.
+func findAttr(elem *helium.Element, name string) (string, bool) {
 	elemNS := getNamespaceURI(elem)
 	var otherNS string
 	if elemNS == lexicon.NamespaceXInclude {
@@ -897,22 +908,22 @@ func getAttr(elem *helium.Element, name string) string {
 	// Pass 1: element's own XInclude namespace
 	for _, a := range attrs {
 		if a.LocalName() == name && a.URI() == elemNS {
-			return a.Value()
+			return a.Value(), true
 		}
 	}
 	// Pass 2: the other XInclude namespace
 	for _, a := range attrs {
 		if a.LocalName() == name && a.URI() == otherNS {
-			return a.Value()
+			return a.Value(), true
 		}
 	}
 	// Pass 3: unqualified (no namespace)
 	for _, a := range attrs {
 		if a.LocalName() == name && a.URI() == "" {
-			return a.Value()
+			return a.Value(), true
 		}
 	}
-	return ""
+	return "", false
 }
 
 func resolveURI(href, base string) (string, error) {

--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -673,13 +673,17 @@ func (p *processor) includeText(inc *helium.Element, uri string, incBase string)
 	encName := getAttr(inc, "encoding")
 	if encName != "" {
 		enc := encoding.Load(encName)
-		if enc != nil {
-			decoded, decErr := enc.NewDecoder().Bytes(data)
-			if decErr != nil {
-				return fmt.Errorf("xi:include: error decoding %q with encoding %q: %w", uri, encName, decErr)
-			}
-			data = decoded
+		// An unsupported requested encoding is a resource error: the raw bytes
+		// must not be silently treated as UTF-8. Returning an error here lets
+		// the caller's fallback handling apply (or fail the inclusion).
+		if enc == nil {
+			return fmt.Errorf("xi:include: unsupported encoding %q for %q", encName, uri)
 		}
+		decoded, decErr := enc.NewDecoder().Bytes(data)
+		if decErr != nil {
+			return fmt.Errorf("xi:include: error decoding %q with encoding %q: %w", uri, encName, decErr)
+		}
+		data = decoded
 	}
 
 	// Validate that text contains only valid XML characters

--- a/xinclude/xinclude_test.go
+++ b/xinclude/xinclude_test.go
@@ -422,6 +422,69 @@ func TestXIncludeFallback(t *testing.T) {
 	require.True(t, found, "fallback content not found")
 }
 
+// TestXIncludeTextEmptyEncoding verifies that a present-but-empty encoding=""
+// on a parse="text" include is treated as an unsupported encoding (a resource
+// error), not as an absent encoding that would let the raw bytes be consumed as
+// UTF-8. Without a fallback the inclusion must fail; with an xi:fallback the
+// fallback content must be used.
+func TestXIncludeTextEmptyEncoding(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no fallback errors", func(t *testing.T) {
+		t.Parallel()
+		doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
+			<xi:include href="data.txt" parse="text" encoding=""/>
+		</root>`)
+
+		resolver := &stringResolver{
+			files: map[string]string{
+				"data.txt": "Hello World",
+			},
+		}
+
+		_, err := xinclude.NewProcessor().
+			Resolver(resolver).
+			NoXIncludeMarkers().
+			NoBaseFixup().
+			Process(t.Context(), doc)
+		require.Error(t, err, "present-but-empty encoding must be an error, not silently UTF-8")
+	})
+
+	t.Run("fallback used", func(t *testing.T) {
+		t.Parallel()
+		doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
+			<xi:include href="data.txt" parse="text" encoding="">
+				<xi:fallback><fallback-content/></xi:fallback>
+			</xi:include>
+		</root>`)
+
+		resolver := &stringResolver{
+			files: map[string]string{
+				"data.txt": "Hello World",
+			},
+		}
+
+		count, err := xinclude.NewProcessor().
+			Resolver(resolver).
+			NoXIncludeMarkers().
+			NoBaseFixup().
+			Process(t.Context(), doc)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+
+		root := docElement(doc)
+		var found bool
+		for c := root.FirstChild(); c != nil; c = c.NextSibling() {
+			if c.Type() == helium.ElementNode {
+				if c.(*helium.Element).LocalName() == "fallback-content" {
+					found = true
+				}
+			}
+		}
+		require.True(t, found, "fallback content not used for empty encoding")
+	})
+}
+
 func TestXIncludeMissingNoFallback(t *testing.T) {
 	t.Parallel()
 	doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/xinclude/xinclude_test.go
+++ b/xinclude/xinclude_test.go
@@ -791,6 +791,60 @@ func TestXIncludeTextEncoding(t *testing.T) {
 	require.Contains(t, content, "café")
 }
 
+func TestXIncludeTextUnsupportedEncoding(t *testing.T) {
+	t.Parallel()
+	// An unsupported requested encoding must be treated as a resource error:
+	// the raw bytes must NOT be silently read as UTF-8. Use ASCII-safe data so
+	// validateXMLChars cannot mask the bug by rejecting the bytes anyway.
+	resolver := &byteResolver{
+		files: map[string][]byte{
+			"data.txt": []byte("hello"),
+		},
+	}
+
+	t.Run("no fallback errors", func(t *testing.T) {
+		t.Parallel()
+		doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
+			<xi:include href="data.txt" parse="text" encoding="bogus-encoding"/>
+		</root>`)
+
+		_, err := xinclude.NewProcessor().
+			Resolver(resolver).
+			NoXIncludeMarkers().
+			NoBaseFixup().
+			Process(t.Context(), doc)
+		require.Error(t, err)
+	})
+
+	t.Run("fallback used", func(t *testing.T) {
+		t.Parallel()
+		doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
+			<xi:include href="data.txt" parse="text" encoding="bogus-encoding">
+				<xi:fallback><fallback-content/></xi:fallback>
+			</xi:include>
+		</root>`)
+
+		count, err := xinclude.NewProcessor().
+			Resolver(resolver).
+			NoXIncludeMarkers().
+			NoBaseFixup().
+			Process(t.Context(), doc)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+
+		root := docElement(doc)
+		var found bool
+		for c := root.FirstChild(); c != nil; c = c.NextSibling() {
+			if c.Type() == helium.ElementNode {
+				if c.(*helium.Element).LocalName() == "fallback-content" {
+					found = true
+				}
+			}
+		}
+		require.True(t, found, "fallback content not found")
+	})
+}
+
 func TestXIncludeProcessTree(t *testing.T) {
 	t.Parallel()
 	doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">


### PR DESCRIPTION
- `includeText` now returns an error when `parse="text"` requests an encoding that `encoding.Load` cannot resolve, instead of silently reading the raw bytes as UTF-8
- An unsupported encoding now triggers xi:fallback (or fails the inclusion) like other resource errors