### PR TITLE
route relaxng xsd datatypes through value validator

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -170,11 +170,15 @@ spaces (date/time/duration ranges, integer subtype bounds, binary alphabets) so
 RELAX NG and XSD stay consistent. `xsdDatatypeNames` is the recognized-name
 allowlist; any name outside it is an unknown datatype and is rejected (no silent
 accept). `xs:string` keeps the local `<param>`-facet path (whiteSpace=preserve).
-`<value>` matches by whitespace-processed lexical equality first, then — for the
-value-space-comparable types in `xsdValueSpaceTypes` (numeric, boolean,
-date/time, binary; mirrors xsd's `enumValueSpaceTypes`) — by `value.Compare`
-value-space equality (e.g. integer `5`≡`+5`≡`05`, NaN≡NaN for float/double).
-String-family and anyURI stay lexical-only.
+For `<value>` with a value-space-comparable type in `xsdValueSpaceTypes`
+(numeric, boolean, date/time, binary; mirrors xsd's `enumValueSpaceTypes`),
+`matchXSDValue` first requires **both** the instance text and the `<value>`
+literal to be lexically valid via `ValidateBuiltin` — the lexical-equality
+fast-path runs only after that, so an identical-but-invalid lexical (e.g.
+`type="integer"` with both forms `5.0`) is rejected, not accepted. Valid forms
+then match by `value.Compare` value-space equality (e.g. integer `5`≡`+5`≡`05`,
+NaN≡NaN for float/double). String-family and anyURI stay lexical-only
+(whitespace-processed lexical equality, no `ValidateBuiltin` gate).
 
 ### Error Suppression
 

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -161,6 +161,21 @@ is a thin greedy-max wrapper over `matchAttrTokensCounts`. `validateList` (the
 naive `validatePattern` path) delegates to `matchListContent`, so every `<list>`
 path shares these semantics.
 
+### XSD Datatype Library (`<data>` / `<value>`)
+
+When `datatypeLibrary` is the XSD datatypes namespace, `validateXSDType`
+(`<data>`) and `matchXSDValue` (`<value>`) route through the shared XSD value
+validator (`internal/xsd/value`): `ValidateBuiltin` enforces lexical/value
+spaces (date/time/duration ranges, integer subtype bounds, binary alphabets) so
+RELAX NG and XSD stay consistent. `xsdDatatypeNames` is the recognized-name
+allowlist; any name outside it is an unknown datatype and is rejected (no silent
+accept). `xs:string` keeps the local `<param>`-facet path (whiteSpace=preserve).
+`<value>` matches by whitespace-processed lexical equality first, then — for the
+value-space-comparable types in `xsdValueSpaceTypes` (numeric, boolean,
+date/time, binary; mirrors xsd's `enumValueSpaceTypes`) — by `value.Compare`
+value-space equality (e.g. integer `5`≡`+5`≡`05`, NaN≡NaN for float/double).
+String-family and anyURI stay lexical-only.
+
 ### Error Suppression
 
 - `suppressDepth` counter incremented during choice branch exploration

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -170,15 +170,18 @@ spaces (date/time/duration ranges, integer subtype bounds, binary alphabets) so
 RELAX NG and XSD stay consistent. `xsdDatatypeNames` is the recognized-name
 allowlist; any name outside it is an unknown datatype and is rejected (no silent
 accept). `xs:string` keeps the local `<param>`-facet path (whiteSpace=preserve).
-For `<value>` with a value-space-comparable type in `xsdValueSpaceTypes`
-(numeric, boolean, date/time, binary; mirrors xsd's `enumValueSpaceTypes`),
-`matchXSDValue` first requires **both** the instance text and the `<value>`
-literal to be lexically valid via `ValidateBuiltin` — the lexical-equality
-fast-path runs only after that, so an identical-but-invalid lexical (e.g.
-`type="integer"` with both forms `5.0`) is rejected, not accepted. Valid forms
-then match by `value.Compare` value-space equality (e.g. integer `5`≡`+5`≡`05`,
-NaN≡NaN for float/double). String-family and anyURI stay lexical-only
-(whitespace-processed lexical equality, no `ValidateBuiltin` gate).
+For `<value>`, `matchXSDValue` first requires **both** the instance text and the
+`<value>` literal to be lexically valid via `ValidateBuiltin` for **every**
+recognized XSD datatype — this gate runs before the lexical-equality fast-path
+and the value-space branch, so an identical-but-invalid lexical is rejected for
+both comparable types (e.g. `type="integer"` with both forms `5.0`) and
+constrained non-comparable string-family types (e.g. `type="NCName"` with both
+forms `1foo`). `ValidateBuiltin` imposes no constraint on `xs:string`/`xs:anyURI`,
+so those stay effectively lexical-only. After the gate, value-space-comparable
+types in `xsdValueSpaceTypes` (numeric, boolean, date/time, binary; mirrors
+xsd's `enumValueSpaceTypes`) match by `value.Compare` value-space equality (e.g.
+integer `5`≡`+5`≡`05`, NaN≡NaN for float/double); all other recognized types
+(string-family, anyURI) match by whitespace-processed lexical equality.
 
 ### Error Suppression
 

--- a/internal/xsd/value/compare.go
+++ b/internal/xsd/value/compare.go
@@ -140,6 +140,39 @@ func whitespaceReplace(s string) string {
 	}, s)
 }
 
+// WhiteSpace returns the effective XSD whiteSpace facet ("preserve", "replace",
+// or "collapse") for a builtin datatype's local name. xs:string preserves,
+// xs:normalizedString replaces, and every other builtin (token, the integer and
+// date/time families, boolean, the NCName/Name/NMTOKEN family, list types,
+// anyURI, …) collapses, per the XSD 1.1 datatype spec. Unknown names default to
+// "collapse" so callers normalize conservatively.
+func WhiteSpace(builtinLocal string) string {
+	switch builtinLocal {
+	case "string":
+		return "preserve"
+	case "normalizedString":
+		return "replace"
+	default:
+		return "collapse"
+	}
+}
+
+// Normalize applies the XSD whiteSpace facet of the named builtin datatype to a
+// lexical value, returning the whitespace-processed form that must be used
+// before lexical validation (ValidateBuiltin) or value comparison. "preserve"
+// leaves the value untouched, "replace" turns each tab/newline/CR into a space,
+// and "collapse" additionally collapses runs of spaces and trims the ends.
+func Normalize(s, builtinLocal string) string {
+	switch WhiteSpace(builtinLocal) {
+	case "preserve":
+		return s
+	case "replace":
+		return whitespaceReplace(s)
+	default: // collapse
+		return strings.Join(strings.Fields(s), " ")
+	}
+}
+
 func canonicalDateTimeKey(s, builtinLocal string) (string, bool) {
 	var dt xsdDateTime
 	var ok bool

--- a/internal/xsd/value/compare.go
+++ b/internal/xsd/value/compare.go
@@ -130,7 +130,10 @@ func canonicalFloatKey(s string, bitSize int) (string, bool) {
 }
 
 // whitespaceReplace applies the XSD whiteSpace="replace" normalization: each
-// tab, newline, and carriage return becomes a single space.
+// of the four XSD whitespace characters tab (#x9), newline (#xA), and carriage
+// return (#xD) becomes a single space (#x20). Per the XSD datatype spec only
+// those ASCII whitespace characters are affected; Unicode whitespace such as
+// NBSP (U+00A0) is left untouched.
 func whitespaceReplace(s string) string {
 	return strings.Map(func(r rune) rune {
 		if r == '\t' || r == '\n' || r == '\r' {
@@ -138,6 +141,31 @@ func whitespaceReplace(s string) string {
 		}
 		return r
 	}, s)
+}
+
+// whitespaceCollapse applies the XSD whiteSpace="collapse" normalization:
+// replace tab/newline/CR with space (ASCII-only, like whitespaceReplace), then
+// collapse runs of spaces and trim leading/trailing spaces. Only the four XSD
+// whitespace characters (#x20, #x9, #xD, #xA) are treated as whitespace; Unicode
+// whitespace such as NBSP (U+00A0) is preserved, so an invalid value containing
+// it remains invalid under subsequent lexical validation.
+func whitespaceCollapse(s string) string {
+	replaced := whitespaceReplace(s)
+	var b strings.Builder
+	b.Grow(len(replaced))
+	inSpace := true // treat start as space to trim leading
+	for i := range len(replaced) {
+		if replaced[i] == ' ' {
+			inSpace = true
+			continue
+		}
+		if inSpace && b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteByte(replaced[i])
+		inSpace = false
+	}
+	return b.String()
 }
 
 // WhiteSpace returns the effective XSD whiteSpace facet ("preserve", "replace",
@@ -169,7 +197,7 @@ func Normalize(s, builtinLocal string) string {
 	case "replace":
 		return whitespaceReplace(s)
 	default: // collapse
-		return strings.Join(strings.Fields(s), " ")
+		return whitespaceCollapse(s)
 	}
 }
 

--- a/internal/xsd/value/validate_test.go
+++ b/internal/xsd/value/validate_test.go
@@ -368,3 +368,38 @@ func TestCompareValues(t *testing.T) {
 		})
 	}
 }
