### PR TITLE
require xmldsig namespace for references

### DIFF
--- a/xmldsig1/reference_namespace_test.go
+++ b/xmldsig1/reference_namespace_test.go
@@ -1,0 +1,106 @@
+package xmldsig1
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestForeignNamespaceReferenceRejected guards against a namespace-confusion
+// bypass of the empty-reference check (see TestEmptyReferencesRejected). The
+// "at least one Reference" rule must count only ds:Reference elements in the
+// XML-Signature namespace. If parseSignedInfo matched on local name alone, a
+// SignedInfo carrying zero genuine ds:Reference children plus a single
+// foreign-namespace <evil:Reference> would satisfy len(references) > 0 and
+// verify against a recomputed SignatureValue while covering no document
+// content — re-opening the no-content-signature bypass.
+//
+// As with the empty-reference attack, full key control is assumed (the worst
+// case): produce a genuine signature, rewrite its only ds:Reference into a
+// foreign namespace, then recompute a valid SignatureValue over the mutated
+// SignedInfo.
+func TestForeignNamespaceReferenceRejected(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(`<root><data Id="payload">secret</data></root>`))
+	require.NoError(t, err)
+
+	sigElem, err := NewSigner().
+		SignatureAlgorithm(AlgRSASHA256).
+		Reference(ReferenceConfig{
+			URI:             "#payload",
+			DigestAlgorithm: DigestSHA256,
+			Transforms:      []Transform{ExcC14NTransform()},
+		}).
+		SignDetached(context.Background(), doc, key)
+	require.NoError(t, err)
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	signedInfo := findChild(t, sigElem, "SignedInfo")
+	ref := findChild(t, signedInfo, "Reference")
+
+	// Move the genuine ds:Reference into a foreign namespace so that, by local
+	// name alone, the SignedInfo still appears to contain a Reference while it
+	// no longer carries any ds:Reference.
+	const evilNS = "urn:example:evil"
+	require.NoError(t, ref.DeclareNamespace("evil", evilNS))
+	require.NoError(t, ref.SetActiveNamespace("evil", evilNS))
+	require.Equal(t, evilNS, elementNamespaceURI(ref))
+
+	// Recompute a valid SignatureValue over the mutated SignedInfo so the only
+	// thing standing between this document and a false "verified" result is the
+	// namespace check on the Reference count.
+	canonical, err := canonicalizeSubtree(ExcC14N10, signedInfo, nil)
+	require.NoError(t, err)
+	sigBytes, err := signBytes(AlgRSASHA256, key, canonical)
+	require.NoError(t, err)
+
+	sigValueElem := findChild(t, sigElem, "SignatureValue")
+	for c := sigValueElem.FirstChild(); c != nil; c = sigValueElem.FirstChild() {
+		mc, ok := c.(helium.MutableNode)
+		require.True(t, ok)
+		helium.UnlinkNode(mc)
+	}
+	require.NoError(t, sigValueElem.AddChild(
+		doc.CreateText([]byte(base64.StdEncoding.EncodeToString(sigBytes)))))
+
+	verifier := NewVerifier(StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(context.Background(), doc)
+	require.Error(t, err, "signature whose only Reference is in a foreign namespace must be rejected")
+	require.ErrorIs(t, err, ErrInvalidSignature)
+	require.True(t, strings.Contains(err.Error(), "Reference"),
+		"error should mention the missing Reference: %v", err)
+}
+
+// TestGenuineReferenceStillVerifies is the positive control: a normal
+// ds:Reference signature must continue to verify after the namespace guard is
+// added, so the fix rejects only foreign-namespace References.
+func TestGenuineReferenceStillVerifies(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(`<root><data Id="payload">secret</data></root>`))
+	require.NoError(t, err)
+
+	sigElem, err := NewSigner().
+		SignatureAlgorithm(AlgRSASHA256).
+		Reference(ReferenceConfig{
+			URI:             "#payload",
+			DigestAlgorithm: DigestSHA256,
+			Transforms:      []Transform{ExcC14NTransform()},
+		}).
+		SignDetached(context.Background(), doc, key)
+	require.NoError(t, err)
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	verifier := NewVerifier(StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(context.Background(), doc)
+	require.NoError(t, err, "a genuine ds:Reference signature must still verify")
+}

--- a/xmldsig1/reference_namespace_test.go
+++ b/xmldsig1/reference_namespace_test.go
@@ -79,6 +79,65 @@ func TestForeignNamespaceReferenceRejected(t *testing.T) {
 		"error should mention the missing Reference: %v", err)
 }
 
