### PR TITLE
raise XTDE0860 in attribute capture branches

### DIFF
--- a/xslt3/attribute_prefix_test.go
+++ b/xslt3/attribute_prefix_test.go
@@ -1,0 +1,45 @@
+package xslt3_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xslt3"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAttributeUndeclaredPrefixSequenceMode verifies that xsl:attribute with a
+// computed name using an undeclared prefix raises XTDE0860 even when the
+// attribute is constructed in sequence mode (xsl:variable/xsl:param with an
+// "as" type), rather than being captured silently as a no-namespace attribute.
+func TestAttributeUndeclaredPrefixSequenceMode(t *testing.T) {
+	ctx := t.Context()
+
+	// The variable has an "as" type, so xsl:attribute is constructed in
+	// sequence mode. The computed name "p:a" uses prefix "p" which is not
+	// declared anywhere in scope, so XTDE0860 must be raised.
+	xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:variable name="v" as="attribute()*">
+      <xsl:attribute name="{'p:a'}" select="'x'"/>
+    </xsl:variable>
+    <out/>
+  </xsl:template>
+</xsl:stylesheet>`
+
+	doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+	require.NoError(t, err)
+	ss, err := xslt3.CompileStylesheet(ctx, doc)
+	require.NoError(t, err)
+
+	src, err := helium.NewParser().Parse(ctx, []byte(`<root/>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(src).Serialize(ctx)
+	require.Error(t, err, "undeclared prefix in computed attribute name must raise an error")
+	require.True(t, strings.Contains(err.Error(), "XTDE0860"),
+		"expected XTDE0860, got: %v", err)
+}

--- a/xslt3/attribute_prefix_test.go
+++ b/xslt3/attribute_prefix_test.go
@@ -43,3 +43,105 @@ func TestAttributeUndeclaredPrefixSequenceMode(t *testing.T) {
 	require.True(t, strings.Contains(err.Error(), "XTDE0860"),
 		"expected XTDE0860, got: %v", err)
 }
+
+// TestAttributeUndeclaredPrefixItemCapture verifies that xsl:attribute with a
+// computed name using an undeclared prefix raises XTDE0860 when the attribute is
+// captured as a standalone item (here via an item-serialization output method
+// that captures the result rather than building a tree).
+func TestAttributeUndeclaredPrefixItemCapture(t *testing.T) {
+	ctx := t.Context()
+
+	// method="adaptive" is an item-serialization method, so an xsl:attribute
+	// constructed directly under the document node is captured as a pending
+	// item. The computed name "p:a" uses an undeclared prefix "p", so XTDE0860
+	// must be raised.
+	xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="adaptive"/>
+  <xsl:template match="/">
+    <xsl:attribute name="{'p:a'}" select="'x'"/>
+  </xsl:template>
+</xsl:stylesheet>`
+
+	doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+	require.NoError(t, err)
+	ss, err := xslt3.CompileStylesheet(ctx, doc)
+	require.NoError(t, err)
+
+	src, err := helium.NewParser().Parse(ctx, []byte(`<root/>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(src).Serialize(ctx)
+	require.Error(t, err, "undeclared prefix in computed attribute name must raise an error")
+	require.True(t, strings.Contains(err.Error(), "XTDE0860"),
+		"expected XTDE0860, got: %v", err)
+}
+
+// TestAttributeInvalidQNameSequenceMode verifies that xsl:attribute with a
+// computed name that is not a lexically valid QName raises XTDE0850 in sequence
+// mode (xsl:variable/xsl:param with an "as" type), rather than silently
+// producing an attribute with an invalid name.
+func TestAttributeInvalidQNameSequenceMode(t *testing.T) {
+	ctx := t.Context()
+
+	// "1bad" is not a valid NCName/QName (NCNames cannot start with a digit),
+	// so XTDE0850 must be raised even though the attribute is constructed in
+	// sequence mode.
+	xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:variable name="v" as="attribute()*">
+      <xsl:attribute name="{'1bad'}" select="'x'"/>
+    </xsl:variable>
+    <out/>
+  </xsl:template>
+</xsl:stylesheet>`
+
+	doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+	require.NoError(t, err)
+	ss, err := xslt3.CompileStylesheet(ctx, doc)
+	require.NoError(t, err)
+
+	src, err := helium.NewParser().Parse(ctx, []byte(`<root/>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(src).Serialize(ctx)
+	require.Error(t, err, "invalid QName in computed attribute name must raise an error")
+	require.True(t, strings.Contains(err.Error(), "XTDE0850"),
+		"expected XTDE0850, got: %v", err)
+}
+
+// TestAttributeInvalidQNameItemCapture verifies that xsl:attribute with a
+// computed name that is not a lexically valid QName raises XTDE0850 when the
+// attribute is captured as a standalone item via an item-serialization output
+// method.
+func TestAttributeInvalidQNameItemCapture(t *testing.T) {
+	ctx := t.Context()
+
+	// As above, "1bad" is not a valid QName. With method="adaptive" the
+	// attribute is captured as a pending item, and XTDE0850 must still be
+	// raised.
+	xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="adaptive"/>
+  <xsl:template match="/">
+    <xsl:attribute name="{'1bad'}" select="'x'"/>
+  </xsl:template>
+</xsl:stylesheet>`
+
+	doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+	require.NoError(t, err)
+	ss, err := xslt3.CompileStylesheet(ctx, doc)
+	require.NoError(t, err)
+
+	src, err := helium.NewParser().Parse(ctx, []byte(`<root/>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(src).Serialize(ctx)
+	require.Error(t, err, "invalid QName in computed attribute name must raise an error")
+	require.True(t, strings.Contains(err.Error(), "XTDE0850"),
+		"expected XTDE0850, got: %v", err)
+}

