### PR TITLE
fix xsi:nil for no-type elems and nillable lexical

### DIFF
--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -32,6 +32,16 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 				if edecl.Fixed == nil {
 					edecl.Fixed = ge.Fixed
 				}
+				// Copy the referenced declaration's substitution-group
+				// affiliation. A no-type substitution-group member leaves
+				// edecl.Type nil here; without the affiliation, effectiveDeclType
+				// cannot walk to the typed head, so xsi:nil lexical and
+				// nilled-empty checks would be silently skipped for a direct
+				// ref="member". The member's own Nillable (copied below) still
+				// governs the nilled-element check.
+				if edecl.SubstitutionGroup == (QName{}) {
+					edecl.SubstitutionGroup = ge.SubstitutionGroup
+				}
 				edecl.Nillable = ge.Nillable
 				edecl.Abstract = ge.Abstract
 				if !edecl.BlockSet {

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/xpath1"
 )
 
@@ -82,7 +83,7 @@ func (c *compiler) readElementDecl(ctx context.Context, elem *helium.Element, op
 		Name:      QName{Local: opts.name, NS: opts.namespace},
 		MinOccurs: opts.minOccurs,
 		MaxOccurs: opts.maxOccurs,
-		Nillable:  getAttr(elem, attrNillable) == attrValTrue,
+		Nillable:  c.readBooleanAttr(ctx, elem, attrNillable),
 	}
 
 	if opts.allowAbstract {
@@ -120,6 +121,28 @@ func (c *compiler) readElementDecl(ctx context.Context, elem *helium.Element, op
 	return decl, nil
 }
 
+// readBooleanAttr reads a schema-side xs:boolean attribute (e.g. nillable),
+// applying whitespace-collapse lexical rules (true/false/1/0). An absent
+// attribute is false. An invalid lexical is reported as a schema parser error
+// and treated as false.
+func (c *compiler) readBooleanAttr(ctx context.Context, elem *helium.Element, attr string) bool {
+	if !hasAttr(elem, attr) {
+		return false
+	}
+	v := normalizeWhiteSpace(getAttr(elem, attr), "collapse")
+	switch v {
+	case "true", "1":
+		return true
+	case "false", "0":
+		return false
+	}
+	msg := fmt.Sprintf("'%s' is not a valid value of the atomic type 'xs:boolean'.", v)
+	c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, elem.Line(),
+		elem.LocalName(), elemElement, attr, msg), helium.ErrorLevelFatal))
+	c.errorCount++
+	return false
+}
+
 func (c *compiler) readElementType(ctx context.Context, elem *helium.Element, decl *ElementDecl, sourceName string) error {
 	typeRef := getAttr(elem, attrType)
 	if typeRef != "" {
@@ -153,6 +176,16 @@ func (c *compiler) readElementType(ctx context.Context, elem *helium.Element, de
 			}
 			decl.Type = td
 		}
+	}
+
+	// An element declaration with no explicit type, no inline type, and no
+	// substitution-group head to inherit from defaults to the built-in
+	// xs:anyType (XSD 3.3.2: {type definition} defaults to xs:anyType). This
+	// ensures xsi:nil lexical validation and nilled-empty enforcement run for
+	// no-type declarations the same as for typed ones. Substitution-group
+	// members are left untyped so they can inherit the head's type at validation.
+	if decl.Type == nil && decl.SubstitutionGroup == (QName{}) {
+		decl.Type = c.schema.types[QName{Local: "anyType", NS: lexicon.NamespaceXSD}]
 	}
 
 	return nil

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -189,29 +189,25 @@ func (vc *validationContext) validateRootElement(ctx context.Context, elem *heli
 		return fmt.Errorf("no matching global declaration")
 	}
 
