### PR TITLE
cap external dtd reads with byte limit

### DIFF
--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -10,6 +10,7 @@ All error formatting matches libxml2 output for golden test compatibility.
 - **`ErrorDomain`** — `ErrorDomainParser`, `ErrorDomainNamespace`
 - **`ErrorLeveler`** interface — optional interface for errors to report their `ErrorLevel()`; default is `ErrorLevelWarning`
 - **`NewLeveledError(msg, level)`** — factory creating error implementing `ErrorLeveler`
+- **`ErrExternalDTDTooLarge`** (`errors.go`) — sentinel returned from the `ExternalSubset` bounded read when a loaded external DTD subset exceeds the byte cap (`MaxExternalDTDBytes` or default `MaxExternalDTDSize`, 10 MiB). Enforced against actual bytes read, never the advisory `fs.FileInfo.Size()`, and checked before any read error; match with `errors.Is`
 
 ### ErrParseError (root package, `errors.go`)
 

--- a/.claude/docs/libxml2-parity.md
+++ b/.claude/docs/libxml2-parity.md
@@ -73,7 +73,7 @@ These affect multiple packages (especially C14N test skips):
 
 1. **Duplicate namespace declarations** — helium rejects, libxml2 uses last. Affects 7 C14N tests.
 2. **Entity refs in single-quoted attributes** — not expanded. Affects 3 C14N tests.
-3. **External entity resolution** — limited; requires explicit config. External subsets need `LoadExternalDTD(true)`, and inline expansion of parsed external entities needs `SubstituteEntities(true)`. `BlockXXE(true)` blocks all.
+3. **External entity resolution** — limited; requires explicit config. External subsets need `LoadExternalDTD(true)`, and inline expansion of parsed external entities needs `SubstituteEntities(true)`. `BlockXXE(true)` blocks all. External DTD subsets are read through a strict byte cap (`MaxExternalDTDSize`, 10 MiB default; overridable via `MaxExternalDTDBytes`) enforced against the actual bytes read — not any advisory `Stat` size — and a subset exceeding the cap is rejected with `ErrExternalDTDTooLarge`.
 
 ## Feature Status
 
@@ -146,6 +146,7 @@ These affect multiple packages (especially C14N test skips):
 | BlockXXE(bool) | XML_PARSE_NOXXE | ✅ | Block XXE attacks |
 | SkipIDs(bool) | XML_PARSE_SKIP_IDS | ✅ | Skip ID interning |
 | LenientXMLDecl(bool) | *(helium extension)* | ✅ | Relaxed XML decl attribute order |
+| MaxExternalDTDBytes(int) | *(helium extension)* | ✅ | Byte cap for external DTD subset reads; ≤0 → `MaxExternalDTDSize` (10 MiB). Enforced against actual bytes read; over-cap → `ErrExternalDTDTooLarge` |
 | CompactTextNodes(bool) | XML_PARSE_COMPACT | no-op | Go memory model |
 | BigLineNumbers(bool) | XML_PARSE_BIG_LINES | no-op | Go ints are 64-bit |
 | *(dropped)* | XML_PARSE_NOUNZIP | no-op | No decompression support |

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -8,7 +8,7 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
 
 - **NewParser() → Parser** — create fluent builder for XML parsing (clone-on-write value type)
   - Flag methods: `RecoverOnError(bool)`, `SubstituteEntities(bool)`, `LoadExternalDTD(bool)`, `DefaultDTDAttributes(bool)`, `ValidateDTD(bool)`, `SuppressErrors(bool)`, `SuppressWarnings(bool)`, `PedanticErrors(bool)`, `StripBlanks(bool)`, `ProcessXInclude(bool)`, `AllowNetwork(bool)`, `CleanNamespaces(bool)`, `MergeCDATA(bool)`, `XIncludeNodes(bool)`, `CompactTextNodes(bool)`, `FixBaseURIs(bool)`, `RelaxLimits(bool)`, `IgnoreEncoding(bool)`, `BigLineNumbers(bool)`, `BlockXXE(bool)`, `ReuseDict(bool)`, `SkipIDs(bool)`, `LenientXMLDecl(bool)`
-  - Config methods: `SAXHandler(sax.SAX2Handler)`, `BaseURI(string)`, `CharBufferSize(int)`, `MaxDepth(int)`, `Catalog(CatalogResolver)`
+  - Config methods: `SAXHandler(sax.SAX2Handler)`, `BaseURI(string)`, `CharBufferSize(int)`, `MaxDepth(int)`, `MaxExternalDTDBytes(int)`, `Catalog(CatalogResolver)`
   - Terminal methods: `Parse(ctx, []byte) → (*Document, error)`, `ParseReader(ctx, io.Reader) → (*Document, error)`, `ParseFile(ctx, string) → (*Document, error)`, `ParseInNodeContext(ctx, Node, []byte) → (Node, error)`, `NewPushParser(ctx) → *PushParser`
 - **NewWriter() → Writer** — create fluent XML writer builder
   - Writer methods: `Format(bool)`, `IndentString(string)`, `SelfCloseEmptyElements(bool)`, `XMLDeclaration(bool)`, `IncludeDTD(bool)`, `EscapeNonASCII(bool)`, `AllowPrefixUndeclarations(bool)`

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -22,6 +22,9 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
 - Parse flags configured via fluent methods on Parser (internal bitset, not public)
 - `ErrorHandler` interface — async error delivery during parsing
 - `CatalogResolver` interface — public interface for custom catalog resolvers (`Resolve(ctx, pubID, sysID)`, `ResolveURI(ctx, uri)`)