--- a/xslt3/attribute_prefix_test.go
+++ b/xslt3/attribute_prefix_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xpath3"
 	"github.com/lestrrat-go/helium/xslt3"
 	"github.com/stretchr/testify/require"
 )
@@ -144,4 +145,94 @@ func TestAttributeInvalidQNameItemCapture(t *testing.T) {
 	require.Error(t, err, "invalid QName in computed attribute name must raise an error")
 	require.True(t, strings.Contains(err.Error(), "XTDE0850"),
 		"expected XTDE0850, got: %v", err)
+}
+
+// TestAttributeExplicitNamespaceSequenceMode verifies that an xsl:attribute with
+// a computed name using an undeclared prefix BUT an explicit namespace= attribute
+// is assigned that namespace (not no-namespace) when constructed in sequence mode.
+func TestAttributeExplicitNamespaceSequenceMode(t *testing.T) {
+	ctx := t.Context()
+
+	// The prefix "p" is undeclared, but namespace="urn:p" is supplied, so the
+	// attribute must be in urn:p, not in no-namespace. We capture it in a
+	// sequence-typed variable and emit its namespace URI as text.
+	xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="text"/>
+  <xsl:template match="/">
+    <xsl:variable name="v" as="attribute()*">
+      <xsl:attribute name="{'p:a'}" namespace="urn:p" select="'x'"/>
+    </xsl:variable>
+    <xsl:value-of select="namespace-uri-from-QName(node-name($v[1]))"/>
+  </xsl:template>
+</xsl:stylesheet>`
+
+	doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+	require.NoError(t, err)
+	ss, err := xslt3.CompileStylesheet(ctx, doc)
+	require.NoError(t, err)
+
+	src, err := helium.NewParser().Parse(ctx, []byte(`<root/>`))
+	require.NoError(t, err)
+
+	out, err := ss.Transform(src).Serialize(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "urn:p", strings.TrimSpace(out),
+		"computed attribute with explicit namespace= must be in that namespace in sequence mode")
+}
+
+// primaryItemsCapture is a PrimaryItemsHandler that records the items captured
+// from the primary output so a test can inspect captured attribute nodes.
+type primaryItemsCapture struct {
+	seq xpath3.Sequence
+}
+
+func (p *primaryItemsCapture) HandlePrimaryItems(seq xpath3.Sequence) error {
+	p.seq = seq
+	return nil
+}
+
+// TestAttributeExplicitNamespaceItemCapture verifies that an xsl:attribute with a
+// computed name using an undeclared prefix BUT an explicit namespace= attribute
+// is assigned that namespace (not no-namespace) when captured as a standalone
+// item via an item-serialization output method (the item-capture path). The
+// captured attribute node's namespace URI is inspected via a PrimaryItemsHandler.
+func TestAttributeExplicitNamespaceItemCapture(t *testing.T) {
+	ctx := t.Context()
+
+	// method="adaptive" is an item-serialization method, so the standalone
+	// xsl:attribute at the top level is captured as a pending item rather than
+	// attached to an element. The undeclared prefix "p" is overridden by
+	// namespace="urn:p", so the captured attribute node must be in urn:p.
+	xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="adaptive"/>
+  <xsl:template match="/">
+    <xsl:attribute name="{'p:a'}" namespace="urn:p" select="'x'"/>
+  </xsl:template>
+</xsl:stylesheet>`
+
+	doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+	require.NoError(t, err)
+	ss, err := xslt3.CompileStylesheet(ctx, doc)
+	require.NoError(t, err)
+
+	src, err := helium.NewParser().Parse(ctx, []byte(`<root/>`))
+	require.NoError(t, err)
+
+	capture := &primaryItemsCapture{}
+	_, err = ss.Transform(src).PrimaryItemsHandler(capture).Do(ctx)
+	require.NoError(t, err)
+
+	require.NotNil(t, capture.seq, "expected primary items to be captured")
+	require.Equal(t, 1, capture.seq.Len(), "expected a single captured attribute item")
+	ni, ok := capture.seq.Get(0).(xpath3.NodeItem)
+	require.True(t, ok, "captured item must be a node item")
+	attr, ok := helium.AsNode[*helium.Attribute](ni.Node)
+	require.True(t, ok, "captured node must be an attribute")
+	require.Equal(t, "a", attr.LocalName())
+	require.Equal(t, "urn:p", attr.URI(),
+		"computed attribute with explicit namespace= must be in that namespace in item-capture mode")
 }

