### PR TITLE
fix eval-reuse focus loss and frozen clock

### DIFF
--- a/xpath3/eval_reuse.go
+++ b/xpath3/eval_reuse.go
@@ -3,6 +3,7 @@ package xpath3
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/lestrrat-go/helium"
 	ixpath "github.com/lestrrat-go/helium/internal/xpath"
@@ -18,15 +19,32 @@ import (
 type EvalState struct {
 	ec      evalContext
 	oneItem [1]Item // reusable backing for single-item results
+
+	// baseNode / baseContextItem capture the focus seeded by NewEvalState so
+	// each EvaluateReuse call starts from that base focus rather than a focus
+	// mutated by a prior call.
+	baseNode        helium.Node
+	baseContextItem Item
+
+	// explicitTime is true when the Evaluator had an explicitly configured
+	// CurrentTime. When false, EvaluateReuse refreshes the clock per call so
+	// fn:current-dateTime() does not stay frozen across reuse calls.
+	explicitTime bool
 }
 
 // SetContextItem sets the non-node context item on the eval state.
 // This is used when the context is an atomic value rather than a node
 // (e.g., sorting a sequence of atomic items).
+//
+// The item becomes the base focus, so it persists as the starting focus
+// for subsequent EvaluateReuse calls (a reuse call with a non-nil node
+// still overrides it for that call only).
 func (s *EvalState) SetContextItem(item Item) {
 	s.ec.contextItem = item
+	s.baseContextItem = item
 	if item != nil {
 		s.ec.node = nil
+		s.baseNode = nil
 	}
 }
 
@@ -49,12 +67,28 @@ func (e *Expression) EvaluateReuse(ctx context.Context, state *EvalState, node h
 	}
 
 	ec := &state.ec
-	ec.node = node
+
+	// Start from the base focus seeded by NewEvalState/SetContextItem so a
+	// prior reuse call cannot leak its focus into this one. A non-nil node
+	// overrides the base focus for this call only.
 	if node != nil {
+		ec.node = node
 		ec.contextItem = nil
+	} else {
+		ec.node = state.baseNode
+		ec.contextItem = state.baseContextItem
 	}
 	ec.depth = 0
 	*ec.opCount = 0
+
+	// When CurrentTime was not explicitly configured on the Evaluator, refresh
+	// the clock per call so fn:current-dateTime() / fn:current-date() track
+	// wall-clock time instead of staying frozen at NewEvalState construction.
+	// A user-pinned CurrentTime is preserved untouched.
+	if !state.explicitTime {
+		now := time.Now()
+		ec.currentTime = &now
+	}
 
 	// Fast path for "." — skip eval entirely, reuse backing array
 	if e.program != nil && e.program.stream.isContextItem {
@@ -128,5 +162,16 @@ func (e Evaluator) NewEvalState(node helium.Node) *EvalState {
 	// guard, same custom max-node limit, and the same complete set of copied
 	// fields (preserved ID annotations, TraceWriter, etc.).
 	s := &EvalState{ec: *e.newEvalCtx(node)}
+
+	// Capture the seeded base focus so each EvaluateReuse call can reset to it.
+	// newEvalCtx clears ec.node when a non-node context item is configured, so
+	// read both back from the freshly built context.
+	s.baseNode = s.ec.node
+	s.baseContextItem = s.ec.contextItem
+
+	// Record whether CurrentTime was explicitly configured. If so, the reuse
+	// path must keep it pinned; otherwise the reuse path refreshes per call.
+	s.explicitTime = e.cfg != nil && e.cfg.currentTime != nil
+
 	return s
 }

--- a/xpath3/eval_reuse_focus_time_test.go
+++ b/xpath3/eval_reuse_focus_time_test.go
@@ -1,0 +1,92 @@
+package xpath3_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// The atomic context item seeded via Evaluator.ContextItem / NewEvalState must
+// survive across EvaluateReuse calls. A reuse call with a non-nil node clears
+// the focus for that call; a later reuse call with a nil node must fall back to
+// the NewEvalState-seeded base context item rather than erroring with XPDY0002.
+func TestEvaluateReuse_RestoresSeededContextItem(t *testing.T) {
+	compiled, err := xpath3.NewCompiler().Compile(".")
+	require.NoError(t, err)
+
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		ContextItem(xpath3.AtomicValue{TypeName: "xs:integer", Value: int64(42)})
+	state := eval.NewEvalState(nil)
+
+	// First call against the seeded base focus.
+	res, err := compiled.EvaluateReuse(t.Context(), state, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Sequence().Len())
+
+	// A reuse call with a non-nil node uses that node as focus.
+	doc := mustParseXML(t, "<root/>")
+	res, err = compiled.EvaluateReuse(t.Context(), state, doc)
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Sequence().Len())
+
+	// A later reuse call with a nil node must fall back to the seeded
+	// atomic context item, NOT lose it and raise XPDY0002.
+	res, err = compiled.EvaluateReuse(t.Context(), state, nil)
+	require.NoError(t, err, "seeded context item must be restored on reuse with nil node")
+	require.Equal(t, 1, res.Sequence().Len())
+}
+
+// Without an explicitly configured CurrentTime, fn:current-dateTime() must
+// re-read the clock on each EvaluateReuse call rather than staying frozen at
+// the time NewEvalState was constructed.
+func TestEvaluateReuse_CurrentTimeRefreshesWhenUnset(t *testing.T) {
+	compiled, err := xpath3.NewCompiler().Compile("current-dateTime()")
+	require.NoError(t, err)
+
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions)
+	state := eval.NewEvalState(nil)
+
+	first, err := compiled.EvaluateReuse(t.Context(), state, nil)
+	require.NoError(t, err)
+	firstStr := first.StringValue()
+
+	// Advance the wall clock enough to guarantee a distinguishable timestamp.
+	target := time.Now().Add(2 * time.Millisecond)
+	for time.Now().Before(target) {
+	}
+
+	second, err := compiled.EvaluateReuse(t.Context(), state, nil)
+	require.NoError(t, err)
+	secondStr := second.StringValue()
+
+	require.NotEqual(t, firstStr, secondStr,
+		"current-dateTime() must not be frozen across reuse calls when CurrentTime is unset")
+}
+
+// An explicitly configured CurrentTime must stay pinned across EvaluateReuse
+// calls — the refresh must not clobber a user-pinned clock.
+func TestEvaluateReuse_CurrentTimePinnedWhenSet(t *testing.T) {
+	compiled, err := xpath3.NewCompiler().Compile("current-dateTime()")
+	require.NoError(t, err)
+
+	pinned := time.Date(2001, 2, 3, 4, 5, 6, 0, time.UTC)
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).CurrentTime(pinned)
+	state := eval.NewEvalState(nil)
+
+	first, err := compiled.EvaluateReuse(t.Context(), state, nil)
+	require.NoError(t, err)
+	firstStr := first.StringValue()
+
+	target := time.Now().Add(2 * time.Millisecond)
+	for time.Now().Before(target) {
+	}
+
+	second, err := compiled.EvaluateReuse(t.Context(), state, nil)
+	require.NoError(t, err)
+	secondStr := second.StringValue()
+
+	require.Equal(t, firstStr, secondStr,
+		"pinned CurrentTime must remain fixed across reuse calls")
+}


### PR DESCRIPTION
- EvaluateReuse now restores the NewEvalState/SetContextItem-seeded base focus per call, fixing #548-area focus loss (later reuse with nil node no longer raises XPDY0002)
- refresh ec.currentTime per reuse call when CurrentTime is not explicitly configured, fixing frozen fn:current-dateTime()/fn:current-date() across reuse calls
- a user-pinned CurrentTime stays fixed