### PR TITLE
use uri-aware resolution for xslt resources

### DIFF
--- a/xslt3/compile.go
+++ b/xslt3/compile.go
@@ -1085,14 +1085,7 @@ func compile(ctx context.Context, doc *helium.Document, cfg *compileConfig) (*St
 	// the effective base URI becomes /a/b/innerdoc/style.xsl, so that
 	// filepath.Dir() returns /a/b/innerdoc for relative URI resolution.
 	if xmlBase := getAttr(root, lexicon.QNameXMLBase); xmlBase != "" {
-		if strings.Contains(xmlBase, "://") {
-			// Absolute URI (http://, file://, etc.) — use as-is.
-			c.baseURI = xmlBase
-		} else if c.baseURI != "" {
-			baseDir := filepath.Dir(c.baseURI)
-			baseName := filepath.Base(c.baseURI)
-			c.baseURI = filepath.Join(baseDir, xmlBase, baseName)
-		}
+		c.baseURI = resolveRootXMLBase(c.baseURI, xmlBase)
 	}
 
 	// Collect namespace declarations from root
@@ -1404,6 +1397,46 @@ func compile(ctx context.Context, doc *helium.Document, cfg *compileConfig) (*St
 	sortAccumulatorOrder(c.stylesheet)
 
 	return c.stylesheet, nil
+}
+
+// resolveRootXMLBase resolves a root-element xml:base value against the current
+// module base URI to produce the new effective base URI.
+//
+// Absoluteness is decided with [xsd.URIScheme] (RFC 3986), not a "://"
+// substring check: an absolute-URI xml:base may carry a scheme with no "//"
+// authority (e.g. xml:base="urn:base") and must be used as-is, while a
+// relative/root-relative xml:base under a URI base must be resolved per RFC
+// 3986 so the base scheme/authority survives. Only when both the current base
+// and xml:base are local filesystem paths is filepath used.
+//
+// To mirror the local-path branch — which re-appends the stylesheet filename so
+// filepath.Dir() recovers the directory downstream — the URI branch resolves
+// xml:base as a directory and re-resolves the original filename against it:
+// xml:base="innerdoc/" under "mem:/a/b/style.xsl" yields
+// "mem:/a/b/innerdoc/style.xsl".
+func resolveRootXMLBase(baseURI, xmlBase string) string {
+	switch {
+	case xsd.URIScheme(xmlBase) != "":
+		// Absolute URI — use as-is.
+		return xmlBase
+	case baseURI != "" && xsd.URIScheme(baseURI) != "":
+		baseName := filepath.Base(baseURI)
+		dirURI, err := xsd.ResolveSchemaURI(xmlBase, baseURI)
+		if err != nil {
+			return baseURI
+		}
+		resolved, err := xsd.ResolveSchemaURI(baseName, dirURI)
+		if err != nil {
+			return baseURI
+		}
+		return resolved
+	case baseURI != "":
+		baseDir := filepath.Dir(baseURI)
+		baseName := filepath.Base(baseURI)
+		return filepath.Join(baseDir, xmlBase, baseName)
+	default:
+		return baseURI
+	}
 }
 
 // checkAbstractComponents checks that no abstract components remain

--- a/xslt3/compile_formats.go
+++ b/xslt3/compile_formats.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/lestrrat-go/helium/xsd"
 )
 
 func (c *compiler) compileCharacterMap(ctx context.Context, elem *helium.Element) error {
@@ -502,10 +503,23 @@ func (c *compiler) loadParameterDocument(ctx context.Context, outDef *OutputDef,
 // called at both compile-time and runtime; the loadBytes callback performs the
 // actual retrieval so each caller supplies its own (opt-in) loader.
 func loadParameterDocumentFromFile(ctx context.Context, outDef *OutputDef, baseURI, href string, loadBytes func(context.Context, string) ([]byte, error)) error {
+	// Decide absoluteness with xsd.URIScheme (RFC 3986), not filepath.IsAbs or a
+	// "://" substring check: an absolute-URI href may carry a scheme with no
+	// "//" authority (e.g. "urn:params", "file:/p/p.xml") and must pass through
+	// unchanged, while a relative href against a URI base must keep the base
+	// scheme/authority. Only when both base and ref are local filesystem paths
+	// is filepath.Join used.
 	uri := href
-	if baseURI != "" && !strings.Contains(href, "://") && !filepath.IsAbs(href) {
-		baseDir := filepath.Dir(baseURI)
-		uri = filepath.Join(baseDir, href)
+	if baseURI != "" {
+		switch {
+		case xsd.URIScheme(href) != "" || xsd.URIScheme(baseURI) != "":
+			resolved, rErr := xsd.ResolveSchemaURI(href, baseURI)
+			if rErr == nil {
+				uri = resolved
+			}
+		case !filepath.IsAbs(href):
+			uri = filepath.Join(filepath.Dir(baseURI), href)
+		}
 	}
 
 	data, err := loadBytes(ctx, uri)

--- a/xslt3/document_uri_base_integration_test.go
+++ b/xslt3/document_uri_base_integration_test.go
@@ -1,0 +1,84 @@
+package xslt3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xslt3"
+	"github.com/stretchr/testify/require"
+)
+
+// docURIBaseStylesheet calls doc()/document() with a relative href so the
+// runtime must resolve it against the stylesheet's base URI.
+const docURIBaseStylesheet = `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <out>
+      <a><xsl:value-of select="doc('doc.xml')/data/@v"/></a>
+      <b><xsl:value-of select="document('doc.xml')/data/@v"/></b>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`
+
+// TestDocumentResolutionPreservesURIBase is an end-to-end regression for the
+// base-URI corruption fixed in this change. When the stylesheet is compiled
+// with Compiler.BaseURI("mem://pkg/main.xsl"), doc('doc.xml') and
+// document('doc.xml') must reach the runtime URIResolver with the URI
+// "mem://pkg/doc.xml" — i.e. the sibling reference resolved against the FULL
+// URI base preserving scheme+authority.
+//
+// Before the fix, ec.baseDir() ran filepath.Dir over the URI base first,
+// collapsing "mem://pkg/main.xsl" to "mem:/pkg", so the resolver was instead
+// asked for "mem:/pkg/doc.xml" (host dropped). This test fails on that path.
+func TestDocumentResolutionPreservesURIBase(t *testing.T) {
+	const wantURI = "mem://pkg/doc.xml"
+
+	resolver := &recordingURIResolver{files: map[string][]byte{
+		wantURI: []byte(`<data v="hello"/>`),
+	}}
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(docURIBaseStylesheet))
+	require.NoError(t, err)
+
+	ss, err := xslt3.NewCompiler().BaseURI("mem://pkg/main.xsl").Compile(t.Context(), doc)
+	require.NoError(t, err)
+
+	source := parseTransformSource(t)
+	result, err := ss.Transform(source).URIResolver(resolver).Serialize(t.Context())
+	require.NoError(t, err)
+
+	require.True(t, resolver.seen(wantURI),
+		"runtime resolver must receive %q; got %v", wantURI, resolver.requests)
+	// Confirm the host was not dropped (the pre-fix bug produced mem:/pkg/...).
+	require.False(t, resolver.seen("mem:/pkg/doc.xml"),
+		"resolver must not receive the host-collapsed URI; got %v", resolver.requests)
+
+	require.Contains(t, result, "<a>hello</a>")
+	require.Contains(t, result, "<b>hello</b>")
+}
+
+// TestDocumentResolutionLocalBaseUnchanged guards against a regression in
+// local-filesystem document resolution: a relative doc()/document() href under
+// a plain local base must still resolve against the containing directory via
+// filepath, NOT be treated as a URI.
+func TestDocumentResolutionLocalBaseUnchanged(t *testing.T) {
+	const wantURI = "/styles/doc.xml"
+
+	resolver := &recordingURIResolver{files: map[string][]byte{
+		wantURI: []byte(`<data v="local"/>`),
+	}}
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(docURIBaseStylesheet))
+	require.NoError(t, err)
+
+	ss, err := xslt3.NewCompiler().BaseURI("/styles/main.xsl").Compile(t.Context(), doc)
+	require.NoError(t, err)
+
+	source := parseTransformSource(t)
+	result, err := ss.Transform(source).URIResolver(resolver).Serialize(t.Context())
+	require.NoError(t, err)
+
+	require.True(t, resolver.seen(wantURI),
+		"runtime resolver must receive %q; got %v", wantURI, resolver.requests)
+	require.Contains(t, result, "<a>local</a>")
+}

--- a/xslt3/execute.go
+++ b/xslt3/execute.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"maps"
-	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
@@ -131,9 +130,9 @@ type execContext struct {
 func (ec *execContext) setCurrentTemplate(tmpl *template) {
 	ec.currentTemplate = tmpl
 	if tmpl != nil && tmpl.BaseURI != "" {
-		ec.currentTemplateBaseDir = filepath.Dir(tmpl.BaseURI)
+		ec.currentTemplateBaseDir = documentBaseDir(tmpl.BaseURI)
 	} else if ec.stylesheet.baseURI != "" {
-		ec.currentTemplateBaseDir = filepath.Dir(ec.stylesheet.baseURI)
+		ec.currentTemplateBaseDir = documentBaseDir(ec.stylesheet.baseURI)
 	} else {
 		ec.currentTemplateBaseDir = ""
 	}

--- a/xslt3/functions.go
+++ b/xslt3/functions.go
@@ -188,7 +188,7 @@ func (ec *execContext) fnDocument(ctx context.Context, args []xpath3.Sequence) (
 		if ni, ok := args[1].Get(0).(xpath3.NodeItem); ok {
 			nodeBase := documentBaseURI(ni.Node)
 			if nodeBase != "" {
-				baseDir = filepath.Dir(nodeBase)
+				baseDir = documentBaseDir(nodeBase)
 			} else if !nodeHasDocumentRoot(ni.Node) {
 				// XTDE1162: second argument is an orphan node (no
 				// document root) with no base URI.
@@ -208,7 +208,7 @@ func (ec *execContext) fnDocument(ctx context.Context, args []xpath3.Sequence) (
 		if len(args) < 2 {
 			if ni, ok := item.(xpath3.NodeItem); ok {
 				if nodeBase := documentBaseURI(ni.Node); nodeBase != "" {
-					itemBaseDir = filepath.Dir(nodeBase)
+					itemBaseDir = documentBaseDir(nodeBase)
 				} else if !nodeHasDocumentRoot(ni.Node) {
 					// XTDE1162: first argument node has no base URI
 					// and no document root (parentless text node).
@@ -316,7 +316,7 @@ func (ec *execContext) loadDocument(ctx context.Context, uri string, baseDir str
 		// xml:base overrides the base URI — resolve the empty string
 		// against the effective base URI to load the target document.
 		uri = effectiveBase
-		baseDir = filepath.Dir(effectiveBase)
+		baseDir = documentBaseDir(effectiveBase)
 	}
 
 	// Strip fragment identifier before loading.
@@ -586,6 +586,30 @@ func splitURIFragment(uri string) (string, string) {
 		return uri, ""
 	}
 	return base, fragment
+}
+
+// documentBaseDir derives the base passed to resolveDocumentURI /
+// resolveAgainstBaseURI for a runtime document base such as a stylesheet or
+// node base URI.
+//
+// For a URI base (it has a scheme per [xsd.URIScheme]) the FULL base URI is
+// returned unchanged: the URI-aware resolvers delegate to [xsd.ResolveSchemaURI],
+// which performs RFC 3986 resolution and replaces the base's last path segment
+// itself. Applying filepath.Dir here would instead collapse the "//" authority
+// separator (e.g. "mem://pkg/main.xsl" -> "mem:/pkg"), dropping the host so a
+// sibling "doc.xml" wrongly resolves to "mem:/pkg/doc.xml" instead of
+// "mem://pkg/doc.xml".
+//
+// For a genuine local filesystem base, filepath.Dir is used as before so a
+// sibling reference resolves against the containing directory.
+func documentBaseDir(base string) string {
+	if base == "" {
+		return ""
+	}
+	if xsd.URIScheme(base) != "" {
+		return base
+	}
+	return filepath.Dir(base)
 }
 
 // baseURIDir extracts the directory from a base URI. If the base URI looks

--- a/xslt3/functions.go
+++ b/xslt3/functions.go
@@ -617,7 +617,22 @@ func (ec *execContext) resolveDocumentURI(uri string, baseDir string) string {
 	if strings.HasPrefix(cleanURI, "file:///") {
 		return cleanURI[len("file://"):]
 	}
-	if strings.Contains(cleanURI, "://") || filepath.IsAbs(cleanURI) {
+	// Decide absoluteness with xsd.URIScheme (RFC 3986), not a "://" substring
+	// check or filepath.IsAbs: an absolute-URI ref may carry a scheme with no
+	// "//" authority (e.g. document('urn:doc'), doc('file:/x.xml')) and must be
+	// returned unchanged, while a relative ref against a URI base must keep the
+	// base scheme/authority (resolved per RFC 3986) instead of being joined as a
+	// local path. Only when both base and ref are local filesystem paths is
+	// filepath.Join used. Resolution of the URI cases is delegated to the shared
+	// canonical xsd.ResolveSchemaURI helper.
+	if xsd.URIScheme(cleanURI) != "" || (baseDir != "" && xsd.URIScheme(baseDir) != "") {
+		resolved, err := xsd.ResolveSchemaURI(cleanURI, baseDir)
+		if err != nil {
+			return cleanURI
+		}
+		return resolved
+	}
+	if filepath.IsAbs(cleanURI) {
 		return cleanURI
 	}
 	if baseDir != "" {

--- a/xslt3/functions.go
+++ b/xslt3/functions.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/sequence"
 	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/lestrrat-go/helium/xsd"
 )
 
 // xsltFunctions returns the XSLT-specific functions that need to be
@@ -549,11 +550,30 @@ func fetchHTTPBytes(ctx context.Context, client *http.Client, uri string) ([]byt
 // path from xml:base processing (e.g., /a/b). For file paths (containing a
 // dot-extension in the last segment), the directory part is extracted via
 // filepath.Dir. For directory-like paths, the path is used directly.
+//
+// Absoluteness is decided with [xsd.URIScheme] (RFC 3986), not filepath.IsAbs
+// or a "://" substring check: an absolute-URI reference may carry a scheme with
+// no "//" authority (e.g. "urn:shared", "file:/docs/d.xml") and must be returned
+// unchanged, while a relative reference against a URI base must keep the base
+// scheme/authority. Only when both base and ref are local filesystem paths is
+// filepath.Join used. Resolution of the URI cases is delegated to the shared
+// canonical [xsd.ResolveSchemaURI] helper.
 func resolveAgainstBaseURI(uri string, baseURI string) string {
 	if uri == "" || baseURI == "" {
 		return uri
 	}
-	if strings.Contains(uri, "://") || filepath.IsAbs(uri) {
+	// Absolute-URI ref, or any ref against a URI base: defer to the shared
+	// canonical resolver (RFC 3986 + OmitHost preservation). On error, fall
+	// back to the raw ref rather than producing a host-dropping filepath join.
+	if xsd.URIScheme(uri) != "" || xsd.URIScheme(baseURI) != "" {
+		resolved, err := xsd.ResolveSchemaURI(uri, baseURI)
+		if err != nil {
+			return uri
+		}
+		return resolved
+	}
+	// Both base and ref are local filesystem paths.
+	if filepath.IsAbs(uri) {
 		return uri
 	}
 	baseDir := baseURIDir(baseURI)

--- a/xslt3/functions_transform.go
+++ b/xslt3/functions_transform.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/sequence"
 	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/lestrrat-go/helium/xsd"
 )
 
 // paramKeyToClark converts an XPath map key to the Clark notation string
@@ -282,20 +282,25 @@ func (c resultDocCollector) HandleResultDocument(href string, doc *helium.Docume
 	return nil
 }
 
-// resolveRelativeURI resolves a relative reference against a base URI.
-// For URIs with a scheme (e.g. mem://pkg/main.xsl), it uses net/url
-// resolution to preserve the scheme and authority. For plain file
-// paths it falls back to filepath.Join.
+// resolveRelativeURI resolves a reference against a base URI.
+//
+// Absoluteness is decided with [xsd.URIScheme] (RFC 3986): an absolute-URI ref
+// (it carries its own scheme, e.g. "urn:shared", "file:/modules/m.xsl") is
+// returned unchanged and must never be filepath.Join'ed onto a local base
+// (which would corrupt it into "/styles/urn:shared"). A relative ref against a
+// URI base is resolved with RFC 3986 semantics (scheme/authority preserved);
+// against a local filesystem base it keeps historical filepath.Join handling.
+// Resolution of the URI cases is delegated to the shared canonical
+// [xsd.ResolveSchemaURI] helper.
 func resolveRelativeURI(base, ref string) string {
-	baseURL, err := url.Parse(base)
-	if err != nil || baseURL.Scheme == "" {
-		return filepath.Join(filepath.Dir(base), ref)
+	if xsd.URIScheme(ref) != "" || xsd.URIScheme(base) != "" {
+		resolved, err := xsd.ResolveSchemaURI(ref, base)
+		if err != nil {
+			return ref
+		}
+		return resolved
 	}
-	refURL, err := url.Parse(ref)
-	if err != nil {
-		return filepath.Join(filepath.Dir(base), ref)
-	}
-	return baseURL.ResolveReference(refURL).String()
+	return filepath.Join(filepath.Dir(base), ref)
 }
 
 // newNestedCompiler creates a Compiler pre-configured with the same

--- a/xslt3/functions_transform.go
+++ b/xslt3/functions_transform.go
@@ -303,6 +303,25 @@ func resolveRelativeURI(base, ref string) string {
 	return filepath.Join(filepath.Dir(base), ref)
 }
 
+// resolveStylesheetLocation resolves an fn:transform stylesheet-location loc
+// against the current stylesheet base URI.
+//
+// Absoluteness is decided with [xsd.URIScheme] (RFC 3986), not filepath.IsAbs:
+// when base is a URI (it has a scheme), a filepath-absolute or root-relative
+// loc such as "/inner.xsl" must be resolved against the base scheme/authority
+// (mem://pkg/main.xsl + /inner.xsl -> mem://pkg/inner.xsl) rather than passed
+// through verbatim. Only a purely-local absolute path against a local base is
+// left unchanged.
+func resolveStylesheetLocation(base, loc string) string {
+	if base == "" {
+		return loc
+	}
+	if xsd.URIScheme(base) != "" || !filepath.IsAbs(loc) {
+		return resolveRelativeURI(base, loc)
+	}
+	return loc
+}
+
 // newNestedCompiler creates a Compiler pre-configured with the same
 // resolver, package resolver, and import schemas that were used to
 // compile this stylesheet, so that fn:transform nested compiles
@@ -439,11 +458,8 @@ func (ec *execContext) fnTransform(ctx context.Context, args []xpath3.Sequence) 
 	// Compile the stylesheet
 	var ss *Stylesheet
 	if stylesheetLoc != "" {
-		// Resolve relative to the current stylesheet base URI
-		loc := stylesheetLoc
-		if ec.stylesheet.baseURI != "" && !filepath.IsAbs(loc) {
-			loc = resolveRelativeURI(ec.stylesheet.baseURI, loc)
-		}
+		// Resolve relative to the current stylesheet base URI.
+		loc := resolveStylesheetLocation(ec.stylesheet.baseURI, stylesheetLoc)
 		var data []byte
 		baseURI := loc
 		if ec.stylesheet.uriResolver == nil {

--- a/xslt3/resolve_uri_internal_test.go
+++ b/xslt3/resolve_uri_internal_test.go
@@ -1,0 +1,71 @@
+package xslt3
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveAgainstBaseURIAbsolute verifies that resolveAgainstBaseURI
+// (used by document() / xsl:source-document resolution) treats an absolute
+// URI reference that has a scheme but no "://" authority (e.g. "urn:shared",
+// "file:/docs/d.xml") as absolute and returns it UNCHANGED, instead of
+// filepath.Join'ing it onto the base directory.
+func TestResolveAgainstBaseURIAbsolute(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		uri  string
+		base string
+		want string
+	}{
+		{"urn opaque", "urn:shared", "/docs/main.xml", "urn:shared"},
+		{"file single slash", "file:/docs/d.xml", "/docs/main.xml", "file:/docs/d.xml"},
+		{"http authority", "http://example.com/d.xml", "/docs/main.xml", "http://example.com/d.xml"},
+		{"relative against local base", "child.xml", "/docs/main.xml", "/docs/child.xml"},
+		// Root-relative ref against a URI base keeps scheme+authority.
+		{"root-relative against uri base", "/other/d.xml", "mem:/docs/main.xml", "mem:/other/d.xml"},
+		{"relative against uri base", "child.xml", "mem:/docs/main.xml", "mem:/docs/child.xml"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveAgainstBaseURI(tc.uri, tc.base)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestLoadParameterDocumentURIAbsolute verifies that the serialization
+// parameter-document loader hands an absolute-URI href (scheme, no "://")
+// to its loader unchanged rather than filepath.Join'ing it onto the base.
+func TestLoadParameterDocumentURIAbsolute(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		base string
+		href string
+		want string
+	}{
+		{"urn opaque", "/styles/main.xsl", "urn:params", "urn:params"},
+		{"file single slash", "/styles/main.xsl", "file:/params/p.xml", "file:/params/p.xml"},
+		{"http authority", "/styles/main.xsl", "http://example.com/p.xml", "http://example.com/p.xml"},
+		{"relative against local base", "/styles/main.xsl", "p.xml", "/styles/p.xml"},
+		{"root-relative against uri base", "mem:/styles/main.xsl", "/p/p.xml", "mem:/p/p.xml"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var seen string
+			loadBytes := func(_ context.Context, uri string) ([]byte, error) {
+				seen = uri
+				// Return a non-nil error to short-circuit parsing; we only
+				// care which URI the loader was asked for.
+				return nil, errStopAfterResolve
+			}
+			_ = loadParameterDocumentFromFile(context.Background(), &OutputDef{}, tc.base, tc.href, loadBytes)
+			require.Equal(t, tc.want, seen)
+		})
+	}
+}
+
+var errStopAfterResolve = stopAfterResolveError{}
+
+type stopAfterResolveError struct{}
+
+func (stopAfterResolveError) Error() string { return "stop after resolve" }

--- a/xslt3/resolve_uri_internal_test.go
+++ b/xslt3/resolve_uri_internal_test.go
@@ -7,6 +7,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testStylesMainXSL = "/styles/main.xsl"
+	testDocsDir       = "/docs"
+	testDocsMainXML   = "/docs/main.xml"
+)
+
 // TestResolveAgainstBaseURIAbsolute verifies that resolveAgainstBaseURI
 // (used by document() / xsl:source-document resolution) treats an absolute
 // URI reference that has a scheme but no "://" authority (e.g. "urn:shared",
@@ -19,10 +25,10 @@ func TestResolveAgainstBaseURIAbsolute(t *testing.T) {
 		base string
 		want string
 	}{
-		{"urn opaque", "urn:shared", "/docs/main.xml", "urn:shared"},
-		{"file single slash", "file:/docs/d.xml", "/docs/main.xml", "file:/docs/d.xml"},
-		{"http authority", "http://example.com/d.xml", "/docs/main.xml", "http://example.com/d.xml"},
-		{"relative against local base", "child.xml", "/docs/main.xml", "/docs/child.xml"},
+		{"urn opaque", "urn:shared", testDocsMainXML, "urn:shared"},
+		{"file single slash", "file:/docs/d.xml", testDocsMainXML, "file:/docs/d.xml"},
+		{"http authority", "http://example.com/d.xml", testDocsMainXML, "http://example.com/d.xml"},
+		{"relative against local base", "child.xml", testDocsMainXML, "/docs/child.xml"},
 		// Root-relative ref against a URI base keeps scheme+authority.
 		{"root-relative against uri base", "/other/d.xml", "mem:/docs/main.xml", "mem:/other/d.xml"},
 		{"relative against uri base", "child.xml", "mem:/docs/main.xml", "mem:/docs/child.xml"},
@@ -44,10 +50,10 @@ func TestLoadParameterDocumentURIAbsolute(t *testing.T) {
 		href string
 		want string
 	}{
-		{"urn opaque", "/styles/main.xsl", "urn:params", "urn:params"},
-		{"file single slash", "/styles/main.xsl", "file:/params/p.xml", "file:/params/p.xml"},
-		{"http authority", "/styles/main.xsl", "http://example.com/p.xml", "http://example.com/p.xml"},
-		{"relative against local base", "/styles/main.xsl", "p.xml", "/styles/p.xml"},
+		{"urn opaque", testStylesMainXSL, "urn:params", "urn:params"},
+		{"file single slash", testStylesMainXSL, "file:/params/p.xml", "file:/params/p.xml"},
+		{"http authority", testStylesMainXSL, "http://example.com/p.xml", "http://example.com/p.xml"},
+		{"relative against local base", testStylesMainXSL, "p.xml", "/styles/p.xml"},
 		{"root-relative against uri base", "mem:/styles/main.xsl", "/p/p.xml", "mem:/p/p.xml"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -60,6 +66,94 @@ func TestLoadParameterDocumentURIAbsolute(t *testing.T) {
 			}
 			_ = loadParameterDocumentFromFile(context.Background(), &OutputDef{}, tc.base, tc.href, loadBytes)
 			require.Equal(t, tc.want, seen)
+		})
+	}
+}
+
+// TestResolveTransformStylesheetLocURIBase verifies that fn:transform
+// stylesheet-location resolution (functions_transform.go) is URI-aware for the
+// base: when the stylesheet base URI has a scheme, a filepath-absolute /
+// root-relative stylesheet-location such as "/inner.xsl" is resolved against
+// the base scheme/authority (mem://pkg/main.xsl + /inner.xsl ->
+// mem://pkg/inner.xsl) instead of being passed through verbatim, while a
+// purely-local absolute path against a local base is left unchanged.
+func TestResolveTransformStylesheetLocURIBase(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		base string
+		loc  string
+		want string
+	}{
+		// Regression: root-relative loc under a URI base must keep scheme+authority.
+		{"root-relative under uri base", "mem://pkg/main.xsl", "/inner.xsl", "mem://pkg/inner.xsl"},
+		{"root-relative under uri base no authority", "mem:/pkg/main.xsl", "/inner.xsl", "mem:/inner.xsl"},
+		{"relative under uri base", "mem://pkg/main.xsl", "inner.xsl", "mem://pkg/inner.xsl"},
+		{"absolute uri loc", "mem://pkg/main.xsl", "urn:other", "urn:other"},
+		// Purely-local absolute path under a local base is left unchanged.
+		{"local absolute under local base", testStylesMainXSL, "/inner.xsl", "/inner.xsl"},
+		{"local relative under local base", testStylesMainXSL, "inner.xsl", "/styles/inner.xsl"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, resolveStylesheetLocation(tc.base, tc.loc))
+		})
+	}
+}
+
+// TestResolveDocumentURIAbsolute verifies that runtime document()/doc()
+// resolution (functions.go resolveDocumentURI) is URI-aware: an absolute-URI
+// ref carrying a scheme with no "//" authority (e.g. document('urn:doc'),
+// doc('file:/x.xml')) is returned UNCHANGED rather than filepath.Join'ed onto
+// the base dir, and a relative ref against a URI base keeps the base
+// scheme/authority instead of losing it before retrieveDocumentBytes.
+func TestResolveDocumentURIAbsolute(t *testing.T) {
+	ec := &execContext{}
+	for _, tc := range []struct {
+		name    string
+		uri     string
+		baseDir string
+		want    string
+	}{
+		// Regression: absolute-URI refs (scheme, no "//") pass through unchanged.
+		{"urn opaque", "urn:doc", testDocsDir, "urn:doc"},
+		{"file single slash", "file:/x.xml", testDocsDir, "file:/x.xml"},
+		{"http authority", "http://example.com/d.xml", testDocsDir, "http://example.com/d.xml"},
+		// Relative ref against a URI base keeps scheme/authority.
+		{"relative under uri base", "child.xml", "mem://pkg", "mem://pkg/child.xml"},
+		{"root-relative under uri base", "/other.xml", "mem://pkg/sub", "mem://pkg/other.xml"},
+		// Both local: historical filepath behavior preserved.
+		{"local relative", "child.xml", testDocsDir, "/docs/child.xml"},
+		{"local absolute", "/abs.xml", testDocsDir, "/abs.xml"},
+		{"file triple slash", "file:///abs/x.xml", testDocsDir, "/abs/x.xml"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ec.resolveDocumentURI(tc.uri, tc.baseDir)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestRootXMLBaseURIAware verifies that root xml:base handling (compile.go) is
+// URI-aware: an absolute-URI xml:base with no "//" authority (xml:base="urn:base")
+// is used as-is, and a root-relative xml:base ("/pkg/") under a URI base keeps
+// the base scheme/authority (resolved per RFC 3986) instead of being corrupted
+// by a strings.Contains("://") classification + filepath.Join.
+func TestRootXMLBaseURIAware(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		baseURI string
+		xmlBase string
+		want    string
+	}{
+		// Regression: absolute-URI xml:base without "//" is used as-is.
+		{"absolute uri without slashes", "mem://pkg/main.xsl", "urn:base", "urn:base"},
+		// Regression: root-relative xml:base under a URI base keeps scheme+authority.
+		{"root-relative under uri base", "mem://pkg/a/main.xsl", "/pkg2/", "mem://pkg/pkg2/main.xsl"},
+		{"relative under uri base", "mem://pkg/a/main.xsl", "inner/", "mem://pkg/a/inner/main.xsl"},
+		{"absolute uri with authority", "file:///a/main.xsl", "http://h/x.xsl", "http://h/x.xsl"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveRootXMLBase(tc.baseURI, tc.xmlBase)
+			require.Equal(t, tc.want, got)
 		})
 	}
 }


### PR DESCRIPTION
- Decide absoluteness in xslt3 resource resolution with `xsd.URIScheme` (RFC 3986), not `filepath.IsAbs` / `"://"` substring checks
- Route `document()`/`xsl:source-document`, `fn:transform` stylesheet-location, and serialization parameter-document hrefs through the shared canonical `xsd.ResolveSchemaURI`, so absolute-URI refs without `//` authority (`urn:`, `file:/`) pass through unchanged and root-relative refs against URI bases keep scheme/authority