+- `ErrExternalDTDTooLarge` — sentinel error returned when a loaded external DTD subset exceeds the byte cap; enforced against actual bytes read, never the advisory `fs.FileInfo.Size()`
+- `MaxExternalDTDSize` — default external-DTD byte cap (10 MiB), used when `MaxExternalDTDBytes` is unset or ≤ 0
+- `Parser.MaxExternalDTDBytes(n int)` — override the external-DTD byte cap (n ≤ 0 → `MaxExternalDTDSize`)
 - `AsNode[T Node](n Node) (T, bool)` — generic safe type assertion for Node types
 - `Document.GetElementByID(id)` — O(1) via hash table, O(n) fallback
 - `Walk(doc, fn)`, `Children(node)`, `Descendants(node)` — tree traversal

--- a/.claude/docs/parser-internals.md
+++ b/.claude/docs/parser-internals.md
@@ -167,6 +167,7 @@ Expands `&#NNN;`, `&#xHHH;`, `&name;`, `%name;` based on substitution type. Recu
 - `InternalSubset` → create internal DTD
 - `ExternalSubset` → load external DTD, parse declarations
   - Temporarily switches parser `baseURI` to the resolved DTD path while parsing the subset so entity system IDs resolve relative to the DTD file
+  - Bounded read: the DTD is read through `io.LimitReader(f, limit+1)` where `limit` is `ctx.maxExtDTDSize` (set by `Parser.MaxExternalDTDBytes`) or `MaxExternalDTDSize` (10 MiB) when unset/≤0. `fs.FileInfo.Size()` is advisory only — never used to accept or reject — because a valid `fs.FS` may stream, synthesize, under-report, or over-report size; the cap is enforced against actual bytes read. If `len(data) > limit` the load returns `ErrExternalDTDTooLarge`. The size cap is checked BEFORE the read error, so a reader that returns `n>0` with a non-EOF error on the cap-crossing read is still rejected; any other (non-cap) read error is silently ignored. The file is closed immediately after the bounded read, before the buffered DTD is parsed.
 - `GetEntity`/`GetParameterEntity` → lookup in document entity table
 
 ### Parent Selection

