### PR TITLE
retain empty default and fixed constraints

### DIFF
--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -39,12 +39,14 @@ func parseParticleOccurs(elem *helium.Element) (int, int) {
 
 func readDefaultOrFixed(elem *helium.Element) (*string, *string) {
 	var defaultValue *string
-	if v := getAttr(elem, attrDefault); v != "" {
+	if hasAttr(elem, attrDefault) {
+		v := getAttr(elem, attrDefault)
 		defaultValue = &v
 	}
 
 	var fixedValue *string
-	if v := getAttr(elem, attrFixed); v != "" {
+	if hasAttr(elem, attrFixed) {
+		v := getAttr(elem, attrFixed)
 		fixedValue = &v
 	}
 
@@ -328,10 +330,12 @@ func (c *compiler) parseAttributeUse(ctx context.Context, elem *helium.Element) 
 		if getAttr(elem, attrUse) == attrValRequired {
 			au.Required = true
 		}
-		if v := getAttr(elem, attrDefault); v != "" {
+		if hasAttr(elem, attrDefault) {
+			v := getAttr(elem, attrDefault)
 			au.Default = &v
 		}
-		if v := getAttr(elem, attrFixed); v != "" {
+		if hasAttr(elem, attrFixed) {
+			v := getAttr(elem, attrFixed)
 			au.Fixed = &v
 		}
 		c.attrRefs[au] = qn

--- a/xsd/read_empty_default_fixed_test.go
+++ b/xsd/read_empty_default_fixed_test.go
@@ -1,0 +1,31 @@
+package xsd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmptyFixedConstraint checks that a fixed="" constraint is retained and
+// enforced. An empty-string fixed value is a valid constraint: it requires the
+// element to be empty, so non-empty content must be rejected. Previously the
+// reader dropped fixed="" (treating present-but-empty as absent), so the
+// constraint was silently ignored and any content was accepted.
+func TestEmptyFixedConstraint(t *testing.T) {
+	t.Parallel()
+
+	schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" type="xs:string" fixed=""/>
+</xs:schema>`
+
+	t.Run("accepts empty content", func(t *testing.T) {
+		require.NoError(t, compileAndValidate(t, schemaXML, `<root/>`, nil))
+	})
+
+	t.Run("rejects non-empty content", func(t *testing.T) {
+		var out string
+		err := compileAndValidate(t, schemaXML, `<root>x</root>`, &out)
+		require.Error(t, err)
+		require.Contains(t, out, "does not match the fixed value constraint")
+	})
+}


### PR DESCRIPTION
- `readDefaultOrFixed` (and the attribute-ref path) used `getAttr`, which can't tell a missing attribute from `default=""`/`fixed=""`, so empty-string constraints were dropped
- switch to `hasAttr` presence check so a present-but-empty default/fixed is stored as a non-nil pointer and enforced
- add test: `fixed=""` now requires empty element content