+
+// TestNormalize verifies that Normalize applies the XSD whiteSpace facet using
+// only the four ASCII XSD whitespace characters (#x20, #x9, #xD, #xA). Unicode
+// whitespace such as NBSP (U+00A0) must NOT be treated as whitespace, so an
+// invalid value containing it survives normalization and is later rejected by
+// lexical validation.
+func TestNormalize(t *testing.T) {
+	const nbsp = " "
+	tests := []struct {
+		typ  string
+		in   string
+		want string
+	}{
+		// preserve: xs:string leaves everything untouched.
+		{lexicon.TypeString, "  a\tb  ", "  a\tb  "},
+		// replace: xs:normalizedString maps the ASCII whitespace to spaces but
+		// does not collapse or trim, and leaves NBSP alone.
+		{"normalizedString", "a\tb\nc\rd", "a b c d"},
+		{"normalizedString", "a" + nbsp + "b", "a" + nbsp + "b"},
+		// collapse (the default for token and other types): ASCII whitespace runs
+		// collapse to a single space and the ends trim.
+		{lexicon.TypeToken, "  a\t b  ", "a b"},
+		{lexicon.TypeToken, "a  b", "a b"},
+		// collapse must NOT touch NBSP: it is preserved verbatim so the value
+		// remains lexically invalid afterwards.
+		{lexicon.TypeToken, "a" + nbsp + "b", "a" + nbsp + "b"},
+		{lexicon.TypeInteger, nbsp + "5", nbsp + "5"},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s/%q", tt.typ, tt.in), func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, value.Normalize(tt.in, tt.typ))
+		})
+	}
+}

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1643,13 +1643,65 @@ func (v *validator) matchValue(pat *pattern, text string) int {
 				expected = normalizeToken(expected)
 			}
 		case lexicon.NamespaceXSDDatatypes:
