### PR TITLE
fix xsd all particle qname matching

### DIFF
--- a/xsd/validate_all_qname_test.go
+++ b/xsd/validate_all_qname_test.go
@@ -1,0 +1,69 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateAllParticleQName verifies that an xs:all particle declared
+// without a namespace (unqualified local form, elementFormDefault="unqualified")
+// matches on the child element's full expanded name. A namespaced child must NOT
+// be accepted by an unqualified <all> particle, while the correctly unqualified
+// child is accepted.
+func TestValidateAllParticleQName(t *testing.T) {
+	t.Parallel()
+
+	// targetNamespace with unqualified local elements: the wrapper is
+	// {urn:right}root, but its <all> children "a"/"b" are unqualified ({}a, {}b).
+	const schemaSrc = `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:right"
+           xmlns="urn:right"
+           elementFormDefault="unqualified">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:all>
+        <xs:element name="a" type="xs:string"/>
+        <xs:element name="b" type="xs:string"/>
+      </xs:all>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+	compile := func(t *testing.T) *xsd.Schema {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaSrc))
+		require.NoError(t, err)
+		schema, err := xsd.NewCompiler().Compile(t.Context(), doc)
+		require.NoError(t, err)
+		return schema
+	}
+
+	t.Run("unqualified children accepted", func(t *testing.T) {
+		t.Parallel()
+		schema := compile(t)
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(`<?xml version="1.0"?>
+<root xmlns="urn:right"><a xmlns="">x</a><b xmlns="">y</b></root>`))
+		require.NoError(t, err)
+		require.NoError(t, xsd.NewValidator(schema).Validate(t.Context(), doc))
+	})
+
+	t.Run("namespaced child rejected by unqualified particle", func(t *testing.T) {
+		t.Parallel()
+		schema := compile(t)
+		// Here <a>/<b> inherit the urn:right default namespace, so they are
+		// {urn:right}a / {urn:right}b — they must NOT match the unqualified
+		// {}a / {}b particles in the <all> group.
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(`<?xml version="1.0"?>
+<root xmlns="urn:right"><a>x</a><b>y</b></root>`))
+		require.NoError(t, err)
+
+		var errs string
+		err = validateWithOutput(t, xsd.NewValidator(schema), doc, &errs)
+		require.Error(t, err)
+		require.Contains(t, errs, "not expected")
+	})
+}

--- a/xsd/validate_elem.go
+++ b/xsd/validate_elem.go
@@ -169,10 +169,6 @@ func (vc *validationContext) matchAll(ctx context.Context, parent *helium.Elemen
 		child := children[pos+consumed]
 		idx, ok := nameToIdx[QName{Local: child.name, NS: child.ns}]
 		if !ok {
-			// Try without namespace for unqualified declarations.
-			idx, ok = nameToIdx[QName{Local: child.name}]
-		}
-		if !ok {
 			// Unknown child in <all>.
 			expected := unseenParticleNames(mg.Particles, seen, vc.schema)
 			msg := "This element is not expected."
@@ -222,9 +218,6 @@ func (vc *validationContext) matchAll(ctx context.Context, parent *helium.Elemen
 		child := children[pos+i]
 		childQN := QName{Local: child.name, NS: child.ns}
 		idx, ok := nameToIdx[childQN]
-		if !ok {
-			idx, ok = nameToIdx[QName{Local: child.name}]
-		}
 		if !ok {
 			continue
 		}
@@ -593,9 +586,6 @@ func (vc *validationContext) tryMatchAll(_ context.Context, mg *ModelGroup, chil
 	for pos+consumed < len(children) {
 		child := children[pos+consumed]
 		idx, ok := nameToIdx[QName{Local: child.name, NS: child.ns}]
-		if !ok {
-			idx, ok = nameToIdx[QName{Local: child.name}]
-		}
 		if !ok {
 			break
 		}


### PR DESCRIPTION
- `matchAll`/`tryMatchAll` dropped the namespace via a local-name-only fallback, so an unqualified xs:all particle wrongly accepted a target-namespace child
- Match the full expanded QName only, mirroring `matchesDeclDirect`
- Add a test asserting a namespaced child is rejected by an unqualified particle while the qualified one still validates