--- a/xslt3/execute_element.go
+++ b/xslt3/execute_element.go
@@ -706,6 +706,11 @@ func (ec *execContext) execAttribute(ctx context.Context, inst *attributeInst) e
 			prefix := name[:idx]
 			localName = name[idx+1:]
 			nsURI = ec.resolvePrefix(prefix)
+			if nsURI == "" && inst.Namespace == nil {
+				// XTDE0860: prefix in computed attribute name is undeclared.
+				return dynamicError(errCodeXTDE0860,
+					"undeclared namespace prefix %q in attribute name %q", prefix, name)
+			}
 			if nsURI != "" {
 				ns, _ := out.doc.CreateNamespace(prefix, nsURI)
 				attrNS = ns
@@ -764,6 +769,11 @@ func (ec *execContext) execAttribute(ctx context.Context, inst *attributeInst) e
 					prefix := name[:idx]
 					local := name[idx+1:]
 					uri := ec.resolvePrefix(prefix)
+					if uri == "" && inst.Namespace == nil {
+						// XTDE0860: prefix in computed attribute name is undeclared.
+						return dynamicError(errCodeXTDE0860,
+							"undeclared namespace prefix %q in attribute name %q", prefix, name)
+					}
 					ns, _ := tmpDoc.CreateNamespace(prefix, uri)
 					_, _ = tmpElem.SetAttributeNS(local, value, ns)
 				} else {

--- a/xslt3/execute_element.go
+++ b/xslt3/execute_element.go
@@ -612,9 +612,40 @@ func (ec *execContext) annotateAttributesFromType(elem *helium.Element, typeName
 	}
 }
 
