### PR TITLE
reject unsafe html element and attr names

### DIFF
--- a/html/dump.go
+++ b/html/dump.go
@@ -191,12 +191,81 @@ func (d *htmlDumper) checkName(kind, name string) {
 // accepts it and it does not break out of the tag, so rejecting it would
 // regress parse/serialize round-trip parity. A validly-encoded U+FFFD is
 // likewise accepted; only invalid UTF-8 is rejected, by the caller.
+//
+// This is the loose rule used for ATTRIBUTE names. Element names use the
+// stricter checkElementName / isElementNameRune grammar instead.
 func isUnsafeNameRune(r rune) bool {
 	switch r {
 	case ' ', '\t', '\n', '\r', '\f', '"', '\'', '<', '>', '=', '/':
 		return true
 	}
 	return r < 0x20 || r == 0x7f
+}
+
+// checkElementName verifies that an element name is a valid HTML tag name
+// before it is written into a tag. Unlike checkName (the loose attribute
+// rule), this enforces the HTML tag-name grammar so that names libxml2 treats
+// as malformed — e.g. CreateElement("a?b") or CreateElement("a&b") — are
+// rejected rather than serialized verbatim as <a?b> / <a&b>.
+//
+// The accepted set is derived from what the HTML parser tokenizes as a tag
+// name (parser.parseName via isNameChar): ASCII letters, digits, ':', '-',
+// '_', '.'. ASCII punctuation outside that set — '?', '&', '=', '/', quotes,
+// angle brackets, whitespace, control chars — is rejected. Non-ASCII runes
+// are permitted so that legitimate Unicode element names (e.g. produced by
+// XSLT HTML output) are not over-rejected; a validly-encoded U+FFFD is one
+// such rune and is accepted, while invalid UTF-8 is rejected.
+func (d *htmlDumper) checkElementName(name string) {
+	if d.err != nil {
+		return
+	}
+	if name == "" {
+		d.check(fmt.Errorf("invalid HTML element name: empty"))
+		return
+	}
+	// Decode rune-by-rune rather than ranging over the string: a range loop
+	// yields utf8.RuneError both for genuinely invalid bytes and for a
+	// validly-encoded U+FFFD. DecodeRuneInString returns size==1 for invalid
+	// encodings, letting us reject only the former while permitting a real
+	// U+FFFD (size==3), which the parser accepts and which does not break out
+	// of the tag.
+	for i := 0; i < len(name); {
+		r, size := utf8.DecodeRuneInString(name[i:])
+		if r == utf8.RuneError && size == 1 {
+			d.check(fmt.Errorf("invalid HTML element name %q", name))
+			return
+		}
+		if !isElementNameRune(r) {
+			d.check(fmt.Errorf("invalid HTML element name %q", name))
+			return
+		}
+		i += size
+	}
+}
+
+// isElementNameRune reports whether r may appear in a serialized HTML element
+// name. ASCII runes must be a valid HTML tag-name character (letters, digits,
+// ':', '-', '_', '.'), mirroring the parser's isNameChar; this rejects
+// tag-breaking and clearly-malformed characters such as '?', '&', '=', '/',
+// quotes, angle brackets, whitespace and control characters. Non-ASCII runes
+// are permitted to avoid over-rejecting legitimate Unicode element names.
+func isElementNameRune(r rune) bool {
+	if r >= 0x80 {
+		return true
+	}
+	switch {
+	case r >= 'A' && r <= 'Z':
+		return true
+	case r >= 'a' && r <= 'z':
+		return true
+	case r >= '0' && r <= '9':
+		return true
+	}
+	switch r {
+	case ':', '-', '_', '.':
+		return true
+	}
+	return false
 }
 
 // writeBytes writes b to out, recording the first failure as the sticky
@@ -423,9 +492,10 @@ func (d *htmlDumper) dumpElement(out io.Writer, e *helium.Element) error {
 		name = e.Name()
 	}
 
-	// Reject names that would produce malformed or injected markup (spaces,
-	// quotes, angle brackets) before writing them into the tag.
-	d.checkName("element", name)
+	// Reject element names that are not valid HTML tag names (malformed names
+	// such as "a?b" or "a&b", or names containing tag-breaking characters)
+	// before writing them into the tag.
+	d.checkElementName(name)
 	if d.err != nil {
 		return d.err
 	}

--- a/html/dump.go
+++ b/html/dump.go
@@ -142,6 +142,48 @@ func (d *htmlDumper) writeString(out io.Writer, s string) {
 	d.check(err)
 }
 
+// checkName verifies that an element or attribute name is safe to write into
+// an HTML tag. Names built through public DOM construction paths
+// (CreateElement, SetLiteralAttribute, ...) are not validated, so a name
+// containing characters that terminate or escape a tag — whitespace, quotes,
+// '<', '>', '=', '/', or control characters — would otherwise be written
+// verbatim and produce malformed or injected markup. When name is unsafe (or
+// empty), the first such failure is recorded as the sticky error so
+// serialization aborts before writing.
+//
+// This is intentionally permissive about characters HTML tolerates but XML
+// does not (e.g. '?' or '.' in "gentus?.?"), matching libxml2's HTML
+// serializer, which preserves such names verbatim. Only characters that can
+// break out of the tag are rejected.
+func (d *htmlDumper) checkName(kind, name string) {
+	if d.err != nil {
+		return
+	}
+	if name == "" {
+		d.check(fmt.Errorf("invalid HTML %s name: empty", kind))
+		return
+	}
+	for _, r := range name {
+		if !isUnsafeNameRune(r) {
+			continue
+		}
+		d.check(fmt.Errorf("invalid HTML %s name %q", kind, name))
+		return
+	}
+}
+
+// isUnsafeNameRune reports whether r may not appear in a serialized HTML
+// element or attribute name because it would terminate or escape the tag.
+// The set mirrors the characters HTML5 forbids in tag/attribute names plus
+// ASCII control characters and the replacement character.
+func isUnsafeNameRune(r rune) bool {
+	switch r {
+	case ' ', '\t', '\n', '\r', '\f', '"', '\'', '<', '>', '=', '/', '&', utf8.RuneError:
+		return true
+	}
+	return r < 0x20 || r == 0x7f
+}
+
 // writeBytes writes b to out, recording the first failure as the sticky
 // error. It is a no-op once an error has been recorded. A short write
 // reported with a nil error by a non-conformant io.Writer is promoted to
@@ -366,6 +408,13 @@ func (d *htmlDumper) dumpElement(out io.Writer, e *helium.Element) error {
 		name = e.Name()
 	}
 
+	// Reject names that would produce malformed or injected markup (spaces,
+	// quotes, angle brackets) before writing them into the tag.
+	d.checkName("element", name)
+	if d.err != nil {
+		return d.err
+	}
+
 	// Opening tag
 	d.writeString(out, "<")
 	d.writeString(out, name)
@@ -509,6 +558,11 @@ func (d *htmlDumper) dumpAttributes(out io.Writer, e *helium.Element) error {
 		attrName := attrNameLower
 		if d.preserveCase {
 			attrName = attr.Name()
+		}
+		// Reject names that would inject markup into the tag.
+		d.checkName("attribute", attrName)
+		if d.err != nil {
+			return d.err
 		}
 		d.writeString(out, " ")
 		d.writeString(out, attrName)

--- a/html/dump.go
+++ b/html/dump.go
@@ -163,25 +163,37 @@ func (d *htmlDumper) checkName(kind, name string) {
 		d.check(fmt.Errorf("invalid HTML %s name: empty", kind))
 		return
 	}
-	for _, r := range name {
-		if !isUnsafeNameRune(r) {
-			continue
+	// Decode rune-by-rune rather than ranging over the string: a range loop
+	// yields utf8.RuneError both for genuinely invalid bytes and for a
+	// validly-encoded U+FFFD, so we cannot tell them apart by rune alone.
+	// DecodeRuneInString returns size==1 for invalid encodings, letting us
+	// reject only the former while permitting a real U+FFFD (size==3), which
+	// the parser accepts and which does not break out of the tag.
+	for i := 0; i < len(name); {
+		r, size := utf8.DecodeRuneInString(name[i:])
+		if r == utf8.RuneError && size == 1 {
+			d.check(fmt.Errorf("invalid HTML %s name %q", kind, name))
+			return
 		}
-		d.check(fmt.Errorf("invalid HTML %s name %q", kind, name))
-		return
+		if isUnsafeNameRune(r) {
+			d.check(fmt.Errorf("invalid HTML %s name %q", kind, name))
+			return
+		}
+		i += size
 	}
 }
 
 // isUnsafeNameRune reports whether r may not appear in a serialized HTML
 // element or attribute name because it would terminate or escape the tag.
 // The set mirrors the characters that terminate an attribute name in the
-// HTML parser (see parser.parseAttrName) plus ASCII control characters and
-// the replacement character. '&' is intentionally excluded: the parser's
-// liberal attribute-name rule accepts it and it does not break out of the
-// tag, so rejecting it would regress parse/serialize round-trip parity.
+// HTML parser (see parser.parseAttrName) plus ASCII control characters.
+// '&' is intentionally excluded: the parser's liberal attribute-name rule
+// accepts it and it does not break out of the tag, so rejecting it would
+// regress parse/serialize round-trip parity. A validly-encoded U+FFFD is
+// likewise accepted; only invalid UTF-8 is rejected, by the caller.
 func isUnsafeNameRune(r rune) bool {
 	switch r {
-	case ' ', '\t', '\n', '\r', '\f', '"', '\'', '<', '>', '=', '/', utf8.RuneError:
+	case ' ', '\t', '\n', '\r', '\f', '"', '\'', '<', '>', '=', '/':
 		return true
 	}
 	return r < 0x20 || r == 0x7f

--- a/html/dump.go
+++ b/html/dump.go
@@ -174,11 +174,14 @@ func (d *htmlDumper) checkName(kind, name string) {
 
 // isUnsafeNameRune reports whether r may not appear in a serialized HTML
 // element or attribute name because it would terminate or escape the tag.
-// The set mirrors the characters HTML5 forbids in tag/attribute names plus
-// ASCII control characters and the replacement character.
+// The set mirrors the characters that terminate an attribute name in the
+// HTML parser (see parser.parseAttrName) plus ASCII control characters and
+// the replacement character. '&' is intentionally excluded: the parser's
+// liberal attribute-name rule accepts it and it does not break out of the
+// tag, so rejecting it would regress parse/serialize round-trip parity.
 func isUnsafeNameRune(r rune) bool {
 	switch r {
-	case ' ', '\t', '\n', '\r', '\f', '"', '\'', '<', '>', '=', '/', '&', utf8.RuneError:
+	case ' ', '\t', '\n', '\r', '\f', '"', '\'', '<', '>', '=', '/', utf8.RuneError:
 		return true
 	}
 	return r < 0x20 || r == 0x7f
@@ -606,13 +609,21 @@ func (d *htmlDumper) writeNSDecl(out io.Writer, prefix, uri string) {
 		d.writeString(out, " xmlns=\"")
 		d.writeString(out, uri)
 		d.writeString(out, "\"")
-	} else {
-		d.writeString(out, " xmlns:")
-		d.writeString(out, prefix)
-		d.writeString(out, "=\"")
-		d.writeString(out, uri)
-		d.writeString(out, "\"")
+		return
 	}
+	// A non-empty prefix is written verbatim into the xmlns: attribute name,
+	// so an unsafe prefix could break out of the tag (e.g. a prefix
+	// containing a space and quote yields a separate injected attribute).
+	// Reject it the same way element/attribute names are rejected.
+	d.checkName("namespace prefix", prefix)
+	if d.err != nil {
+		return
+	}
+	d.writeString(out, " xmlns:")
+	d.writeString(out, prefix)
+	d.writeString(out, "=\"")
+	d.writeString(out, uri)
+	d.writeString(out, "\"")
 }
 
 // emitAttrNSDecls emits namespace declarations for attribute prefixes

--- a/html/dump_name_validation_test.go
+++ b/html/dump_name_validation_test.go
@@ -26,6 +26,57 @@ func TestWriteRejectsInvalidElementName(t *testing.T) {
 	}
 }
 
+// TestWriteRejectsMalformedElementName ensures the HTML serializer refuses to
+// write element names that libxml2 treats as malformed tag names — e.g.
+// CreateElement("a?b") or CreateElement("a&b") — rather than serializing them
+// verbatim as <a?b> / <a&b>. Element names use the stricter HTML tag-name
+// grammar; '?' and '&' (accepted in the loose ATTRIBUTE rule) are rejected
+// here.
+func TestWriteRejectsMalformedElementName(t *testing.T) {
+	for _, name := range []string{"a?b", "a&b", "a=b"} {
+		doc := helium.NewHTMLDocument()
+		root := doc.CreateElement(name)
+		require.NoError(t, doc.SetDocumentElement(root))
+
+		out, err := html.WriteString(doc)
+		require.Error(t, err, "serializing malformed element name %q must error, got output %q", name, out)
+	}
+}
+
+// TestWriteAcceptsValidElementNames confirms the stricter element-name grammar
+// does not over-reject names the parser/suite legitimately produces: ASCII
+// tag-name characters (letters, digits, ':', '-', '_', '.').
+func TestWriteAcceptsValidElementNames(t *testing.T) {
+	for _, name := range []string{"div", "my-elem", "a.b", "x_y", "h1", "svg:rect"} {
+		doc := helium.NewHTMLDocument()
+		root := doc.CreateElement("html")
+		child := doc.CreateElement(name)
+		require.NoError(t, root.AddChild(child))
+		require.NoError(t, doc.SetDocumentElement(root))
+
+		var buf bytes.Buffer
+		err := html.NewWriter().PreserveCase(true).Format(false).
+			DefaultDTD(false).WriteTo(&buf, doc)
+		require.NoError(t, err, "serializing valid element name %q must not error", name)
+		require.Contains(t, buf.String(), name, "got %q", buf.String())
+	}
+}
+
+// TestRoundTripLooseCharsInAttrNameNotElement proves the split: '?' and '&'
+// remain valid in ATTRIBUTE names (loose rule, libxml2 round-trip parity) even
+// though they are rejected in ELEMENT names.
+func TestRoundTripLooseCharsInAttrNameNotElement(t *testing.T) {
+	doc := helium.NewHTMLDocument()
+	root := doc.CreateElement("img")
+	require.NoError(t, root.SetBooleanAttribute("a?b"))
+	require.NoError(t, doc.SetDocumentElement(root))
+
+	var buf bytes.Buffer
+	err := html.NewWriter().DefaultDTD(false).Format(false).WriteTo(&buf, doc)
+	require.NoError(t, err, "attribute name 'a?b' must remain valid (loose rule)")
+	require.Contains(t, buf.String(), "a?b", "got %q", buf.String())
+}
+
 // TestWriteRejectsInvalidAttributeName ensures the HTML serializer refuses to
 // write an attribute whose name is not a valid XML/HTML name, since such a
 // name (with a space or quote) would otherwise inject markup into the tag.

--- a/html/dump_name_validation_test.go
+++ b/html/dump_name_validation_test.go
@@ -137,3 +137,35 @@ func TestRoundTripAmpersandInAttrName(t *testing.T) {
 	require.NoError(t, err, "serializing parsed `a&b` attribute name must not error")
 	require.Contains(t, buf.String(), "a&b", "attribute name with '&' should round-trip, got %q", buf.String())
 }
+
+// TestRoundTripReplacementCharInAttrName proves that a validly-encoded U+FFFD
+// (REPLACEMENT CHARACTER) in an attribute name round-trips through parse and
+// serialize. The HTML parser accepts any non-terminator character, and a real
+// U+FFFD does not break out of the tag, so the serializer must accept it too.
+func TestRoundTripReplacementCharInAttrName(t *testing.T) {
+	const input = "<div a�b=v></div>"
+	doc, err := html.NewParser().SuppressImplied(true).Parse(t.Context(), []byte(input))
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = html.NewWriter().DefaultDTD(false).Format(false).WriteTo(&buf, doc)
+	require.NoError(t, err, "serializing parsed U+FFFD attribute name must not error")
+	require.Contains(t, buf.String(), "a�b", "attribute name with U+FFFD should round-trip, got %q", buf.String())
+}
+
+// TestWriteRejectsInvalidUTF8InAttributeName ensures that an actually-invalid
+// UTF-8 byte sequence in a name is still rejected, distinct from a valid
+// U+FFFD. A lone 0xFF byte is not valid UTF-8 and must not be serialized.
+// PreserveCase(true) is used so the raw name reaches checkName verbatim; the
+// lowercasing path would otherwise sanitize the invalid byte into a valid
+// U+FFFD before validation.
+func TestWriteRejectsInvalidUTF8InAttributeName(t *testing.T) {
+	doc := helium.NewHTMLDocument()
+	root := doc.CreateElement("div")
+	require.NoError(t, root.SetLiteralAttribute("a\xffb", "v"))
+	require.NoError(t, doc.SetDocumentElement(root))
+
+	var buf bytes.Buffer
+	err := html.NewWriter().PreserveCase(true).DefaultDTD(false).Format(false).WriteTo(&buf, doc)
+	require.Error(t, err, "serializing attribute name with invalid UTF-8 must error, got output %q", buf.String())
+}

--- a/html/dump_name_validation_test.go
+++ b/html/dump_name_validation_test.go
@@ -86,3 +86,54 @@ func TestWriteAcceptsHTMLLooseName(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, strings.Contains(buf.String(), "gentus?.?"), "got %q", buf.String())
 }
+
+// TestWriteRejectsInjectedNamespacePrefix ensures the HTML serializer refuses
+// to write a namespace declaration whose prefix is unsafe. DeclareNamespace
+// accepts an arbitrary prefix, so without validation a prefix like
+// `p injected="1` would be written verbatim into the xmlns: attribute name
+// under PreserveCase(true), producing an injected attribute in the tag.
+func TestWriteRejectsInjectedNamespacePrefix(t *testing.T) {
+	doc := helium.NewHTMLDocument()
+	root := doc.CreateElement("html")
+	require.NoError(t, root.DeclareNamespace(`p injected="1`, "urn:x"))
+	require.NoError(t, doc.SetDocumentElement(root))
+
+	var buf bytes.Buffer
+	err := html.NewWriter().PreserveCase(true).Format(false).
+		DefaultDTD(false).WriteTo(&buf, doc)
+	require.Error(t, err, "serializing injected namespace prefix must error, got output %q", buf.String())
+	require.NotContains(t, buf.String(), `injected="1`, "injected markup must not be written")
+}
+
+// TestWriteRejectsInjectedAttributeNamespacePrefix covers the
+// emitAttrNSDecls path: an attribute whose namespace prefix is unsafe must
+// also be rejected rather than emitted as an xmlns: declaration.
+func TestWriteRejectsInjectedAttributeNamespacePrefix(t *testing.T) {
+	doc := helium.NewHTMLDocument()
+	root := doc.CreateElement("svg")
+	ns, err := doc.CreateNamespace(`p injected="1`, "urn:x")
+	require.NoError(t, err)
+	require.NoError(t, root.SetLiteralAttributeNS("href", "v", ns))
+	require.NoError(t, doc.SetDocumentElement(root))
+
+	var buf bytes.Buffer
+	err = html.NewWriter().PreserveCase(true).Format(false).
+		DefaultDTD(false).WriteTo(&buf, doc)
+	require.Error(t, err, "serializing injected attribute namespace prefix must error, got output %q", buf.String())
+	require.NotContains(t, buf.String(), `injected="1`, "injected markup must not be written")
+}
+
+// TestRoundTripAmpersandInAttrName proves that '&' in an attribute name
+// round-trips through parse and serialize. The HTML parser's liberal
+// attribute-name rule accepts '&' (it does not terminate the tag), so the
+// serializer must accept it too; rejecting it would regress parity.
+func TestRoundTripAmpersandInAttrName(t *testing.T) {
+	const input = `<div a&b=v></div>`
+	doc, err := html.NewParser().SuppressImplied(true).Parse(t.Context(), []byte(input))
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = html.NewWriter().DefaultDTD(false).Format(false).WriteTo(&buf, doc)
+	require.NoError(t, err, "serializing parsed `a&b` attribute name must not error")
+	require.Contains(t, buf.String(), "a&b", "attribute name with '&' should round-trip, got %q", buf.String())
+}

--- a/html/dump_name_validation_test.go
+++ b/html/dump_name_validation_test.go
@@ -1,0 +1,88 @@
+package html_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/html"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWriteRejectsInvalidElementName ensures the HTML serializer refuses to
+// write an element whose name is not a valid XML/HTML name. Without
+// validation, a name containing a space or '>' is written verbatim into the
+// tag, producing malformed or injected markup.
+func TestWriteRejectsInvalidElementName(t *testing.T) {
+	for _, name := range []string{"a b", "a>x", `a"x`, "a<x", ""} {
+		doc := helium.NewHTMLDocument()
+		root := doc.CreateElement(name)
+		require.NoError(t, doc.SetDocumentElement(root))
+
+		out, err := html.WriteString(doc)
+		require.Error(t, err, "serializing element name %q must error, got output %q", name, out)
+	}
+}
+
+// TestWriteRejectsInvalidAttributeName ensures the HTML serializer refuses to
+// write an attribute whose name is not a valid XML/HTML name, since such a
+// name (with a space or quote) would otherwise inject markup into the tag.
+func TestWriteRejectsInvalidAttributeName(t *testing.T) {
+	for _, name := range []string{"a b", `a"x`, "a=x", "a>x"} {
+		doc := helium.NewHTMLDocument()
+		root := doc.CreateElement("div")
+		// Use the namespaced setter to bypass the colon check; these names
+		// contain no colon but are still invalid.
+		require.NoError(t, root.SetLiteralAttribute(name, "v"))
+		require.NoError(t, doc.SetDocumentElement(root))
+
+		out, err := html.WriteString(doc)
+		require.Error(t, err, "serializing attribute name %q must error, got output %q", name, out)
+	}
+}
+
+// TestWriteRejectsInvalidBooleanAttributeName covers the boolean-attribute
+// path (attribute with no value child).
+func TestWriteRejectsInvalidBooleanAttributeName(t *testing.T) {
+	doc := helium.NewHTMLDocument()
+	root := doc.CreateElement("input")
+	require.NoError(t, root.SetBooleanAttribute("a b"))
+	require.NoError(t, doc.SetDocumentElement(root))
+
+	out, err := html.WriteString(doc)
+	require.Error(t, err, "serializing boolean attribute with space must error, got output %q", out)
+}
+
+// TestWriteAcceptsValidNamespacedName confirms that valid names containing a
+// single colon (namespaced names used in XSLT HTML5 output) are still
+// accepted.
+func TestWriteAcceptsValidNamespacedName(t *testing.T) {
+	doc := helium.NewHTMLDocument()
+	root := doc.CreateElement("html")
+	child := doc.CreateElement("svg:rect")
+	require.NoError(t, root.AddChild(child))
+	require.NoError(t, doc.SetDocumentElement(root))
+
+	var buf bytes.Buffer
+	err := html.NewWriter().PreserveCase(true).Format(false).
+		DefaultDTD(false).WriteTo(&buf, doc)
+	require.NoError(t, err)
+	require.True(t, strings.Contains(buf.String(), "svg:rect"), "got %q", buf.String())
+}
+
+// TestWriteAcceptsHTMLLooseName confirms that names HTML tolerates but XML
+// does not (e.g. attribute names like "gentus?.?" the HTML parser produces
+// from malformed markup) are still serialized verbatim, matching libxml2.
+func TestWriteAcceptsHTMLLooseName(t *testing.T) {
+	doc := helium.NewHTMLDocument()
+	root := doc.CreateElement("img")
+	require.NoError(t, root.SetBooleanAttribute("gentus?.?"))
+	require.NoError(t, doc.SetDocumentElement(root))
+
+	var buf bytes.Buffer
+	err := html.NewWriter().DefaultDTD(false).Format(false).WriteTo(&buf, doc)
+	require.NoError(t, err)
+	require.True(t, strings.Contains(buf.String(), "gentus?.?"), "got %q", buf.String())
+}


### PR DESCRIPTION
- HTML serializer now rejects element/attribute names containing tag-breaking characters (whitespace, quotes, `<`, `>`, `=`, `/`, control chars) before writing, returning an error instead of emitting malformed/injected markup
- stays permissive about HTML-only loose names (e.g. `gentus?.?`) to preserve libxml2 byte-for-byte compatibility