-	if edecl.Type == nil {
-		// Substitution group members inherit the type from the head element.
-		if edecl.SubstitutionGroup != (QName{}) {
-			headDecl, headOK := vc.schema.LookupElement(edecl.SubstitutionGroup.Local, edecl.SubstitutionGroup.NS)
-			if headOK && headDecl.Type != nil {
-				edecl = headDecl
-			} else {
-				return nil
-			}
-		} else {
-			return nil
-		}
+	// Keep edecl as the ACTUAL root declaration so its own Nillable flag is
+	// honored by the nilled-element check. For a no-type substitution-group
+	// member, the effective TYPE is inherited from the head (effectiveDeclType
+	// walks the substitutionGroup chain), but the declaration — and thus the
+	// nillable flag — stays the member's. This mirrors the particle paths.
+	declType := effectiveDeclType(edecl, vc.schema)
+	if declType == nil {
+		return nil
 	}
 
-	td, err := vc.resolveXsiType(ctx, elem, edecl.Type)
+	td, err := vc.resolveXsiType(ctx, elem, declType)
 	if err != nil {
 		return err
 	}
 	// Check block flags against xsi:type derivation.
-	if td != edecl.Type && edecl.Type != nil && isDerivationBlocked(td, edecl.Type, edecl.Block) {
+	if td != declType && isDerivationBlocked(td, declType, edecl.Block) {
 		msg := "The xsi:type definition is blocked by the element declaration."
 		vc.reportValidityError(ctx, vc.filename, elem.Line(), elemDisplayName(elem), msg)
-		td = edecl.Type // fall back to declared type
+		td = declType // fall back to declared type
 	}
 	if td != nil && td.Abstract {
 		msg := "The type definition is abstract."

--- a/xsd/validate_elem.go
+++ b/xsd/validate_elem.go
@@ -233,7 +233,7 @@ func (vc *validationContext) matchAll(ctx context.Context, parent *helium.Elemen
 			continue
 		}
 		actualDecl := resolveSubstDecl(child, edecl, vc.schema)
-		td := actualDecl.Type
+		td := effectiveDeclType(actualDecl, vc.schema)
 		td, xsiErr := vc.resolveXsiType(ctx, child.elem, td)
 		if xsiErr != nil {
 			contentErr = xsiErr
@@ -356,14 +356,14 @@ func (vc *validationContext) matchElementParticle(ctx context.Context, parent *h
 	for i := range count {
 		child := children[pos+i]
 		actualDecl := resolveSubstDecl(child, edecl, vc.schema)
-		td := actualDecl.Type
-		td, xsiErr := vc.resolveXsiType(ctx, child.elem, td)
+		declType := effectiveDeclType(actualDecl, vc.schema)
+		td, xsiErr := vc.resolveXsiType(ctx, child.elem, declType)
 		if xsiErr != nil {
 			contentErr = xsiErr
 			continue
 		}
 		// Check block flags against xsi:type derivation.
-		if td != actualDecl.Type && actualDecl.Type != nil && isDerivationBlocked(td, actualDecl.Type, actualDecl.Block) {
+		if td != declType && declType != nil && isDerivationBlocked(td, declType, actualDecl.Block) {
 			msg := "The xsi:type definition is blocked by the element declaration."
 			vc.reportValidityError(ctx, vc.filename, child.elem.Line(), elemDisplayName(child.elem), msg)
 			contentErr = fmt.Errorf("blocked xsi:type")
@@ -409,6 +409,43 @@ func resolveSubstDecl(child childElem, edecl *ElementDecl, schema *Schema) *Elem
 		}
 	}
 	return edecl
+}
+
+// effectiveDeclType returns the effective type definition for a declaration.
+// It is actualDecl.Type when present; otherwise, for a no-type
+// substitution-group member, it is the type inherited from the substitution
+// head (walking the substitutionGroup chain until a typed head is found).
+// Returns nil when no type can be resolved. The returned type is used to drive
+// xsi:nil lexical validation and nilled-empty enforcement for no-type members;
+// the member declaration itself is still used elsewhere so its own nillable
+// flag is honored independently of the head.
+func effectiveDeclType(decl *ElementDecl, schema *Schema) *TypeDef {
+	if decl == nil {
+		return nil
+	}
+	if decl.Type != nil {
+		return decl.Type
+	}
+	if schema == nil {
+		return nil
+	}
+	seen := map[QName]struct{}{decl.Name: {}}
+	head := decl.SubstitutionGroup
+	for head != (QName{}) {
+		if _, ok := seen[head]; ok {
+			return nil
+		}
+		seen[head] = struct{}{}
+		headDecl, ok := schema.LookupElement(head.Local, head.NS)
+		if !ok {
+			return nil
+		}
+		if headDecl.Type != nil {
+			return headDecl.Type
+		}
+		head = headDecl.SubstitutionGroup
+	}
+	return nil
 }
 
 // tryMatchParticle is like matchParticle but does not write errors.
@@ -614,7 +651,7 @@ func (vc *validationContext) matchWildcardParticle(ctx context.Context, parent *
 				}
 				continue
 			}
-			td := edecl.Type
+			td := effectiveDeclType(edecl, vc.schema)
 			td, xsiErr := vc.resolveXsiType(ctx, child.elem, td)
 			if xsiErr != nil {
 				contentErr = xsiErr

--- a/xsd/validate_xsi_nil_anytype_test.go
+++ b/xsd/validate_xsi_nil_anytype_test.go
@@ -1,0 +1,76 @@
+package xsd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestXsiNilNoTypeElement checks that an element declaration with NO explicit
+// type (which XSD defaults to xs:anyType) still runs xsi:nil lexical validation
+// and nilled-empty enforcement. Previously these checks sat behind a nil-type
+// early return, so a no-type nillable declaration accepted invalid xsi:nil
+// lexicals and non-empty nilled content.
+func TestXsiNilNoTypeElement(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" nillable="true"/>
+</xs:schema>`
+
+	const xsiDecl = `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"`
+
+	t.Run("nil=true empty is accepted", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+` xsi:nil="true"/>`, nil))
+	})
+
+	t.Run("nil=true with child content is rejected", func(t *testing.T) {
+		t.Parallel()
+		var out string
+		err := compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+` xsi:nil="true"><child/></root>`, &out)
+		require.Error(t, err)
+		require.Contains(t, out, "nilled")
+	})
+
+	t.Run("nil=maybe is a lexical error", func(t *testing.T) {
+		t.Parallel()
+		var out string
+		err := compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+` xsi:nil="maybe"/>`, &out)
+		require.Error(t, err)
+		require.NotContains(t, out, "nilled")
+		require.Contains(t, out, "not a valid value")
+	})
+}
+
+// TestSchemaNillableLexical checks that the schema-side nillable attribute is
+// parsed as an xs:boolean (after whitespace collapse): nillable="1" means true,
+// and an invalid lexical produces a schema parser error.
+func TestSchemaNillableLexical(t *testing.T) {
+	t.Parallel()
+
+	const xsiDecl = `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"`
+
+	t.Run("nillable=1 is honored as true", func(t *testing.T) {
+		t.Parallel()
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" type="xs:string" nillable="1"/>
+</xs:schema>`
+		// nilled element with empty content must be accepted (nillable honored).
+		require.NoError(t, compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+` xsi:nil="true"/>`, nil))
+	})
+
+	t.Run("invalid nillable lexical is a schema error", func(t *testing.T) {
+		t.Parallel()
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" type="xs:string" nillable="maybe"/>
+</xs:schema>`
+		_, errs := compileWithErrors(t, schemaXML)
+		require.NotEmpty(t, errs)
+		require.Contains(t, errs, "not a valid value")
+	})
+}