+// validateComputedAttributeName performs the name-validity checks for a
+// computed xsl:attribute name that are independent of the output target:
+// XTDE0855 (the name must not be "xmlns" when no namespace attribute is given)
+// and XTDE0850 (the name must be a lexically valid QName/EQName). It is invoked
+// before the element-output, sequence-mode, and item-capture branches so every
+// path enforces the same rules.
+func validateComputedAttributeName(name string, inst *attributeInst) error {
+	// XTDE0855: when no namespace attribute, name must not be "xmlns"
+	if inst.Namespace == nil && name == lexicon.PrefixXMLNS {
+		return dynamicError(errCodeXTDE0855,
+			"xsl:attribute name must not be %q when no namespace attribute is specified", name)
+	}
+
+	// XTDE0850: name must be a valid QName
+	if !isValidQName(name) && !isValidEQName(name) {
+		return dynamicError(errCodeXTDE0850,
+			"xsl:attribute name %q is not a valid QName", name)
+	}
+
+	return nil
+}
+
 func (ec *execContext) execAttribute(ctx context.Context, inst *attributeInst) error {
 	name, err := inst.Name.evaluate(ctx, ec.contextNode)
 	if err != nil {
+		return err
+	}
+
+	// Validate the computed attribute name up front so that the lexical-QName
+	// (XTDE0850) and reserved-xmlns (XTDE0855) checks apply uniformly across the
+	// element-output, sequence-mode, and item-capture paths below. The
+	// undeclared-prefix (XTDE0860) check stays inline in each path because it
+	// only applies when no explicit namespace attribute is supplied.
+	if err := validateComputedAttributeName(name, inst); err != nil {
 		return err
 	}
 
@@ -795,18 +826,6 @@ func (ec *execContext) execAttribute(ctx context.Context, inst *attributeInst) e
 	// and later filtered, so attribute-after-child is permitted during evaluation.
 	if elem.FirstChild() != nil && !out.wherePopulated {
 		return dynamicError(errCodeXTRE0540, "cannot add attribute to element after children have been added")
-	}
-
-	// XTDE0855: when no namespace attribute, name must not be "xmlns"
-	if inst.Namespace == nil && name == lexicon.PrefixXMLNS {
-		return dynamicError(errCodeXTDE0855,
-			"xsl:attribute name must not be %q when no namespace attribute is specified", name)
-	}
-
-	// XTDE0850: name must be a valid QName
-	if !isValidQName(name) && !isValidEQName(name) {
-		return dynamicError(errCodeXTDE0850,
-			"xsl:attribute name %q is not a valid QName", name)
 	}
 
 	if inst.Namespace != nil {

--- a/xslt3/execute_element.go
+++ b/xslt3/execute_element.go
@@ -634,6 +634,70 @@ func validateComputedAttributeName(name string, inst *attributeInst) error {
 	return nil
 }
 
+// resolvedAttrName is the fully resolved expanded name of a computed
+// xsl:attribute: the local name, the namespace URI it belongs to, and the
+// prefix that should be used when serializing it.
+type resolvedAttrName struct {
+	localName string
+	nsURI     string
+	prefix    string
+}
+
+// resolveComputedAttributeName resolves the expanded name of a computed
+// xsl:attribute exactly once, honoring an explicit namespace= attribute when
+// present and otherwise resolving the lexical prefix against the in-scope
+// namespaces. It enforces the namespace-related constraints (XTDE0865 for the
+// reserved xmlns URI, XTDE0860 for an undeclared prefix when no namespace
+// attribute is given). The lexical-QName (XTDE0850) and reserved-xmlns-name
+// (XTDE0855) checks are performed separately by validateComputedAttributeName.
+//
+// The resulting {localName, nsURI, prefix} is reused by every output path
+// (sequence-mode capture, item capture, and element output) so a name such as
+// name="p:a" namespace="urn:p" yields an attribute in urn:p in all modes.
+func (ec *execContext) resolveComputedAttributeName(ctx context.Context, name string, inst *attributeInst) (resolvedAttrName, error) {
+	prefix := ""
+	localName := name
+	if p, l, ok := strings.Cut(name, ":"); ok {
+		prefix = p
+		localName = l
+	}
+
+	// An explicit namespace= attribute overrides prefix resolution.
+	if inst.Namespace != nil {
+		nsURI, err := inst.Namespace.evaluate(ctx, ec.contextNode)
+		if err != nil {
+			return resolvedAttrName{}, err
+		}
+		// XTDE0865: the xmlns namespace URI is reserved.
+		if nsURI == lexicon.NamespaceXMLNS {
+			return resolvedAttrName{}, dynamicError(errCodeXTDE0865,
+				"namespace URI %q is reserved and cannot be used for attributes", nsURI)
+		}
+		if nsURI == "" {
+			// namespace="" explicitly: no-namespace attribute, prefix discarded.
+			return resolvedAttrName{localName: localName}, nil
+		}
+		// Attributes in a namespace require a non-empty prefix (unlike
+		// elements, the default namespace does not apply to attributes).
+		if prefix == "" {
+			prefix = "ns0"
+		}
+		return resolvedAttrName{localName: localName, nsURI: nsURI, prefix: prefix}, nil
+	}
+
+	// No explicit namespace= attribute: resolve the lexical prefix.
+	if prefix == "" {
+		return resolvedAttrName{localName: localName}, nil
+	}
+	nsURI := ec.resolvePrefix(prefix)
+	if nsURI == "" {
+		// XTDE0860: prefix in computed attribute name is undeclared.
+		return resolvedAttrName{}, dynamicError(errCodeXTDE0860,
+			"undeclared namespace prefix %q in attribute name %q", prefix, name)
+	}
+	return resolvedAttrName{localName: localName, nsURI: nsURI, prefix: prefix}, nil
+}
+
 func (ec *execContext) execAttribute(ctx context.Context, inst *attributeInst) error {
 	name, err := inst.Name.evaluate(ctx, ec.contextNode)
 	if err != nil {
@@ -642,10 +706,18 @@ func (ec *execContext) execAttribute(ctx context.Context, inst *attributeInst) e
 
 	// Validate the computed attribute name up front so that the lexical-QName
 	// (XTDE0850) and reserved-xmlns (XTDE0855) checks apply uniformly across the
-	// element-output, sequence-mode, and item-capture paths below. The
-	// undeclared-prefix (XTDE0860) check stays inline in each path because it
-	// only applies when no explicit namespace attribute is supplied.
+	// element-output, sequence-mode, and item-capture paths below.
 	if err := validateComputedAttributeName(name, inst); err != nil {
+		return err
+	}
+
+	// Resolve the full expanded name (local name + namespace URI + prefix) once,
+	// honoring an explicit namespace= attribute and enforcing the namespace
+	// constraints (XTDE0860 undeclared prefix, XTDE0865 reserved xmlns URI). Every
+	// output path below reuses this resolved name so that, e.g., name="p:a"
+	// namespace="urn:p" produces an attribute in urn:p in all modes.
+	resolved, err := ec.resolveComputedAttributeName(ctx, name, inst)
+	if err != nil {
 		return err
 	}
 
@@ -729,23 +801,12 @@ func (ec *execContext) execAttribute(ctx context.Context, inst *attributeInst) e
 	// standalone item rather than attaching it to an element.
 	out := ec.currentOutput()
 	if out.sequenceMode {
-		// Resolve namespace for prefixed attribute names.
+		localName := resolved.localName
+		nsURI := resolved.nsURI
 		var attrNS *helium.Namespace
-		localName := name
-		nsURI := ""
-		if idx := strings.IndexByte(name, ':'); idx >= 0 {
-			prefix := name[:idx]
-			localName = name[idx+1:]
-			nsURI = ec.resolvePrefix(prefix)
-			if nsURI == "" && inst.Namespace == nil {
-				// XTDE0860: prefix in computed attribute name is undeclared.
-				return dynamicError(errCodeXTDE0860,
-					"undeclared namespace prefix %q in attribute name %q", prefix, name)
-			}
-			if nsURI != "" {
-				ns, _ := out.doc.CreateNamespace(prefix, nsURI)
-				attrNS = ns
-			}
+		if nsURI != "" {
+			ns, _ := out.doc.CreateNamespace(resolved.prefix, nsURI)
+			attrNS = ns
 		}
 		// Schema validation when validation attribute is set.
 		if inst.Validation == validationStrict || inst.Validation == validationLax {
@@ -796,19 +857,11 @@ func (ec *execContext) execAttribute(ctx context.Context, inst *attributeInst) e
 			tmpDoc := helium.NewDefaultDocument()
 			tmpElem := tmpDoc.CreateElement("_tmp")
 			{
-				if idx := strings.IndexByte(name, ':'); idx >= 0 {
-					prefix := name[:idx]
-					local := name[idx+1:]
-					uri := ec.resolvePrefix(prefix)
-					if uri == "" && inst.Namespace == nil {
-						// XTDE0860: prefix in computed attribute name is undeclared.
-						return dynamicError(errCodeXTDE0860,
-							"undeclared namespace prefix %q in attribute name %q", prefix, name)
-					}
-					ns, _ := tmpDoc.CreateNamespace(prefix, uri)
-					_, _ = tmpElem.SetAttributeNS(local, value, ns)
+				if resolved.nsURI != "" {
+					ns, _ := tmpDoc.CreateNamespace(resolved.prefix, resolved.nsURI)
+					_, _ = tmpElem.SetAttributeNS(resolved.localName, value, ns)
 				} else {
-					_, _ = tmpElem.SetAttribute(name, value)
+					_, _ = tmpElem.SetAttribute(resolved.localName, value)
 				}
 				for _, attr := range tmpElem.Attributes() {
 					out.pendingItems = append(out.pendingItems, xpath3.NodeItem{Node: attr})
@@ -828,116 +881,53 @@ func (ec *execContext) execAttribute(ctx context.Context, inst *attributeInst) e
 		return dynamicError(errCodeXTRE0540, "cannot add attribute to element after children have been added")
 	}
 
-	if inst.Namespace != nil {
-		nsURI, err := inst.Namespace.evaluate(ctx, ec.contextNode)
-		if err != nil {
-			return err
-		}
-		// XTDE0865: the xmlns namespace URI is reserved
-		if nsURI == lexicon.NamespaceXMLNS {
-			return dynamicError(errCodeXTDE0865,
-				"namespace URI %q is reserved and cannot be used for attributes", nsURI)
-		}
-		if nsURI != "" {
-			prefix := ""
-			localName := name
-			if idx := strings.IndexByte(name, ':'); idx >= 0 {
-				prefix = name[:idx]
-				localName = name[idx+1:]
-			}
-			// Attributes in a namespace require a non-empty prefix (unlike
-			// elements, the default namespace does not apply to attributes).
-			if prefix == "" {
-				prefix = "ns0"
-			}
-			// Schema validation when validation attribute is set.
-			if inst.Validation == validationStrict || inst.Validation == validationLax {
-				if err := ec.validateConstructedAttribute(ctx, localName, nsURI, value, inst.Validation); err != nil {
-					return err
-				}
-			}
-			// If the prefix is already bound to a different URI on this element,
-			// generate a unique prefix to avoid conflicts.
-			prefix = uniqueNSPrefix(elem, prefix, nsURI)
-			// Ensure the namespace is declared on the element
-			if !hasNSDecl(elem, prefix, nsURI) {
-				if err := elem.DeclareNamespace(prefix, nsURI); err != nil {
-					return err
-				}
-			}
-			// Remove existing attribute with same expanded name to allow replacement
-			elem.RemoveAttributeNS(localName, nsURI)
-			ns, err := ec.resultDoc.CreateNamespace(prefix, nsURI)
-			if err != nil {
-				return err
-			}
-			// Use literal mode: XSLT evaluation values are plain text
-			// that may contain & from resolved entities.
-			_ = elem.SetLiteralAttributeNS(localName, value, ns)
-			ec.annotateAttr(elem, inst.TypeName, localName, nsURI, value)
-			out.noteOutput()
-			return nil
-		}
-		// namespace="" explicitly: strip prefix, use no-namespace attribute
-		if idx := strings.IndexByte(name, ':'); idx >= 0 {
-			name = name[idx+1:]
-		}
-		// Schema validation for no-namespace attribute.
+	// Attribute belongs to a namespace: declare the namespace on the element
+	// (applying prefix fixup) and attach the namespaced attribute.
+	if resolved.nsURI != "" {
+		localName := resolved.localName
+		nsURI := resolved.nsURI
+		// Schema validation when validation attribute is set.
 		if inst.Validation == validationStrict || inst.Validation == validationLax {
-			if err := ec.validateConstructedAttribute(ctx, name, "", value, inst.Validation); err != nil {
+			if err := ec.validateConstructedAttribute(ctx, localName, nsURI, value, inst.Validation); err != nil {
 				return err
 			}
 		}
-		elem.RemoveAttribute(name)
-		_ = elem.SetLiteralAttribute(name, value)
-		ec.annotateAttr(elem, inst.TypeName, name, "", value)
-		out.noteOutput()
-		return nil
-	}
-
-	// Handle prefixed attribute names without explicit namespace
-	if prefix, localName, ok := strings.Cut(name, ":"); ok {
-		uri := ec.resolvePrefix(prefix)
-		if uri == "" {
-			// XTDE0860: prefix in computed attribute name is undeclared
-			return dynamicError(errCodeXTDE0860,
-				"undeclared namespace prefix %q in attribute name %q", prefix, name)
-		}
-		// Schema validation for prefixed attribute.
-		if inst.Validation == validationStrict || inst.Validation == validationLax {
-			if err := ec.validateConstructedAttribute(ctx, localName, uri, value, inst.Validation); err != nil {
-				return err
-			}
-		}
+		// If the prefix is already bound to a different URI on this element,
+		// generate a unique prefix to avoid conflicts.
+		prefix := uniqueNSPrefix(elem, resolved.prefix, nsURI)
 		// Ensure the namespace is declared on the element
-		if !hasNSDecl(elem, prefix, uri) {
-			if err := elem.DeclareNamespace(prefix, uri); err != nil {
+		if !hasNSDecl(elem, prefix, nsURI) {
+			if err := elem.DeclareNamespace(prefix, nsURI); err != nil {
 				return err
 			}
 		}
 		// Remove existing attribute with same expanded name to allow replacement
-		elem.RemoveAttributeNS(localName, uri)
-		ns, err := ec.resultDoc.CreateNamespace(prefix, uri)
+		elem.RemoveAttributeNS(localName, nsURI)
+		ns, err := ec.resultDoc.CreateNamespace(prefix, nsURI)
 		if err != nil {
 			return err
 		}
+		// Use literal mode: XSLT evaluation values are plain text
+		// that may contain & from resolved entities.
 		_ = elem.SetLiteralAttributeNS(localName, value, ns)
-		ec.annotateAttr(elem, inst.TypeName, localName, uri, value)
+		ec.annotateAttr(elem, inst.TypeName, localName, nsURI, value)
 		out.noteOutput()
 		return nil
 	}
 
-	// Schema validation for simple unprefixed attribute.
+	// No-namespace attribute (no namespace= and either no prefix, or an
+	// explicit namespace="" that discarded the prefix).
+	localName := resolved.localName
+	// Schema validation for no-namespace attribute.
 	if inst.Validation == validationStrict || inst.Validation == validationLax {
-		if err := ec.validateConstructedAttribute(ctx, name, "", value, inst.Validation); err != nil {
+		if err := ec.validateConstructedAttribute(ctx, localName, "", value, inst.Validation); err != nil {
 			return err
 		}
 	}
-
 	// Remove existing attribute with same name to allow replacement
-	elem.RemoveAttribute(name)
-	_ = elem.SetLiteralAttribute(name, value)
-	ec.annotateAttr(elem, inst.TypeName, name, "", value)
+	elem.RemoveAttribute(localName)
+	_ = elem.SetLiteralAttribute(localName, value)
+	ec.annotateAttr(elem, inst.TypeName, localName, "", value)
 	out.noteOutput()
 	return nil
 }


### PR DESCRIPTION
- xsl:attribute sequence-mode and item-capture branches now resolve and validate the computed QName prefix, raising XTDE0860 for an undeclared prefix instead of silently dropping the namespace
- reuses the same undeclared-prefix check as the element-output path