+// TestDSig11NamespaceReferenceRejected guards the core/1.1 namespace split. The
+// XML-Signature 1.1 namespace (http://www.w3.org/2009/xmldsig11#) is only for
+// new 1.1-specific elements (e.g. ECKeyValue), NOT an alternate spelling of the
+// core Reference. A dsig11:Reference therefore must not count toward the
+// at-least-one-Reference rule, so mutating the only ds:Reference into the 1.1
+// namespace must make verification fail just like a foreign-namespace Reference.
+func TestDSig11NamespaceReferenceRejected(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(`<root><data Id="payload">secret</data></root>`))
+	require.NoError(t, err)
+
+	sigElem, err := NewSigner().
+		SignatureAlgorithm(AlgRSASHA256).
+		Reference(ReferenceConfig{
+			URI:             "#payload",
+			DigestAlgorithm: DigestSHA256,
+			Transforms:      []Transform{ExcC14NTransform()},
+		}).
+		SignDetached(context.Background(), doc, key)
+	require.NoError(t, err)
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	signedInfo := findChild(t, sigElem, "SignedInfo")
+	ref := findChild(t, signedInfo, "Reference")
+
+	// Move the genuine ds:Reference into the XML-Signature 1.1 namespace. By
+	// local name alone the SignedInfo still appears to contain a Reference, but
+	// xmldsig11# is not the core namespace, so it must not be accepted as one.
+	require.NoError(t, ref.DeclareNamespace("dsig11", NamespaceDSig11))
+	require.NoError(t, ref.SetActiveNamespace("dsig11", NamespaceDSig11))
+	require.Equal(t, NamespaceDSig11, elementNamespaceURI(ref))
+
+	// Recompute a valid SignatureValue over the mutated SignedInfo so the only
+	// thing standing between this document and a false "verified" result is the
+	// core-namespace check on the Reference count.
+	canonical, err := canonicalizeSubtree(ExcC14N10, signedInfo, nil)
+	require.NoError(t, err)
+	sigBytes, err := signBytes(AlgRSASHA256, key, canonical)
+	require.NoError(t, err)
+
+	sigValueElem := findChild(t, sigElem, "SignatureValue")
+	for c := sigValueElem.FirstChild(); c != nil; c = sigValueElem.FirstChild() {
+		mc, ok := c.(helium.MutableNode)
+		require.True(t, ok)
+		helium.UnlinkNode(mc)
+	}
+	require.NoError(t, sigValueElem.AddChild(
+		doc.CreateText([]byte(base64.StdEncoding.EncodeToString(sigBytes)))))
+
+	verifier := NewVerifier(StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(context.Background(), doc)
+	require.Error(t, err, "signature whose only Reference is in the xmldsig11# namespace must be rejected")
+	require.ErrorIs(t, err, ErrInvalidSignature)
+	require.True(t, strings.Contains(err.Error(), "Reference"),
+		"error should mention the missing Reference: %v", err)
+}
+
 // TestGenuineReferenceStillVerifies is the positive control: a normal
 // ds:Reference signature must continue to verify after the namespace guard is
 // added, so the fix rejects only foreign-namespace References.