-			// XSD type-aware comparison: normalize both values
-			text = strings.TrimSpace(text)
-			expected = strings.TrimSpace(expected)
+			return matchXSDValue(pat.dataType.name, text, expected)
 		}
 	}
 
 	if text == expected {
+		return 0
+	}
+	return -1
+}
+
+// xsdValueSpaceTypes is the set of XSD datatypes for which value.Compare
+// implements correct value-space equality. It mirrors the XSD layer's
+// enumValueSpaceTypes and deliberately excludes string-family and anyURI types:
+// value.Compare falls back to decimal comparison for unrecognized builtins, which
+// would wrongly treat numeric-looking lexicals as equal (e.g. a string "5"
+// matching "5.0"). Those types compare by their whitespace-processed lexical
+// value, which equals their value space.
+var xsdValueSpaceTypes = map[string]struct{}{
+	"decimal": {}, "integer": {}, "nonPositiveInteger": {}, "negativeInteger": {},
+	"long": {}, "int": {}, "short": {}, "byte": {},
+	"nonNegativeInteger": {}, "unsignedLong": {}, "unsignedInt": {},
+	"unsignedShort": {}, "unsignedByte": {}, lexicon.TypePositiveInteger: {},
+	"float": {}, "double": {},
+	"boolean":  {},
+	"dateTime": {}, "date": {}, "time": {}, "duration": {},
+	"gYear": {}, "gYearMonth": {}, "gMonth": {}, "gDay": {}, "gMonthDay": {},
+	"hexBinary": {}, "base64Binary": {},
+}
+
+// matchXSDValue compares an instance value against a <value> literal using the
+// XSD value space for the named datatype. A lexical match (after whitespace
+// processing) always succeeds; additionally, for value-space-comparable types
+// (numeric, boolean, date/time, binary) a lexically distinct but value-equal form
+// also matches (e.g. integer "5" == "+5" == "05"), agreeing with the XSD layer.
+// String-family and anyURI types stay lexical-only. An unknown datatype name
+// never matches.
+func matchXSDValue(typeName, text, expected string) int {
+	if _, ok := xsdDatatypeNames[typeName]; !ok {
+		return -1
+	}
+	text = strings.TrimSpace(text)
+	expected = strings.TrimSpace(expected)
+
+	if text == expected {
+		return 0
+	}
+
+	if _, ok := xsdValueSpaceTypes[typeName]; !ok {
+		// Lexical-only type and the lexical forms differ.
+		return -1
+	}
+	// Value-space comparison: both operands must be lexically valid for the type.
+	if value.ValidateBuiltin(text, typeName) != nil || value.ValidateBuiltin(expected, typeName) != nil {
+		return -1
+	}
+	if (typeName == "float" || typeName == "double") && value.IsFloatNaN(text) && value.IsFloatNaN(expected) {
+		return 0
+	}
+	if cmpResult, ok := value.Compare(text, expected, typeName); ok && cmpResult == 0 {
 		return 0
 	}
 	return -1
@@ -1679,79 +1731,44 @@ func (v *validator) matchData(pat *pattern, text string) int {
 	return 0
 }
 
-// validateXSDType validates a value against an XSD datatype.
-func validateXSDType(typeName, value string, params []*param) int {
-	switch typeName {
-	case "string":
-		return validateWithParams(value, params)
-	case "normalizedString", "token":
-		return 0
-	case "integer", "int", "long", "short", "byte",
-		"nonNegativeInteger", lexicon.TypePositiveInteger,
-		"nonPositiveInteger", "negativeInteger",
-		"unsignedInt", "unsignedLong", "unsignedShort", "unsignedByte":
-		return validateXSDInteger(typeName, value)
-	case "decimal":
-		return validateXSDDecimal(value)
-	case "float", "double":
-		return validateXSDFloat(value)
-	case "boolean":
-		return validateXSDBoolean(value)
-	case "date":
-		if len(value) < 10 {
-			return -1
-		}
-		return 0
-	case "dateTime":
-		if len(value) < 19 {
-			return -1
-		}
-		return 0
-	case "time":
-		if len(value) < 8 {
-			return -1
-		}
-		return 0
-	case "duration":
-		if len(value) < 2 || value[0] != 'P' {
-			return -1
-		}
-		return 0
-	case "anyURI":
-		return 0
-	case "QName":
-		return validateXSDQName(value)
-	case "NCName", "ID", "IDREF":
-		return validateXSDNCName(value)
-	case "Name":
-		return validateXSDName(value)
-	case "NMTOKEN":
-		return validateXSDNMTOKEN(value)
-	case "NMTOKENS":
-		return validateXSDNMTOKENS(value)
-	case "IDREFS":
-		tokens := strings.Fields(value)
-		if len(tokens) == 0 {
-			return -1
-		}
-		for _, t := range tokens {
-			if validateXSDNCName(t) != 0 {
-				return -1
-			}
-		}
-		return 0
-	case "language":
-		return 0
-	case "base64Binary":
-		// Reuse the shared XSD lexical validator so RELAX NG and XSD agree on
-		// base64Binary semantics (alphabet-only; unpadded forms accepted as
-		// value-equivalent, matching the XSD layer).
-		return validateXSDBase64Binary(value)
-	case "hexBinary":
-		return validateXSDHexBinary(value)
-	default:
-		return 0
+// xsdDatatypeNames is the set of XSD datatype-library names RELAX NG recognizes.
+// Validation of any of these is routed through the shared XSD value validator
+// (internal/xsd/value) so RELAX NG and XSD agree on lexical/value spaces. Any
+// name outside this set is an unknown datatype and is rejected (a <data> against
+// an unsupported XSD type cannot be satisfied), rather than silently accepted.
+var xsdDatatypeNames = map[string]struct{}{
+	"string": {}, "normalizedString": {}, "token": {},
+	"integer": {}, "int": {}, "long": {}, "short": {}, "byte": {},
+	"nonNegativeInteger": {}, lexicon.TypePositiveInteger: {},
+	"nonPositiveInteger": {}, "negativeInteger": {},
+	"unsignedInt": {}, "unsignedLong": {}, "unsignedShort": {}, "unsignedByte": {},
+	"decimal": {}, "float": {}, "double": {}, "boolean": {},
+	"date": {}, "dateTime": {}, "time": {}, "duration": {},
+	"gYear": {}, "gYearMonth": {}, "gMonth": {}, "gDay": {}, "gMonthDay": {},
+	"anyURI": {}, "QName": {}, "NOTATION": {},
+	"NCName": {}, "ID": {}, "IDREF": {}, "ENTITY": {}, "Name": {},
+	"NMTOKEN": {}, "NMTOKENS": {}, "IDREFS": {}, "ENTITIES": {},
+	"language": {}, "base64Binary": {}, "hexBinary": {},
+}
+
+// validateXSDType validates a value against an XSD datatype. Recognized type
+// names are validated through the shared XSD value validator so RELAX NG and
+// XSD stay consistent (date/time/duration value-space ranges, integer subtype
+// ranges, binary alphabets, …). xs:string carries RELAX NG <param> facets, so it
+// stays on the local param path. Unknown type names are rejected.
+func validateXSDType(typeName, text string, params []*param) int {
+	if _, ok := xsdDatatypeNames[typeName]; !ok {
+		return -1
 	}
+	// xs:string has whiteSpace=preserve and may carry RELAX NG <param> facets
+	// (pattern, length, …); validate those locally.
+	if typeName == "string" {
+		return validateWithParams(text, params)
+	}
+	if value.ValidateBuiltin(text, typeName) != nil {
+		return -1
+	}
+	return 0
 }
 
 func validateWithParams(value string, params []*param) int {
@@ -1769,210 +1786,6 @@ func validateWithParams(value string, params []*param) int {
 		}
 	}
 	return 0
-}
-
-func validateXSDInteger(typeName, value string) int {
-	if value == "" {
-		return -1
-	}
-	start := 0
-	if value[0] == '+' || value[0] == '-' {
-		start = 1
-	}
-	if start >= len(value) {
-		return -1
-	}
-	for i := start; i < len(value); i++ {
-		if value[i] < '0' || value[i] > '9' {
-			return -1
-		}
-	}
-	switch typeName {
-	case "nonNegativeInteger", "positiveInteger", "unsignedInt", "unsignedLong", "unsignedShort", "unsignedByte":
-		if value[0] == '-' {
-			return -1
-		}
-		if typeName == "positiveInteger" && value == "0" {
-			return -1
-		}
-	case "nonPositiveInteger":
-		if value[0] != '-' && value != "0" {
-			return -1
-		}
-	case "negativeInteger":
-		if value[0] != '-' || value == "-0" {
-			return -1
-		}
-	}
-	return 0
-}
-
-func validateXSDDecimal(value string) int {
-	if value == "" {
-		return -1
-	}
-	start := 0
-	if value[0] == '+' || value[0] == '-' {
-		start = 1
-	}
-	if start >= len(value) {
-		return -1
-	}
-	dotSeen := false
-	for i := start; i < len(value); i++ {
-		if value[i] == '.' {
-			if dotSeen {
-				return -1
-			}
-			dotSeen = true
-		} else if value[i] < '0' || value[i] > '9' {
-			return -1
-		}
-	}
-	return 0
-}
-
-func validateXSDFloat(value string) int {
-	if value == "" {
-		return -1
-	}
-	switch value {
-	case "INF", "-INF", "+INF", "NaN":
-		return 0
-	}
-	start := 0
-	if value[0] == '+' || value[0] == '-' {
-		start = 1
-	}
-	if start >= len(value) {
-		return -1
-	}
-	dotSeen := false
-	eSeen := false
-	for i := start; i < len(value); i++ {
-		if value[i] == '.' {
-			if dotSeen || eSeen {
-				return -1
-			}
-			dotSeen = true
-		} else if value[i] == 'e' || value[i] == 'E' {
-			if eSeen {
-				return -1
-			}
-			eSeen = true
-			if i+1 < len(value) && (value[i+1] == '+' || value[i+1] == '-') {
-				i++
-			}
-		} else if value[i] < '0' || value[i] > '9' {
-			return -1
-		}
-	}
-	return 0
-}
-
-func validateXSDBoolean(value string) int {
-	switch value {
-	case "true", "false", "1", "0":
-		return 0
-	}
-	return -1
-}
-
-func validateXSDQName(value string) int {
-	parts := strings.SplitN(value, ":", 2)
-	for _, p := range parts {
-		if validateXSDNCName(p) != 0 {
-			return -1
-		}
-	}
-	return 0
-}
-
-func validateXSDNCName(value string) int {
-	if value == "" {
-		return -1
-	}
-	if !isNameStartChar(rune(value[0])) {
-		return -1
-	}
-	for _, r := range value[1:] {
-		if !isNameChar(r) || r == ':' {
-			return -1
-		}
-	}
-	return 0
-}
-
-func validateXSDName(value string) int {
-	if value == "" {
-		return -1
-	}
-	if !isNameStartChar(rune(value[0])) && value[0] != ':' {
-		return -1
-	}
-	for _, r := range value[1:] {
-		if !isNameChar(r) {
-			return -1
-		}
-	}
-	return 0
-}
-
-func validateXSDNMTOKEN(value string) int {
-	if value == "" {
-		return -1
-	}
-	for _, r := range value {
-		if !isNameChar(r) {
-			return -1
-		}
-	}
-	return 0
-}
-
-func validateXSDNMTOKENS(value string) int {
-	tokens := strings.Fields(value)
-	if len(tokens) == 0 {
-		return -1
-	}
-	for _, t := range tokens {
-		if validateXSDNMTOKEN(t) != 0 {
-			return -1
-		}
-	}
-	return 0
-}
-
-// validateXSDBase64Binary checks the lexical space of xs:base64Binary by
-// delegating to the shared XSD value validator (internal/xsd/value) so RELAX NG
-// and XSD agree on the datatype. The shared validator accepts the base64
-// alphabet plus whitespace and treats unpadded forms as value-equivalent to
-// their padded counterparts; only characters outside the alphabet are rejected.
-func validateXSDBase64Binary(s string) int {
-	if value.ValidateBuiltin(s, "base64Binary") != nil {
-		return -1
-	}
-	return 0
-}
-
-func validateXSDHexBinary(value string) int {
-	if len(value)%2 != 0 {
-		return -1
-	}
-	for _, r := range value {
-		if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
-			return -1
-		}
-	}
-	return 0
-}
-
-func isNameStartChar(r rune) bool {
-	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_'
-}
-
-func isNameChar(r rune) bool {
-	return isNameStartChar(r) || (r >= '0' && r <= '9') || r == '-' || r == '.' || r == ':'
 }
 
 // normalizeToken collapses whitespace and trims.

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1673,12 +1673,15 @@ var xsdValueSpaceTypes = map[string]struct{}{
 }
 
 // matchXSDValue compares an instance value against a <value> literal using the
-// XSD value space for the named datatype. A lexical match (after whitespace
-// processing) always succeeds; additionally, for value-space-comparable types
-// (numeric, boolean, date/time, binary) a lexically distinct but value-equal form
-// also matches (e.g. integer "5" == "+5" == "05"), agreeing with the XSD layer.
-// String-family and anyURI types stay lexical-only. An unknown datatype name
-// never matches.
+// XSD value space for the named datatype. For value-space-comparable types
+// (numeric, boolean, date/time, binary) both the instance text and the <value>
+// literal must first be lexically valid for the type; a lexically distinct but
+// value-equal form then also matches (e.g. integer "5" == "+5" == "05"),
+// agreeing with the XSD layer. Because the lexical-validity check runs before
+// the equality fast-path, an identical-but-invalid lexical (e.g.
+// type="integer" with both forms "5.0") is rejected rather than accepted.
+// String-family and anyURI types stay lexical-only (whitespace-processed
+// lexical equality). An unknown datatype name never matches.
 func matchXSDValue(typeName, text, expected string) int {
 	if _, ok := xsdDatatypeNames[typeName]; !ok {
 		return -1
@@ -1686,17 +1689,24 @@ func matchXSDValue(typeName, text, expected string) int {
 	text = strings.TrimSpace(text)
 	expected = strings.TrimSpace(expected)
 
-	if text == expected {
-		return 0
+	if _, ok := xsdValueSpaceTypes[typeName]; !ok {
+		// Lexical-only (string-family/anyURI) type: compare by whitespace-processed
+		// lexical value, which equals the value space for these types.
+		if text == expected {
+			return 0
+		}
+		return -1
 	}
 
-	if _, ok := xsdValueSpaceTypes[typeName]; !ok {
-		// Lexical-only type and the lexical forms differ.
-		return -1
-	}
-	// Value-space comparison: both operands must be lexically valid for the type.
+	// Value-space-comparable type. Both the instance text and the <value>
+	// literal must be lexically valid for the type before either the equality
+	// fast-path or value-space comparison may accept: an identical-but-invalid
+	// lexical (e.g. type="integer">5.0< accepting <e>5.0</e>) must be rejected.
 	if value.ValidateBuiltin(text, typeName) != nil || value.ValidateBuiltin(expected, typeName) != nil {
 		return -1
+	}
+	if text == expected {
+		return 0
 	}
 	if (typeName == "float" || typeName == "double") && value.IsFloatNaN(text) && value.IsFloatNaN(expected) {
 		return 0

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1687,8 +1687,13 @@ func matchXSDValue(typeName, text, expected string) int {
 	if _, ok := xsdDatatypeNames[typeName]; !ok {
 		return -1
 	}
-	text = strings.TrimSpace(text)
-	expected = strings.TrimSpace(expected)
+	// Normalize both the instance text and the <value> literal using the
+	// datatype's XSD whiteSpace facet (preserve/replace/collapse) before
+	// validating or comparing, rather than a blanket TrimSpace. This lets a
+	// collapsible token like "a  b" validate and value-match "a b", while leaving
+	// xs:string untouched (preserve).
+	text = value.Normalize(text, typeName)
+	expected = value.Normalize(expected, typeName)
 
 	// Both the instance text and the <value> literal must be lexically valid for
 	// the type before either the equality fast-path or value-space comparison may
@@ -1730,12 +1735,14 @@ func (v *validator) matchData(pat *pattern, text string) int {
 	}
 
 	dt := pat.dataType
-	text = strings.TrimSpace(text)
 
 	switch dt.library {
 	case lexicon.NamespaceXSDDatatypes:
+		// validateXSDType applies the per-datatype XSD whiteSpace facet itself, so
+		// the raw (un-trimmed) text is passed through.
 		return validateXSDType(dt.name, text, pat.params)
 	case "":
+		// Built-in RELAX NG datatypes: both "token" and "string" accept any text.
 		switch dt.name {
 		case lexicon.TypeToken:
 			return 0
@@ -1777,10 +1784,14 @@ func validateXSDType(typeName, text string, params []*param) int {
 		return -1
 	}
 	// xs:string has whiteSpace=preserve and may carry RELAX NG <param> facets
-	// (pattern, length, …); validate those locally.
+	// (pattern, length, …); validate those locally against the preserved text.
 	if typeName == "string" {
 		return validateWithParams(text, params)
 	}
+	// Apply the datatype's XSD whiteSpace facet (replace for normalizedString,
+	// collapse for everything else here) before lexical validation, so a value
+	// such as xs:token "a  b" (collapses to "a b") is accepted.
+	text = value.Normalize(text, typeName)
 	if value.ValidateBuiltin(text, typeName) != nil {
 		return -1
 	}

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1673,21 +1673,32 @@ var xsdValueSpaceTypes = map[string]struct{}{
 }
 
 // matchXSDValue compares an instance value against a <value> literal using the
-// XSD value space for the named datatype. For value-space-comparable types
-// (numeric, boolean, date/time, binary) both the instance text and the <value>
-// literal must first be lexically valid for the type; a lexically distinct but
-// value-equal form then also matches (e.g. integer "5" == "+5" == "05"),
-// agreeing with the XSD layer. Because the lexical-validity check runs before
-// the equality fast-path, an identical-but-invalid lexical (e.g.
-// type="integer" with both forms "5.0") is rejected rather than accepted.
-// String-family and anyURI types stay lexical-only (whitespace-processed
-// lexical equality). An unknown datatype name never matches.
+// XSD value space for the named datatype. For every recognized XSD datatype,
+// both the instance text and the <value> literal must first be lexically valid
+// for the type (via value.ValidateBuiltin); an invalid lexical never matches,
+// even when the two forms are identical (e.g. type="NCName">1foo< does not
+// accept <e>1foo</e>, and type="integer">5.0< does not accept <e>5.0</e>). For
+// value-space-comparable types (numeric, boolean, date/time, binary) a
+// lexically distinct but value-equal form then also matches (e.g. integer
+// "5" == "+5" == "05"), agreeing with the XSD layer. String-family and anyURI
+// types stay lexical-only (whitespace-processed lexical equality, which equals
+// their value space). An unknown datatype name never matches.
 func matchXSDValue(typeName, text, expected string) int {
 	if _, ok := xsdDatatypeNames[typeName]; !ok {
 		return -1
 	}
 	text = strings.TrimSpace(text)
 	expected = strings.TrimSpace(expected)
+
+	// Both the instance text and the <value> literal must be lexically valid for
+	// the type before either the equality fast-path or value-space comparison may
+	// accept. This gate runs for every recognized type so that an invalid lexical
+	// (e.g. "1foo" for NCName, or "5.0" for integer) is rejected even when the two
+	// forms are byte-identical. value.ValidateBuiltin imposes no constraint on
+	// xs:string / xs:anyURI, so those stay effectively lexical-only.
+	if value.ValidateBuiltin(text, typeName) != nil || value.ValidateBuiltin(expected, typeName) != nil {
+		return -1
+	}
 
 	if _, ok := xsdValueSpaceTypes[typeName]; !ok {
 		// Lexical-only (string-family/anyURI) type: compare by whitespace-processed
@@ -1698,13 +1709,8 @@ func matchXSDValue(typeName, text, expected string) int {
 		return -1
 	}
 
-	// Value-space-comparable type. Both the instance text and the <value>
-	// literal must be lexically valid for the type before either the equality
-	// fast-path or value-space comparison may accept: an identical-but-invalid
-	// lexical (e.g. type="integer">5.0< accepting <e>5.0</e>) must be rejected.
-	if value.ValidateBuiltin(text, typeName) != nil || value.ValidateBuiltin(expected, typeName) != nil {
-		return -1
-	}
+	// Value-space-comparable type: a lexically distinct but value-equal form
+	// matches (e.g. integer "5" == "+5" == "05", NaN == NaN for float/double).
 	if text == expected {
 		return 0
 	}

--- a/relaxng/xsddatatype_test.go
+++ b/relaxng/xsddatatype_test.go
@@ -1,0 +1,147 @@
+package relaxng_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/relaxng"
+	"github.com/stretchr/testify/require"
+)
+
+// compileXSDDataSchema compiles a grammar whose single element carries a
+// <data type="..."/> from the XSD datatype library and returns the grammar.
+func compileXSDDataSchema(t *testing.T, typeName string) *relaxng.Grammar {
+	t.Helper()
+	schema := `<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <element name="e">
+      <data type="` + typeName + `"/>
+    </element>
+  </start>
+</grammar>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(schema))
+	require.NoError(t, err)
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	grammar, err := relaxng.NewCompiler().ErrorHandler(collector).Compile(t.Context(), doc)
+	require.NoError(t, err)
+	_ = collector.Close()
+	_, compileErrors := partitionCompileErrors(collector.Errors())
+	require.Empty(t, compileErrors, "schema should compile without errors")
+	return grammar
+}
+
+func validateXSDInstance(t *testing.T, grammar *relaxng.Grammar, value string) error {
+	t.Helper()
+	xmlDoc, err := helium.NewParser().Parse(t.Context(), []byte("<e>"+value+"</e>"))
+	require.NoError(t, err)
+	return relaxng.NewValidator(grammar).Validate(t.Context(), xmlDoc)
+}
+
+// TestXSDDataTypeLexical exercises the XSD datatype library path of <data>.
+// Date/time/duration values that are not lexically valid must be rejected
+// (the previous code accepted them by mere length/prefix), and an unknown
+// datatype name must be rejected rather than silently accepted.
+func TestXSDDataTypeLexical(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		typeName string
+		valid    []string
+		invalid  []string
+	}{
+		{
+			typeName: "date",
+			valid:    []string{"2020-01-15", "2020-12-31Z", "2020-06-18+09:00"},
+			invalid:  []string{"abcdefghij", "2020-13-01", "2020-01-32", "not-a-date"},
+		},
+		{
+			typeName: "dateTime",
+			valid:    []string{"2020-01-15T10:20:30", "2020-01-15T10:20:30Z"},
+			invalid:  []string{"2020-01-15 10:20:30", "abcdefghijklmnopqrs", "2020-01-15T25:00:00"},
+		},
+		{
+			typeName: "time",
+			valid:    []string{"10:20:30", "23:59:59Z"},
+			invalid:  []string{"abcdefgh", "25:00:00", "10-20-30"},
+		},
+		{
+			typeName: "duration",
+			valid:    []string{"P1Y", "PT1H30M", "P1Y2M3DT4H5M6S"},
+			invalid:  []string{"Pxyz", "P", "PT", "1Y"},
+		},
+		{
+			typeName: "integer",
+			valid:    []string{"5", "-3", "+42"},
+			invalid:  []string{"5.0", "abc", "1e3"},
+		},
+		{
+			typeName: "boolean",
+			valid:    []string{"true", "false", "1", "0"},
+			invalid:  []string{"yes", "True", "2"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.typeName, func(t *testing.T) {
+			grammar := compileXSDDataSchema(t, tc.typeName)
+			for _, v := range tc.valid {
+				t.Run("valid/"+v, func(t *testing.T) {
+					require.NoError(t, validateXSDInstance(t, grammar, v),
+						"%q should be accepted as %s", v, tc.typeName)
+				})
+			}
+			for _, v := range tc.invalid {
+				t.Run("invalid/"+v, func(t *testing.T) {
+					require.Error(t, validateXSDInstance(t, grammar, v),
+						"%q should be rejected as %s", v, tc.typeName)
+				})
+			}
+		})
+	}
+}
+
+// TestXSDDataTypeUnknown verifies that an unknown XSD datatype name is rejected
+// instead of being silently accepted.
+func TestXSDDataTypeUnknown(t *testing.T) {
+	t.Parallel()
+	grammar := compileXSDDataSchema(t, "notARealXSDType")
+	require.Error(t, validateXSDInstance(t, grammar, "anything"),
+		"an unknown XSD datatype name should be rejected")
+}
+
+// TestXSDValueValueSpace verifies that <value> with an XSD datatype compares in
+// value space, so lexically distinct but value-equal forms match.
+func TestXSDValueValueSpace(t *testing.T) {
+	t.Parallel()
+
+	const schema = `<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <element name="e">
+      <value type="integer">5</value>
+    </element>
+  </start>
+</grammar>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(schema))
+	require.NoError(t, err)
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	grammar, err := relaxng.NewCompiler().ErrorHandler(collector).Compile(t.Context(), doc)
+	require.NoError(t, err)
+	_ = collector.Close()
+	_, compileErrors := partitionCompileErrors(collector.Errors())
+	require.Empty(t, compileErrors)
+
+	for _, v := range []string{"5", "+5", "05"} {
+		t.Run("match/"+v, func(t *testing.T) {
+			require.NoError(t, validateXSDInstance(t, grammar, v),
+				"%q should value-match integer 5", v)
+		})
+	}
+	for _, v := range []string{"6", "5.0", "abc"} {
+		t.Run("nomatch/"+v, func(t *testing.T) {
+			require.Error(t, validateXSDInstance(t, grammar, v),
+				"%q should not value-match integer 5", v)
+		})
+	}
+}

--- a/relaxng/xsddatatype_test.go
+++ b/relaxng/xsddatatype_test.go
@@ -160,7 +160,10 @@ func TestXSDValueValueSpace(t *testing.T) {
 // valid lexical form for its XSD datatype is rejected even when the instance
 // text is byte-identical to that literal. The previous code returned success on
 // the lexical equality fast-path before validating either form, wrongly
-// accepting identical-but-invalid typed values.
+// accepting identical-but-invalid typed values. This must hold for both
+// value-space-comparable types (integer, date) and constrained NON-comparable
+// string-family types (NCName), the latter of which the prior fix missed
+// because its lexical gate ran only for comparable types.
 func TestXSDValueInvalidLexical(t *testing.T) {
 	t.Parallel()
 
@@ -172,6 +175,10 @@ func TestXSDValueInvalidLexical(t *testing.T) {
 	}{
 		{"integer-5.0", typeInteger, "5.0", "5.0"},
 		{"date-not-a-date", "date", "not-a-date", "not-a-date"},
+		// NCName is constrained but NOT value-space-comparable. "1foo" is an
+		// invalid NCName (leading digit), so an identical-but-invalid lexical
+		// must still be rejected.
+		{"ncname-leading-digit", "NCName", "1foo", "1foo"},
 	}
 
 	for _, tc := range cases {
@@ -188,5 +195,13 @@ func TestXSDValueInvalidLexical(t *testing.T) {
 		grammar := compileXSDValueSchema(t, typeInteger, "5")
 		require.NoError(t, validateXSDInstance(t, grammar, "+5"),
 			"valid integer +5 should value-match 5")
+	})
+
+	// A valid NCName literal must still match a byte-identical valid instance
+	// (lexical equality for a constrained non-comparable type).
+	t.Run("valid-ncname-equality", func(t *testing.T) {
+		grammar := compileXSDValueSchema(t, "NCName", "foo")
+		require.NoError(t, validateXSDInstance(t, grammar, "foo"),
+			"valid NCName foo should match literal foo")
 	})
 }

--- a/relaxng/xsddatatype_test.go
+++ b/relaxng/xsddatatype_test.go
@@ -260,6 +260,27 @@ func TestXSDValueWhitespaceFacet(t *testing.T) {
 		})
 	})
 
+	t.Run("nbsp-not-collapsed", func(t *testing.T) {
+		// The XSD whiteSpace facet collapses ONLY the four ASCII whitespace
+		// characters (#x20, #x9, #xD, #xA). Unicode whitespace such as NBSP
+		// (U+00A0, &#160;) is NOT whitespace, so it must survive normalization and
+		// leave the value lexically invalid / non-matching.
+		t.Run("integer-rejects-nbsp", func(t *testing.T) {
+			grammar := compileXSDDataSchema(t, typeInteger)
+			require.Error(t, validateXSDInstance(t, grammar, "&#160;5"),
+				"NBSP is not XSD whitespace, so \"\\u00A05\" is not a valid integer")
+		})
+		t.Run("token-nbsp-no-match", func(t *testing.T) {
+			// <value type="token">a b</value> (ASCII space) must NOT match an
+			// instance "a&#160;b" (NBSP), because NBSP does not collapse.
+			grammar := compileXSDValueSchema(t, "token", "a b")
+			require.Error(t, validateXSDInstance(t, grammar, "a&#160;b"),
+				"token literal \"a b\" must not match NBSP-separated \"a\\u00A0b\"")
+			require.NoError(t, validateXSDInstance(t, grammar, "a  b"),
+				"token literal \"a b\" must still match ASCII-collapsible \"a  b\"")
+		})
+	})
+
 	t.Run("normalizedString-replace-match", func(t *testing.T) {
 		// normalizedString=replace: a literal with a tab and an instance with a
 		// space both normalize to "a b" and match. But two internal spaces do NOT

--- a/relaxng/xsddatatype_test.go
+++ b/relaxng/xsddatatype_test.go
@@ -205,3 +205,73 @@ func TestXSDValueInvalidLexical(t *testing.T) {
 			"valid NCName foo should match literal foo")
 	})
 }
+
+// TestXSDDataTypeWhitespaceFacet verifies that <data> applies the per-datatype
+// XSD whiteSpace facet (collapse/replace/preserve) before validating, instead of
+// a blanket TrimSpace. xs:token collapses internal whitespace, so "a  b" is a
+// valid token value; xs:normalizedString replaces tab/newline/CR with spaces but
+// does not collapse, so internal runs of spaces survive but a tab is normalized
+// to a single space (still valid).
+func TestXSDDataTypeWhitespaceFacet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("token-collapsible-internal-whitespace", func(t *testing.T) {
+		grammar := compileXSDDataSchema(t, "token")
+		for _, v := range []string{"a b", "a  b", "a\tb", "  a   b  "} {
+			t.Run("valid/"+v, func(t *testing.T) {
+				require.NoError(t, validateXSDInstance(t, grammar, v),
+					"token collapses whitespace, so %q is a valid xs:token value", v)
+			})
+		}
+	})
+
+	t.Run("normalizedString-replaces-but-not-collapses", func(t *testing.T) {
+		grammar := compileXSDDataSchema(t, "normalizedString")
+		// normalizedString=replace: tab/newline/CR become single spaces and the
+		// result is always lexically valid; internal multi-space runs survive.
+		for _, v := range []string{"a b", "a  b", "a\tb", "a\nb"} {
+			t.Run("valid/"+v, func(t *testing.T) {
+				require.NoError(t, validateXSDInstance(t, grammar, v),
+					"normalizedString replaces whitespace, so %q is valid", v)
+			})
+		}
+	})
+}
+
+// TestXSDValueWhitespaceFacet verifies that <value> normalizes the instance text
+// AND the literal using the datatype's XSD whiteSpace facet before comparing, so
+// value-equal forms that differ only in collapsible whitespace match.
+func TestXSDValueWhitespaceFacet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("token-collapse-match", func(t *testing.T) {
+		// <value type="token">a  b</value> must match instances whose collapsed
+		// form is also "a b".
+		grammar := compileXSDValueSchema(t, "token", "a  b")
+		for _, v := range []string{"a b", "a  b", "a   b", "  a b  ", "a\tb"} {
+			t.Run("match/"+v, func(t *testing.T) {
+				require.NoError(t, validateXSDInstance(t, grammar, v),
+					"token literal \"a  b\" should value-match collapsed %q", v)
+			})
+		}
+		t.Run("nomatch/a-c", func(t *testing.T) {
+			require.Error(t, validateXSDInstance(t, grammar, "a c"),
+				"token literal \"a  b\" should not match \"a c\"")
+		})
+	})
+
+	t.Run("normalizedString-replace-match", func(t *testing.T) {
+		// normalizedString=replace: a literal with a tab and an instance with a
+		// space both normalize to "a b" and match. But two internal spaces do NOT
+		// collapse, so "a b" != "a  b" for normalizedString.
+		grammar := compileXSDValueSchema(t, "normalizedString", "a\tb")
+		t.Run("match/space", func(t *testing.T) {
+			require.NoError(t, validateXSDInstance(t, grammar, "a b"),
+				"normalizedString literal \"a\\tb\" should value-match \"a b\"")
+		})
+		t.Run("nomatch/double-space", func(t *testing.T) {
+			require.Error(t, validateXSDInstance(t, grammar, "a  b"),
+				"normalizedString does not collapse, so \"a  b\" must not match \"a b\"")
+		})
+	})
+}

--- a/relaxng/xsddatatype_test.go
+++ b/relaxng/xsddatatype_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const typeInteger = "integer"
+
 // compileXSDDataSchema compiles a grammar whose single element carries a
 // <data type="..."/> from the XSD datatype library and returns the grammar.
 func compileXSDDataSchema(t *testing.T, typeName string) *relaxng.Grammar {
@@ -71,7 +73,7 @@ func TestXSDDataTypeLexical(t *testing.T) {
 			invalid:  []string{"Pxyz", "P", "PT", "1Y"},
 		},
 		{
-			typeName: "integer",
+			typeName: typeInteger,
 			valid:    []string{"5", "-3", "+42"},
 			invalid:  []string{"5.0", "abc", "1e3"},
 		},
@@ -110,16 +112,15 @@ func TestXSDDataTypeUnknown(t *testing.T) {
 		"an unknown XSD datatype name should be rejected")
 }
 
-// TestXSDValueValueSpace verifies that <value> with an XSD datatype compares in
-// value space, so lexically distinct but value-equal forms match.
-func TestXSDValueValueSpace(t *testing.T) {
-	t.Parallel()
-
-	const schema = `<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+// compileXSDValueSchema compiles a grammar whose single element carries a
+// <value type="..."> literal from the XSD datatype library.
+func compileXSDValueSchema(t *testing.T, typeName, literal string) *relaxng.Grammar {
+	t.Helper()
+	schema := `<grammar xmlns="http://relaxng.org/ns/structure/1.0"
     datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <start>
     <element name="e">
-      <value type="integer">5</value>
+      <value type="` + typeName + `">` + literal + `</value>
     </element>
   </start>
 </grammar>`
@@ -130,7 +131,16 @@ func TestXSDValueValueSpace(t *testing.T) {
 	require.NoError(t, err)
 	_ = collector.Close()
 	_, compileErrors := partitionCompileErrors(collector.Errors())
-	require.Empty(t, compileErrors)
+	require.Empty(t, compileErrors, "schema should compile without errors")
+	return grammar
+}
+
+// TestXSDValueValueSpace verifies that <value> with an XSD datatype compares in
+// value space, so lexically distinct but value-equal forms match.
+func TestXSDValueValueSpace(t *testing.T) {
+	t.Parallel()
+
+	grammar := compileXSDValueSchema(t, typeInteger, "5")
 
 	for _, v := range []string{"5", "+5", "05"} {
 		t.Run("match/"+v, func(t *testing.T) {
@@ -144,4 +154,39 @@ func TestXSDValueValueSpace(t *testing.T) {
 				"%q should not value-match integer 5", v)
 		})
 	}
+}
+
+// TestXSDValueInvalidLexical verifies that a <value> literal which is not a
+// valid lexical form for its XSD datatype is rejected even when the instance
+// text is byte-identical to that literal. The previous code returned success on
+// the lexical equality fast-path before validating either form, wrongly
+// accepting identical-but-invalid typed values.
+func TestXSDValueInvalidLexical(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		typeName string
+		literal  string
+		instance string
+	}{
+		{"integer-5.0", typeInteger, "5.0", "5.0"},
+		{"date-not-a-date", "date", "not-a-date", "not-a-date"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			grammar := compileXSDValueSchema(t, tc.typeName, tc.literal)
+			require.Error(t, validateXSDInstance(t, grammar, tc.instance),
+				"identical-but-invalid lexical %q should be rejected as %s",
+				tc.instance, tc.typeName)
+		})
+	}
+
+	// A valid value with distinct lexical forms must still value-match.
+	t.Run("valid-value-equality", func(t *testing.T) {
+		grammar := compileXSDValueSchema(t, typeInteger, "5")
+		require.NoError(t, validateXSDInstance(t, grammar, "+5"),
+			"valid integer +5 should value-match 5")
+	})
 }


### PR DESCRIPTION
- Route RELAX NG XSD `<data>`/`<value>` validation through `internal/xsd/value` so date/time/duration ranges and integer/binary lexical spaces match XSD
- Reject unknown XSD datatype names instead of silently accepting them
- Compare `<value>` in value space for numeric/boolean/date-time/binary types (e.g. integer `5`≡`+5`≡`05`); string-family stays lexical-only
