### PR TITLE
compare xsd fixed values in value space

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -40,6 +40,14 @@ Files: `xsd/xsd.go` (API), `compile*.go` + `read_*.go` + `link_refs.go` + `check
      - Simple: no child elements, validate text vs type facets
      - Element-only/Mixed: match children against ModelGroup (`matchSequence()`/`matchChoice()`)
 
+Fixed value constraints (element content and attribute values) are compared in
+the declared simple type's value space via `fixedValueMatches`
+(`value.CanonicalKey` keyed off `builtinBaseLocal`), which applies the type's
+whitespace facet (preserve/replace/collapse). So integer fixed `1` accepts
+instance `+1`/`01`, while an `xs:string` fixed value with significant trailing
+whitespace is not silently trimmed. When the builtin base cannot be resolved it
+falls back to raw string equality.
+
 Enumeration facets are compared in value space, not raw lexical text. A value is
 a member if it lexically equals a member OR value-compares equal to one (e.g.
 decimal `5.0`≡`5`, boolean `1`≡`true`, float `1.50`≡`1.5`, equal dateTimes in

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -71,10 +71,21 @@ element *declaration's* type (`edecl.Type`), not an `xsi:type` actual type, so a
 declared `xs:string` (whiteSpace="preserve") fixed `abc ` keeps its trailing space
 even when the instance's `xsi:type` collapses whitespace — element content is still
 validated against the actual type. In `fixedUnionMatches`, when the fixed and
-instance values resolve to *different* active members sharing a value-space family
-(e.g. integer/decimal), each operand is whitespace-normalized with *its* active
-member's effective whiteSpace facet before `value.Compare`, so union fixed `1.0`
-accepts both `1` and ` 1 `. `unionActiveMember` returns the active *basic*
+instance values resolve to *different* active members, they are value-equal iff
+their members reduce to the same *primitive* value-space family
+(`primitiveValueSpaceFamily`, XSD 1.1 §2.3 — restrictions create no new values):
+all integer types → `decimal`; all xs:string-derived types
+(string/normalizedString/token/language/Name/NCName/NMTOKEN/IDREF/ENTITY/…) and
+anyURI → `string`; each remaining comparable primitive (boolean, float, double,
+date/time family, hexBinary, base64Binary) is its own family; QName/NOTATION have
+no shared family (namespace-context dependent). Each operand is first
+whitespace-normalized with *its* active member's effective whiteSpace facet; the
+`decimal`/comparable families then compare via `value.Compare` (so union fixed
+`1.0` accepts both `1` and ` 1 `), while the `string` family compares the
+normalized lexical forms (so fixed `a b` active in one xs:string restriction
+accepts instance ` a   b ` active in another xs:string restriction with
+whiteSpace="collapse", both denoting `a b`). This includes string-derived members
+— it is **not** gated on the `enumValueSpaceTypes` allowlist. `unionActiveMember` returns the active *basic*
 (atomic) member, descending through nested unions to the basic member that
 actually accepts the value, so an outer union `memberTypes="inner xs:decimal"`
 (with `inner` a union `xs:integer xs:boolean`) compares instance `1` (active

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -64,7 +64,17 @@ side via the `FixedNS` map captured on the `ElementDecl`/`AttrUse` at read time
 to the same URI are equal while a same-prefix different-URI binding is not (an
 unresolved prefix on either side falls back to lexical equality). `fixedValueMatches`
 takes the instance and fixed namespace contexts as parameters. When `td` is nil it
-falls back to raw string equality.
+falls back to raw string equality. The element fixed-value comparison uses the
+element *declaration's* type (`edecl.Type`), not an `xsi:type` actual type, so a
+declared `xs:string` (whiteSpace="preserve") fixed `abc ` keeps its trailing space
+even when the instance's `xsi:type` collapses whitespace — element content is still
+validated against the actual type. In `fixedUnionMatches`, when the fixed and
+instance values resolve to *different* active members sharing a value-space family
+(e.g. integer/decimal), each operand is whitespace-normalized with *its* active
+member's effective whiteSpace facet before `value.Compare`, so union fixed `1.0`
+accepts both `1` and ` 1 `. Global attributes matched through an `xs:anyAttribute`
+wildcard (`validateWildcardAttr`, processContents strict/lax) also enforce the
+global attribute's `Fixed`/`FixedNS` via `fixedValueMatches`.
 
 Enumeration facets are compared in value space, not raw lexical text. A value is
 a member if it lexically equals a member OR value-compares equal to one (e.g.

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -41,11 +41,19 @@ Files: `xsd/xsd.go` (API), `compile*.go` + `read_*.go` + `link_refs.go` + `check
      - Element-only/Mixed: match children against ModelGroup (`matchSequence()`/`matchChoice()`)
 
 Fixed value constraints (element content and attribute values) are compared in
-the declared simple type's value space via `fixedValueMatches`
-(`value.CanonicalKey` keyed off `builtinBaseLocal`), which applies the type's
-whitespace facet (preserve/replace/collapse). So integer fixed `1` accepts
-instance `+1`/`01`, while an `xs:string` fixed value with significant trailing
-whitespace is not silently trimmed. When the builtin base cannot be resolved it
+the declared simple type's value space via `fixedValueMatches`. Both the fixed
+and instance values are first whitespace-normalized using the type's *effective*
+whiteSpace facet (`resolveWhiteSpace` walks the derivation chain, so a facet
+derived on a restriction — e.g. `xs:string` restricted with
+`whiteSpace="collapse"` — is honoured, not just the builtin default). Then the
+comparison dispatches on variety (`resolveVariety`): list types split into items
+and compare item-by-item in the item type's value space (so `xs:integer` list
+fixed `1 2` accepts `01 +2`); union types accept when any member's value space
+matches; atomic types compare via `value.Compare` for the value-comparable
+builtins in `enumValueSpaceTypes` (numeric, boolean, date/time, and binary — so
+`xs:hexBinary` fixed `0A` accepts `0a` and integer fixed `1` accepts `+1`/`01`),
+falling back to normalized-lexical equality for string-family/anyURI (so a
+numeric-looking `xs:string` fixed `5` does not accept `5.0`). When `td` is nil it
 falls back to raw string equality.
 
 Enumeration facets are compared in value space, not raw lexical text. A value is

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -47,13 +47,23 @@ whiteSpace facet (`resolveWhiteSpace` walks the derivation chain, so a facet
 derived on a restriction — e.g. `xs:string` restricted with
 `whiteSpace="collapse"` — is honoured, not just the builtin default). Then the
 comparison dispatches on variety (`resolveVariety`): list types split into items
-and compare item-by-item in the item type's value space (so `xs:integer` list
-fixed `1 2` accepts `01 +2`); union types accept when any member's value space
-matches; atomic types compare via `value.Compare` for the value-comparable
-builtins in `enumValueSpaceTypes` (numeric, boolean, date/time, and binary — so
-`xs:hexBinary` fixed `0A` accepts `0a` and integer fixed `1` accepts `+1`/`01`),
-falling back to normalized-lexical equality for string-family/anyURI (so a
-numeric-looking `xs:string` fixed `5` does not accept `5.0`). When `td` is nil it
+and recurse each item through the variety-aware comparator on the actual item
+type, so an `xs:integer` list fixed `1 2` accepts `01 +2` **and** a list whose
+item type is a union dispatches each item to the union's member value spaces;
+union types accept when any member's value space matches; atomic types compare
+via `value.Compare` for the value-comparable builtins in `enumValueSpaceTypes`
+(numeric, boolean, date/time, and binary — so `xs:hexBinary` fixed `0A` accepts
+`0a` and integer fixed `1` accepts `+1`/`01`), falling back to normalized-lexical
+equality for string-family/anyURI (so a numeric-looking `xs:string` fixed `5`
+does not accept `5.0`). `xs:QName`/`xs:NOTATION` fixed values are resolved in
+namespace context: each lexical QName is resolved against its own in-scope
+namespaces — the instance side via `collectNSContext(elem)`, the schema fixed
+side via the `FixedNS` map captured on the `ElementDecl`/`AttrUse` at read time
+(`collectNSContext` over the declaring schema element) — and the resolved
+`{namespace URI, local name}` pairs are compared, so two different prefixes bound
+to the same URI are equal while a same-prefix different-URI binding is not (an
+unresolved prefix on either side falls back to lexical equality). `fixedValueMatches`
+takes the instance and fixed namespace contexts as parameters. When `td` is nil it
 falls back to raw string equality.
 
 Enumeration facets are compared in value space, not raw lexical text. A value is

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -61,8 +61,10 @@ namespaces — the instance side via `collectNSContext(elem)`, the schema fixed
 side via the `FixedNS` map captured on the `ElementDecl`/`AttrUse` at read time
 (`collectNSContext` over the declaring schema element) — and the resolved
 `{namespace URI, local name}` pairs are compared, so two different prefixes bound
-to the same URI are equal while a same-prefix different-URI binding is not (an
-unresolved prefix on either side falls back to lexical equality). `fixedValueMatches`
+to the same URI are equal while a same-prefix different-URI binding is not. An
+unresolved prefix on either side is a *rejection*, not a lexical fallback (a
+QName/NOTATION whose prefix cannot be resolved is itself invalid, so the fixed
+comparison must not pass on raw lexical match). `fixedValueMatches`
 takes the instance and fixed namespace contexts as parameters. When `td` is nil it
 falls back to raw string equality. The element fixed-value comparison uses the
 element *declaration's* type (`edecl.Type`), not an `xsi:type` actual type, so a
@@ -72,7 +74,12 @@ validated against the actual type. In `fixedUnionMatches`, when the fixed and
 instance values resolve to *different* active members sharing a value-space family
 (e.g. integer/decimal), each operand is whitespace-normalized with *its* active
 member's effective whiteSpace facet before `value.Compare`, so union fixed `1.0`
-accepts both `1` and ` 1 `. Global attributes matched through an `xs:anyAttribute`
+accepts both `1` and ` 1 `. `unionActiveMember` returns the active *basic*
+(atomic) member, descending through nested unions to the basic member that
+actually accepts the value, so an outer union `memberTypes="inner xs:decimal"`
+(with `inner` a union `xs:integer xs:boolean`) compares instance `1` (active
+basic member xs:integer) against fixed `1.0` (xs:decimal) in the shared decimal
+value space rather than rejecting. Global attributes matched through an `xs:anyAttribute`
 wildcard (`validateWildcardAttr`, processContents strict/lax) also enforce the
 global attribute's `Fixed`/`FixedNS` via `fixedValueMatches`.
 