--- a/xsd/validate_xsi_nil_anytype_test.go
+++ b/xsd/validate_xsi_nil_anytype_test.go
@@ -96,6 +96,72 @@ func TestXsiNilSubstGroupMemberNoType(t *testing.T) {
 	})
 }
 
+// TestXsiNilRootSubstGroupMemberNoType checks that a no-type substitution-group
+// member appearing as the VALIDATION ROOT inherits the head's type for type
+// resolution but honors its OWN nillable flag for the nilled-element check —
+// independent of the head's nillable flag. This exercises the root path
+// (validateRootElement), distinct from the particle paths above.
+func TestXsiNilRootSubstGroupMemberNoType(t *testing.T) {
+	t.Parallel()
+
+	const xsiDecl = `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"`
+
+	t.Run("member nillable, head not nillable: nil=true empty accepted", func(t *testing.T) {
+		t.Parallel()
+		// head is NOT nillable; member (no type) IS nillable. A nilled empty
+		// member root must be accepted because the member's own flag governs.
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="head" type="xs:string"/>
+  <xs:element name="member" substitutionGroup="head" nillable="true"/>
+</xs:schema>`
+		require.NoError(t, compileAndValidate(t, schemaXML,
+			`<member `+xsiDecl+` xsi:nil="true"/>`, nil))
+	})
+
+	t.Run("member not nillable, head nillable: nil=true rejected", func(t *testing.T) {
+		t.Parallel()
+		// head IS nillable; member (no type) is NOT nillable. A nilled member
+		// root must be rejected because the member's own flag governs, not the
+		// head's.
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="head" type="xs:string" nillable="true"/>
+  <xs:element name="member" substitutionGroup="head"/>
+</xs:schema>`
+		var out string
+		err := compileAndValidate(t, schemaXML,
+			`<member `+xsiDecl+` xsi:nil="true"/>`, &out)
+		require.Error(t, err)
+		require.Contains(t, out, "not nillable")
+	})
+
+	t.Run("member nillable: nil=true with content rejected", func(t *testing.T) {
+		t.Parallel()
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="head" type="xs:string"/>
+  <xs:element name="member" substitutionGroup="head" nillable="true"/>
+</xs:schema>`
+		var out string
+		err := compileAndValidate(t, schemaXML,
+			`<member `+xsiDecl+` xsi:nil="true">content</member>`, &out)
+		require.Error(t, err)
+		require.Contains(t, out, "nilled")
+	})
+
+	t.Run("member nillable: nil=maybe is a lexical error", func(t *testing.T) {
+		t.Parallel()
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="head" type="xs:string"/>
+  <xs:element name="member" substitutionGroup="head" nillable="true"/>
+</xs:schema>`
+		var out string
+		err := compileAndValidate(t, schemaXML,
+			`<member `+xsiDecl+` xsi:nil="maybe"/>`, &out)
+		require.Error(t, err)
+		require.NotContains(t, out, "nilled")
+		require.Contains(t, out, "not a valid value")
+	})
+}
+
 // TestSchemaNillableLexical checks that the schema-side nillable attribute is
 // parsed as an xs:boolean (after whitespace collapse): nillable="1" means true,
 // and an invalid lexical produces a schema parser error.

