### PR TITLE
validate xsi:nil as xs:boolean lexical

### DIFF
--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -222,7 +222,11 @@ func (vc *validationContext) validateRootElement(ctx context.Context, elem *heli
 	// Annotate root element with its type.
 	vc.annotateElement(ctx, elem, td)
 
-	if hasXsiNil(elem) {
+	nilled, err := vc.checkXsiNil(ctx, elem)
+	if err != nil {
+		return err
+	}
+	if nilled {
 		return vc.validateNilledElement(ctx, elem, edecl, td)
 	}
 
@@ -578,14 +582,29 @@ func isBlank(b []byte) bool {
 	return true
 }
 
-// hasXsiNil returns true if the element has xsi:nil="true".
-func hasXsiNil(elem *helium.Element) bool {
+// checkXsiNil parses the element's xsi:nil attribute as an xs:boolean (after
+// whitespace collapse). It returns whether the element is nilled ("true"/"1").
+// "false"/"0" and an absent attribute mean not-nilled. Any other lexical form
+// is an invalid xs:boolean value: a validity error is reported and a non-nil
+// error is returned so the element is not silently validated as ordinary
+// content.
+func (vc *validationContext) checkXsiNil(ctx context.Context, elem *helium.Element) (bool, error) {
 	for _, a := range elem.Attributes() {
-		if a.URI() == lexicon.NamespaceXSI && a.LocalName() == attrNil {
-			return a.Value() == "true" || a.Value() == "1"
+		if a.URI() != lexicon.NamespaceXSI || a.LocalName() != attrNil {
+			continue
 		}
+		v := normalizeWhiteSpace(a.Value(), "collapse")
+		switch v {
+		case "true", "1":
+			return true, nil
+		case "false", "0":
+			return false, nil
+		}
+		msg := fmt.Sprintf("'%s' is not a valid value of the atomic type 'xs:boolean'.", v)
+		vc.reportValidityErrorAttr(ctx, vc.filename, elem.Line(), elemDisplayName(elem), attrDisplayName(a), msg)
+		return false, fmt.Errorf("invalid xsi:nil value %q", a.Value())
 	}
-	return false
+	return false, nil
 }
 
 // validateNilledElement handles an element with xsi:nil="true".

--- a/xsd/validate_elem.go
+++ b/xsd/validate_elem.go
@@ -247,7 +247,10 @@ func (vc *validationContext) matchAll(ctx context.Context, parent *helium.Elemen
 		}
 		vc.annotateElement(ctx, child.elem, td)
 		if td != nil {
-			if hasXsiNil(child.elem) {
+			nilled, nilErr := vc.checkXsiNil(ctx, child.elem)
+			if nilErr != nil {
+				contentErr = nilErr
+			} else if nilled {
 				if err := vc.validateNilledElement(ctx, child.elem, actualDecl, td); err != nil {
 					contentErr = err
 				}
@@ -375,7 +378,10 @@ func (vc *validationContext) matchElementParticle(ctx context.Context, parent *h
 		// Annotate child element with its type.
 		vc.annotateElement(ctx, child.elem, td)
 		if td != nil {
-			if hasXsiNil(child.elem) {
+			nilled, nilErr := vc.checkXsiNil(ctx, child.elem)
+			if nilErr != nil {
+				contentErr = nilErr
+			} else if nilled {
 				if err := vc.validateNilledElement(ctx, child.elem, actualDecl, td); err != nil {
 					contentErr = err
 				}
@@ -623,7 +629,10 @@ func (vc *validationContext) matchWildcardParticle(ctx context.Context, parent *
 			// Annotate wildcard-matched element with its type.
 			vc.annotateElement(ctx, child.elem, td)
 			if td != nil {
-				if hasXsiNil(child.elem) {
+				nilled, nilErr := vc.checkXsiNil(ctx, child.elem)
+				if nilErr != nil {
+					contentErr = nilErr
+				} else if nilled {
 					if err := vc.validateNilledElement(ctx, child.elem, edecl, td); err != nil {
 						contentErr = err
 					}

--- a/xsd/validate_xsi_nil_lexical_test.go
+++ b/xsd/validate_xsi_nil_lexical_test.go
@@ -1,0 +1,73 @@
+package xsd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestXsiNilLexical checks that the value of xsi:nil is parsed as an xs:boolean
+// (after whitespace collapse). Only "true"/"1" mean nilled; "false"/"0" mean
+// not-nilled; any other lexical (e.g. "maybe") is a lexical error rather than
+// being silently treated as if the attribute were absent.
+func TestXsiNilLexical(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" type="xs:string" nillable="true"/>
+</xs:schema>`
+
+	const xsiDecl = `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"`
+
+	t.Run("nil=true is nilled (no content allowed)", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+` xsi:nil="true"/>`, nil))
+		// Content is rejected because the element is nilled.
+		var out string
+		err := compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+` xsi:nil="true">x</root>`, &out)
+		require.Error(t, err)
+		require.Contains(t, out, "nilled")
+	})
+
+	t.Run("nil=1 is nilled (no content allowed)", func(t *testing.T) {
+		t.Parallel()
+		var out string
+		err := compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+` xsi:nil="1">x</root>`, &out)
+		require.Error(t, err)
+		require.Contains(t, out, "nilled")
+	})
+
+	t.Run("nil=false is not nilled (content allowed)", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+` xsi:nil="false">x</root>`, nil))
+	})
+
+	t.Run("nil=0 is not nilled (content allowed)", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+` xsi:nil="0">x</root>`, nil))
+	})
+
+	t.Run("nil=true with surrounding whitespace is collapsed", func(t *testing.T) {
+		t.Parallel()
+		var out string
+		err := compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+` xsi:nil="  true  ">x</root>`, &out)
+		require.Error(t, err)
+		require.Contains(t, out, "nilled")
+	})
+
+	t.Run("nil=maybe is a lexical error", func(t *testing.T) {
+		t.Parallel()
+		var out string
+		err := compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+` xsi:nil="maybe">x</root>`, &out)
+		require.Error(t, err)
+		require.NotContains(t, out, "nilled")
+		require.Contains(t, out, "not a valid value")
+	})
+}


### PR DESCRIPTION
- Parse xsi:nil as xs:boolean with whitespace collapse; only true/1 nil the element, false/0 don't
- Report a lexical validity error for any other value (e.g. xsi:nil="maybe") instead of silently validating as ordinary content