--- a/internal/xsd/value/compare.go
+++ b/internal/xsd/value/compare.go
@@ -18,8 +18,10 @@ func Compare(a, b, builtinLocal string) (int, bool) {
 	switch builtinLocal {
 	case "boolean":
 		return compareBoolean(a, b)
-	case "float", "double":
-		return compareFloat(a, b)
+	case "float":
+		return compareFloat(a, b, true)
+	case "double":
+		return compareFloat(a, b, false)
 	case "dateTime":
 		return compareDateTime(a, b)
 	case "date":
@@ -287,7 +289,14 @@ func IsFloatNaN(s string) bool {
 	return ok && math.IsNaN(f)
 }
 
-func compareFloat(a, b string) (int, bool) {
+// compareFloat compares two xs:float/xs:double lexical values in their numeric
+// value space. When single is true the operands are xs:float, whose value space
+// is IEEE-754 single precision: both are rounded to float32 first so values that
+// round to the same single-precision number compare equal (e.g. "16777216" ==
+// "16777217"). When single is false they are xs:double and compared as float64.
+// Infinities round-trip identically through float32, so only the finite path
+// changes precision.
+func compareFloat(a, b string, single bool) (int, bool) {
 	fa, ok1 := parseXSDFloat(a)
 	fb, ok2 := parseXSDFloat(b)
 	if !ok1 || !ok2 {
@@ -295,6 +304,10 @@ func compareFloat(a, b string) (int, bool) {
 	}
 	if math.IsNaN(fa) || math.IsNaN(fb) {
 		return 0, false
+	}
+	if single {
+		fa = float64(float32(fa))
+		fb = float64(float32(fb))
 	}
 	if fa < fb {
 		return -1, true

--- a/internal/xsd/value/validate_test.go
+++ b/internal/xsd/value/validate_test.go
@@ -272,10 +272,18 @@ func TestCompareValues(t *testing.T) {
 		{lexicon.TypeFloat, lexicon.FloatNaN, lexicon.FloatNaN, 0, false},
 		{lexicon.TypeFloat, "1e2", "100", 0, true},
 		{lexicon.TypeFloat, "1.5E-3", "0.0015", 0, true},
+		// xs:float value space is IEEE-754 single precision: 16777216 and
+		// 16777217 round to the same float32 (2^24 and 2^24+1 are not both
+		// representable), so they are equal in the xs:float value space.
+		{lexicon.TypeFloat, "16777216", "16777217", 0, true},
+		{lexicon.TypeFloat, "16777217", "16777216", 0, true},
 
-		// double (same path as float)
+		// double (the value space is float64, so 16777216 and 16777217 remain
+		// distinct — only the float path rounds to single precision).
 		{lexicon.TypeDouble, lexicon.FloatINF, lexicon.FloatNegINF, 1, true},
 		{lexicon.TypeDouble, "1e10", "9999999999", 1, true},
+		{lexicon.TypeDouble, "16777216", "16777217", -1, true},
+		{lexicon.TypeDouble, "16777217", "16777216", 1, true},
 
 		// dateTime
 		{lexicon.TypeDateTime, testDT0, testDT0, 0, true},

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -31,6 +31,7 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 				}
 				if edecl.Fixed == nil {
 					edecl.Fixed = ge.Fixed
+					edecl.FixedNS = ge.FixedNS
 				}
 				edecl.Nillable = ge.Nillable
 				edecl.Abstract = ge.Abstract
@@ -159,6 +160,7 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 		}
 		if au.Fixed == nil {
 			au.Fixed = ga.Fixed
+			au.FixedNS = ga.FixedNS
 		}
 		if au.TypeName == (QName{}) {
 			au.TypeName = ga.TypeName

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -94,6 +94,9 @@ func (c *compiler) readElementDecl(ctx context.Context, elem *helium.Element, op
 	}
 
 	decl.Default, decl.Fixed = readDefaultOrFixed(elem)
+	if decl.Fixed != nil {
+		decl.FixedNS = collectNSContext(elem)
+	}
 
 	if hasAttr(elem, attrBlock) {
 		decl.Block = parseBlockFlags(getAttr(elem, attrBlock))
@@ -195,6 +198,9 @@ func (c *compiler) readAttributeUseDecl(ctx context.Context, elem *helium.Elemen
 		}
 	}
 	au.Default, au.Fixed = readDefaultOrFixed(elem)
+	if au.Fixed != nil {
+		au.FixedNS = collectNSContext(elem)
+	}
 	return au
 }
 
@@ -333,6 +339,7 @@ func (c *compiler) parseAttributeUse(ctx context.Context, elem *helium.Element) 
 		}
 		if v := getAttr(elem, attrFixed); v != "" {
 			au.Fixed = &v
+			au.FixedNS = collectNSContext(elem)
 		}
 		c.attrRefs[au] = qn
 		return au

--- a/xsd/schema.go
+++ b/xsd/schema.go
@@ -143,10 +143,14 @@ type ElementDecl struct {
 	IDCs              []*IDConstraint
 	Default           *string // nil = not set
 	Fixed             *string // nil = not set
-	Block             BlockFlags
-	BlockSet          bool // true if block was explicitly set (even to empty)
-	Final             FinalFlags
-	FinalSet          bool // true if final was explicitly set (even to empty)
+	// FixedNS holds the in-scope namespace bindings (prefix → URI) at the point
+	// the Fixed value was declared in the schema document. It is used to resolve
+	// a QName/NOTATION fixed value's prefix when comparing in value space.
+	FixedNS  map[string]string
+	Block    BlockFlags
+	BlockSet bool // true if block was explicitly set (even to empty)
+	Final    FinalFlags
+	FinalSet bool // true if final was explicitly set (even to empty)
 }
 
 // IDCKind describes the kind of identity constraint.
@@ -245,6 +249,10 @@ type AttrUse struct {
 	Prohibited bool
 	Default    *string // nil = not set
 	Fixed      *string // nil = not set
+	// FixedNS holds the in-scope namespace bindings (prefix → URI) at the point
+	// the Fixed value was declared in the schema document, used to resolve a
+	// QName/NOTATION fixed value's prefix when comparing in value space.
+	FixedNS map[string]string
 }
 
 // ModelGroup is a content model compositor (sequence, choice, all).

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -149,7 +149,14 @@ func fixedUnionMatches(ctx context.Context, instance, fixed string, td *TypeDef,
 	if !fok || !iok || fixedFamily != instanceFamily {
 		return false
 	}
-	cmp, ok := value.Compare(instance, fixed, fixedFamily)
+	// Normalize each operand with ITS active member's effective whiteSpace facet
+	// before comparing. value.Compare receives raw lexicals, so without this an
+	// instance " 1 " (whose active member would collapse the surrounding space)
+	// would be passed verbatim and fail the comparison even though it is
+	// value-equal to the fixed "1.0".
+	ni := normalizeWhiteSpace(instance, resolveWhiteSpace(instanceMember))
+	nf := normalizeWhiteSpace(fixed, resolveWhiteSpace(fixedMember))
+	cmp, ok := value.Compare(ni, nf, fixedFamily)
 	return ok && cmp == 0
 }
 
@@ -510,11 +517,20 @@ func (vc *validationContext) validateSimpleContent(ctx context.Context, elem *he
 	}
 
 	// Fixed value mismatch check (only when element has actual content).
-	// Compare in the declared type's value space (applying its whitespace
+	// Compare in the *declared* type's value space (applying its whitespace
 	// facet) rather than an unconditional TrimSpace, so value-equal lexical
-	// variants are accepted and significant whitespace stays significant.
+	// variants are accepted and significant whitespace stays significant. The
+	// fixed-value constraint is defined by the element declaration's own type,
+	// not by an xsi:type actual type that may derive a different whiteSpace
+	// facet — content is still validated against the actual td below, but the
+	// fixed comparison must use edecl.Type so e.g. a declared xs:string
+	// fixed="abc " keeps its trailing space even when xsi:type collapses.
 	if !isEmpty && edecl != nil && edecl.Fixed != nil {
-		if !fixedValueMatches(ctx, value, *edecl.Fixed, td, collectNSContext(elem), edecl.FixedNS) {
+		fixedType := edecl.Type
+		if fixedType == nil {
+			fixedType = td
+		}
+		if !fixedValueMatches(ctx, value, *edecl.Fixed, fixedType, collectNSContext(elem), edecl.FixedNS) {
 			msg := fmt.Sprintf("The element content '%s' does not match the fixed value constraint '%s'.", value, *edecl.Fixed)
 			vc.reportValidityError(ctx, vc.filename, elem.Line(), elemDisplayName(elem), msg)
 			return fmt.Errorf("fixed value constraint")
@@ -753,6 +769,17 @@ func (vc *validationContext) validateWildcardAttr(ctx context.Context, a *helium
 	// TypeDef.Validate handles facets, lists, and unions, not just the builtin
 	// base lexical space.
 	attrTD, ok := vc.attrUseType(globalAttr)
+
+	// Enforce the global attribute's fixed-value constraint. A wildcard-matched
+	// global fixed attribute must still satisfy its fixed value, in the declared
+	// type's value space (mirroring the non-wildcard attribute path).
+	if globalAttr.Fixed != nil && !fixedValueMatches(ctx, a.Value(), *globalAttr.Fixed, attrTD, collectNSContext(elem), globalAttr.FixedNS) {
+		ad := attrDisplayName(a)
+		msg := fmt.Sprintf("The value '%s' does not match the fixed value constraint '%s'.", a.Value(), *globalAttr.Fixed)
+		vc.reportValidityErrorAttr(ctx, vc.filename, elem.Line(), elemDisplayName(elem), ad, msg)
+		return fmt.Errorf("fixed value constraint")
+	}
+
 	if ok && attrTD.ContentType == ContentTypeSimple {
 		value := a.Value()
 		if err := attrTD.Validate(ctx, value, collectNSContext(elem)); err != nil {

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -98,16 +98,21 @@ func fixedListMatches(ctx context.Context, instance, fixed string, td *TypeDef, 
 //
 //   - If either value has no valid active member, it is not a valid union value,
 //     so for fixed-comparison purposes it is treated as not-equal.
-//   - If the two active members differ, the values live in different value
-//     spaces and are not equal — e.g. memberTypes="xs:integer xs:boolean" with
-//     fixed="1" (active member xs:integer) and instance="true" (active member
-//     xs:boolean) is a mismatch even though both are valid union values.
 //   - If the active member is the same, the two values are compared in *that*
 //     member's value space by recursing through fixedValueMatches with the
 //     member type (which applies the member's own whiteSpace facet). Thus
 //     memberTypes="xs:string xs:integer" with fixed="1" resolves both sides to
 //     the xs:string member (the first member, which accepts any text), so "1"
 //     and "01" compare as strings and do NOT match.
+//   - If the active members DIFFER, the values may still be equal when both
+//     members reduce to the same comparable value-space family (e.g.
+//     memberTypes="xs:integer xs:decimal" with fixed="1.0" → active member
+//     xs:decimal, instance "1" → active member xs:integer: both reduce to the
+//     decimal value space, and 1.0 == 1, so they MUST compare equal). The shared
+//     family is determined by valueSpaceFamily, and the comparison is performed
+//     with value.Compare in that family. Cross-family pairs (xs:string vs
+//     xs:integer, xs:integer vs xs:boolean, …) have no shared comparable value
+//     space and remain unequal.
 //
 // The active member is resolved with unionActiveMember, which reuses the same
 // per-member validateValue path the normal (non-fixed) validation uses, so the
@@ -124,14 +129,57 @@ func fixedUnionMatches(ctx context.Context, instance, fixed string, td *TypeDef,
 	if instanceMember == nil {
 		return false
 	}
-	if fixedMember != instanceMember {
-		return false
+
+	if fixedMember == instanceMember {
+		// Same active member: compare in that member's value space. A union has no
+		// whiteSpace facet of its own, so the raw values are forwarded and the
+		// member normalizes both with its own facet inside fixedValueMatches.
+		return fixedValueMatches(ctx, instance, fixed, fixedMember, instanceNS, fixedNS)
 	}
 
-	// Same active member: compare in that member's value space. A union has no
-	// whiteSpace facet of its own, so the raw values are forwarded and the member
-	// normalizes both with its own facet inside fixedValueMatches.
-	return fixedValueMatches(ctx, instance, fixed, fixedMember, instanceNS, fixedNS)
+	// Different active members. They are still equal iff both reduce to the same
+	// comparable value-space family and the values are equal in that family — so
+	// xs:integer "1" equals xs:decimal "1.0". valueSpaceFamily returns the shared
+	// family only for value-comparable builtins (it excludes string-family/anyURI
+	// and QName/NOTATION, whose value spaces are not cross-member comparable).
+	fixedLocal := builtinBaseLocal(fixedMember)
+	instanceLocal := builtinBaseLocal(instanceMember)
+	fixedFamily, fok := valueSpaceFamily(fixedLocal)
+	instanceFamily, iok := valueSpaceFamily(instanceLocal)
+	if !fok || !iok || fixedFamily != instanceFamily {
+		return false
+	}
+	cmp, ok := value.Compare(instance, fixed, fixedFamily)
+	return ok && cmp == 0
+}
+
+// valueSpaceFamily maps a builtin's local name to the local name of the type
+// whose value space it shares for cross-member fixed-value comparison, returning
+// (family, true) only for value-comparable builtins. All xs:decimal-derived
+// integer types collapse to "decimal" so an xs:integer value compares equal to a
+// value-equal xs:decimal value; every other comparable primitive (boolean,
+// float, double, each date/time-family type, hexBinary, base64Binary) is its own
+// family, so cross-family pairs do not compare. String-family/anyURI and
+// QName/NOTATION are not value-comparable across members and return ("", false),
+// preserving the cross-family rejection.
+//
+// The returned family name is a key value.Compare understands, so callers can
+// pass it straight to value.Compare. Membership is gated on enumValueSpaceTypes,
+// the same allowlist the enumeration path uses, so the two value-space notions
+// stay consistent.
+func valueSpaceFamily(builtinLocal string) (string, bool) {
+	if _, ok := enumValueSpaceTypes[builtinLocal]; !ok {
+		return "", false
+	}
+	switch builtinLocal {
+	case "decimal", "integer",
+		"nonPositiveInteger", "negativeInteger", "long", "int", "short", "byte",
+		"nonNegativeInteger", "unsignedLong", "unsignedInt", "unsignedShort",
+		"unsignedByte", "positiveInteger":
+		return "decimal", true
+	default:
+		return builtinLocal, true
+	}
 }
 
 // unionActiveMember returns the active basic member type for a value within a

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -12,23 +12,91 @@ import (
 
 // fixedValueMatches reports whether an instance value satisfies a fixed value
 // constraint whose declared simple type is td. The comparison is performed in
-// the type's value space via value.CanonicalKey, which applies the type's
-// whitespace facet (preserve/replace/collapse) — so a value-equal but
-// lexically-distinct instance (e.g. integer fixed "1" vs instance "+1") is
-// accepted, while a string-type fixed value with significant trailing
-// whitespace is not collapsed away. When the builtin base type cannot be
-// resolved, it falls back to raw string equality.
+// the type's value space (XSD 1.1 §3.16, cvc-au/cvc-elt fixed-value rules):
+//
+//   - Both values are first whitespace-normalized using the type's *effective*
+//     whiteSpace facet, resolved up the derivation chain via resolveWhiteSpace.
+//     This honours a facet derived on a restriction (e.g. xs:string restricted
+//     with whiteSpace="collapse"), which a builtin-name-only canonicalization
+//     would ignore.
+//   - For list types, the normalized values are split into items and compared
+//     item-by-item in the item type's value space.
+//   - For atomic types, the comparison uses the declared builtin's value space:
+//     value-comparable builtins (numeric, boolean, date/time, binary including
+//     hexBinary/base64Binary) compare via value.Compare, so "0A" == "0a" and
+//     "1" == "+1"; non-comparable (string-family/anyURI) types compare their
+//     whitespace-normalized lexical forms, so a numeric-looking string fixed
+//     value "5" does not accept "5.0".
+//
+// When td is nil the comparison falls back to raw string equality.
 func fixedValueMatches(instance, fixed string, td *TypeDef) bool {
-	builtinLocal := ""
-	if td != nil {
-		builtinLocal = builtinBaseLocal(td)
-	}
-	if builtinLocal == "" {
+	if td == nil {
 		return instance == fixed
 	}
-	ik, _ := value.CanonicalKey(instance, builtinLocal)
-	fk, _ := value.CanonicalKey(fixed, builtinLocal)
-	return ik == fk
+
+	ws := resolveWhiteSpace(td)
+	ni := normalizeWhiteSpace(instance, ws)
+	nf := normalizeWhiteSpace(fixed, ws)
+
+	switch resolveVariety(td) {
+	case TypeVarietyList:
+		return fixedListMatches(ni, nf, td)
+	case TypeVarietyUnion:
+		return fixedUnionMatches(ni, nf, td)
+	default:
+		return fixedAtomicMatches(ni, nf, builtinBaseLocal(td))
+	}
+}
+
+// fixedListMatches compares two whitespace-normalized list values item by item
+// in the list's item-type value space.
+func fixedListMatches(instance, fixed string, td *TypeDef) bool {
+	ii := strings.Fields(instance)
+	fi := strings.Fields(fixed)
+	if len(ii) != len(fi) {
+		return false
+	}
+	itemType := resolveItemType(td)
+	itemLocal := ""
+	if itemType != nil {
+		itemLocal = builtinBaseLocal(itemType)
+	}
+	for i := range ii {
+		if !fixedAtomicMatches(ii[i], fi[i], itemLocal) {
+			return false
+		}
+	}
+	return true
+}
+
+// fixedUnionMatches accepts the instance when it is value-equal to the fixed
+// value under any member type's value space. Member values are re-normalized
+// with the member's own whiteSpace facet before comparison.
+func fixedUnionMatches(instance, fixed string, td *TypeDef) bool {
+	for _, member := range resolveUnionMembers(td) {
+		ws := resolveWhiteSpace(member)
+		if fixedValueMatches(normalizeWhiteSpace(instance, ws), normalizeWhiteSpace(fixed, ws), member) {
+			return true
+		}
+	}
+	return false
+}
+
+// fixedAtomicMatches compares two already whitespace-normalized atomic values in
+// the builtin type's value space. Value-comparable builtins use value.Compare
+// (covering numeric, boolean, date/time, and binary value spaces); everything
+// else falls back to exact equality of the normalized lexical forms.
+func fixedAtomicMatches(instance, fixed, builtinLocal string) bool {
+	if _, ok := enumValueSpaceTypes[builtinLocal]; ok {
+		if (builtinLocal == "float" || builtinLocal == "double") &&
+			value.IsFloatNaN(instance) && value.IsFloatNaN(fixed) {
+			return true
+		}
+		if cmp, ok := value.Compare(instance, fixed, builtinLocal); ok {
+			return cmp == 0
+		}
+	}
+	return instance == fixed
 }
 
 type validationContext struct {

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -105,14 +105,18 @@ func fixedListMatches(ctx context.Context, instance, fixed string, td *TypeDef, 
 //     the xs:string member (the first member, which accepts any text), so "1"
 //     and "01" compare as strings and do NOT match.
 //   - If the active members DIFFER, the values may still be equal when both
-//     members reduce to the same comparable value-space family (e.g.
-//     memberTypes="xs:integer xs:decimal" with fixed="1.0" → active member
-//     xs:decimal, instance "1" → active member xs:integer: both reduce to the
-//     decimal value space, and 1.0 == 1, so they MUST compare equal). The shared
-//     family is determined by valueSpaceFamily, and the comparison is performed
-//     with value.Compare in that family. Cross-family pairs (xs:string vs
-//     xs:integer, xs:integer vs xs:boolean, …) have no shared comparable value
-//     space and remain unequal.
+//     members reduce to the same PRIMITIVE value-space family (XSD 1.1 §2.3:
+//     restrictions do not create new values). e.g. memberTypes="xs:integer
+//     xs:decimal" with fixed="1.0" → active member xs:decimal, instance "1" →
+//     active member xs:integer: both reduce to the decimal value space, and
+//     1.0 == 1, so they MUST compare equal. This includes string-derived members:
+//     fixed "a b" (active in one xs:string restriction) and instance " a   b "
+//     (active in another xs:string restriction with whiteSpace="collapse") both
+//     reduce to the string value space and denote "a b". The shared family is
+//     determined by primitiveValueSpaceFamily; value-comparable families compare
+//     with value.Compare, while the string family compares whitespace-normalized
+//     lexical forms. Cross-family pairs (xs:string vs xs:integer, xs:integer vs
+//     xs:boolean, …) have no shared value space and remain unequal.
 //
 // The active member is resolved with unionActiveMember, which reuses the same
 // per-member validateValue path the normal (non-fixed) validation uses, so the
@@ -137,55 +141,82 @@ func fixedUnionMatches(ctx context.Context, instance, fixed string, td *TypeDef,
 		return fixedValueMatches(ctx, instance, fixed, fixedMember, instanceNS, fixedNS)
 	}
 
-	// Different active members. They are still equal iff both reduce to the same
-	// comparable value-space family and the values are equal in that family — so
-	// xs:integer "1" equals xs:decimal "1.0". valueSpaceFamily returns the shared
-	// family only for value-comparable builtins (it excludes string-family/anyURI
-	// and QName/NOTATION, whose value spaces are not cross-member comparable).
+	// Different active members. XSD 1.1 §2.3 — restrictions do not create new
+	// values, so two values are equal iff they denote the same value in their
+	// SHARED PRIMITIVE value-space family (the primitive built-in their members
+	// reduce to). This includes string-derived members: a value active in one
+	// xs:string restriction (e.g. whiteSpace="collapse") compares equal to a value
+	// active in another xs:string-family member when both denote the same string.
+	// primitiveValueSpaceFamily reduces each member's builtin to that primitive
+	// family (e.g. all integer types → "decimal", all string-derived types →
+	// "string"). Cross-family pairs (string vs integer, integer vs boolean, …) have
+	// no shared value space and remain unequal. QName/NOTATION are excluded because
+	// their equality is namespace-context dependent, not a raw lexical/value
+	// comparison.
 	fixedLocal := builtinBaseLocal(fixedMember)
 	instanceLocal := builtinBaseLocal(instanceMember)
-	fixedFamily, fok := valueSpaceFamily(fixedLocal)
-	instanceFamily, iok := valueSpaceFamily(instanceLocal)
+	fixedFamily, fComparable, fok := primitiveValueSpaceFamily(fixedLocal)
+	instanceFamily, _, iok := primitiveValueSpaceFamily(instanceLocal)
 	if !fok || !iok || fixedFamily != instanceFamily {
 		return false
 	}
 	// Normalize each operand with ITS active member's effective whiteSpace facet
-	// before comparing. value.Compare receives raw lexicals, so without this an
-	// instance " 1 " (whose active member would collapse the surrounding space)
-	// would be passed verbatim and fail the comparison even though it is
-	// value-equal to the fixed "1.0".
+	// before comparing, so an instance " 1 " (whose member collapses the spaces)
+	// or " a   b " (whose member collapses to "a b") is reduced to its value-space
+	// form first.
 	ni := normalizeWhiteSpace(instance, resolveWhiteSpace(instanceMember))
 	nf := normalizeWhiteSpace(fixed, resolveWhiteSpace(fixedMember))
+	if !fComparable {
+		// String-family: the value space equals the whitespace-processed lexical
+		// space, so compare the normalized lexical forms directly.
+		return ni == nf
+	}
 	cmp, ok := value.Compare(ni, nf, fixedFamily)
 	return ok && cmp == 0
 }
 
-// valueSpaceFamily maps a builtin's local name to the local name of the type
-// whose value space it shares for cross-member fixed-value comparison, returning
-// (family, true) only for value-comparable builtins. All xs:decimal-derived
-// integer types collapse to "decimal" so an xs:integer value compares equal to a
-// value-equal xs:decimal value; every other comparable primitive (boolean,
-// float, double, each date/time-family type, hexBinary, base64Binary) is its own
-// family, so cross-family pairs do not compare. String-family/anyURI and
-// QName/NOTATION are not value-comparable across members and return ("", false),
-// preserving the cross-family rejection.
+// primitiveValueSpaceFamily maps a builtin's local name to the local name of the
+// PRIMITIVE built-in whose value space it shares, for cross-member fixed-value
+// comparison (XSD 1.1 §2.3: restrictions do not create new values). It returns
+// (family, comparable, true) for every type with a recognized primitive ancestor,
+// where:
 //
-// The returned family name is a key value.Compare understands, so callers can
-// pass it straight to value.Compare. Membership is gated on enumValueSpaceTypes,
-// the same allowlist the enumeration path uses, so the two value-space notions
-// stay consistent.
-func valueSpaceFamily(builtinLocal string) (string, bool) {
-	if _, ok := enumValueSpaceTypes[builtinLocal]; !ok {
-		return "", false
-	}
+//   - family is a stable key identifying the shared primitive value space. All
+//     xs:decimal-derived integer types collapse to "decimal"; all xs:string-derived
+//     types (string, normalizedString, token, language, Name, NCName, NMTOKEN,
+//     IDREF, ENTITY, …) and anyURI collapse to "string"; every other primitive
+//     (boolean, float, double, each date/time-family type, hexBinary,
+//     base64Binary) is its own family.
+//   - comparable is true when value.Compare implements value-space equality for
+//     that family (the enumValueSpaceTypes allowlist); for the "string" family it
+//     is false, so callers compare whitespace-normalized lexical forms instead
+//     (the string value space equals the whitespace-processed lexical space).
+//
+// QName/NOTATION return ("", false, false): their equality is namespace-context
+// dependent, not a cross-member value/lexical comparison, so they have no shared
+// primitive family for this path.
+func primitiveValueSpaceFamily(builtinLocal string) (string, bool, bool) {
 	switch builtinLocal {
+	case "QName", "NOTATION", "":
+		return "", false, false
 	case "decimal", "integer",
 		"nonPositiveInteger", "negativeInteger", "long", "int", "short", "byte",
 		"nonNegativeInteger", "unsignedLong", "unsignedInt", "unsignedShort",
 		"unsignedByte", "positiveInteger":
-		return "decimal", true
+		return "decimal", true, true
+	case "string", "normalizedString", "token", "language",
+		"Name", "NCName", "ID", "IDREF", "IDREFS", "ENTITY", "ENTITIES",
+		"NMTOKEN", "NMTOKENS", "anyURI":
+		// String value space equals the whitespace-processed lexical space; not
+		// value-comparable via value.Compare, so the caller compares lexically.
+		return lexicon.TypeString, false, true
 	default:
-		return builtinLocal, true
+		// Remaining comparable primitives (boolean, float, double, date/time
+		// family, binary) are gated on the same allowlist the enumeration path uses.
+		if _, ok := enumValueSpaceTypes[builtinLocal]; !ok {
+			return "", false, false
+		}
+		return builtinLocal, true, true
 	}
 }
 

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -16,9 +16,10 @@ import (
 //
 //   - The comparison branches on the type's variety *before* applying any
 //     whiteSpace facet. A union has no whiteSpace facet of its own, so its raw
-//     values are forwarded and each member normalizes with its own facet (see
-//     fixedUnionMatches); this preserves significant whitespace for an xs:string
-//     member that a "collapse" at the union level would have stripped.
+//     values are forwarded to fixedUnionMatches, which resolves each value's
+//     active member (ordered union semantics) and compares in that member's
+//     value space — preserving significant whitespace for an xs:string member
+//     that a "collapse" at the union level would have stripped.
 //   - For atomic and list types, both values are first whitespace-normalized
 //     using the type's *effective* whiteSpace facet, resolved up the derivation
 //     chain via resolveWhiteSpace. This honours a facet derived on a restriction
@@ -40,7 +41,7 @@ import (
 // value and the schema fixed value respectively; they are only consulted for
 // QName/NOTATION types. When td is nil the comparison falls back to raw string
 // equality.
-func fixedValueMatches(instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string) bool {
+func fixedValueMatches(ctx context.Context, instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string) bool {
 	if td == nil {
 		return instance == fixed
 	}
@@ -53,7 +54,7 @@ func fixedValueMatches(instance, fixed string, td *TypeDef, instanceNS, fixedNS 
 	// each member normalize with its own facet. List and atomic types keep their
 	// type-level normalization.
 	if resolveVariety(td) == TypeVarietyUnion {
-		return fixedUnionMatches(instance, fixed, td, instanceNS, fixedNS)
+		return fixedUnionMatches(ctx, instance, fixed, td, instanceNS, fixedNS)
 	}
 
 	ws := resolveWhiteSpace(td)
@@ -61,7 +62,7 @@ func fixedValueMatches(instance, fixed string, td *TypeDef, instanceNS, fixedNS 
 	nf := normalizeWhiteSpace(fixed, ws)
 
 	if resolveVariety(td) == TypeVarietyList {
-		return fixedListMatches(ni, nf, td, instanceNS, fixedNS)
+		return fixedListMatches(ctx, ni, nf, td, instanceNS, fixedNS)
 	}
 	return fixedAtomicMatches(ni, nf, builtinBaseLocal(td), instanceNS, fixedNS)
 }
@@ -71,7 +72,7 @@ func fixedValueMatches(instance, fixed string, td *TypeDef, instanceNS, fixedNS 
 // variety-aware comparator on the actual item type, so a list whose item type is
 // a union (or itself a list) is compared in the correct value space rather than
 // raw lexical text.
-func fixedListMatches(instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string) bool {
+func fixedListMatches(ctx context.Context, instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string) bool {
 	ii := strings.Fields(instance)
 	fi := strings.Fields(fixed)
 	if len(ii) != len(fi) {
@@ -79,45 +80,78 @@ func fixedListMatches(instance, fixed string, td *TypeDef, instanceNS, fixedNS m
 	}
 	itemType := resolveItemType(td)
 	for i := range ii {
-		if !fixedValueMatches(ii[i], fi[i], itemType, instanceNS, fixedNS) {
+		if !fixedValueMatches(ctx, ii[i], fi[i], itemType, instanceNS, fixedNS) {
 			return false
 		}
 	}
 	return true
 }
 
-// fixedUnionMatches accepts the instance when it is value-equal to the fixed
-// value under any member type's value space. It receives the *raw* (un-
-// normalized) instance and fixed values: a union has no whiteSpace facet of its
-// own to apply, so each member normalizes both values with its *own* whiteSpace
-// facet before comparison. This preserves significant whitespace for an
-// xs:string member (whiteSpace="preserve") while still collapsing for members
-// like xs:integer (whiteSpace="collapse").
-func fixedUnionMatches(instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string) bool {
-	for _, member := range resolveUnionMembers(td) {
-		// A member can only mediate the comparison if *both* the instance and the
-		// fixed value are valid instances of that member type. Without this guard,
-		// the atomic fallback to lexical equality (used when value.Compare can't
-		// parse a value) would let a non-conforming text match through a value-
-		// space member — e.g. "abc" "matching" via an xs:integer member because
-		// the parse fails and the lexical strings happen to be equal. Members that
-		// are themselves a list or union recurse through fixedValueMatches, which
-		// applies their own validity semantics. Atomic members are validity-checked
-		// here against the member's builtin lexical space.
-		ws := resolveWhiteSpace(member)
-		ni := normalizeWhiteSpace(instance, ws)
-		nf := normalizeWhiteSpace(fixed, ws)
-		if resolveVariety(member) == TypeVarietyAtomic {
-			builtin := builtinBaseLocal(member)
-			if value.ValidateBuiltin(ni, builtin) != nil || value.ValidateBuiltin(nf, builtin) != nil {
-				continue
-			}
+// fixedUnionMatches compares an instance value against a fixed value whose
+// declared type is a union, using XSD's *ordered* union semantics. Union
+// membership is not "any member that makes the two lexicals compare equal":
+// each lexical value has a single ACTIVE member — the first member type, in
+// declaration order, that the value fully validates against (facets, lists, and
+// nested unions all enforced). The fixed value and the instance value each
+// resolve their own active member (the fixed value uses the schema's in-scope
+// namespaces, the instance the document's). The comparison is then:
+//
+//   - If either value has no valid active member, it is not a valid union value,
+//     so for fixed-comparison purposes it is treated as not-equal.
+//   - If the two active members differ, the values live in different value
+//     spaces and are not equal — e.g. memberTypes="xs:integer xs:boolean" with
+//     fixed="1" (active member xs:integer) and instance="true" (active member
+//     xs:boolean) is a mismatch even though both are valid union values.
+//   - If the active member is the same, the two values are compared in *that*
+//     member's value space by recursing through fixedValueMatches with the
+//     member type (which applies the member's own whiteSpace facet). Thus
+//     memberTypes="xs:string xs:integer" with fixed="1" resolves both sides to
+//     the xs:string member (the first member, which accepts any text), so "1"
+//     and "01" compare as strings and do NOT match.
+//
+// The active member is resolved with unionActiveMember, which reuses the same
+// per-member validateValue path the normal (non-fixed) validation uses, so the
+// fixed-comparison and ordinary-validation notions of "active member" stay
+// consistent.
+func fixedUnionMatches(ctx context.Context, instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string) bool {
+	members := resolveUnionMembers(td)
+
+	fixedMember := unionActiveMember(ctx, fixed, fixedNS, members)
+	if fixedMember == nil {
+		return false
+	}
+	instanceMember := unionActiveMember(ctx, instance, instanceNS, members)
+	if instanceMember == nil {
+		return false
+	}
+	if fixedMember != instanceMember {
+		return false
+	}
+
+	// Same active member: compare in that member's value space. A union has no
+	// whiteSpace facet of its own, so the raw values are forwarded and the member
+	// normalizes both with its own facet inside fixedValueMatches.
+	return fixedValueMatches(ctx, instance, fixed, fixedMember, instanceNS, fixedNS)
+}
+
+// unionActiveMember returns the active basic member type for a value within a
+// union: the first member (in declaration order) the value fully validates
+// against. It reuses the validateValue path so the validity criteria match the
+// main validation engine exactly (facets, list items, nested unions, and
+// QName/NOTATION namespace resolution). Errors are discarded via a suppressing
+// validation context with a NilErrorHandler. Returns nil when no member accepts
+// the value.
+func unionActiveMember(ctx context.Context, value string, valueNS map[string]string, members []*TypeDef) *TypeDef {
+	for _, member := range members {
+		vc := &validationContext{
+			errorHandler:  helium.NilErrorHandler{},
+			suppressDepth: 1,
 		}
-		if fixedValueMatches(ni, nf, member, instanceNS, fixedNS) {
-			return true
+		if validateValue(ctx, value, valueNS, member, "", "", 0, vc) == nil {
+			return member
 		}
 	}
-	return false
+	return nil
 }
 
 // fixedAtomicMatches compares two already whitespace-normalized atomic values in
@@ -432,7 +466,7 @@ func (vc *validationContext) validateSimpleContent(ctx context.Context, elem *he
 	// facet) rather than an unconditional TrimSpace, so value-equal lexical
 	// variants are accepted and significant whitespace stays significant.
 	if !isEmpty && edecl != nil && edecl.Fixed != nil {
-		if !fixedValueMatches(value, *edecl.Fixed, td, collectNSContext(elem), edecl.FixedNS) {
+		if !fixedValueMatches(ctx, value, *edecl.Fixed, td, collectNSContext(elem), edecl.FixedNS) {
 			msg := fmt.Sprintf("The element content '%s' does not match the fixed value constraint '%s'.", value, *edecl.Fixed)
 			vc.reportValidityError(ctx, vc.filename, elem.Line(), elemDisplayName(elem), msg)
 			return fmt.Errorf("fixed value constraint")
@@ -566,7 +600,7 @@ func (vc *validationContext) validateAttributes(ctx context.Context, elem *heliu
 			// compare in the type's value space (applying its whitespace
 			// facet) rather than by raw string equality.
 			attrTD, tdOK := vc.attrUseType(au)
-			if au.Fixed != nil && !fixedValueMatches(a.Value(), *au.Fixed, attrTD, collectNSContext(elem), au.FixedNS) {
+			if au.Fixed != nil && !fixedValueMatches(ctx, a.Value(), *au.Fixed, attrTD, collectNSContext(elem), au.FixedNS) {
 				ad := attrDisplayName(a)
 				msg := fmt.Sprintf("The value '%s' does not match the fixed value constraint '%s'.", a.Value(), *au.Fixed)
 				vc.reportValidityErrorAttr(ctx, vc.filename, elem.Line(), elemDisplayName(elem), ad, msg)

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -14,11 +14,16 @@ import (
 // constraint whose declared simple type is td. The comparison is performed in
 // the type's value space (XSD 1.1 §3.16, cvc-au/cvc-elt fixed-value rules):
 //
-//   - Both values are first whitespace-normalized using the type's *effective*
-//     whiteSpace facet, resolved up the derivation chain via resolveWhiteSpace.
-//     This honours a facet derived on a restriction (e.g. xs:string restricted
-//     with whiteSpace="collapse"), which a builtin-name-only canonicalization
-//     would ignore.
+//   - The comparison branches on the type's variety *before* applying any
+//     whiteSpace facet. A union has no whiteSpace facet of its own, so its raw
+//     values are forwarded and each member normalizes with its own facet (see
+//     fixedUnionMatches); this preserves significant whitespace for an xs:string
+//     member that a "collapse" at the union level would have stripped.
+//   - For atomic and list types, both values are first whitespace-normalized
+//     using the type's *effective* whiteSpace facet, resolved up the derivation
+//     chain via resolveWhiteSpace. This honours a facet derived on a restriction
+//     (e.g. xs:string restricted with whiteSpace="collapse"), which a
+//     builtin-name-only canonicalization would ignore.
 //   - For list types, the normalized values are split into items and compared
 //     item-by-item in the item type's value space.
 //   - For atomic types, the comparison uses the declared builtin's value space:
@@ -40,18 +45,25 @@ func fixedValueMatches(instance, fixed string, td *TypeDef, instanceNS, fixedNS 
 		return instance == fixed
 	}
 
+	// Branch on variety *before* normalizing with the type's own whiteSpace
+	// facet. A union type has no meaningful whiteSpace of its own — each member
+	// applies its own facet — so normalizing here (the union default is
+	// "collapse") would strip significant whitespace before an xs:string member
+	// ever sees it. The union path therefore receives the raw values and lets
+	// each member normalize with its own facet. List and atomic types keep their
+	// type-level normalization.
+	if resolveVariety(td) == TypeVarietyUnion {
+		return fixedUnionMatches(instance, fixed, td, instanceNS, fixedNS)
+	}
+
 	ws := resolveWhiteSpace(td)
 	ni := normalizeWhiteSpace(instance, ws)
 	nf := normalizeWhiteSpace(fixed, ws)
 
-	switch resolveVariety(td) {
-	case TypeVarietyList:
+	if resolveVariety(td) == TypeVarietyList {
 		return fixedListMatches(ni, nf, td, instanceNS, fixedNS)
-	case TypeVarietyUnion:
-		return fixedUnionMatches(ni, nf, td, instanceNS, fixedNS)
-	default:
-		return fixedAtomicMatches(ni, nf, builtinBaseLocal(td), instanceNS, fixedNS)
 	}
+	return fixedAtomicMatches(ni, nf, builtinBaseLocal(td), instanceNS, fixedNS)
 }
 
 // fixedListMatches compares two whitespace-normalized list values item by item
@@ -75,12 +87,33 @@ func fixedListMatches(instance, fixed string, td *TypeDef, instanceNS, fixedNS m
 }
 
 // fixedUnionMatches accepts the instance when it is value-equal to the fixed
-// value under any member type's value space. Member values are re-normalized
-// with the member's own whiteSpace facet before comparison.
+// value under any member type's value space. It receives the *raw* (un-
+// normalized) instance and fixed values: a union has no whiteSpace facet of its
+// own to apply, so each member normalizes both values with its *own* whiteSpace
+// facet before comparison. This preserves significant whitespace for an
+// xs:string member (whiteSpace="preserve") while still collapsing for members
+// like xs:integer (whiteSpace="collapse").
 func fixedUnionMatches(instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string) bool {
 	for _, member := range resolveUnionMembers(td) {
+		// A member can only mediate the comparison if *both* the instance and the
+		// fixed value are valid instances of that member type. Without this guard,
+		// the atomic fallback to lexical equality (used when value.Compare can't
+		// parse a value) would let a non-conforming text match through a value-
+		// space member — e.g. "abc" "matching" via an xs:integer member because
+		// the parse fails and the lexical strings happen to be equal. Members that
+		// are themselves a list or union recurse through fixedValueMatches, which
+		// applies their own validity semantics. Atomic members are validity-checked
+		// here against the member's builtin lexical space.
 		ws := resolveWhiteSpace(member)
-		if fixedValueMatches(normalizeWhiteSpace(instance, ws), normalizeWhiteSpace(fixed, ws), member, instanceNS, fixedNS) {
+		ni := normalizeWhiteSpace(instance, ws)
+		nf := normalizeWhiteSpace(fixed, ws)
+		if resolveVariety(member) == TypeVarietyAtomic {
+			builtin := builtinBaseLocal(member)
+			if value.ValidateBuiltin(ni, builtin) != nil || value.ValidateBuiltin(nf, builtin) != nil {
+				continue
+			}
+		}
+		if fixedValueMatches(ni, nf, member, instanceNS, fixedNS) {
 			return true
 		}
 	}

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -189,22 +189,38 @@ func valueSpaceFamily(builtinLocal string) (string, bool) {
 	}
 }
 
-// unionActiveMember returns the active basic member type for a value within a
-// union: the first member (in declaration order) the value fully validates
-// against. It reuses the validateValue path so the validity criteria match the
-// main validation engine exactly (facets, list items, nested unions, and
-// QName/NOTATION namespace resolution). Errors are discarded via a suppressing
-// validation context with a NilErrorHandler. Returns nil when no member accepts
-// the value.
+// unionActiveMember returns the active BASIC (atomic) member type for a value
+// within a union: the first member (in declaration order) the value fully
+// validates against, descending through nested unions to the basic member that
+// actually accepts the value. It reuses the validateValue path so the validity
+// criteria match the main validation engine exactly (facets, list items, nested
+// unions, and QName/NOTATION namespace resolution). Errors are discarded via a
+// suppressing validation context with a NilErrorHandler. Returns nil when no
+// member accepts the value.
+//
+// Descending into nested unions matters for cross-member value-space comparison:
+// an outer member that is itself a union must contribute its active basic member
+// (e.g. xs:integer), not the union TypeDef, so valueSpaceFamily can reduce it to
+// the comparable family (decimal) and compare it against a sibling decimal
+// member's value.
 func unionActiveMember(ctx context.Context, value string, valueNS map[string]string, members []*TypeDef) *TypeDef {
 	for _, member := range members {
 		vc := &validationContext{
 			errorHandler:  helium.NilErrorHandler{},
 			suppressDepth: 1,
 		}
-		if validateValue(ctx, value, valueNS, member, "", "", 0, vc) == nil {
-			return member
+		if validateValue(ctx, value, valueNS, member, "", "", 0, vc) != nil {
+			continue
 		}
+		// The member accepts the value. If it is itself a union, recurse to find
+		// the active basic member within it; the validateValue success above
+		// guarantees at least one nested member accepts the value.
+		if resolveVariety(member) == TypeVarietyUnion {
+			if basic := unionActiveMember(ctx, value, valueNS, resolveUnionMembers(member)); basic != nil {
+				return basic
+			}
+		}
+		return member
 	}
 	return nil
 }
@@ -219,11 +235,14 @@ func fixedAtomicMatches(instance, fixed, builtinLocal string, instanceNS, fixedN
 	if builtinLocal == "QName" || builtinLocal == "NOTATION" {
 		iqn, ierr := resolveLexicalQName(instance, instanceNS)
 		fqn, ferr := resolveLexicalQName(fixed, fixedNS)
-		if ierr == nil && ferr == nil {
-			return iqn == fqn
+		// A prefix that cannot be resolved makes the QName/NOTATION itself invalid;
+		// the fixed comparison must NOT fall back to raw lexical equality (which
+		// would wrongly accept a fixed "s:name" against an instance "s:name" that
+		// has no binding for s). Reject instead.
+		if ierr != nil || ferr != nil {
+			return false
 		}
-		// A prefix could not be resolved on one side; fall back to lexical.
-		return instance == fixed
+		return iqn == fqn
 	}
 	if _, ok := enumValueSpaceTypes[builtinLocal]; ok {
 		if (builtinLocal == "float" || builtinLocal == "double") &&

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -24,12 +24,18 @@ import (
 //   - For atomic types, the comparison uses the declared builtin's value space:
 //     value-comparable builtins (numeric, boolean, date/time, binary including
 //     hexBinary/base64Binary) compare via value.Compare, so "0A" == "0a" and
-//     "1" == "+1"; non-comparable (string-family/anyURI) types compare their
-//     whitespace-normalized lexical forms, so a numeric-looking string fixed
-//     value "5" does not accept "5.0".
+//     "1" == "+1"; QName/NOTATION resolve each lexical QName against its own
+//     in-scope namespaces (instanceNS for the instance, fixedNS for the schema
+//     fixed value) and compare the resolved {namespace URI, local name}, so two
+//     different prefixes bound to the same URI are equal; non-comparable
+//     (string-family/anyURI) types compare their whitespace-normalized lexical
+//     forms, so a numeric-looking string fixed value "5" does not accept "5.0".
 //
-// When td is nil the comparison falls back to raw string equality.
-func fixedValueMatches(instance, fixed string, td *TypeDef) bool {
+// instanceNS and fixedNS carry the in-scope namespace bindings for the instance
+// value and the schema fixed value respectively; they are only consulted for
+// QName/NOTATION types. When td is nil the comparison falls back to raw string
+// equality.
+func fixedValueMatches(instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string) bool {
 	if td == nil {
 		return instance == fixed
 	}
@@ -40,29 +46,28 @@ func fixedValueMatches(instance, fixed string, td *TypeDef) bool {
 
 	switch resolveVariety(td) {
 	case TypeVarietyList:
-		return fixedListMatches(ni, nf, td)
+		return fixedListMatches(ni, nf, td, instanceNS, fixedNS)
 	case TypeVarietyUnion:
-		return fixedUnionMatches(ni, nf, td)
+		return fixedUnionMatches(ni, nf, td, instanceNS, fixedNS)
 	default:
-		return fixedAtomicMatches(ni, nf, builtinBaseLocal(td))
+		return fixedAtomicMatches(ni, nf, builtinBaseLocal(td), instanceNS, fixedNS)
 	}
 }
 
 // fixedListMatches compares two whitespace-normalized list values item by item
-// in the list's item-type value space.
-func fixedListMatches(instance, fixed string, td *TypeDef) bool {
+// in the list's item-type value space. Each item is dispatched through the
+// variety-aware comparator on the actual item type, so a list whose item type is
+// a union (or itself a list) is compared in the correct value space rather than
+// raw lexical text.
+func fixedListMatches(instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string) bool {
 	ii := strings.Fields(instance)
 	fi := strings.Fields(fixed)
 	if len(ii) != len(fi) {
 		return false
 	}
 	itemType := resolveItemType(td)
-	itemLocal := ""
-	if itemType != nil {
-		itemLocal = builtinBaseLocal(itemType)
-	}
 	for i := range ii {
-		if !fixedAtomicMatches(ii[i], fi[i], itemLocal) {
+		if !fixedValueMatches(ii[i], fi[i], itemType, instanceNS, fixedNS) {
 			return false
 		}
 	}
@@ -72,10 +77,10 @@ func fixedListMatches(instance, fixed string, td *TypeDef) bool {
 // fixedUnionMatches accepts the instance when it is value-equal to the fixed
 // value under any member type's value space. Member values are re-normalized
 // with the member's own whiteSpace facet before comparison.
-func fixedUnionMatches(instance, fixed string, td *TypeDef) bool {
+func fixedUnionMatches(instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string) bool {
 	for _, member := range resolveUnionMembers(td) {
 		ws := resolveWhiteSpace(member)
-		if fixedValueMatches(normalizeWhiteSpace(instance, ws), normalizeWhiteSpace(fixed, ws), member) {
+		if fixedValueMatches(normalizeWhiteSpace(instance, ws), normalizeWhiteSpace(fixed, ws), member, instanceNS, fixedNS) {
 			return true
 		}
 	}
@@ -83,10 +88,21 @@ func fixedUnionMatches(instance, fixed string, td *TypeDef) bool {
 }
 
 // fixedAtomicMatches compares two already whitespace-normalized atomic values in
-// the builtin type's value space. Value-comparable builtins use value.Compare
-// (covering numeric, boolean, date/time, and binary value spaces); everything
-// else falls back to exact equality of the normalized lexical forms.
-func fixedAtomicMatches(instance, fixed, builtinLocal string) bool {
+// the builtin type's value space. QName/NOTATION resolve each side's prefix
+// against its own in-scope namespaces and compare the resolved {URI, local}.
+// Other value-comparable builtins use value.Compare (covering numeric, boolean,
+// date/time, and binary value spaces); everything else falls back to exact
+// equality of the normalized lexical forms.
+func fixedAtomicMatches(instance, fixed, builtinLocal string, instanceNS, fixedNS map[string]string) bool {
+	if builtinLocal == "QName" || builtinLocal == "NOTATION" {
+		iqn, ierr := resolveLexicalQName(instance, instanceNS)
+		fqn, ferr := resolveLexicalQName(fixed, fixedNS)
+		if ierr == nil && ferr == nil {
+			return iqn == fqn
+		}
+		// A prefix could not be resolved on one side; fall back to lexical.
+		return instance == fixed
+	}
 	if _, ok := enumValueSpaceTypes[builtinLocal]; ok {
 		if (builtinLocal == "float" || builtinLocal == "double") &&
 			value.IsFloatNaN(instance) && value.IsFloatNaN(fixed) {
@@ -383,7 +399,7 @@ func (vc *validationContext) validateSimpleContent(ctx context.Context, elem *he
 	// facet) rather than an unconditional TrimSpace, so value-equal lexical
 	// variants are accepted and significant whitespace stays significant.
 	if !isEmpty && edecl != nil && edecl.Fixed != nil {
-		if !fixedValueMatches(value, *edecl.Fixed, td) {
+		if !fixedValueMatches(value, *edecl.Fixed, td, collectNSContext(elem), edecl.FixedNS) {
 			msg := fmt.Sprintf("The element content '%s' does not match the fixed value constraint '%s'.", value, *edecl.Fixed)
 			vc.reportValidityError(ctx, vc.filename, elem.Line(), elemDisplayName(elem), msg)
 			return fmt.Errorf("fixed value constraint")
@@ -517,7 +533,7 @@ func (vc *validationContext) validateAttributes(ctx context.Context, elem *heliu
 			// compare in the type's value space (applying its whitespace
 			// facet) rather than by raw string equality.
 			attrTD, tdOK := vc.attrUseType(au)
-			if au.Fixed != nil && !fixedValueMatches(a.Value(), *au.Fixed, attrTD) {
+			if au.Fixed != nil && !fixedValueMatches(a.Value(), *au.Fixed, attrTD, collectNSContext(elem), au.FixedNS) {
 				ad := attrDisplayName(a)
 				msg := fmt.Sprintf("The value '%s' does not match the fixed value constraint '%s'.", a.Value(), *au.Fixed)
 				vc.reportValidityErrorAttr(ctx, vc.filename, elem.Line(), elemDisplayName(elem), ad, msg)

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -7,7 +7,29 @@ import (
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/xsd/value"
 )
+
+// fixedValueMatches reports whether an instance value satisfies a fixed value
+// constraint whose declared simple type is td. The comparison is performed in
+// the type's value space via value.CanonicalKey, which applies the type's
+// whitespace facet (preserve/replace/collapse) — so a value-equal but
+// lexically-distinct instance (e.g. integer fixed "1" vs instance "+1") is
+// accepted, while a string-type fixed value with significant trailing
+// whitespace is not collapsed away. When the builtin base type cannot be
+// resolved, it falls back to raw string equality.
+func fixedValueMatches(instance, fixed string, td *TypeDef) bool {
+	builtinLocal := ""
+	if td != nil {
+		builtinLocal = builtinBaseLocal(td)
+	}
+	if builtinLocal == "" {
+		return instance == fixed
+	}
+	ik, _ := value.CanonicalKey(instance, builtinLocal)
+	fk, _ := value.CanonicalKey(fixed, builtinLocal)
+	return ik == fk
+}
 
 type validationContext struct {
 	schema        *Schema
@@ -289,9 +311,12 @@ func (vc *validationContext) validateSimpleContent(ctx context.Context, elem *he
 	}
 
 	// Fixed value mismatch check (only when element has actual content).
+	// Compare in the declared type's value space (applying its whitespace
+	// facet) rather than an unconditional TrimSpace, so value-equal lexical
+	// variants are accepted and significant whitespace stays significant.
 	if !isEmpty && edecl != nil && edecl.Fixed != nil {
-		if strings.TrimSpace(value) != strings.TrimSpace(*edecl.Fixed) {
-			msg := fmt.Sprintf("The element content '%s' does not match the fixed value constraint '%s'.", strings.TrimSpace(value), *edecl.Fixed)
+		if !fixedValueMatches(value, *edecl.Fixed, td) {
+			msg := fmt.Sprintf("The element content '%s' does not match the fixed value constraint '%s'.", value, *edecl.Fixed)
 			vc.reportValidityError(ctx, vc.filename, elem.Line(), elemDisplayName(elem), msg)
 			return fmt.Errorf("fixed value constraint")
 		}
@@ -420,7 +445,11 @@ func (vc *validationContext) validateAttributes(ctx context.Context, elem *heliu
 		aqn := QName{Local: a.LocalName(), NS: a.URI()}
 		present[aqn] = struct{}{}
 		if au, ok := allowed[aqn]; ok {
-			if au.Fixed != nil && a.Value() != *au.Fixed {
+			// Resolve the declared type up front so the fixed-value check can
+			// compare in the type's value space (applying its whitespace
+			// facet) rather than by raw string equality.
+			attrTD, tdOK := vc.attrUseType(au)
+			if au.Fixed != nil && !fixedValueMatches(a.Value(), *au.Fixed, attrTD) {
 				ad := attrDisplayName(a)
 				msg := fmt.Sprintf("The value '%s' does not match the fixed value constraint '%s'.", a.Value(), *au.Fixed)
 				vc.reportValidityErrorAttr(ctx, vc.filename, elem.Line(), elemDisplayName(elem), ad, msg)
@@ -428,7 +457,6 @@ func (vc *validationContext) validateAttributes(ctx context.Context, elem *heliu
 			}
 			// Validate the attribute value against its declared type
 			// (inline anonymous simpleType takes precedence over a named type).
-			attrTD, tdOK := vc.attrUseType(au)
 			if tdOK && attrTD.ContentType == ContentTypeSimple {
 				if err := attrTD.Validate(ctx, a.Value(), collectNSContext(elem)); err != nil {
 					ad := attrDisplayName(a)

--- a/xsd/validate_enumeration_value_space_test.go
+++ b/xsd/validate_enumeration_value_space_test.go
@@ -9,11 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	xsDecimalType = "xs:decimal"
-	nanLexical    = "NaN"
-)
-
 // TestEnumerationValueSpace verifies that the enumeration facet is compared in
 // value space, not raw lexical space. A value that is lexically distinct from
 // every enumeration member but value-equal to one of them must be accepted; a
@@ -36,9 +31,9 @@ func TestEnumerationValueSpace(t *testing.T) {
 		{name: "decimal non-member", baseType: xsDecimalType, enum: []string{"5"}, instance: "6", wantReject: true},
 
 		// boolean — "true"/"1" and "false"/"0" are value-equal pairs.
-		{name: "boolean true vs 1", baseType: "xs:boolean", enum: []string{"true"}, instance: "1"},
-		{name: "boolean false vs 0", baseType: "xs:boolean", enum: []string{"false"}, instance: "0"},
-		{name: "boolean non-member", baseType: "xs:boolean", enum: []string{"true"}, instance: "0", wantReject: true},
+		{name: "boolean true vs 1", baseType: xsBooleanType, enum: []string{"true"}, instance: "1"},
+		{name: "boolean false vs 0", baseType: xsBooleanType, enum: []string{"false"}, instance: "0"},
+		{name: "boolean non-member", baseType: xsBooleanType, enum: []string{"true"}, instance: "0", wantReject: true},
 
 		// float / double — trailing zero and exponent forms.
 		{name: "float trailing zero", baseType: "xs:float", enum: []string{"1.5"}, instance: "1.50"},
@@ -55,9 +50,9 @@ func TestEnumerationValueSpace(t *testing.T) {
 
 		// hexBinary — value space is the decoded octets, so case differences are
 		// not significant ("0A" == "0a"); a different byte must be rejected.
-		{name: "hexBinary case-insensitive", baseType: "xs:hexBinary", enum: []string{"0A"}, instance: "0a"},
-		{name: "hexBinary mixed case member", baseType: "xs:hexBinary", enum: []string{"deadBEEF"}, instance: "DEADbeef"},
-		{name: "hexBinary non-member", baseType: "xs:hexBinary", enum: []string{"0A"}, instance: "0b", wantReject: true},
+		{name: "hexBinary case-insensitive", baseType: xsHexBinaryType, enum: []string{"0A"}, instance: "0a"},
+		{name: "hexBinary mixed case member", baseType: xsHexBinaryType, enum: []string{"deadBEEF"}, instance: "DEADbeef"},
+		{name: "hexBinary non-member", baseType: xsHexBinaryType, enum: []string{"0A"}, instance: "0b", wantReject: true},
 
 		// base64Binary — value space is the decoded octets; whitespace in the
 		// lexical form is not significant.
@@ -76,19 +71,19 @@ func TestEnumerationValueSpace(t *testing.T) {
 			enum: []string{"2000-01-01T12:00:00Z"}, instance: "2000-01-01T12:00:01Z", wantReject: true},
 
 		// string — lexical members must still be matched lexically.
-		{name: "string member", baseType: "xs:string", enum: []string{"alpha", "beta"}, instance: "beta"},
-		{name: "string non-member", baseType: "xs:string", enum: []string{"alpha"}, instance: "gamma", wantReject: true},
+		{name: "string member", baseType: xsStringType, enum: []string{"alpha", "beta"}, instance: "beta"},
+		{name: "string non-member", baseType: xsStringType, enum: []string{"alpha"}, instance: "gamma", wantReject: true},
 
 		// string-family types must stay lexical-only: a numeric-looking instance
 		// must NOT be accepted via numeric value-space comparison against a
 		// numeric-looking member ("5" must not accept "5.0").
-		{name: "string numeric lexical not value-equal", baseType: "xs:string",
+		{name: "string numeric lexical not value-equal", baseType: xsStringType,
 			enum: []string{"5"}, instance: "5.0", wantReject: true},
 		{name: "token numeric lexical not value-equal", baseType: "xs:token",
 			enum: []string{"10"}, instance: "1e1", wantReject: true},
 		{name: "anyURI numeric lexical not value-equal", baseType: "xs:anyURI",
 			enum: []string{"5"}, instance: "5.00", wantReject: true},
-		{name: "string numeric member exact", baseType: "xs:string", enum: []string{"5"}, instance: "5"},
+		{name: "string numeric member exact", baseType: xsStringType, enum: []string{"5"}, instance: "5"},
 	}
 
 	for _, tc := range cases {

--- a/xsd/validate_enumeration_value_space_test.go
+++ b/xsd/validate_enumeration_value_space_test.go
@@ -36,17 +36,17 @@ func TestEnumerationValueSpace(t *testing.T) {
 		{name: "boolean non-member", baseType: xsBooleanType, enum: []string{"true"}, instance: "0", wantReject: true},
 
 		// float / double — trailing zero and exponent forms.
-		{name: "float trailing zero", baseType: "xs:float", enum: []string{"1.5"}, instance: "1.50"},
-		{name: "float exponent form", baseType: "xs:float", enum: []string{"1.5"}, instance: "1.5E0"},
-		{name: "double exponent form", baseType: "xs:double", enum: []string{"1.5"}, instance: "1.5E0"},
-		{name: "double non-member", baseType: "xs:double", enum: []string{"1.5"}, instance: "2.5", wantReject: true},
+		{name: "float trailing zero", baseType: xsFloatType, enum: []string{"1.5"}, instance: "1.50"},
+		{name: "float exponent form", baseType: xsFloatType, enum: []string{"1.5"}, instance: "1.5E0"},
+		{name: "double exponent form", baseType: xsDoubleType, enum: []string{"1.5"}, instance: "1.5E0"},
+		{name: "double non-member", baseType: xsDoubleType, enum: []string{"1.5"}, instance: "2.5", wantReject: true},
 
 		// float NaN — per XSD, NaN equals NaN for enumeration purposes; signed
 		// lexical forms (accepted by the float validator) must match too.
-		{name: "float NaN matches NaN", baseType: "xs:float", enum: []string{nanLexical}, instance: nanLexical},
-		{name: "double NaN matches NaN", baseType: "xs:double", enum: []string{nanLexical}, instance: nanLexical},
-		{name: "float signed NaN matches NaN", baseType: "xs:float", enum: []string{nanLexical}, instance: "+NaN"},
-		{name: "double signed NaN matches NaN", baseType: "xs:double", enum: []string{nanLexical}, instance: "-NaN"},
+		{name: "float NaN matches NaN", baseType: xsFloatType, enum: []string{nanLexical}, instance: nanLexical},
+		{name: "double NaN matches NaN", baseType: xsDoubleType, enum: []string{nanLexical}, instance: nanLexical},
+		{name: "float signed NaN matches NaN", baseType: xsFloatType, enum: []string{nanLexical}, instance: "+NaN"},
+		{name: "double signed NaN matches NaN", baseType: xsDoubleType, enum: []string{nanLexical}, instance: "-NaN"},
 
 		// hexBinary — value space is the decoded octets, so case differences are
 		// not significant ("0A" == "0a"); a different byte must be rejected.

--- a/xsd/validate_fixed_value_space_test.go
+++ b/xsd/validate_fixed_value_space_test.go
@@ -38,6 +38,13 @@ func TestFixedValueSpace(t *testing.T) {
 		{name: "boolean true vs 1", typ: xsBooleanType, fixed: "true", instance: "1"},
 		{name: "boolean value mismatch", typ: xsBooleanType, fixed: "true", instance: "0", wantReject: true},
 
+		// float — value space is IEEE-754 single precision, so 16777216 and
+		// 16777217 round to the same float32 and must be accepted; xs:double keeps
+		// them distinct as float64 and must be rejected.
+		{name: "float single-precision equal", typ: xsFloatType, fixed: "16777216", instance: "16777217"},
+		{name: "float value mismatch", typ: xsFloatType, fixed: "16777216", instance: "16777220", wantReject: true},
+		{name: "double full-precision distinct", typ: xsDoubleType, fixed: "16777216", instance: "16777217", wantReject: true},
+
 		// hexBinary — value space is the decoded octets, so case differences are
 		// not significant ("0A" == "0a"); a different byte must be rejected.
 		{name: "hexBinary case-insensitive", typ: xsHexBinaryType, fixed: "0A", instance: "0a"},

--- a/xsd/validate_fixed_value_space_test.go
+++ b/xsd/validate_fixed_value_space_test.go
@@ -187,6 +187,120 @@ func TestFixedValueSpaceList(t *testing.T) {
 	})
 }
 
+// TestFixedValueSpaceQName verifies that a fixed value of xs:QName is compared in
+// value space: each lexical QName is resolved against its own in-scope namespaces
+// (the schema's namespaces for the fixed value, the instance's for the instance
+// value) and the resolved {namespace URI, local name} pairs are compared. Two
+// different prefixes bound to the same URI must be equal; a same-prefix different
+// URI binding or a different local name must be rejected.
+func TestFixedValueSpaceQName(t *testing.T) {
+	const targetURI = "urn:example:target"
+
+	t.Run("element/prefix-differs-same-uri", func(t *testing.T) {
+		t.Parallel()
+		// Schema binds prefix s -> targetURI and fixes the QName as s:name.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:s="` + targetURI + `">
+  <xs:element name="root" type="xs:QName" fixed="s:name"/>
+</xs:schema>`
+		// Instance binds a different prefix i -> the same URI; i:name resolves equal.
+		instanceXML := `<root xmlns:i="` + targetURI + `">i:name</root>`
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+
+	t.Run("element/different-uri", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:s="` + targetURI + `">
+  <xs:element name="root" type="xs:QName" fixed="s:name"/>
+</xs:schema>`
+		// Same prefix text but bound to a different URI -> resolved QNames differ.
+		instanceXML := `<root xmlns:s="urn:example:other">s:name</root>`
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+
+	t.Run("element/different-localname", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:s="` + targetURI + `">
+  <xs:element name="root" type="xs:QName" fixed="s:name"/>
+</xs:schema>`
+		instanceXML := `<root xmlns:i="` + targetURI + `">i:other</root>`
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+
+	t.Run("attribute/prefix-differs-same-uri", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:s="` + targetURI + `">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="a" type="xs:QName" fixed="s:name"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		instanceXML := `<root xmlns:i="` + targetURI + `" a="i:name"/>`
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+
+	t.Run("attribute/different-uri", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:s="` + targetURI + `">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="a" type="xs:QName" fixed="s:name"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		instanceXML := `<root xmlns:s="urn:example:other" a="s:name"/>`
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+}
+
+// TestFixedValueSpaceListOfUnion verifies that a fixed value of an xs:list whose
+// itemType is a union dispatches each item through the union's member value
+// spaces, so a value-equal item under any member type (e.g. integer "01" == "1")
+// satisfies the constraint while a value-distinct item is rejected.
+func TestFixedValueSpaceListOfUnion(t *testing.T) {
+	const typeDefs = `  <xs:simpleType name="intOrBool">
+    <xs:union memberTypes="xs:integer xs:boolean"/>
+  </xs:simpleType>
+  <xs:simpleType name="unionList">
+    <xs:list itemType="intOrBool"/>
+  </xs:simpleType>`
+
+	t.Run("element/value-equal items", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root" type="unionList" fixed="1 true"/>
+</xs:schema>`
+		// "01" is integer-equal to "1"; "1" is boolean-equal to "true".
+		instanceXML := "<root>01 1</root>"
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+
+	t.Run("element/item mismatch", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root" type="unionList" fixed="1 true"/>
+</xs:schema>`
+		instanceXML := "<root>2 true</root>"
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+
+	t.Run("attribute/value-equal items", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="a" type="unionList" fixed="1 true"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		instanceXML := `<root a="01 1"/>`
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+}
+
 func runFixedValueCase(t *testing.T, schemaXML, instanceXML string, wantReject bool) {
 	t.Helper()
 

--- a/xsd/validate_fixed_value_space_test.go
+++ b/xsd/validate_fixed_value_space_test.go
@@ -301,6 +301,71 @@ func TestFixedValueSpaceListOfUnion(t *testing.T) {
 	})
 }
 
+// TestFixedValueSpaceUnion verifies that a fixed value of an xs:union dispatches
+// the raw (un-normalized) instance and fixed values to each member, letting each
+// member apply its *own* whiteSpace facet. A union containing xs:string must
+// preserve significant trailing whitespace under the string member: fixed="abc "
+// must NOT accept instance "abc" even though a sibling xs:integer member would
+// collapse whitespace. A value-equal instance under any member (e.g. the integer
+// member) must still be accepted.
+func TestFixedValueSpaceUnion(t *testing.T) {
+	const typeDefs = `  <xs:simpleType name="strOrInt">
+    <xs:union memberTypes="xs:string xs:integer"/>
+  </xs:simpleType>`
+
+	t.Run("element/string member trailing space significant", func(t *testing.T) {
+		t.Parallel()
+		// fixed has a trailing space; the xs:string member preserves it, so the
+		// instance "abc" (no trailing space) is value-distinct. The xs:integer
+		// member rejects the non-integer text. The constraint must be rejected.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root" type="strOrInt" fixed="` + abcLiteral + ` "/>
+</xs:schema>`
+		instanceXML := `<root>` + abcLiteral + `</root>`
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+
+	t.Run("element/integer member value-equal", func(t *testing.T) {
+		t.Parallel()
+		// The xs:integer member treats "01" as value-equal to "1".
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root" type="strOrInt" fixed="1"/>
+</xs:schema>`
+		instanceXML := "<root>01</root>"
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+
+	t.Run("attribute/string member trailing space significant", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="a" type="strOrInt" fixed="` + abcLiteral + ` "/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		instanceXML := `<root a="` + abcLiteral + `"/>`
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+
+	t.Run("attribute/integer member value-equal", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="a" type="strOrInt" fixed="1"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		instanceXML := `<root a="01"/>`
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+}
+
 func runFixedValueCase(t *testing.T, schemaXML, instanceXML string, wantReject bool) {
 	t.Helper()
 

--- a/xsd/validate_fixed_value_space_test.go
+++ b/xsd/validate_fixed_value_space_test.go
@@ -638,6 +638,102 @@ func TestFixedValueSpaceXsiTypeDeclaredType(t *testing.T) {
 	runFixedValueCase(t, schemaXML, instanceXML, true)
 }
 
+// TestFixedValueSpaceUnionStringFamily verifies that when the fixed and instance
+// values resolve to DIFFERENT active union members that nonetheless share the
+// same PRIMITIVE string value-space family, they compare equal by their
+// whitespace-normalized lexical forms. memberTypes lists two distinct xs:string
+// restrictions (one with whiteSpace="collapse"); fixed "a b" against instance
+// " a   b " denotes the same collapsed string and must be ACCEPTED. A genuinely
+// different string is rejected, and a cross-family pair (string vs integer) is
+// rejected.
+func TestFixedValueSpaceUnionStringFamily(t *testing.T) {
+	// strExact is an xs:string restriction with whiteSpace="preserve" (inherited)
+	// and a pattern that matches "a b" with a SINGLE internal space; it rejects a
+	// padded/multi-space form. strColl is a SECOND xs:string restriction with
+	// whiteSpace="collapse" that accepts the padded form by collapsing it. Both
+	// reduce to the xs:string primitive value space, so a fixed value active in
+	// strExact and an instance active in strColl that collapse to the same string
+	// must compare equal.
+	const typeDefs = `  <xs:simpleType name="strExact">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z] [a-z]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="strColl">
+    <xs:restriction base="xs:string">
+      <xs:whiteSpace value="collapse"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="strExactOrColl">
+    <xs:union memberTypes="strExact strColl"/>
+  </xs:simpleType>`
+
+	t.Run("element/different string members value-equal", func(t *testing.T) {
+		t.Parallel()
+		// fixed "a b": matches strExact's pattern (single space) -> active member
+		// strExact (preserve). instance " a   b ": strExact's pattern does NOT match
+		// the padded form (preserve keeps the spaces) -> falls to strColl, which
+		// collapses to "a b". Active members DIFFER (strExact vs strColl) yet both
+		// reduce to the xs:string primitive family and normalize to "a b" -> EQUAL.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root" type="strExactOrColl" fixed="a b"/>
+</xs:schema>`
+		instanceXML := "<root> a   b </root>"
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+
+	t.Run("element/different string value rejected", func(t *testing.T) {
+		t.Parallel()
+		// fixed "a b" -> strExact; instance " a   c " -> strColl collapses to "a c".
+		// Same string primitive family but "a b" != "a c" -> rejected.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root" type="strExactOrColl" fixed="a b"/>
+</xs:schema>`
+		instanceXML := "<root> a   c </root>"
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+
+	t.Run("attribute/different string members value-equal", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="a" type="strExactOrColl" fixed="a b"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		instanceXML := `<root a="  a   b  "/>`
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+
+	t.Run("element/cross-family string vs integer rejected", func(t *testing.T) {
+		t.Parallel()
+		// memberTypes="strColl xs:integer": fixed "1" -> strColl is a collapsing
+		// xs:string and is the first member, so fixed's active member is strColl
+		// (string family). instance "1" -> also strColl. To force a cross-family
+		// pair, put xs:integer first so a bare "1" picks xs:integer while a padded
+		// instance can only pick the string member. integer vs string differ.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="strColl">
+    <xs:restriction base="xs:string">
+      <xs:whiteSpace value="collapse"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="intOrStrColl">
+    <xs:union memberTypes="xs:integer strColl"/>
+  </xs:simpleType>
+  <xs:element name="root" type="intOrStrColl" fixed="1"/>
+</xs:schema>`
+		// instance "x 1" -> xs:integer rejects, strColl accepts (collapses to "x 1").
+		// fixed "1" -> xs:integer accepts (active member xs:integer). Cross-family.
+		instanceXML := "<root>x 1</root>"
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+}
+
 // TestFixedValueSpaceUnionWhitespaceOperand verifies that for union values whose
 // active members DIFFER but share a value-space family, each operand is
 // whitespace-normalized with ITS active member's effective whiteSpace facet

--- a/xsd/validate_fixed_value_space_test.go
+++ b/xsd/validate_fixed_value_space_test.go
@@ -258,6 +258,19 @@ func TestFixedValueSpaceQName(t *testing.T) {
 		instanceXML := `<root xmlns:s="urn:example:other" a="s:name"/>`
 		runFixedValueCase(t, schemaXML, instanceXML, true)
 	})
+
+	t.Run("element/instance-prefix-unresolved-rejected", func(t *testing.T) {
+		t.Parallel()
+		// Schema binds prefix s -> targetURI and fixes s:name. The instance text is
+		// the same lexical "s:name" but the instance has NO xmlns:s binding, so the
+		// instance QName prefix cannot be resolved. A genuinely unresolvable QName is
+		// itself invalid; the fixed comparison must NOT pass on raw lexical match.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:s="` + targetURI + `">
+  <xs:element name="root" type="xs:QName" fixed="s:name"/>
+</xs:schema>`
+		instanceXML := `<root>s:name</root>`
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
 }
 
 // TestFixedValueSpaceListOfUnion verifies that a fixed value of an xs:list whose
@@ -558,6 +571,47 @@ func TestFixedValueSpaceUnionSharedValueSpace(t *testing.T) {
 </xs:schema>`
 		instanceXML := "<root>true</root>"
 		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+
+	t.Run("element/nested union member same decimal value space", func(t *testing.T) {
+		t.Parallel()
+		// Outer union memberTypes="inner xs:decimal" where inner is ITSELF a union
+		// "xs:integer xs:boolean". fixed "1.0": xs:integer rejects it, xs:boolean
+		// rejects it, so inner rejects and the active member is the outer xs:decimal.
+		// instance "1": validates against inner (xs:integer first), so its active
+		// member is the inner union — and within it, the active basic member is
+		// xs:integer. The active basic members differ (decimal vs integer) but both
+		// reduce to the decimal value space and 1.0 == 1, so the constraint holds.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="inner">
+    <xs:union memberTypes="xs:integer xs:boolean"/>
+  </xs:simpleType>
+  <xs:simpleType name="outer">
+    <xs:union memberTypes="inner xs:decimal"/>
+  </xs:simpleType>
+  <xs:element name="root" type="outer" fixed="1.0"/>
+</xs:schema>`
+		instanceXML := "<root>1</root>"
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+
+	t.Run("attribute/nested union member same decimal value space", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="inner">
+    <xs:union memberTypes="xs:integer xs:boolean"/>
+  </xs:simpleType>
+  <xs:simpleType name="outer">
+    <xs:union memberTypes="inner xs:decimal"/>
+  </xs:simpleType>
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="a" type="outer" fixed="1.0"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		instanceXML := `<root a="1"/>`
+		runFixedValueCase(t, schemaXML, instanceXML, false)
 	})
 }
 

--- a/xsd/validate_fixed_value_space_test.go
+++ b/xsd/validate_fixed_value_space_test.go
@@ -561,6 +561,94 @@ func TestFixedValueSpaceUnionSharedValueSpace(t *testing.T) {
 	})
 }
 
+// TestFixedValueSpaceXsiTypeDeclaredType verifies that the element fixed-value
+// constraint is compared in the element DECLARATION's type, not in an xsi:type
+// ACTUAL type that may derive a different whiteSpace facet. A declared
+// xs:string (whiteSpace="preserve") fixed="abc " keeps its trailing space, so an
+// instance whose xsi:type collapses whitespace and supplies content "abc" must
+// still be REJECTED against the declared string fixed value.
+func TestFixedValueSpaceXsiTypeDeclaredType(t *testing.T) {
+	t.Parallel()
+	// collapsedString derives from xs:string with whiteSpace="collapse"; it is a
+	// valid xsi:type for the declared xs:string element, but the fixed-value
+	// comparison must use the declared xs:string (preserve), not collapse.
+	schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="collapsedString">
+    <xs:restriction base="xs:string">
+      <xs:whiteSpace value="collapse"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="root" type="xs:string" fixed="` + abcLiteral + ` "/>
+</xs:schema>`
+	instanceXML := `<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="collapsedString">` + abcLiteral + `</root>`
+	runFixedValueCase(t, schemaXML, instanceXML, true)
+}
+
+// TestFixedValueSpaceUnionWhitespaceOperand verifies that for union values whose
+// active members DIFFER but share a value-space family, each operand is
+// whitespace-normalized with ITS active member's effective whiteSpace facet
+// before the value-space comparison. union fixed="1.0" must accept the
+// whitespace-padded instance " 1 " (which collapses to "1" under its xs:integer
+// active member) just as it accepts "1".
+func TestFixedValueSpaceUnionWhitespaceOperand(t *testing.T) {
+	const intOrDec = `  <xs:simpleType name="intOrDec">
+    <xs:union memberTypes="xs:integer xs:decimal"/>
+  </xs:simpleType>`
+
+	t.Run("attribute/padded instance accepted", func(t *testing.T) {
+		t.Parallel()
+		// fixed "1.0" -> active member xs:decimal; instance " 1 " -> xs:integer
+		// (after collapse). Different members, shared decimal family, value-equal
+		// after each operand's whiteSpace collapse.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + intOrDec + `
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="a" type="intOrDec" fixed="1.0"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		instanceXML := `<root a=" 1 "/>`
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+}
+
+// TestFixedValueSpaceWildcardGlobalFixed verifies that a global attribute matched
+// through an xs:anyAttribute wildcard (processContents="strict") still enforces
+// the global attribute's fixed value. A different value supplied via the wildcard
+// must be REJECTED.
+func TestFixedValueSpaceWildcardGlobalFixed(t *testing.T) {
+	const gattr = `  <xs:attribute name="ga" type="xs:string" fixed="locked"/>`
+
+	t.Run("wildcard match different value rejected", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + gattr + `
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:anyAttribute processContents="strict"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		instanceXML := `<root ga="other"/>`
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+
+	t.Run("wildcard match fixed value accepted", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + gattr + `
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:anyAttribute processContents="strict"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		instanceXML := `<root ga="locked"/>`
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+}
+
 func runFixedValueCase(t *testing.T, schemaXML, instanceXML string, wantReject bool) {
 	t.Helper()
 

--- a/xsd/validate_fixed_value_space_test.go
+++ b/xsd/validate_fixed_value_space_test.go
@@ -472,6 +472,88 @@ func TestFixedValueSpaceUnionOrdered(t *testing.T) {
 	})
 }
 
+// TestFixedValueSpaceUnionSharedValueSpace exercises the case where the fixed and
+// instance values resolve to DIFFERENT active members that nonetheless live in
+// the same comparable value space (xs:integer and xs:decimal both reduce to the
+// decimal value space). Such values must compare equal in that shared space even
+// though their active members differ. Cross-family pairs (string vs integer,
+// integer vs boolean) stay unequal.
+func TestFixedValueSpaceUnionSharedValueSpace(t *testing.T) {
+	const intOrDec = `  <xs:simpleType name="intOrDec">
+    <xs:union memberTypes="xs:integer xs:decimal"/>
+  </xs:simpleType>`
+
+	t.Run("element/different members same decimal value space", func(t *testing.T) {
+		t.Parallel()
+		// fixed "1.0": xs:integer rejects it, so active member is xs:decimal.
+		// instance "1": xs:integer accepts it, so active member is xs:integer.
+		// Active members differ, but both reduce to the decimal value space and
+		// 1.0 == 1, so the constraint is satisfied.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + intOrDec + `
+  <xs:element name="root" type="intOrDec" fixed="1.0"/>
+</xs:schema>`
+		instanceXML := "<root>1</root>"
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+
+	t.Run("attribute/different members same decimal value space", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + intOrDec + `
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="a" type="intOrDec" fixed="1.0"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		instanceXML := `<root a="1"/>`
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+
+	t.Run("element/same value space but unequal values rejected", func(t *testing.T) {
+		t.Parallel()
+		// fixed "2.0" (active member xs:decimal) vs instance "1" (active member
+		// xs:integer): same value space, but 2.0 != 1, so rejected.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + intOrDec + `
+  <xs:element name="root" type="intOrDec" fixed="2.0"/>
+</xs:schema>`
+		instanceXML := "<root>1</root>"
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+
+	t.Run("element/cross-family string vs integer rejected", func(t *testing.T) {
+		t.Parallel()
+		// memberTypes="xs:integer xs:string": fixed "1" -> active member xs:integer
+		// (first member accepts it); instance " 1" (leading space) -> xs:integer
+		// rejects (leading space invalid for integer), so active member xs:string.
+		// integer and string are different value-space families -> rejected.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="intOrStr">
+    <xs:union memberTypes="xs:integer xs:string"/>
+  </xs:simpleType>
+  <xs:element name="root" type="intOrStr" fixed="1"/>
+</xs:schema>`
+		instanceXML := "<root> x </root>"
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+
+	t.Run("element/cross-family integer vs boolean rejected", func(t *testing.T) {
+		t.Parallel()
+		// Already covered by TestFixedValueSpaceUnionOrdered, restated here to guard
+		// the shared-value-space change: integer and boolean are different families.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="intOrBool">
+    <xs:union memberTypes="xs:integer xs:boolean"/>
+  </xs:simpleType>
+  <xs:element name="root" type="intOrBool" fixed="1"/>
+</xs:schema>`
+		instanceXML := "<root>true</root>"
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+}
+
 func runFixedValueCase(t *testing.T, schemaXML, instanceXML string, wantReject bool) {
 	t.Helper()
 

--- a/xsd/validate_fixed_value_space_test.go
+++ b/xsd/validate_fixed_value_space_test.go
@@ -1,0 +1,102 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFixedValueSpace verifies that fixed value constraints are compared in the
+// declared simple type's value space (applying its whitespace facet), not by
+// unconditional TrimSpace (element content) or raw string equality (attribute
+// value). A lexically distinct but value-equal instance must be accepted; a
+// value-distinct instance must be rejected. For string-family types whose
+// whiteSpace facet is "preserve", trailing whitespace is significant.
+func TestFixedValueSpace(t *testing.T) {
+	type testCase struct {
+		name       string
+		typ        string // type for the element/attribute
+		fixed      string // fixed value
+		instance   string // instance value
+		wantReject bool
+	}
+
+	cases := []testCase{
+		// integer — lexical variants that are value-equal to the fixed value
+		// must be accepted; a value-distinct instance must be rejected.
+		{name: "integer plus sign", typ: "xs:integer", fixed: "1", instance: "+1"},
+		{name: "integer leading zero", typ: "xs:integer", fixed: "1", instance: "01"},
+		{name: "integer value mismatch", typ: "xs:integer", fixed: "1", instance: "2", wantReject: true},
+
+		// decimal — trailing-zero forms are value-equal.
+		{name: "decimal trailing zero", typ: "xs:decimal", fixed: "5", instance: "5.0"},
+		{name: "decimal value mismatch", typ: "xs:decimal", fixed: "5", instance: "6", wantReject: true},
+
+		// boolean — "true"/"1" are value-equal.
+		{name: "boolean true vs 1", typ: "xs:boolean", fixed: "true", instance: "1"},
+		{name: "boolean value mismatch", typ: "xs:boolean", fixed: "true", instance: "0", wantReject: true},
+
+		// string (whiteSpace=preserve) — trailing whitespace is significant, so a
+		// fixed value with a trailing space must NOT match an instance without it.
+		{name: "string trailing space significant", typ: "xs:string", fixed: "abc ", instance: "abc", wantReject: true},
+		{name: "string exact match", typ: "xs:string", fixed: "abc", instance: "abc"},
+		{name: "string value mismatch", typ: "xs:string", fixed: "abc", instance: "xyz", wantReject: true},
+
+		// token (whiteSpace=collapse) — leading/trailing/internal whitespace is
+		// collapsed, so a padded instance value-matches the fixed value.
+		{name: "token collapses whitespace", typ: "xs:token", fixed: "abc", instance: "abc"},
+	}
+
+	for _, tc := range cases {
+		t.Run("element/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" type="` + tc.typ + `" fixed="` + tc.fixed + `"/>
+</xs:schema>`
+			instanceXML := `<root>` + tc.instance + `</root>`
+
+			runFixedValueCase(t, schemaXML, instanceXML, tc.wantReject)
+		})
+
+		t.Run("attribute/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="a" type="` + tc.typ + `" fixed="` + tc.fixed + `"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+			instanceXML := `<root a="` + tc.instance + `"/>`
+
+			runFixedValueCase(t, schemaXML, instanceXML, tc.wantReject)
+		})
+	}
+}
+
+func runFixedValueCase(t *testing.T, schemaXML, instanceXML string, wantReject bool) {
+	t.Helper()
+
+	schemaDOC, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+	require.NoError(t, err)
+
+	schema, err := xsd.NewCompiler().Compile(t.Context(), schemaDOC)
+	require.NoError(t, err)
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(instanceXML))
+	require.NoError(t, err)
+
+	var errs string
+	err = validateWithOutput(t, xsd.NewValidator(schema), doc, &errs)
+
+	if wantReject {
+		require.Error(t, err)
+		require.Contains(t, errs, "fixed value constraint")
+		return
+	}
+	require.NoError(t, err, "validation errors: %s", errs)
+}

--- a/xsd/validate_fixed_value_space_test.go
+++ b/xsd/validate_fixed_value_space_test.go
@@ -254,9 +254,14 @@ func TestFixedValueSpaceQName(t *testing.T) {
 }
 
 // TestFixedValueSpaceListOfUnion verifies that a fixed value of an xs:list whose
-// itemType is a union dispatches each item through the union's member value
-// spaces, so a value-equal item under any member type (e.g. integer "01" == "1")
-// satisfies the constraint while a value-distinct item is rejected.
+// itemType is a union dispatches each item through the union's *ordered* active
+// member. For memberTypes="xs:integer xs:boolean", a value such as "1" validates
+// against the first member (xs:integer) and so has active member xs:integer; a
+// value such as "true" fails xs:integer and has active member xs:boolean. Each
+// item compares only when the fixed and instance items resolve to the SAME
+// active member, in that member's value space — so a value-equal item under that
+// member (integer "01" == "1") satisfies the constraint, while an item whose
+// instance and fixed values resolve to different members does not.
 func TestFixedValueSpaceListOfUnion(t *testing.T) {
 	const typeDefs = `  <xs:simpleType name="intOrBool">
     <xs:union memberTypes="xs:integer xs:boolean"/>
@@ -265,15 +270,31 @@ func TestFixedValueSpaceListOfUnion(t *testing.T) {
     <xs:list itemType="intOrBool"/>
   </xs:simpleType>`
 
-	t.Run("element/value-equal items", func(t *testing.T) {
+	t.Run("element/value-equal items same active member", func(t *testing.T) {
 		t.Parallel()
 		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 ` + typeDefs + `
   <xs:element name="root" type="unionList" fixed="1 true"/>
 </xs:schema>`
-		// "01" is integer-equal to "1"; "1" is boolean-equal to "true".
-		instanceXML := "<root>01 1</root>"
+		// Item 1: fixed "1" and instance "01" both have active member xs:integer
+		// (integer-equal). Item 2: fixed "true" and instance "true" both have
+		// active member xs:boolean (string-equal "true").
+		instanceXML := "<root>01 true</root>"
 		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+
+	t.Run("element/cross-member item rejected", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root" type="unionList" fixed="1 true"/>
+</xs:schema>`
+		// Item 2: fixed "true" has active member xs:boolean, instance "1" has
+		// active member xs:integer (first member accepts "1"). Different active
+		// members -> the item is not equal even though "1" is boolean-equal to
+		// "true". The whole list fixed-value constraint is rejected.
+		instanceXML := "<root>01 1</root>"
+		runFixedValueCase(t, schemaXML, instanceXML, true)
 	})
 
 	t.Run("element/item mismatch", func(t *testing.T) {
@@ -286,7 +307,21 @@ func TestFixedValueSpaceListOfUnion(t *testing.T) {
 		runFixedValueCase(t, schemaXML, instanceXML, true)
 	})
 
-	t.Run("attribute/value-equal items", func(t *testing.T) {
+	t.Run("attribute/value-equal items same active member", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="a" type="unionList" fixed="1 true"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		instanceXML := `<root a="01 true"/>`
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+
+	t.Run("attribute/cross-member item rejected", func(t *testing.T) {
 		t.Parallel()
 		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 ` + typeDefs + `
@@ -297,27 +332,31 @@ func TestFixedValueSpaceListOfUnion(t *testing.T) {
   </xs:element>
 </xs:schema>`
 		instanceXML := `<root a="01 1"/>`
-		runFixedValueCase(t, schemaXML, instanceXML, false)
+		runFixedValueCase(t, schemaXML, instanceXML, true)
 	})
 }
 
-// TestFixedValueSpaceUnion verifies that a fixed value of an xs:union dispatches
-// the raw (un-normalized) instance and fixed values to each member, letting each
-// member apply its *own* whiteSpace facet. A union containing xs:string must
-// preserve significant trailing whitespace under the string member: fixed="abc "
-// must NOT accept instance "abc" even though a sibling xs:integer member would
-// collapse whitespace. A value-equal instance under any member (e.g. the integer
-// member) must still be accepted.
+// TestFixedValueSpaceUnion verifies that a fixed value of an xs:union is compared
+// using XSD's *ordered* active-member semantics, not "any member that makes the
+// lexicals compare equal". Each value's active member is the first member type
+// (in declaration order) it fully validates against; the fixed and instance
+// values compare only when they share the same active member, in that member's
+// value space.
+//
+// For memberTypes="xs:string xs:integer" the first member xs:string accepts any
+// text, so EVERY value's active member is xs:string and the comparison is always
+// string-based: fixed="1" does NOT accept instance "01" (string-distinct) even
+// though a hypothetical integer member would treat them as equal.
 func TestFixedValueSpaceUnion(t *testing.T) {
 	const typeDefs = `  <xs:simpleType name="strOrInt">
     <xs:union memberTypes="xs:string xs:integer"/>
   </xs:simpleType>`
 
-	t.Run("element/string member trailing space significant", func(t *testing.T) {
+	t.Run("element/string active member trailing space significant", func(t *testing.T) {
 		t.Parallel()
-		// fixed has a trailing space; the xs:string member preserves it, so the
-		// instance "abc" (no trailing space) is value-distinct. The xs:integer
-		// member rejects the non-integer text. The constraint must be rejected.
+		// fixed has a trailing space; the active member is xs:string (the first
+		// member), whiteSpace="preserve", so the instance "abc" (no trailing space)
+		// is value-distinct. The constraint must be rejected.
 		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 ` + typeDefs + `
   <xs:element name="root" type="strOrInt" fixed="` + abcLiteral + ` "/>
@@ -326,18 +365,31 @@ func TestFixedValueSpaceUnion(t *testing.T) {
 		runFixedValueCase(t, schemaXML, instanceXML, true)
 	})
 
-	t.Run("element/integer member value-equal", func(t *testing.T) {
+	t.Run("element/string active member rejects integer-equal lexicals", func(t *testing.T) {
 		t.Parallel()
-		// The xs:integer member treats "01" as value-equal to "1".
+		// Both "1" and "01" have active member xs:string (first member accepts any
+		// text), so they compare as strings and are NOT equal — the earlier
+		// "any member that makes them equal" behavior wrongly accepted this.
 		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 ` + typeDefs + `
   <xs:element name="root" type="strOrInt" fixed="1"/>
 </xs:schema>`
 		instanceXML := "<root>01</root>"
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+
+	t.Run("element/string active member exact lexical match", func(t *testing.T) {
+		t.Parallel()
+		// Same active member (xs:string) and string-equal values are accepted.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root" type="strOrInt" fixed="1"/>
+</xs:schema>`
+		instanceXML := "<root>1</root>"
 		runFixedValueCase(t, schemaXML, instanceXML, false)
 	})
 
-	t.Run("attribute/string member trailing space significant", func(t *testing.T) {
+	t.Run("attribute/string active member trailing space significant", func(t *testing.T) {
 		t.Parallel()
 		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 ` + typeDefs + `
@@ -351,7 +403,7 @@ func TestFixedValueSpaceUnion(t *testing.T) {
 		runFixedValueCase(t, schemaXML, instanceXML, true)
 	})
 
-	t.Run("attribute/integer member value-equal", func(t *testing.T) {
+	t.Run("attribute/string active member rejects integer-equal lexicals", func(t *testing.T) {
 		t.Parallel()
 		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 ` + typeDefs + `
@@ -362,6 +414,60 @@ func TestFixedValueSpaceUnion(t *testing.T) {
   </xs:element>
 </xs:schema>`
 		instanceXML := `<root a="01"/>`
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+}
+
+// TestFixedValueSpaceUnionOrdered exercises the ordered active-member rules
+// directly: a same-active-member value-equal pair is accepted, a cross-member
+// pair is rejected, and member declaration ORDER changes the active member (so
+// the same lexicals accept or reject depending on which member comes first).
+func TestFixedValueSpaceUnionOrdered(t *testing.T) {
+	t.Run("integer-first same active member value-equal", func(t *testing.T) {
+		t.Parallel()
+		// memberTypes="xs:integer xs:boolean": "1" and "01" both validate against
+		// xs:integer first, so both have active member xs:integer and compare in
+		// integer value space -> equal.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="intOrBool">
+    <xs:union memberTypes="xs:integer xs:boolean"/>
+  </xs:simpleType>
+  <xs:element name="root" type="intOrBool" fixed="1"/>
+</xs:schema>`
+		instanceXML := "<root>01</root>"
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+
+	t.Run("cross-member rejected", func(t *testing.T) {
+		t.Parallel()
+		// memberTypes="xs:integer xs:boolean": fixed "1" has active member
+		// xs:integer; instance "true" has active member xs:boolean. Different
+		// active members -> not equal.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="intOrBool">
+    <xs:union memberTypes="xs:integer xs:boolean"/>
+  </xs:simpleType>
+  <xs:element name="root" type="intOrBool" fixed="1"/>
+</xs:schema>`
+		instanceXML := "<root>true</root>"
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+
+	t.Run("member order changes active member", func(t *testing.T) {
+		t.Parallel()
+		// memberTypes="xs:boolean xs:integer": "1" validates against xs:boolean
+		// first (boolean accepts "1"), so its active member is xs:boolean — not
+		// xs:integer. fixed "1" and instance "true" both resolve to xs:boolean
+		// (boolean value-equal "1" == "true"), so the constraint is satisfied.
+		// With the reverse order (integer first) this same pair is rejected (see
+		// the cross-member case above) — demonstrating order matters.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="boolOrInt">
+    <xs:union memberTypes="xs:boolean xs:integer"/>
+  </xs:simpleType>
+  <xs:element name="root" type="boolOrInt" fixed="1"/>
+</xs:schema>`
+		instanceXML := "<root>true</root>"
 		runFixedValueCase(t, schemaXML, instanceXML, false)
 	})
 }

--- a/xsd/validate_fixed_value_space_test.go
+++ b/xsd/validate_fixed_value_space_test.go
@@ -35,18 +35,23 @@ func TestFixedValueSpace(t *testing.T) {
 		{name: "decimal value mismatch", typ: "xs:decimal", fixed: "5", instance: "6", wantReject: true},
 
 		// boolean — "true"/"1" are value-equal.
-		{name: "boolean true vs 1", typ: "xs:boolean", fixed: "true", instance: "1"},
-		{name: "boolean value mismatch", typ: "xs:boolean", fixed: "true", instance: "0", wantReject: true},
+		{name: "boolean true vs 1", typ: xsBooleanType, fixed: "true", instance: "1"},
+		{name: "boolean value mismatch", typ: xsBooleanType, fixed: "true", instance: "0", wantReject: true},
+
+		// hexBinary — value space is the decoded octets, so case differences are
+		// not significant ("0A" == "0a"); a different byte must be rejected.
+		{name: "hexBinary case-insensitive", typ: xsHexBinaryType, fixed: "0A", instance: "0a"},
+		{name: "hexBinary value mismatch", typ: xsHexBinaryType, fixed: "0A", instance: "0b", wantReject: true},
 
 		// string (whiteSpace=preserve) — trailing whitespace is significant, so a
 		// fixed value with a trailing space must NOT match an instance without it.
-		{name: "string trailing space significant", typ: "xs:string", fixed: "abc ", instance: "abc", wantReject: true},
-		{name: "string exact match", typ: "xs:string", fixed: "abc", instance: "abc"},
-		{name: "string value mismatch", typ: "xs:string", fixed: "abc", instance: "xyz", wantReject: true},
+		{name: "string trailing space significant", typ: xsStringType, fixed: abcLiteral + " ", instance: abcLiteral, wantReject: true},
+		{name: "string exact match", typ: xsStringType, fixed: abcLiteral, instance: abcLiteral},
+		{name: "string value mismatch", typ: xsStringType, fixed: abcLiteral, instance: "xyz", wantReject: true},
 
 		// token (whiteSpace=collapse) — leading/trailing/internal whitespace is
 		// collapsed, so a padded instance value-matches the fixed value.
-		{name: "token collapses whitespace", typ: "xs:token", fixed: "abc", instance: "abc"},
+		{name: "token collapses whitespace", typ: "xs:token", fixed: abcLiteral, instance: abcLiteral},
 	}
 
 	for _, tc := range cases {
@@ -76,6 +81,110 @@ func TestFixedValueSpace(t *testing.T) {
 			runFixedValueCase(t, schemaXML, instanceXML, tc.wantReject)
 		})
 	}
+}
+
+// TestFixedValueSpaceDerivedWhitespace verifies that a fixed value declared with
+// a simple type whose whiteSpace facet is *derived* on a restriction (not the
+// builtin's default) is compared after applying that derived facet. A
+// builtin-name-only canonicalization would use xs:string's "preserve" and
+// wrongly reject a value-equal-but-whitespace-padded instance.
+func TestFixedValueSpaceDerivedWhitespace(t *testing.T) {
+	// collapsedString restricts xs:string with whiteSpace="collapse", so leading,
+	// trailing, and internal runs of whitespace are collapsed before comparison.
+	const typeDefs = `  <xs:simpleType name="collapsedString">
+    <xs:restriction base="xs:string">
+      <xs:whiteSpace value="collapse"/>
+    </xs:restriction>
+  </xs:simpleType>`
+
+	t.Run("element", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root" type="collapsedString" fixed="a b"/>
+</xs:schema>`
+		// Instance has padded/extra internal whitespace that collapses to "a b".
+		instanceXML := "<root> a   b </root>"
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+
+	t.Run("element/mismatch", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root" type="collapsedString" fixed="a b"/>
+</xs:schema>`
+		instanceXML := "<root>a c</root>"
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+
+	t.Run("attribute", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="a" type="collapsedString" fixed="a b"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		instanceXML := `<root a="  a   b  "/>`
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+}
+
+// TestFixedValueSpaceList verifies that a fixed value of an xs:list type is
+// compared item-by-item in the item type's value space, so lexically distinct
+// but value-equal items (e.g. "01" == "1", "+2" == "2") satisfy the constraint
+// while a value-distinct item is rejected.
+func TestFixedValueSpaceList(t *testing.T) {
+	const typeDefs = `  <xs:simpleType name="intList">
+    <xs:list itemType="xs:integer"/>
+  </xs:simpleType>`
+
+	t.Run("element/value-equal items", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root" type="intList" fixed="1 2"/>
+</xs:schema>`
+		instanceXML := "<root>01 +2</root>"
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
+
+	t.Run("element/item mismatch", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root" type="intList" fixed="1 2"/>
+</xs:schema>`
+		instanceXML := "<root>1 3</root>"
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+
+	t.Run("element/length mismatch", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root" type="intList" fixed="1 2"/>
+</xs:schema>`
+		instanceXML := "<root>1 2 3</root>"
+		runFixedValueCase(t, schemaXML, instanceXML, true)
+	})
+
+	t.Run("attribute/value-equal items", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+` + typeDefs + `
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="a" type="intList" fixed="1 2"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		instanceXML := `<root a="01 +2"/>`
+		runFixedValueCase(t, schemaXML, instanceXML, false)
+	})
 }
 
 func runFixedValueCase(t *testing.T, schemaXML, instanceXML string, wantReject bool) {

--- a/xsd/validate_value_space_test.go
+++ b/xsd/validate_value_space_test.go
@@ -1,0 +1,15 @@
+package xsd_test
+
+// Shared test constants for the value-space comparison tests
+// (validate_enumeration_value_space_test.go and
+// validate_fixed_value_space_test.go). Hoisting the repeated XSD type names and
+// literals here keeps each literal defined once, satisfying goconst.
+const (
+	xsDecimalType   = "xs:decimal"
+	xsBooleanType   = "xs:boolean"
+	xsStringType    = "xs:string"
+	xsHexBinaryType = "xs:hexBinary"
+
+	nanLexical = "NaN"
+	abcLiteral = "abc"
+)

--- a/xsd/validate_value_space_test.go
+++ b/xsd/validate_value_space_test.go
@@ -9,6 +9,8 @@ const (
 	xsBooleanType   = "xs:boolean"
 	xsStringType    = "xs:string"
 	xsHexBinaryType = "xs:hexBinary"
+	xsFloatType     = "xs:float"
+	xsDoubleType    = "xs:double"
 
 	nanLexical = "NaN"
 	abcLiteral = "abc"


### PR DESCRIPTION
- compare element-content and attribute fixed values in the declared simple type's value space (via `value.CanonicalKey`/whitespace facet) instead of `TrimSpace`/raw equality
- accepts value-equal lexical variants (e.g. integer fixed `1` vs `+1`) and keeps significant string whitespace significant