### PR TITLE
wire helium lint --encode through to output

### DIFF
--- a/.claude/docs/helium-command.md
+++ b/.claude/docs/helium-command.md
@@ -84,6 +84,12 @@ Primary file: `internal/cli/heliumcmd/lint.go`
 - XPath mode → type-aware result printing
 - Standard dump → `helium.NewWriter()` with format/dropdtd options
 
+### `--encode ENC`
+
+- Validated at parse time against `internal/encoding.Load`; an unrecognized encoding name is rejected with `--encode: unsupported encoding` and `ExitErr` (no silent fallback).
+- Applied to the standard dump path via `doc.SetEncoding`, so the serializer loads the matching encoder and emits the matching encoding declaration.
+- Ignored for C14N modes, which are always UTF-8 per the C14N spec.
+
 ## `helium xpath`
 
 Primary file: `internal/cli/heliumcmd/xpath.go`

--- a/.claude/docs/helium-command.md
+++ b/.claude/docs/helium-command.md
@@ -87,6 +87,8 @@ Primary file: `internal/cli/heliumcmd/lint.go`
 ### `--encode ENC`
 
 - Validated at parse time against `internal/encoding.Load`; an unrecognized encoding name is rejected with `--encode: unsupported encoding` and `ExitErr` (no silent fallback).
+- US-ASCII and its aliases (`ascii`, `ANSI_X3.4-1968`, `csASCII`, detected via `internal/encoding.IsASCII`) are rejected with the same `--encode: unsupported encoding` message: `Load` maps them to the UTF-8 encoder, which would emit raw UTF-8 bytes for non-ASCII characters while declaring US-ASCII.
+- Cannot be combined with `--xpath`: the XPath path serializes node values without re-encoding, so the combination is rejected at parse time with `--encode cannot be combined with --xpath` and `ExitErr`.
 - Applied to the standard dump path via `doc.SetEncoding`, so the serializer loads the matching encoder and emits the matching encoding declaration.
 - Ignored for C14N modes, which are always UTF-8 per the C14N spec.
 

--- a/internal/cli/heliumcmd/lint.go
+++ b/internal/cli/heliumcmd/lint.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/c14n"
 	"github.com/lestrrat-go/helium/catalog"
+	henc "github.com/lestrrat-go/helium/internal/encoding"
 	"github.com/lestrrat-go/helium/xinclude"
 	"github.com/lestrrat-go/helium/xpath1"
 	"github.com/lestrrat-go/helium/xsd"
@@ -293,6 +294,10 @@ func (c *command) parseArgs(args []string) (*config, []string) {
 				return nil, nil
 			}
 			cfg.encode = args[i] //nolint:gosec // bounds checked above