--- a/xmldsig1/transform_namespace_test.go
+++ b/xmldsig1/transform_namespace_test.go
@@ -1,0 +1,142 @@
+package xmldsig1
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// findTransformByAlgorithm locates the ds:Transform element inside a Reference
+// whose Algorithm attribute matches algURI, so a test can mutate that specific
+// transform.
+func findTransformByAlgorithm(t *testing.T, signedInfo *helium.Element, algURI string) *helium.Element {
+	t.Helper()
+	ref := findChild(t, signedInfo, "Reference")
+	transforms := findChild(t, ref, "Transforms")
+	for c := transforms.FirstChild(); c != nil; c = c.NextSibling() {
+		e, ok := helium.AsNode[*helium.Element](c)
+		if !ok {
+			continue
+		}
+		if localName(e) != "Transform" {
+			continue
+		}
+		alg, _ := e.GetAttribute("Algorithm")
+		if alg == algURI {
+			return e
+		}
+	}
+	t.Fatalf("Transform with Algorithm %q not found", algURI)
+	return nil
+}
+
+// TestForeignNamespaceTransformRejected guards against a namespace-confusion
+// bypass where an attacker rewrites a core ds:Transform into a foreign
+// namespace. A Transform element is itself in the XML-Signature namespace, so
+// parseReferenceElement must honor only ds:Transform elements; matching on
+// local name alone would let an <evil:Transform Algorithm="...enveloped...">
+// drive a privileged transform.
+//
+// The attack: an enveloped signature relies on the enveloped-signature
+// Transform to detach the Signature element before digesting. If a foreign
+// <evil:Transform> carrying the enveloped-signature algorithm is honored, the
+// Signature is detached and the recomputed digest matches. Once the guard
+// ignores the foreign transform, the Signature element is no longer detached,
+// so the canonical bytes include it and the digest no longer matches — the
+// forgery is rejected. Full key control is assumed (worst case): recompute a
+// valid SignatureValue over the mutated SignedInfo.
+func TestForeignNamespaceTransformRejected(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(`<root><data>secret</data></root>`))
+	require.NoError(t, err)
+
+	signer := NewSigner().
+		SignatureAlgorithm(AlgRSASHA256).
+		Reference(ReferenceConfig{
+			URI:             "",
+			DigestAlgorithm: DigestSHA256,
+			Transforms:      []Transform{Enveloped(), ExcC14NTransform()},
+		})
+	require.NoError(t, signer.SignEnveloped(context.Background(), doc, doc.DocumentElement(), key))
+
+	sigElem := findChild(t, doc.DocumentElement(), "Signature")
+	signedInfo := findChild(t, sigElem, "SignedInfo")
+
+	// Move the enveloped-signature Transform into a foreign namespace so that,
+	// by local name alone, it still looks like a Transform while it is no
+	// longer a genuine ds:Transform.
+	envTransform := findTransformByAlgorithm(t, signedInfo, TransformEnvelopedSignature)
+	const evilNS = "urn:example:evil"
+	require.NoError(t, envTransform.DeclareNamespace("evil", evilNS))
+	require.NoError(t, envTransform.SetActiveNamespace("evil", evilNS))
+	require.Equal(t, evilNS, elementNamespaceURI(envTransform))
+
+	// Recompute a valid SignatureValue over the mutated SignedInfo so the only
+	// thing standing between this document and a false "verified" result is the
+	// namespace check on the Transform element.
+	canonical, err := canonicalizeSubtree(ExcC14N10, signedInfo, nil)
+	require.NoError(t, err)
+	sigBytes, err := signBytes(AlgRSASHA256, key, canonical)
+	require.NoError(t, err)
+
+	sigValueElem := findChild(t, sigElem, "SignatureValue")
+	for c := sigValueElem.FirstChild(); c != nil; c = sigValueElem.FirstChild() {
+		mc, ok := c.(helium.MutableNode)
+		require.True(t, ok)
+		helium.UnlinkNode(mc)
+	}
+	require.NoError(t, sigValueElem.AddChild(
+		doc.CreateText([]byte(base64.StdEncoding.EncodeToString(sigBytes)))))
+
+	verifier := NewVerifier(StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(context.Background(), doc)
+	require.Error(t, err, "signature whose enveloped Transform is in a foreign namespace must be rejected")
+	require.ErrorIs(t, err, ErrDigestMismatch)
+}
+
+// TestGenuineTransformsStillVerify is the positive control for the Transform
+// namespace guard. A genuine enveloped + Exclusive C14N signature, including an
+// InclusiveNamespaces child (which lives in the xml-exc-c14n namespace, NOT the
+// XML-Signature namespace), must continue to verify — proving the guard rejects
+// only foreign-namespace Transform elements and does not reach the exc-c14n
+// InclusiveNamespaces child.
+func TestGenuineTransformsStillVerify(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	doc, err := helium.NewParser().Parse(context.Background(),
+		[]byte(`<root xmlns:p="urn:example:p"><p:data>secret</p:data></root>`))
+	require.NoError(t, err)
+
+	signer := NewSigner().
+		SignatureAlgorithm(AlgRSASHA256).
+		Reference(ReferenceConfig{
+			URI:             "",
+			DigestAlgorithm: DigestSHA256,
+			// ExcC14NTransform with a prefix list emits an InclusiveNamespaces
+			// child in the xml-exc-c14n namespace, exercising the exc-c14n
+			// child path the guard must leave untouched.
+			Transforms: []Transform{Enveloped(), ExcC14NTransform("p")},
+		})
+	require.NoError(t, signer.SignEnveloped(context.Background(), doc, doc.DocumentElement(), key))
+
+	// Confirm the InclusiveNamespaces child really is in the exc-c14n namespace,
+	// not the DSig namespace, so the positive control is meaningful.
+	sigElem := findChild(t, doc.DocumentElement(), "Signature")
+	signedInfo := findChild(t, sigElem, "SignedInfo")
+	excTransform := findTransformByAlgorithm(t, signedInfo, ExcC14N10)
+	incNS := findChild(t, excTransform, "InclusiveNamespaces")
+	require.Equal(t, "http://www.w3.org/2001/10/xml-exc-c14n#", elementNamespaceURI(incNS))
+	require.False(t, isDSigNS(incNS), "InclusiveNamespaces must not be in the DSig namespace")
+
+	verifier := NewVerifier(StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(context.Background(), doc)
+	require.NoError(t, err, "a genuine enveloped + exc-c14n signature with InclusiveNamespaces must still verify")
+}

--- a/xmldsig1/transform_namespace_test.go
+++ b/xmldsig1/transform_namespace_test.go
@@ -134,7 +134,7 @@ func TestGenuineTransformsStillVerify(t *testing.T) {
 	excTransform := findTransformByAlgorithm(t, signedInfo, ExcC14N10)
 	incNS := findChild(t, excTransform, "InclusiveNamespaces")
 	require.Equal(t, "http://www.w3.org/2001/10/xml-exc-c14n#", elementNamespaceURI(incNS))
-	require.False(t, isDSigNS(incNS), "InclusiveNamespaces must not be in the DSig namespace")
+	require.False(t, isDSigCoreNS(incNS), "InclusiveNamespaces must not be in the DSig namespace")
 
 	verifier := NewVerifier(StaticKey(&key.PublicKey))
 	_, err = verifier.Verify(context.Background(), doc)

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -306,6 +306,14 @@ func parseReferenceElement(elem *helium.Element) (parsedReference, error) {
 				if !ok {
 					continue
 				}
+				// A Transform element must be in the XML-Signature namespace; do
+				// not honor foreign-namespace look-alikes (e.g.
+				// <evil:Transform Algorithm="...">). Its InclusiveNamespaces
+				// child lives in the xml-exc-c14n namespace and is handled
+				// separately below.
+				if !isDSigNS(te) {
+					continue
+				}
 				if localName(te) != "Transform" {
 					continue
 				}

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -199,8 +199,10 @@ func parseSignatureElement(sigElem *helium.Element) (*parsedSignature, error) {
 		// Only elements in the XML-Signature namespace count as core signature
 		// children. Matching on local name alone lets a foreign-namespace
 		// element masquerade as a core child (e.g. an <evil:Reference> passing
-		// the at-least-one-Reference check), so namespace must be enforced.
-		if !isDSigNS(elem) {
+		// the at-least-one-Reference check), so namespace must be enforced. Core
+		// children live ONLY in the core xmldsig# namespace; the 1.1 xmldsig11#
+		// namespace is for new 1.1 elements and must not satisfy this check.
+		if !isDSigCoreNS(elem) {
 			continue
 		}
 		switch localName(elem) {
@@ -249,8 +251,9 @@ func parseSignedInfo(elem *helium.Element, parsed *parsedSignature) error {
 		// Require the XML-Signature namespace: a foreign-namespace
 		// <evil:Reference> must not be counted toward the mandatory
 		// at-least-one-Reference rule below, which would otherwise re-open the
-		// no-content-signature bypass.
-		if !isDSigNS(e) {
+		// no-content-signature bypass. Only the core xmldsig# namespace counts;
+		// the 1.1 xmldsig11# namespace must not satisfy this check.
+		if !isDSigCoreNS(e) {
 			continue
 		}
 		switch localName(e) {
@@ -294,9 +297,10 @@ func parseReferenceElement(elem *helium.Element) (parsedReference, error) {
 			continue
 		}
 		// Core Reference children (Transforms/DigestMethod/DigestValue) must be
-		// in the XML-Signature namespace; do not honor foreign-namespace
-		// look-alikes.
-		if !isDSigNS(e) {
+		// in the core XML-Signature namespace; do not honor foreign-namespace
+		// look-alikes, and the 1.1 xmldsig11# namespace must not satisfy this
+		// check.
+		if !isDSigCoreNS(e) {
 			continue
 		}
 		switch localName(e) {
@@ -306,12 +310,13 @@ func parseReferenceElement(elem *helium.Element) (parsedReference, error) {
 				if !ok {
 					continue
 				}
-				// A Transform element must be in the XML-Signature namespace; do
-				// not honor foreign-namespace look-alikes (e.g.
-				// <evil:Transform Algorithm="...">). Its InclusiveNamespaces
+				// A Transform element must be in the core XML-Signature
+				// namespace; do not honor foreign-namespace look-alikes (e.g.
+				// <evil:Transform Algorithm="...">), and the 1.1 xmldsig11#
+				// namespace must not satisfy this check. Its InclusiveNamespaces
 				// child lives in the xml-exc-c14n namespace and is handled
 				// separately below.
-				if !isDSigNS(te) {
+				if !isDSigCoreNS(te) {
 					continue
 				}
 				if localName(te) != "Transform" {

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -196,6 +196,13 @@ func parseSignatureElement(sigElem *helium.Element) (*parsedSignature, error) {
 		if !ok {
 			continue
 		}
+		// Only elements in the XML-Signature namespace count as core signature
+		// children. Matching on local name alone lets a foreign-namespace
+		// element masquerade as a core child (e.g. an <evil:Reference> passing
+		// the at-least-one-Reference check), so namespace must be enforced.
+		if !isDSigNS(elem) {
+			continue
+		}
 		switch localName(elem) {
 		case "SignedInfo":
 			if parsed.signedInfoElem != nil {
@@ -239,6 +246,13 @@ func parseSignedInfo(elem *helium.Element, parsed *parsedSignature) error {
 		if !ok {
 			continue
 		}
+		// Require the XML-Signature namespace: a foreign-namespace
+		// <evil:Reference> must not be counted toward the mandatory
+		// at-least-one-Reference rule below, which would otherwise re-open the
+		// no-content-signature bypass.
+		if !isDSigNS(e) {
+			continue
+		}
 		switch localName(e) {
 		case "CanonicalizationMethod":
 			alg, ok := e.GetAttribute("Algorithm")
@@ -277,6 +291,12 @@ func parseReferenceElement(elem *helium.Element) (parsedReference, error) {
 	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
 		e, ok := helium.AsNode[*helium.Element](child)
 		if !ok {
+			continue
+		}
+		// Core Reference children (Transforms/DigestMethod/DigestValue) must be
+		// in the XML-Signature namespace; do not honor foreign-namespace
+		// look-alikes.
+		if !isDSigNS(e) {
 			continue
 		}
 		switch localName(e) {

--- a/xmldsig1/xmldsig1.go
+++ b/xmldsig1/xmldsig1.go
@@ -167,7 +167,7 @@ func findSignatureElements(n helium.Node) []*helium.Element {
 		if !ok {
 			return
 		}
-		if localName(elem) == "Signature" && isDSigNS(elem) {
+		if localName(elem) == "Signature" && isDSigCoreNS(elem) {
 			out = append(out, elem)
 			// Do not descend into a Signature — a Signature inside
 			// another Signature (e.g. inside KeyInfo) is not itself a
@@ -182,9 +182,16 @@ func findSignatureElements(n helium.Node) []*helium.Element {
 	return out
 }
 
-func isDSigNS(e *helium.Element) bool {
-	ns := elementNamespaceURI(e)
-	return ns == NamespaceDSig || ns == NamespaceDSig11
+// isDSigCoreNS reports whether e is in the core XML-Signature namespace
+// (http://www.w3.org/2000/09/xmldsig#). Core structural elements — Signature,
+// SignedInfo, SignatureValue, CanonicalizationMethod, SignatureMethod,
+// Reference, Transforms, Transform, DigestMethod, DigestValue, KeyInfo — are
+// ALWAYS in this namespace. The XML-Signature 1.1 namespace
+// (http://www.w3.org/2009/xmldsig11#) is only for new 1.1-specific elements
+// (e.g. ECKeyValue, DEREncodedKeyValue); it is not an alternate spelling of the
+// core elements, so a dsig11:Reference must not satisfy a core-element check.
+func isDSigCoreNS(e *helium.Element) bool {
+	return elementNamespaceURI(e) == NamespaceDSig
 }
 
 func elementNamespaceURI(e *helium.Element) string {


### PR DESCRIPTION
- Require the XML-Signature namespace when matching core signature children (SignedInfo/SignatureValue/KeyInfo/CanonicalizationMethod/SignatureMethod/Reference and Reference children) in verify
- Closes a namespace bypass of the no-references check from #546: a foreign-namespace <evil:Reference> no longer counts, so a reference-free SignedInfo is rejected
- Add regression tests for foreign-namespace Reference rejection and genuine Reference verification