--- a/errors.go
+++ b/errors.go
@@ -41,8 +41,9 @@ var (
 	ErrDuplicateAttribute = errors.New("duplicate attribute")
 	ErrEntityBoundary     = errors.New("entity boundary violation")
 	// ErrExternalDTDTooLarge is returned when an external DTD subset exceeds
-	// MaxExternalDTDSize bytes. The cap is enforced against the actual number
-	// of bytes read, not any advisory Stat size.
+	// the configured byte cap (set via Parser.MaxExternalDTDBytes), or
+	// MaxExternalDTDSize when no cap is configured. The cap is enforced
+	// against the actual number of bytes read, not any advisory Stat size.
 	ErrExternalDTDTooLarge = errors.New("external DTD exceeds maximum allowed size")
 	errParserStopped       = errors.New("parser stopped")
 	errNoCursor            = errors.New("parser has no input")

--- a/errors.go
+++ b/errors.go
@@ -40,8 +40,12 @@ var (
 	ErrInvalidOperation   = errors.New("operation cannot be performed")
 	ErrDuplicateAttribute = errors.New("duplicate attribute")
 	ErrEntityBoundary     = errors.New("entity boundary violation")
-	errParserStopped      = errors.New("parser stopped")
-	errNoCursor           = errors.New("parser has no input")
+	// ErrExternalDTDTooLarge is returned when an external DTD subset exceeds
+	// MaxExternalDTDSize bytes. The cap is enforced against the actual number
+	// of bytes read, not any advisory Stat size.
+	ErrExternalDTDTooLarge = errors.New("external DTD exceeds maximum allowed size")
+	errParserStopped       = errors.New("parser stopped")
+	errNoCursor            = errors.New("parser has no input")
 )
 
 // DTDDupTokenError is returned when a DTD attribute enumeration contains

--- a/parser.go
+++ b/parser.go
@@ -43,6 +43,7 @@ type parserConfig struct {
 	catalog        CatalogResolver
 	fsys           fs.FS
 	maxDepth       int
+	maxExtDTDSize  int
 	errorHandler   ErrorHandler
 }
 
@@ -440,6 +441,19 @@ func (p Parser) CharBufferSize(size int) Parser {
 func (p Parser) MaxDepth(depth int) Parser {
 	p = p.clone()
 	p.cfg.maxDepth = depth
+	return p
+}
+
+// MaxExternalDTDBytes sets the maximum number of bytes read from an external
+// DTD subset (see [LoadExternalDTD], [ValidateDTD], [DefaultDTDAttributes]).
+// The cap is enforced against the actual number of bytes read, guarding
+// against hostile or pathological sources (e.g. /dev/zero) that could
+// otherwise exhaust memory before any entity or parse limits apply. A value
+// less than or equal to zero (the default) means [MaxExternalDTDSize] (10 MiB)
+// is used.
+func (p Parser) MaxExternalDTDBytes(n int) Parser {
+	p = p.clone()
+	p.cfg.maxExtDTDSize = n
 	return p
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -634,6 +634,62 @@ func TestParseExternalDTDStatAdvisory(t *testing.T) {
 	require.NoError(t, err, "small valid DTD must load even when Stat over-reports its size")
 }
 
+func TestParseExternalDTDConfigurableLimit(t *testing.T) {
+	t.Parallel()
+
+	const input = `<?xml version="1.0"?>
+<!DOCTYPE r SYSTEM "ext.dtd">
+<r/>`
+
+	t.Run("custom small limit rejects larger DTD", func(t *testing.T) {
+		t.Parallel()
+
+		// A 2 KiB DTD must be rejected when the configured cap is 1 KiB.
+		oversized := bytes.Repeat([]byte(" "), 2<<10)
+		fsys := fstest.MapFS{"ext.dtd": &fstest.MapFile{Data: oversized}}
+
+		p := helium.NewParser().
+			LoadExternalDTD(true).
+			DefaultDTDAttributes(true).
+			MaxExternalDTDBytes(1 << 10).
+			FS(fsys)
+		_, err := p.Parse(t.Context(), []byte(input))
+		require.Error(t, err, "DTD larger than the configured cap must be rejected")
+		require.ErrorIs(t, err, helium.ErrExternalDTDTooLarge, "rejection must come from the byte-count cap")
+	})
+
+	t.Run("custom small limit allows smaller DTD", func(t *testing.T) {
+		t.Parallel()
+
+		// A DTD well under the 1 KiB cap must still load.
+		fsys := fstest.MapFS{"ext.dtd": &fstest.MapFile{Data: []byte(`<!ELEMENT r EMPTY>`)}}
+
+		p := helium.NewParser().
+			LoadExternalDTD(true).
+			DefaultDTDAttributes(true).
+			MaxExternalDTDBytes(1 << 10).
+			FS(fsys)
+		_, err := p.Parse(t.Context(), []byte(input))
+		require.NoError(t, err, "DTD under the configured cap must load")
+	})
+
+	t.Run("default cap allows a normal DTD over a small custom cap", func(t *testing.T) {
+		t.Parallel()
+
+		// Without configuring a custom cap, a DTD larger than 1 KiB (but well
+		// under the 10 MiB default) must still load.
+		large := append([]byte(`<!ELEMENT r EMPTY>`), bytes.Repeat([]byte(" "), 4<<10)...)
+		fsys := fstest.MapFS{"ext.dtd": &fstest.MapFile{Data: large}}
+
+		p := helium.NewParser().
+			LoadExternalDTD(true).
+			DefaultDTDAttributes(true).
+			FS(fsys)
+		_, err := p.Parse(t.Context(), []byte(input))
+		require.NoError(t, err, "DTD under the default cap must load")
+	})
+}
+
 func TestParseExternalEntityValidEncoding(t *testing.T) {
 	t.Parallel()
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -575,6 +575,52 @@ func TestParseExternalDTDBoundedRead(t *testing.T) {
 	require.Equal(t, int64(helium.MaxExternalDTDSize)+1, read, "bounded read must consume exactly MaxExternalDTDSize+1 bytes")
 }
 
+// errReadingFS serves a DTD whose Read returns a full buffer of bytes (taking
+// the running total past MaxExternalDTDSize+1) together with a NON-EOF error
+// on the cap-crossing read. The cap must be enforced against the bytes that
+// were returned, before the read error is inspected, so the size-cap error
+// still fires.
+type errReadingFS struct{}
+
+func (errReadingFS) Open(string) (fs.File, error) { return &errReadingFile{}, nil }
+
+type errReadingFile struct {
+	read int64
+}
+
+func (f *errReadingFile) Stat() (fs.FileInfo, error) { return underReportingInfo{}, nil }
+
+func (f *errReadingFile) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = ' '
+	}
+	f.read += int64(len(p))
+	// Once enough bytes have been handed out to cross the cap, return the
+	// filled buffer alongside a non-EOF error. A reader that handled the
+	// error before checking the byte count would escape the cap.
+	if f.read > int64(helium.MaxExternalDTDSize)+1 {
+		return len(p), errors.New("simulated transport failure")
+	}
+	return len(p), nil
+}
+
+func (f *errReadingFile) Close() error { return nil }
+
+func TestParseExternalDTDReadErrorStillCapped(t *testing.T) {
+	t.Parallel()
+
+	const input = `<?xml version="1.0"?>
+<!DOCTYPE r SYSTEM "huge.dtd">
+<r/>`
+
+	// The cap-crossing read returns n>0 plus a non-EOF error. The size cap
+	// must still fire: the returned bytes already exceed MaxExternalDTDSize.
+	p := helium.NewParser().LoadExternalDTD(true).DefaultDTDAttributes(true).FS(errReadingFS{})
+	_, err := p.Parse(t.Context(), []byte(input))
+	require.Error(t, err, "oversized external DTD must produce a parse error even when the read also errors")
+	require.ErrorIs(t, err, helium.ErrExternalDTDTooLarge, "size cap must be enforced before the read error is handled")
+}
+
 // overReportingFS serves a single small, valid DTD whose Stat over-reports the
 // size as MaxExternalDTDSize+1. The actual content is well under the cap, so
 // the parse must succeed: this proves Stat is advisory and never used to
@@ -627,11 +673,19 @@ func TestParseExternalDTDStatAdvisory(t *testing.T) {
 
 	// A small, valid DTD whose Stat over-reports its size must still load:
 	// the cap is enforced against actual bytes read, not the advisory Stat.
-	fsys := overReportingFS{data: []byte(`<!ELEMENT r EMPTY>`)}
+	// The DTD defaults an attribute so the test observes that the external
+	// subset was actually loaded and applied, not silently skipped.
+	fsys := overReportingFS{data: []byte("<!ELEMENT r EMPTY>\n<!ATTLIST r x CDATA \"default\">")}
 
 	p := helium.NewParser().LoadExternalDTD(true).DefaultDTDAttributes(true).FS(fsys)
-	_, err := p.Parse(t.Context(), []byte(input))
+	doc, err := p.Parse(t.Context(), []byte(input))
 	require.NoError(t, err, "small valid DTD must load even when Stat over-reports its size")
+
+	root := doc.DocumentElement()
+	require.NotNil(t, root, "root element should exist")
+	x, ok := root.GetAttribute("x")
+	require.True(t, ok, "external DTD ATTLIST default must be applied, proving the DTD was loaded")
+	require.Equal(t, "default", x, "defaulted attribute value must come from the external DTD")
 }
 
 func TestParseExternalDTDConfigurableLimit(t *testing.T) {
@@ -661,32 +715,47 @@ func TestParseExternalDTDConfigurableLimit(t *testing.T) {
 	t.Run("custom small limit allows smaller DTD", func(t *testing.T) {
 		t.Parallel()
 
-		// A DTD well under the 1 KiB cap must still load.
-		fsys := fstest.MapFS{"ext.dtd": &fstest.MapFile{Data: []byte(`<!ELEMENT r EMPTY>`)}}
+		// A DTD well under the 1 KiB cap must still load. It defaults an
+		// attribute so the test observes that the DTD was actually applied,
+		// not silently skipped.
+		fsys := fstest.MapFS{"ext.dtd": &fstest.MapFile{Data: []byte("<!ELEMENT r EMPTY>\n<!ATTLIST r x CDATA \"default\">")}}
 
 		p := helium.NewParser().
 			LoadExternalDTD(true).
 			DefaultDTDAttributes(true).
 			MaxExternalDTDBytes(1 << 10).
 			FS(fsys)
-		_, err := p.Parse(t.Context(), []byte(input))
+		doc, err := p.Parse(t.Context(), []byte(input))
 		require.NoError(t, err, "DTD under the configured cap must load")
+
+		root := doc.DocumentElement()
+		require.NotNil(t, root, "root element should exist")
+		x, ok := root.GetAttribute("x")
+		require.True(t, ok, "external DTD ATTLIST default must be applied, proving the DTD was loaded")
+		require.Equal(t, "default", x, "defaulted attribute value must come from the external DTD")
 	})
 
 	t.Run("default cap allows a normal DTD over a small custom cap", func(t *testing.T) {
 		t.Parallel()
 
 		// Without configuring a custom cap, a DTD larger than 1 KiB (but well
-		// under the 10 MiB default) must still load.
-		large := append([]byte(`<!ELEMENT r EMPTY>`), bytes.Repeat([]byte(" "), 4<<10)...)
+		// under the 10 MiB default) must still load. It defaults an attribute
+		// so the test observes that the DTD was actually applied.
+		large := append([]byte("<!ELEMENT r EMPTY>\n<!ATTLIST r x CDATA \"default\">"), bytes.Repeat([]byte(" "), 4<<10)...)
 		fsys := fstest.MapFS{"ext.dtd": &fstest.MapFile{Data: large}}
 
 		p := helium.NewParser().
 			LoadExternalDTD(true).
 			DefaultDTDAttributes(true).
 			FS(fsys)
-		_, err := p.Parse(t.Context(), []byte(input))
+		doc, err := p.Parse(t.Context(), []byte(input))
 		require.NoError(t, err, "DTD under the default cap must load")
+
+		root := doc.DocumentElement()
+		require.NotNil(t, root, "root element should exist")
+		x, ok := root.GetAttribute("x")
+		require.True(t, ok, "external DTD ATTLIST default must be applied, proving the DTD was loaded")
+		require.Equal(t, "default", x, "defaulted attribute value must come from the external DTD")
 	})
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -567,7 +567,71 @@ func TestParseExternalDTDBoundedRead(t *testing.T) {
 	p := helium.NewParser().LoadExternalDTD(true).DefaultDTDAttributes(true).FS(fsys)
 	_, err := p.Parse(t.Context(), []byte(input))
 	require.Error(t, err, "oversized external DTD must produce a parse error even when Stat under-reports size")
-	require.LessOrEqual(t, read, int64(helium.MaxExternalDTDSize)+1, "bounded read must not consume more than MaxExternalDTDSize+1 bytes")
+	require.ErrorIs(t, err, helium.ErrExternalDTDTooLarge, "rejection must come from the byte-count cap")
+	// The bounded read must consume exactly MaxExternalDTDSize+1 bytes: enough
+	// to prove the cap was exceeded, but no more. An implementation that
+	// rejected before reading (e.g. trusting an advisory Stat) would leave
+	// read==0 and fail the lower bound; one without a cap would overrun it.
+	require.Equal(t, int64(helium.MaxExternalDTDSize)+1, read, "bounded read must consume exactly MaxExternalDTDSize+1 bytes")
+}
+
+// overReportingFS serves a single small, valid DTD whose Stat over-reports the
+// size as MaxExternalDTDSize+1. The actual content is well under the cap, so
+// the parse must succeed: this proves Stat is advisory and never used to
+// reject.
+type overReportingFS struct {
+	data []byte
+}
+
+func (fsys overReportingFS) Open(string) (fs.File, error) {
+	return &overReportingFile{data: fsys.data}, nil
+}
+
+type overReportingFile struct {
+	data []byte
+	off  int
+}
+
+// Stat lies the other way: it claims a size above the cap even though Read
+// yields only a few valid bytes.
+func (f *overReportingFile) Stat() (fs.FileInfo, error) {
+	return overReportingInfo{}, nil
+}
+
+func (f *overReportingFile) Read(p []byte) (int, error) {
+	if f.off >= len(f.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, f.data[f.off:])
+	f.off += n
+	return n, nil
+}
+
+func (f *overReportingFile) Close() error { return nil }
+
+type overReportingInfo struct{}
+
+func (overReportingInfo) Name() string       { return "small.dtd" }
+func (overReportingInfo) Size() int64        { return helium.MaxExternalDTDSize + 1 }
+func (overReportingInfo) Mode() fs.FileMode  { return 0 }
+func (overReportingInfo) ModTime() time.Time { return time.Time{} }
+func (overReportingInfo) IsDir() bool        { return false }
+func (overReportingInfo) Sys() any           { return nil }
+
+func TestParseExternalDTDStatAdvisory(t *testing.T) {
+	t.Parallel()
+
+	const input = `<?xml version="1.0"?>
+<!DOCTYPE r SYSTEM "small.dtd">
+<r/>`
+
+	// A small, valid DTD whose Stat over-reports its size must still load:
+	// the cap is enforced against actual bytes read, not the advisory Stat.
+	fsys := overReportingFS{data: []byte(`<!ELEMENT r EMPTY>`)}
+
+	p := helium.NewParser().LoadExternalDTD(true).DefaultDTDAttributes(true).FS(fsys)
+	_, err := p.Parse(t.Context(), []byte(input))
+	require.NoError(t, err, "small valid DTD must load even when Stat over-reports its size")
 }
 
 func TestParseExternalEntityValidEncoding(t *testing.T) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/enum"
@@ -506,6 +507,67 @@ func TestParseExternalDTDSizeLimit(t *testing.T) {
 	p := helium.NewParser().LoadExternalDTD(true).DefaultDTDAttributes(true).FS(fsys)
 	_, err := p.Parse(t.Context(), []byte(input))
 	require.Error(t, err, "oversized external DTD must produce a parse error")
+}
+
+// underReportingFS serves a single DTD file whose Stat under-reports the
+// size while Read produces far more than MaxExternalDTDSize. It also counts
+// the bytes pulled from the underlying reader so the test can assert the
+// read is bounded.
+type underReportingFS struct {
+	read *int64
+}
+
+func (fsys underReportingFS) Open(string) (fs.File, error) {
+	return &underReportingFile{read: fsys.read}, nil
+}
+
+type underReportingFile struct {
+	read *int64
+}
+
+// Stat lies: it claims a tiny size so the early precheck does not catch the
+// oversized content.
+func (f *underReportingFile) Stat() (fs.FileInfo, error) {
+	return underReportingInfo{}, nil
+}
+
+func (f *underReportingFile) Read(p []byte) (int, error) {
+	// Endless stream of spaces; the bounded read must stop it.
+	for i := range p {
+		p[i] = ' '
+	}
+	*f.read += int64(len(p))
+	return len(p), nil
+}
+
+func (f *underReportingFile) Close() error { return nil }
+
+type underReportingInfo struct{}
+
+func (underReportingInfo) Name() string       { return "huge.dtd" }
+func (underReportingInfo) Size() int64        { return 1 }
+func (underReportingInfo) Mode() fs.FileMode  { return 0 }
+func (underReportingInfo) ModTime() time.Time { return time.Time{} }
+func (underReportingInfo) IsDir() bool        { return false }
+func (underReportingInfo) Sys() any           { return nil }
+
+func TestParseExternalDTDBoundedRead(t *testing.T) {
+	t.Parallel()
+
+	const input = `<?xml version="1.0"?>
+<!DOCTYPE r SYSTEM "huge.dtd">
+<r/>`
+
+	// A source whose Stat under-reports its size must still be rejected by
+	// the bounded read, and that read must not consume more than
+	// MaxExternalDTDSize+1 bytes from the underlying reader.
+	var read int64
+	fsys := underReportingFS{read: &read}
+
+	p := helium.NewParser().LoadExternalDTD(true).DefaultDTDAttributes(true).FS(fsys)
+	_, err := p.Parse(t.Context(), []byte(input))
+	require.Error(t, err, "oversized external DTD must produce a parse error even when Stat under-reports size")
+	require.LessOrEqual(t, read, int64(helium.MaxExternalDTDSize)+1, "bounded read must not consume more than MaxExternalDTDSize+1 bytes")
 }
 
 func TestParseExternalEntityValidEncoding(t *testing.T) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -491,6 +491,23 @@ func TestParseExternalEntityMalformedEncoding(t *testing.T) {
 	require.Error(t, err, "malformed UTF-16 external entity must fail rather than inserting U+FFFD")
 }
 
+func TestParseExternalDTDSizeLimit(t *testing.T) {
+	t.Parallel()
+
+	const input = `<?xml version="1.0"?>
+<!DOCTYPE r SYSTEM "huge.dtd">
+<r/>`
+
+	// An oversized external DTD must be rejected with a parse error rather
+	// than being read whole into memory (potential OOM/hang).
+	oversized := bytes.Repeat([]byte(" "), helium.MaxExternalDTDSize+1)
+	fsys := fstest.MapFS{"huge.dtd": &fstest.MapFile{Data: oversized}}
+
+	p := helium.NewParser().LoadExternalDTD(true).DefaultDTDAttributes(true).FS(fsys)
+	_, err := p.Parse(t.Context(), []byte(input))
+	require.Error(t, err, "oversized external DTD must produce a parse error")
+}
+
 func TestParseExternalEntityValidEncoding(t *testing.T) {
 	t.Parallel()
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -576,16 +576,25 @@ func TestParseExternalDTDBoundedRead(t *testing.T) {
 }
 
 // errReadingFS serves a DTD whose Read returns a full buffer of bytes (taking
-// the running total past MaxExternalDTDSize+1) together with a NON-EOF error
-// on the cap-crossing read. The cap must be enforced against the bytes that
-// were returned, before the read error is inspected, so the size-cap error
-// still fires.
-type errReadingFS struct{}
+// the running total past the configured cap) together with a NON-EOF error on
+// the cap-crossing read. The cap must be enforced against the bytes that were
+// returned, before the read error is inspected, so the size-cap error still
+// fires. A small cap is used so the bounded read does not pull megabytes; the
+// fake records whether the simulated read error was actually returned so the
+// test can prove the error path was exercised.
+type errReadingFS struct {
+	cap        int
+	hitReadErr *bool
+}
 
-func (errReadingFS) Open(string) (fs.File, error) { return &errReadingFile{}, nil }
+func (fsys errReadingFS) Open(string) (fs.File, error) {
+	return &errReadingFile{cap: fsys.cap, hitReadErr: fsys.hitReadErr}, nil
+}
 
 type errReadingFile struct {
-	read int64
+	cap        int
+	read       int64
+	hitReadErr *bool
 }
 
 func (f *errReadingFile) Stat() (fs.FileInfo, error) { return underReportingInfo{}, nil }
@@ -595,10 +604,11 @@ func (f *errReadingFile) Read(p []byte) (int, error) {
 		p[i] = ' '
 	}
 	f.read += int64(len(p))
-	// Once enough bytes have been handed out to cross the cap, return the
+	// Once enough bytes have been handed out to reach the cap, return the
 	// filled buffer alongside a non-EOF error. A reader that handled the
 	// error before checking the byte count would escape the cap.
-	if f.read > int64(helium.MaxExternalDTDSize)+1 {
+	if f.read >= int64(f.cap) {
+		*f.hitReadErr = true
 		return len(p), errors.New("simulated transport failure")
 	}
 	return len(p), nil
@@ -613,10 +623,17 @@ func TestParseExternalDTDReadErrorStillCapped(t *testing.T) {
 <!DOCTYPE r SYSTEM "huge.dtd">
 <r/>`
 
-	// The cap-crossing read returns n>0 plus a non-EOF error. The size cap
-	// must still fire: the returned bytes already exceed MaxExternalDTDSize.
-	p := helium.NewParser().LoadExternalDTD(true).DefaultDTDAttributes(true).FS(errReadingFS{})
+	// Use a small cap so the bounded read does not pull a 10 MiB stream. The
+	// cap-crossing read returns n>0 plus a non-EOF error. The size cap must
+	// still fire: the returned bytes already exceed the configured cap.
+	const smallCap = 4096
+	var hitReadErr bool
+	fsys := errReadingFS{cap: smallCap, hitReadErr: &hitReadErr}
+
+	p := helium.NewParser().LoadExternalDTD(true).DefaultDTDAttributes(true).
+		MaxExternalDTDBytes(smallCap).FS(fsys)
 	_, err := p.Parse(t.Context(), []byte(input))
+	require.True(t, hitReadErr, "the simulated non-EOF read error must actually be returned by the fake")
 	require.Error(t, err, "oversized external DTD must produce a parse error even when the read also errors")
 	require.ErrorIs(t, err, helium.ErrExternalDTDTooLarge, "size cap must be enforced before the read error is handled")
 }

--- a/parserctx.go
+++ b/parserctx.go
@@ -123,6 +123,7 @@ type parserCtx struct {
 	recoverErr       error             // first fatal error saved during recovery
 	elemDepth        int               // current element nesting depth
 	maxElemDepth     int               // max allowed element nesting depth (0 = unlimited)
+	maxExtDTDSize    int               // max bytes read from an external DTD subset (<= 0 = MaxExternalDTDSize)
 	currentEntityURI string            // URI of the external entity currently being replayed (for base-uri tracking)
 	nameCache        map[string]string // per-parse string interning for element/attribute names
 	charBuf          []byte            // reusable buffer for parseCharDataContent
@@ -443,6 +444,7 @@ func (ctx *parserCtx) init(p *parserConfig, in io.Reader) error {
 			ctx.loadsubset.Set(SkipIDs)
 		}
 		ctx.maxElemDepth = p.maxDepth
+		ctx.maxExtDTDSize = p.maxExtDTDSize
 	}
 	if ctx.fsys == nil {
 		ctx.fsys = iofs.PermissiveRoot{}

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -421,11 +421,15 @@ func (t *TreeBuilder) ExternalSubset(ctxif context.Context, name, eid, uri strin
 	// bytes read below. Read through a strict byte cap, allowing one extra
 	// byte so a source that under-reports (or lies about) its size is still
 	// caught.
-	data, err := io.ReadAll(io.LimitReader(f, MaxExternalDTDSize+1))
+	limit := ctx.maxExtDTDSize
+	if limit <= 0 {
+		limit = MaxExternalDTDSize
+	}
+	data, err := io.ReadAll(io.LimitReader(f, int64(limit)+1))
 	if err != nil {
 		return nil
 	}
-	if len(data) > MaxExternalDTDSize {
+	if len(data) > limit {
 		return ErrExternalDTDTooLarge
 	}
 

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -412,7 +412,6 @@ func (t *TreeBuilder) ExternalSubset(ctxif context.Context, name, eid, uri strin
 		// Silently ignore missing external DTDs
 		return nil
 	}
-	defer f.Close()
 
 	// fs.FileInfo.Size() is only reliable for regular files: a valid fs.FS
 	// may stream or synthesize DTD content and report a non-regular,
@@ -425,12 +424,20 @@ func (t *TreeBuilder) ExternalSubset(ctxif context.Context, name, eid, uri strin
 	if limit <= 0 {
 		limit = MaxExternalDTDSize
 	}
-	data, err := io.ReadAll(io.LimitReader(f, int64(limit)+1))
-	if err != nil {
-		return nil
-	}
+	data, readErr := io.ReadAll(io.LimitReader(f, int64(limit)+1))
+	// Close the file immediately once the bounded read completes, before the
+	// already-buffered DTD is parsed, so the descriptor is not held open for
+	// the lifetime of the parse.
+	f.Close()
+
+	// Enforce the cap authoritatively against the bytes actually read, before
+	// inspecting the read error: a reader that returns n>0 alongside a
+	// non-EOF error on the cap-crossing read must still be rejected.
 	if len(data) > limit {
 		return ErrExternalDTDTooLarge
+	}
+	if readErr != nil {
+		return nil
 	}
 
 	doc := ctx.doc

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/fs"
 	"path/filepath"
 	"strings"
 
@@ -15,6 +14,14 @@ import (
 	"github.com/lestrrat-go/helium/sax"
 	"github.com/lestrrat-go/pdebug"
 )
+
+// MaxExternalDTDSize is the maximum number of bytes read from an external
+// DTD subset. Loading is gated by LoadExternalDTD/ValidateDTD/
+// DefaultDTDAttributes, so an unbounded read of a hostile or pathological
+// source (e.g. /dev/zero) could exhaust memory before any entity or parse
+// limits apply. The DTD is read through a strict byte cap and rejected when
+// it is exceeded.
+const MaxExternalDTDSize = 10 << 20 // 10 MiB
 
 // fileParseInput wraps an os.File as a sax.ParseInput.
 type fileParseInput struct {
@@ -400,10 +407,35 @@ func (t *TreeBuilder) ExternalSubset(ctxif context.Context, name, eid, uri strin
 		resolved = filepath.Join(filepath.Dir(ctx.baseURI), uri)
 	}
 
-	data, err := fs.ReadFile(ctx.fsys, resolved)
+	f, err := ctx.fsys.Open(resolved)
 	if err != nil {
 		// Silently ignore missing external DTDs
 		return nil
+	}
+	defer f.Close()
+
+	// Reject non-regular sources (devices, FIFOs, directories) and oversized
+	// files up front when the size is known. This prevents an unbounded read
+	// of a pathological source such as /dev/zero from exhausting memory.
+	info, err := f.Stat()
+	if err != nil {
+		return nil
+	}
+	if !info.Mode().IsRegular() {
+		return errors.New("external DTD is not a regular file")
+	}
+	if info.Size() > MaxExternalDTDSize {
+		return errors.New("external DTD exceeds maximum allowed size")
+	}
+
+	// Read through a strict byte cap. Allow one extra byte so a source that
+	// under-reports (or lies about) its size is still caught here.
+	data, err := io.ReadAll(io.LimitReader(f, MaxExternalDTDSize+1))
+	if err != nil {
+		return nil
+	}
+	if len(data) > MaxExternalDTDSize {
+		return errors.New("external DTD exceeds maximum allowed size")
 	}
 
 	doc := ctx.doc

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"path/filepath"
 	"strings"
 
@@ -424,7 +425,17 @@ func (t *TreeBuilder) ExternalSubset(ctxif context.Context, name, eid, uri strin
 	if limit <= 0 {
 		limit = MaxExternalDTDSize
 	}
-	data, readErr := io.ReadAll(io.LimitReader(f, int64(limit)+1))
+	// Read one byte past the cap so a source that under-reports (or lies about)
+	// its size is still caught, but guard against overflow: int64(limit)+1
+	// wraps to a negative value for limit==math.MaxInt on 64-bit platforms,
+	// which would make io.LimitReader read zero bytes and silently skip a valid
+	// DTD.
+	limit64 := int64(limit)
+	readLimit := limit64
+	if readLimit < math.MaxInt64 {
+		readLimit++
+	}
+	data, readErr := io.ReadAll(io.LimitReader(f, readLimit))
 	// Close the file immediately once the bounded read completes, before the
 	// already-buffered DTD is parsed, so the descriptor is not held open for
 	// the lifetime of the parse.
@@ -433,7 +444,7 @@ func (t *TreeBuilder) ExternalSubset(ctxif context.Context, name, eid, uri strin
 	// Enforce the cap authoritatively against the bytes actually read, before
 	// inspecting the read error: a reader that returns n>0 alongside a
 	// non-EOF error on the cap-crossing read must still be rejected.
-	if len(data) > limit {
+	if int64(len(data)) > limit64 {
 		return ErrExternalDTDTooLarge
 	}
 	if readErr != nil {

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -414,17 +414,13 @@ func (t *TreeBuilder) ExternalSubset(ctxif context.Context, name, eid, uri strin
 	}
 	defer f.Close()
 
-	// Reject non-regular sources (devices, FIFOs, directories) and oversized
-	// files up front when the size is known. This prevents an unbounded read
-	// of a pathological source such as /dev/zero from exhausting memory.
-	info, err := f.Stat()
-	if err != nil {
-		return nil
-	}
-	if !info.Mode().IsRegular() {
-		return errors.New("external DTD is not a regular file")
-	}
-	if info.Size() > MaxExternalDTDSize {
+	// Stat is advisory only: a valid fs.FS may stream or synthesize DTD
+	// content and legitimately fail Stat or report a non-regular,
+	// unknown, or under-reported size. When Stat succeeds, use the
+	// reported size as an early reject for an obviously oversized source
+	// (e.g. /dev/zero) to avoid starting the read at all. Either way the
+	// authoritative cap is enforced by the bounded read below.
+	if info, statErr := f.Stat(); statErr == nil && info.Size() > MaxExternalDTDSize {
 		return errors.New("external DTD exceeds maximum allowed size")
 	}
 

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -414,24 +414,19 @@ func (t *TreeBuilder) ExternalSubset(ctxif context.Context, name, eid, uri strin
 	}
 	defer f.Close()
 
-	// Stat is advisory only: a valid fs.FS may stream or synthesize DTD
-	// content and legitimately fail Stat or report a non-regular,
-	// unknown, or under-reported size. When Stat succeeds, use the
-	// reported size as an early reject for an obviously oversized source
-	// (e.g. /dev/zero) to avoid starting the read at all. Either way the
-	// authoritative cap is enforced by the bounded read below.
-	if info, statErr := f.Stat(); statErr == nil && info.Size() > MaxExternalDTDSize {
-		return errors.New("external DTD exceeds maximum allowed size")
-	}
-
-	// Read through a strict byte cap. Allow one extra byte so a source that
-	// under-reports (or lies about) its size is still caught here.
+	// fs.FileInfo.Size() is only reliable for regular files: a valid fs.FS
+	// may stream or synthesize DTD content and report a non-regular,
+	// unknown, under-reported, or over-reported size. Stat is therefore
+	// never used to reject — the authoritative cap is the actual number of
+	// bytes read below. Read through a strict byte cap, allowing one extra
+	// byte so a source that under-reports (or lies about) its size is still
+	// caught.
 	data, err := io.ReadAll(io.LimitReader(f, MaxExternalDTDSize+1))
 	if err != nil {
 		return nil
 	}
 	if len(data) > MaxExternalDTDSize {
-		return errors.New("external DTD exceeds maximum allowed size")
+		return ErrExternalDTDTooLarge
 	}
 
 	doc := ctx.doc


### PR DESCRIPTION
- External DTD subset was read whole via `fs.ReadFile` (unbounded), so a hostile/pathological SYSTEM source like `/dev/zero` could OOM/hang before entity or parse limits applied.
- Now opens via the fsys, rejects non-regular sources, and reads through `io.LimitReader` capped at `MaxExternalDTDSize` (10 MiB), returning a parse error when exceeded.