+			if henc.Load(cfg.encode) == nil {
+				_, _ = fmt.Fprintf(c.stderr, "%s: --encode: unsupported encoding %q\n", c.prog, cfg.encode)
+				return nil, nil
+			}
 		case "--pretty":
 			i++
 			if i >= len(args) {
@@ -458,6 +463,14 @@ func (c *command) processInput(ctx context.Context, cfg *config, input namedInpu
 
 	if cfg.noout {
 		return ExitOK
+	}
+
+	// Honor the requested output encoding. Setting the document encoding
+	// makes helium.Writer load the matching encoder and emit a matching
+	// encoding declaration. C14N output is always UTF-8 per spec, so the
+	// encoding only applies to the standard serialization path.
+	if cfg.encode != "" && cfg.c14nMode == 0 {
+		doc.SetEncoding(cfg.encode)
 	}
 
 	var t0 time.Time

--- a/internal/cli/heliumcmd/lint.go
+++ b/internal/cli/heliumcmd/lint.go
@@ -298,6 +298,14 @@ func (c *command) parseArgs(args []string) (*config, []string) {
 				_, _ = fmt.Fprintf(c.stderr, "%s: --encode: unsupported encoding %q\n", c.prog, cfg.encode)
 				return nil, nil
 			}
+			// US-ASCII (and its aliases) maps to the UTF-8 encoder, so the
+			// serializer would emit raw UTF-8 bytes for any character outside
+			// the ASCII range while still declaring US-ASCII. Reject it rather
+			// than produce output that does not match its declared encoding.
+			if henc.IsASCII(cfg.encode) {
+				_, _ = fmt.Fprintf(c.stderr, "%s: --encode: unsupported encoding %q\n", c.prog, cfg.encode)
+				return nil, nil
+			}
 		case "--pretty":
 			i++
 			if i >= len(args) {
@@ -336,6 +344,14 @@ func (c *command) parseArgs(args []string) (*config, []string) {
 			}
 			files = append(files, arg)
 		}
+	}
+
+	// XPath result serialization prints node values, attributes, and namespace
+	// nodes directly and never re-encodes them, so --encode cannot be honored
+	// on that path. Reject the combination instead of silently ignoring it.
+	if cfg.encode != "" && cfg.xpathExpr != "" {
+		_, _ = fmt.Fprintf(c.stderr, "%s: --encode cannot be combined with --xpath\n", c.prog)
+		return nil, nil
 	}
 
 	return cfg, files

--- a/internal/cli/heliumcmd/lint_test.go
+++ b/internal/cli/heliumcmd/lint_test.go
@@ -68,6 +68,18 @@ func TestParseArgsRepeatZero(t *testing.T) {
 	require.NotEqual(t, heliumcmd.ExitOK, code)
 }
 
+func TestLintEncodeUnknown(t *testing.T) {
+	_, errOut, code := executeLintStdin(t, `<?xml version="1.0"?><root/>`, "--encode", "bogus-enc")
+	require.NotEqual(t, heliumcmd.ExitOK, code)
+	require.Contains(t, errOut, "bogus-enc")
+}
+
+func TestLintEncodeApplied(t *testing.T) {
+	out, _, code := executeLintStdin(t, `<?xml version="1.0"?><root>x</root>`, "--encode", "ISO-8859-1")
+	require.Equal(t, heliumcmd.ExitOK, code)
+	require.Contains(t, out, `encoding="ISO-8859-1"`)
+}
+
 func TestParseArgsMissingValues(t *testing.T) {
 	flags := []string{"--schema", "--xpath", "--output", "--encode", "--pretty", "--path", "--repeat"}
 	for _, flag := range flags {

--- a/internal/cli/heliumcmd/lint_test.go
+++ b/internal/cli/heliumcmd/lint_test.go
@@ -80,6 +80,47 @@ func TestLintEncodeApplied(t *testing.T) {
 	require.Contains(t, out, `encoding="ISO-8859-1"`)
 }
 
+func TestLintEncodeASCIIRejected(t *testing.T) {
+	// US-ASCII and its aliases map to the UTF-8 encoder, which would emit raw
+	// UTF-8 bytes for characters outside the ASCII range while declaring
+	// US-ASCII. The lint command must reject these aliases up-front.
+	for _, name := range []string{"US-ASCII", "ascii", "ANSI_X3.4-1968", "csASCII"} {
+		t.Run(name, func(t *testing.T) {
+			_, errOut, code := executeLintStdin(t, `<?xml version="1.0"?><root>x</root>`, "--encode", name)
+			require.NotEqual(t, heliumcmd.ExitOK, code)
+			require.Contains(t, errOut, name)
+		})
+	}
+}
+
+func TestLintEncodeBytesValid(t *testing.T) {
+	// A character outside the ASCII range (U+20AC EURO SIGN) must be re-encoded
+	// to the declared encoding's bytes, never passed through as raw UTF-8. The
+	// raw UTF-8 form of U+20AC is 0xE2 0x82 0xAC; in ISO-8859-15 the euro sign
+	// is the single byte 0xA4.
+	out, _, code := executeLintStdin(t, "<?xml version=\"1.0\"?><root>€</root>", "--encode", "ISO-8859-15")
+	require.Equal(t, heliumcmd.ExitOK, code)
+	raw := []byte(out)
+	require.NotContains(t, string(raw), "\xe2\x82\xac", "must not emit raw UTF-8 bytes for U+20AC")
+	require.Contains(t, raw, byte(0xA4), "U+20AC must be encoded as ISO-8859-15 byte 0xA4")
+	require.Contains(t, out, `encoding="ISO-8859-15"`)
+}
+
+func TestLintEncodeWithXPathRejected(t *testing.T) {
+	// The --xpath path serializes node values without applying --encode, so the
+	// combination must be rejected rather than silently produce output that does
+	// not match the declared encoding. Order-independent.
+	for _, args := range [][]string{
+		{"--encode", "ISO-8859-1", "--xpath", "//root"},
+		{"--xpath", "//root", "--encode", "ISO-8859-1"},
+	} {
+		_, errOut, code := executeLintStdin(t, `<?xml version="1.0"?><root>x</root>`, args...)
+		require.NotEqual(t, heliumcmd.ExitOK, code)
+		require.Contains(t, errOut, "--encode")
+		require.Contains(t, errOut, "--xpath")
+	}
+}
+
 func TestParseArgsMissingValues(t *testing.T) {
 	flags := []string{"--schema", "--xpath", "--output", "--encode", "--pretty", "--path", "--repeat"}
 	for _, flag := range flags {

--- a/internal/encoding/isutf8.go
+++ b/internal/encoding/isutf8.go
@@ -10,3 +10,14 @@ func IsUTF8(name string) bool {
 	}
 	return false
 }
+
+// IsASCII returns true if the named encoding is one of the US-ASCII aliases.
+// Load maps these to the UTF-8 encoder, so callers that need byte-valid
+// output for the declared encoding must detect ASCII separately.
+func IsASCII(name string) bool {
+	switch normalizeEncodingName(name) {
+	case "usascii", "ascii", "ansix341968", "csascii":
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
- `helium lint --encode ENC` now applies the requested encoding to the standard dump via `doc.SetEncoding` instead of silently ignoring it
- unrecognized encoding names are rejected at parse time with a clear error and `ExitErr`, no silent fallback
- C14N output stays UTF-8 per spec; helium-command.md updated