--- a/xsd/validate_xsi_nil_anytype_test.go
+++ b/xsd/validate_xsi_nil_anytype_test.go
@@ -162,6 +162,59 @@ func TestXsiNilRootSubstGroupMemberNoType(t *testing.T) {
 	})
 }
 
+// TestXsiNilDirectRefSubstGroupMemberNoType checks that a no-type
+// substitution-group member referenced DIRECTLY via a local
+// <xs:element ref="member"/> particle (not through the head) still inherits the
+// head's type for xsi:nil lexical validation and nilled-empty enforcement, while
+// honoring the member's own nillable flag. The local ref'd declaration copies
+// the global member's fields, so it must also copy the member's
+// substitutionGroup affiliation — otherwise effectiveDeclType cannot reach the
+// typed head and the xsi:nil checks are silently skipped.
+func TestXsiNilDirectRefSubstGroupMemberNoType(t *testing.T) {
+	t.Parallel()
+
+	// head has a type; member has NO explicit type and sets nillable="true".
+	// root references member DIRECTLY (not the head).
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="head" type="xs:string"/>
+  <xs:element name="member" substitutionGroup="head" nillable="true"/>
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="member"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+	const xsiDecl = `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"`
+
+	t.Run("member nil=true empty is accepted", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+`><member xsi:nil="true"/></root>`, nil))
+	})
+
+	t.Run("member nil=true with content is rejected", func(t *testing.T) {
+		t.Parallel()
+		var out string
+		err := compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+`><member xsi:nil="true">content</member></root>`, &out)
+		require.Error(t, err)
+		require.Contains(t, out, "nilled")
+	})
+
+	t.Run("member nil=maybe is a lexical error", func(t *testing.T) {
+		t.Parallel()
+		var out string
+		err := compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+`><member xsi:nil="maybe"/></root>`, &out)
+		require.Error(t, err)
+		require.NotContains(t, out, "nilled")
+		require.Contains(t, out, "not a valid value")
+	})
+}
+
 // TestSchemaNillableLexical checks that the schema-side nillable attribute is
 // parsed as an xs:boolean (after whitespace collapse): nillable="1" means true,
 // and an invalid lexical produces a schema parser error.

--- a/xsd/validate_xsi_nil_anytype_test.go
+++ b/xsd/validate_xsi_nil_anytype_test.go
@@ -46,6 +46,56 @@ func TestXsiNilNoTypeElement(t *testing.T) {
 	})
 }
 
+// TestXsiNilSubstGroupMemberNoType checks that a no-type substitution-group
+// member (which inherits the head's type at validation) still runs xsi:nil
+// lexical validation and nilled-empty enforcement, honoring the MEMBER's own
+// nillable flag. The member is matched through a ref="head" particle so the
+// non-root particle paths (not the root path) drive validation.
+func TestXsiNilSubstGroupMemberNoType(t *testing.T) {
+	t.Parallel()
+
+	// head has a type; member has NO explicit type and sets nillable="true"
+	// independently of the head. root references head, so member substitutes in.
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="head" type="xs:string"/>
+  <xs:element name="member" substitutionGroup="head" nillable="true"/>
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="head"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+	const xsiDecl = `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"`
+
+	t.Run("member nil=true empty is accepted", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+`><member xsi:nil="true"/></root>`, nil))
+	})
+
+	t.Run("member nil=true with content is rejected", func(t *testing.T) {
+		t.Parallel()
+		var out string
+		err := compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+`><member xsi:nil="true">content</member></root>`, &out)
+		require.Error(t, err)
+		require.Contains(t, out, "nilled")
+	})
+
+	t.Run("member nil=maybe is a lexical error", func(t *testing.T) {
+		t.Parallel()
+		var out string
+		err := compileAndValidate(t, schemaXML,
+			`<root `+xsiDecl+`><member xsi:nil="maybe"/></root>`, &out)
+		require.Error(t, err)
+		require.NotContains(t, out, "nilled")
+		require.Contains(t, out, "not a valid value")
+	})
+}
+
 // TestSchemaNillableLexical checks that the schema-side nillable attribute is
 // parsed as an xs:boolean (after whitespace collapse): nillable="1" means true,
 // and an invalid lexical produces a schema parser error.


### PR DESCRIPTION
- default no-type element declarations to built-in xs:anyType so xsi:nil lexical validation and nilled-empty enforcement run for no-type/anyType elements
- parse schema-side nillable as xs:boolean (collapse; true/false/1/0), reporting invalid lexicals as schema parser errors
- follow-up to #557