### PR TITLE
route NewEvalState through newEvalCtx

### DIFF
--- a/xpath3/eval_reuse.go
+++ b/xpath3/eval_reuse.go
@@ -3,7 +3,6 @@ package xpath3
 import (
 	"context"
 	"strings"
-	"time"
 
 	"github.com/lestrrat-go/helium"
 	ixpath "github.com/lestrrat-go/helium/internal/xpath"
@@ -124,85 +123,10 @@ func (r Result) StringValue() string {
 // The returned EvalState is not safe for concurrent use. The Result from
 // EvaluateReuse is only valid until the next EvaluateReuse call.
 func (e Evaluator) NewEvalState(node helium.Node) *EvalState {
-	opCount := 0
-	now := time.Now()
-	s := &EvalState{}
-	ec := &s.ec
-	cfg := e.cfg
-
-	ec.node = node
-	ec.position = 1
-	ec.size = 1
-	ec.opCount = &opCount
-	ec.docOrder = &ixpath.DocOrderCache{}
-	ec.maxNodes = maxNodeSetLength
-	ec.docCache = make(map[string]helium.Node)
-
-	// namespaces
-	ec.namespaces = cfg.namespaces
-
-	// variables
-	if cfg.variables != nil && cfg.variables.Len() > 0 {
-		ec.vars = newVariableScope(cfg.variables.toMap())
-	}
-
-	// functions
-	if cfg.functions != nil {
-		ec.functions = cfg.functions.localMap()
-		ec.fnsNS = cfg.functions.qnameMap()
-	}
-
-	// resolvers
-	ec.variableResolver = cfg.variableResolver
-	ec.functionResolver = cfg.functionResolver
-	ec.uriResolver = cfg.uriResolver
-	ec.collectionResolver = cfg.collectionResolver
-	ec.httpClient = cfg.httpClient
-
-	// limits
-	ec.opLimit = cfg.opLimit
-	ec.maxRecursionDepth = DefaultMaxRecursionDepth
-
-	// time
-	if cfg.currentTime != nil {
-		ec.currentTime = cfg.currentTime
-	} else {
-		ec.currentTime = &now
-	}
-	ec.implicitTimezone = cfg.implicitTimezone
-
-	// locale / formatting
-	ec.defaultLanguage = cfg.defaultLanguage
-	ec.defaultCollation = cfg.defaultCollation
-	if cfg.defaultDecimal != nil {
-		df := *cfg.defaultDecimal
-		ec.defaultDecimalFormat = &df
-	}
-	ec.decimalFormats = cfg.decimalFormats
-
-	// base URI
-	ec.baseURI = cfg.baseURI
-
-	// schema / typing
-	ec.typeAnnotations = cfg.typeAnnotations
-	ec.schemaDeclarations = cfg.schemaDeclarations
-	ec.strictPrefixes = cfg.strictPrefixes
-	ec.allowXML11Chars = cfg.allowXML11Chars
-
-	// dynamic focus overrides
-	if cfg.position > 0 {
-		ec.position = cfg.position
-	}
-	if cfg.size > 0 {
-		ec.size = cfg.size
-	}
-	if cfg.contextItem != nil {
-		ec.contextItem = cfg.contextItem
-		ec.node = nil
-	}
-	if cfg.docOrder != nil {
-		ec.docOrder = cfg.docOrder
-	}
-
+	// Build the evaluation context through the shared initialization path so
+	// the reuse state stays in lockstep with normal Evaluate: same nil-cfg
+	// guard, same custom max-node limit, and the same complete set of copied
+	// fields (preserved ID annotations, TraceWriter, etc.).
+	s := &EvalState{ec: *e.newEvalCtx(node)}
 	return s
 }

--- a/xpath3/eval_reuse_test.go
+++ b/xpath3/eval_reuse_test.go
@@ -1,0 +1,57 @@
+package xpath3_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// A zero-value Evaluator (cfg == nil) must not panic when building reusable
+// state. newEvalCtx guards the nil cfg; NewEvalState must do the same.
+func TestNewEvalState_ZeroValueEvaluator(t *testing.T) {
+	compiled, err := xpath3.NewCompiler().Compile("1 + 1")
+	require.NoError(t, err)
+
+	var eval xpath3.Evaluator // zero value, cfg == nil
+	require.NotPanics(t, func() {
+		state := eval.NewEvalState(nil)
+		result, evalErr := compiled.EvaluateReuse(t.Context(), state, nil)
+		require.NoError(t, evalErr)
+		n, ok := result.IsNumber()
+		require.True(t, ok)
+		require.Equal(t, 2.0, n)
+	})
+}
+
+// TraceWriter configured on the Evaluator must flow through to the reuse
+// path so fn:trace writes to the caller's writer, not os.Stderr.
+func TestNewEvalState_TraceWriter(t *testing.T) {
+	compiled, err := xpath3.NewCompiler().Compile(`trace(42, "label")`)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).TraceWriter(&buf)
+	state := eval.NewEvalState(nil)
+
+	_, err = compiled.EvaluateReuse(t.Context(), state, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, buf.String(), "fn:trace output must go to the configured TraceWriter on the reuse path")
+}
+
+// A custom max-node limit configured on the Evaluator must be honored on the
+// reuse path. With a tiny limit, a range expression exceeding it must error.
+func TestNewEvalState_MaxNodesLimit(t *testing.T) {
+	compiled, err := xpath3.NewCompiler().Compile("1 to 100")
+	require.NoError(t, err)
+
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).MaxNodesForTesting(10)
+	state := eval.NewEvalState(nil)
+
+	_, err = compiled.EvaluateReuse(t.Context(), state, nil)
+	require.Error(t, err, "range exceeding the configured max-node limit must error on the reuse path")
+	require.True(t, errors.Is(err, xpath3.ErrNodeSetLimit),
+		"expected ErrNodeSetLimit, got %v", err)
+}


### PR DESCRIPTION
- `Evaluator.NewEvalState` rebuilt the eval context by hand and dereferenced a nil `cfg`, panicking on a zero-value Evaluator; it now delegates to the shared `newEvalCtx` path
- this also restores the dropped fields the reuse path was missing: preserved ID annotations, TraceWriter, and custom max-node limits
- adds regression tests for the zero-value panic, TraceWriter propagation, and max-node limit on the reuse path