### PR TITLE
fix relaxng data, attr repeat, and length facets

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -356,6 +356,27 @@ xsd's `enumValueSpaceTypes`) match by `value.Compare` value-space equality (e.g.
 integer `5`≡`+5`≡`05`, NaN≡NaN for float/double); all other recognized types
 (string-family, anyURI) match by whitespace-processed lexical equality.
 
+**Empty / absent `datatypeLibrary`.** The empty built-in library provides only
+`string` and `token`. For libxml2/golden compat, `matchData`/`matchValue` fall
+back to the XSD value path for a recognized bare XSD name (e.g. `<data
+type="integer"/>`) **only when `datatypeLibrary` is genuinely absent** —
+`dataType.libraryDeclared == false`. An explicit `datatypeLibrary=""` (including
+one that resets an inherited XSD library) selects the built-in library and
+rejects bare XSD names. `getDatatypeLibrary` returns `(value, declared)`,
+testing attribute presence (`getAttrOpt`) up the ancestor walk so an explicit
+`""` stops the walk instead of leaking the inherited library. Unknown
+names/libraries fail rather than matching by raw equality.
+
+**Length facets.** `validateWithParams(value, typeName, params)` enforces exact
+`length` as well as `minLength`/`maxLength`, computing length by datatype via
+`facetLength`: rune count for string-family types, XML-whitespace token COUNT
+for XSD list builtins (`NMTOKENS`/`IDREFS`/`ENTITIES`), and decoded OCTET count
+for binary (`hexBinary`/`base64Binary`).
+
+**Tokenization.** All `<list>`, attribute `<group>`/repetition, and
+`<value type="token">` token splitting uses `xmlFields` (XML whitespace #x20,
+#x9, #xA, #xD only) — never `strings.Fields` — so NBSP stays part of a token.
+
 ### Error Suppression
 
 - `suppressDepth` counter incremented during choice branch exploration

--- a/relaxng/grammar.go
+++ b/relaxng/grammar.go
@@ -50,6 +50,13 @@ type pattern struct {
 type dataType struct {
 	library string // datatype library URI
 	name    string // type name (e.g. "integer", "string")
+	// libraryDeclared records whether datatypeLibrary was explicitly present on
+	// this element or an ancestor (even as ""). It distinguishes a truly-absent
+	// library (no datatypeLibrary anywhere) from an explicit datatypeLibrary=""
+	// reset under an inherited library. Only the absent case enables the
+	// libxml2-compat bare-XSD-name fallback in matchData/matchValue; an explicit
+	// "" reset selects the built-in library and rejects bare XSD names.
+	libraryDeclared bool
 }
 
 // param is a facet parameter for data patterns.

--- a/relaxng/parse.go
+++ b/relaxng/parse.go
@@ -808,11 +808,12 @@ func (c *compiler) parseData(ctx context.Context, node *helium.Element) *pattern
 	p := &pattern{kind: patternData, line: node.Line()}
 
 	typeName := getAttr(node, "type")
-	library := getDatatypeLibrary(node)
+	library, declared := getDatatypeLibrary(node)
 
 	p.dataType = &dataType{
-		library: library,
-		name:    typeName,
+		library:         library,
+		name:            typeName,
+		libraryDeclared: declared,
 	}
 
 	// Parse <param> and <except> children
@@ -847,17 +848,19 @@ func (c *compiler) parseValue(_ context.Context, node *helium.Element) *pattern 
 	p := &pattern{kind: patternValue, line: node.Line()}
 
 	typeName := getAttr(node, "type")
-	library := getDatatypeLibrary(node)
+	library, declared := getDatatypeLibrary(node)
 
 	if typeName == "" {
 		// Default type is "token" from the built-in library
 		typeName = "token"
 		library = ""
+		declared = false
 	}
 
 	p.dataType = &dataType{
-		library: library,
-		name:    typeName,
+		library:         library,
+		name:            typeName,
+		libraryDeclared: declared,
 	}
 	p.value = textContent(node)
 
@@ -1148,26 +1151,33 @@ func getAncestorNS(node *helium.Element) string {
 }
 
 // getDatatypeLibrary walks up the tree to find the datatypeLibrary attribute.
-func getDatatypeLibrary(node *helium.Element) string {
-	// Check the element itself first
-	lib := getAttr(node, "datatypeLibrary")
-	if lib != "" {
-		return lib
+// Per RELAX NG, datatypeLibrary is inherited from the nearest ancestor that
+// carries it, but an explicit datatypeLibrary="" RESETS to the built-in
+// library even under an inherited XSD library. The walk therefore tests for
+// attribute PRESENCE (via getAttrOpt) rather than non-emptiness, so an explicit
+// empty value stops the walk and returns "" instead of leaking the inherited
+// XSD library. The second return value reports whether datatypeLibrary was
+// declared anywhere (on the element or an ancestor), so callers can tell an
+// explicit empty reset from a truly-absent library.
+func getDatatypeLibrary(node *helium.Element) (string, bool) {
+	// Check the element itself first.
+	if lib, ok := getAttrOpt(node, "datatypeLibrary"); ok {
+		return lib, true
 	}
-	// Walk up parents
+	// Walk up parents, stopping at the nearest ancestor that declares the
+	// attribute (even if empty).
 	current := node.Parent()
 	for current != nil {
-		if elem, ok := current.(*helium.Element); ok {
-			lib = getAttr(elem, "datatypeLibrary")
-			if lib != "" {
-				return lib
-			}
-			current = elem.Parent()
-		} else {
+		elem, ok := current.(*helium.Element)
+		if !ok {
 			break
 		}
+		if lib, has := getAttrOpt(elem, "datatypeLibrary"); has {
+			return lib, true
+		}
+		current = elem.Parent()
 	}
-	return ""
+	return "", false
 }
 
 // addSchemaError records a schema compilation error.

--- a/relaxng/parse.go
+++ b/relaxng/parse.go
@@ -1133,6 +1133,21 @@ func getAttrOpt(elem *helium.Element, name string) (string, bool) {
 	return strings.TrimSpace(attr.Value()), true
 }
 
+// getUnqualifiedAttrOpt returns the value and presence of an UNQUALIFIED
+// (no-namespace) attribute. RELAX NG structural attributes such as
+// datatypeLibrary are always unqualified, so a foreign-namespaced attribute
+// sharing the local name (e.g. f:datatypeLibrary) must not be mistaken for the
+// RELAX NG attribute. Foreign attributes are removed during simplification
+// (spec §§4.1, 4.3) before datatypeLibrary inheritance is computed, so they
+// must not affect the inherited library.
+func getUnqualifiedAttrOpt(elem *helium.Element, name string) (string, bool) {
+	attr, ok := elem.FindAttribute(helium.NSPredicate{Local: name, NamespaceURI: ""})
+	if !ok {
+		return "", false
+	}
+	return strings.TrimSpace(attr.Value()), true
+}
+
 // getAncestorNS walks up the RNG element tree to find the ns attribute.
 // An explicit ns="" on an ancestor stops the walk (empty namespace).
 func getAncestorNS(node *helium.Element) string {
@@ -1160,19 +1175,21 @@ func getAncestorNS(node *helium.Element) string {
 // declared anywhere (on the element or an ancestor), so callers can tell an
 // explicit empty reset from a truly-absent library.
 func getDatatypeLibrary(node *helium.Element) (string, bool) {
-	// Check the element itself first.
-	if lib, ok := getAttrOpt(node, "datatypeLibrary"); ok {
+	// Check the element itself first. Only the UNQUALIFIED datatypeLibrary
+	// counts: a foreign-namespaced f:datatypeLibrary is removed during
+	// simplification and must not reset an inherited library.
+	if lib, ok := getUnqualifiedAttrOpt(node, "datatypeLibrary"); ok {
 		return lib, true
 	}
 	// Walk up parents, stopping at the nearest ancestor that declares the
-	// attribute (even if empty).
+	// (unqualified) attribute (even if empty).
 	current := node.Parent()
 	for current != nil {
 		elem, ok := current.(*helium.Element)
 		if !ok {
 			break
 		}
-		if lib, has := getAttrOpt(elem, "datatypeLibrary"); has {
+		if lib, has := getUnqualifiedAttrOpt(elem, "datatypeLibrary"); has {
 			return lib, true
 		}
 		current = elem.Parent()

--- a/relaxng/token_matcher_test.go
+++ b/relaxng/token_matcher_test.go
@@ -118,3 +118,64 @@ func TestTokenMatcherChoiceShadowAttr(t *testing.T) {
 		require.Error(t, err, `attribute "1 2 3" should be rejected`)
 	})
 }
+
+// TestTokenMatcherListInRepetitionAttr covers a <list> nested inside a
+// repetition in an attribute (matchAttrTokensCounts patternList case). Each
+// repetition iteration consumes one full run of the list's children; the
+// repetition machinery chains those runs. Without the patternList case the
+// list match returns no counts and every such attribute is wrongly rejected.
+func TestTokenMatcherListInRepetitionAttr(t *testing.T) {
+	t.Parallel()
+
+	oneOrMore := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <attribute name="v">
+    <oneOrMore>
+      <list>
+        <value>foo</value>
+        <value>bar</value>
+      </list>
+    </oneOrMore>
+  </attribute>
+</element>`
+
+	t.Run("oneOrMore single occurrence", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, oneOrMore, `<a v="foo bar"/>`)
+		require.NoError(t, err, `"foo bar" should validate as one list occurrence`)
+	})
+
+	t.Run("oneOrMore two occurrences", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, oneOrMore, `<a v="foo bar foo bar"/>`)
+		require.NoError(t, err, `"foo bar foo bar" should validate as two list occurrences`)
+	})
+
+	t.Run("oneOrMore incomplete list", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, oneOrMore, `<a v="foo"/>`)
+		require.Error(t, err, `"foo" is an incomplete list and should be rejected`)
+	})
+
+	t.Run("oneOrMore wrong second token", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, oneOrMore, `<a v="foo baz"/>`)
+		require.Error(t, err, `"foo baz" has a wrong second token and should be rejected`)
+	})
+
+	zeroOrMore := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <attribute name="v">
+    <zeroOrMore>
+      <list>
+        <value>foo</value>
+        <value>bar</value>
+      </list>
+    </zeroOrMore>
+  </attribute>
+</element>`
+
+	t.Run("zeroOrMore empty", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, zeroOrMore, `<a v=""/>`)
+		require.NoError(t, err, `empty attribute should validate against zeroOrMore-of-list`)
+	})
+}

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
@@ -1075,14 +1077,17 @@ func (v *validator) matchAttrContent(pat *pattern, text string, elem *helium.Ele
 			return -1
 		}
 		return v.matchAttrContent(def, text, elem)
-	case patternOneOrMore:
-		content := wrapChildren(pat.children)
-		if v.matchAttrContent(content, text, elem) != 0 {
-			return -1
+	case patternOneOrMore, patternZeroOrMore:
+		// Match the repetition against the attribute's tokens via the
+		// backtracking token matcher, requiring that the whole token sequence
+		// is consumed. Without the full-consumption check, a zeroOrMore would
+		// accept any text (consuming nothing) and a oneOrMore would ignore
+		// trailing non-matching tokens.
+		tokens := strings.Fields(text)
+		if slices.Contains(v.matchAttrTokensCounts(pat, tokens), len(tokens)) {
+			return 0
 		}
-		return 0
-	case patternZeroOrMore:
-		return 0
+		return -1
 	}
 	return 0
 }
@@ -1749,9 +1754,18 @@ func (v *validator) matchData(pat *pattern, text string) int {
 		case "string":
 			return 0
 		}
+		// A schema may name an XSD datatype (e.g. "integer", "NMTOKEN") without
+		// declaring the XSD datatype library; route recognized names through the
+		// shared XSD validator. Unrecognized names fall through to the failure
+		// below.
+		if _, ok := xsdDatatypeNames[dt.name]; ok {
+			return validateXSDType(dt.name, text, pat.params)
+		}
 	}
 
-	return 0
+	// Unknown built-in datatype name or unknown library: an unsupported datatype
+	// cannot be satisfied, so it must fail rather than silently match everything.
+	return -1
 }
 
 // xsdDatatypeNames is the set of XSD datatype-library names RELAX NG recognizes.
@@ -1807,9 +1821,21 @@ func validateWithParams(value string, params []*param) int {
 				return -1
 			}
 		case "minLength":
-			// simplified: just check length
+			n, err := strconv.Atoi(strings.TrimSpace(p.value))
+			if err != nil {
+				return -1
+			}
+			if utf8.RuneCountInString(value) < n {
+				return -1
+			}
 		case "maxLength":
-			// simplified: just check length
+			n, err := strconv.Atoi(strings.TrimSpace(p.value))
+			if err != nil {
+				return -1
+			}
+			if utf8.RuneCountInString(value) > n {
+				return -1
+			}
 		}
 	}
 	return 0

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1213,6 +1213,13 @@ func (v *validator) matchAttrTokensCounts(pat *pattern, tokens []string) []int {
 		return v.repeatCounts(content, tokens, 0)
 	case patternGroup:
 		return v.groupCounts(pat.children, tokens)
+	case patternList:
+		// A <list> nested in a repetition (e.g. oneOrMore/zeroOrMore) consumes
+		// one full run of its children per iteration; return the set of token
+		// counts a sequential match of those children can consume so the
+		// repetition machinery can chain iterations. This mirrors the
+		// full-consumption check matchListContent performs for a standalone list.
+		return v.groupCounts(pat.children, tokens)
 	case patternText:
 		// Text in a list: consume one token (or none when empty).
 		if len(tokens) > 0 {

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -3,6 +3,8 @@ package relaxng
 import (
 	"cmp"
 	"context"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"regexp"
 	"slices"
@@ -1054,8 +1056,10 @@ func (v *validator) matchAttrContent(pat *pattern, text string, elem *helium.Ele
 	case patternGroup:
 		// Sequential match on tokens, backtracking across each member's
 		// consumption options so a greedy repetition or a zero-token choice
-		// branch cannot strand a later mandatory member.
-		tokens := strings.Fields(text)
+		// branch cannot strand a later mandatory member. Tokenization splits on
+		// XML whitespace only (#x20, #x9, #xA, #xD), not arbitrary Unicode
+		// whitespace, so a value such as "a b" stays a single token.
+		tokens := xmlFields(text)
 		if slices.Contains(v.groupCounts(pat.children, tokens), len(tokens)) {
 			return 0
 		}
@@ -1096,7 +1100,9 @@ func (v *validator) matchAttrContent(pat *pattern, text string, elem *helium.Ele
 
 // matchListContent validates a string against a list pattern.
 func (v *validator) matchListContent(pat *pattern, text string, elem *helium.Element) int {
-	tokens := strings.Fields(text)
+	// <list> tokenization splits on XML whitespace only (#x20, #x9, #xA, #xD),
+	// not arbitrary Unicode whitespace (e.g. NBSP stays part of a token).
+	tokens := xmlFields(text)
 	// Backtrack across each member's consumption options so a greedy
 	// repetition or a zero-token choice branch cannot strand a later
 	// mandatory member.
@@ -1644,13 +1650,34 @@ func (v *validator) matchValue(pat *pattern, text string) int {
 
 	if pat.dataType != nil {
 		switch pat.dataType.library {
-		case "":
-			if pat.dataType.name == lexicon.TypeToken {
-				text = normalizeToken(text)
-				expected = normalizeToken(expected)
-			}
 		case lexicon.NamespaceXSDDatatypes:
 			return matchXSDValue(pat.dataType.name, text, expected)
+		case "":
+			// Empty datatypeLibrary selects the built-in RELAX NG library, which
+			// provides only "string" (lexical equality) and "token" (whiteSpace
+			// =collapse equality). Mirror matchData: recognized bare XSD type
+			// names are routed through the same XSD value path used there
+			// (documented libxml2/golden-compat deviation; see matchData and the
+			// token-matcher tests cited there); an unknown name fails rather than
+			// silently matching by raw equality.
+			switch pat.dataType.name {
+			case lexicon.TypeToken:
+				text = normalizeToken(text)
+				expected = normalizeToken(expected)
+			case "string":
+				// Lexical equality below.
+			default:
+				// Only fall back to the XSD value path when datatypeLibrary is
+				// genuinely absent; an explicit "" reset rejects bare XSD names.
+				if _, ok := xsdDatatypeNames[pat.dataType.name]; ok && !pat.dataType.libraryDeclared {
+					return matchXSDValue(pat.dataType.name, text, expected)
+				}
+				return -1
+			}
+		default:
+			// Unknown datatype library: an unsupported <value> datatype cannot be
+			// satisfied, so it must fail rather than fall through to raw equality.
+			return -1
 		}
 	}
 
@@ -1764,15 +1791,27 @@ func (v *validator) matchData(pat *pattern, text string) int {
 		//
 		// We deliberately deviate for libxml2/golden compatibility: libxml2's
 		// RELAX NG engine resolves bare XSD datatype names against its built-in
-		// XSD library, and the established token-matcher unit tests (PR #451)
-		// exercise the group/choice backtracking machinery using bare
-		// <data type="integer"/> and <data type="NMTOKEN"/> schemas. Routing
-		// only RECOGNIZED XSD datatype names through the shared validator keeps
-		// those green while still validating the value (so e.g. an out-of-range
-		// integer is rejected). Crucially, a truly-unknown name such as
-		// type="bogus" is NOT in xsdDatatypeNames and falls through to the
+		// XSD library. The hand-written token-matcher unit tests rely on this:
+		// their schemas use bare <data type="integer"/> and <data type="NMTOKEN"/>
+		// with NO datatypeLibrary declared or inherited anywhere (the root is a
+		// plain <element xmlns="…relaxng…structure/1.0">, no <grammar> ancestor
+		// and no datatypeLibrary attribute). Specifically required by:
+		//   - TestTokenMatcherChoiceShadow / ...ChoiceShadowAttr (token_matcher_test.go)
+		//   - TestTokenMatcherGroupBacktrack (token_matcher_test.go, bare NMTOKEN)
+		//   - TestTokenMatcherNullableOneOrMore / ...NoExponentialBlowup
+		//     (token_matcher_review_test.go, bare integer)
+		// Verified by grepping those fixtures: removing this fallback breaks them.
+		// Routing only RECOGNIZED XSD datatype names through the shared validator
+		// keeps those green while still validating the value (so e.g. an
+		// out-of-range integer is rejected). Crucially, a truly-unknown name such
+		// as type="bogus" is NOT in xsdDatatypeNames and falls through to the
 		// failure below, fixing the original "empty library matches anything" bug.
-		if _, ok := xsdDatatypeNames[dt.name]; ok {
+		//
+		// The fallback applies ONLY when datatypeLibrary is genuinely ABSENT
+		// (libraryDeclared == false). An explicit datatypeLibrary="" — including
+		// one that resets an inherited XSD library — selects the built-in library
+		// conformantly and so rejects bare XSD names like "integer".
+		if _, ok := xsdDatatypeNames[dt.name]; ok && !dt.libraryDeclared {
 			return validateXSDType(dt.name, text, pat.params)
 		}
 	}
@@ -1814,7 +1853,7 @@ func validateXSDType(typeName, text string, params []*param) int {
 	// xs:string has whiteSpace=preserve and may carry RELAX NG <param> facets
 	// (pattern, length, …); validate those locally against the preserved text.
 	if typeName == "string" {
-		return validateWithParams(text, params)
+		return validateWithParams(text, typeName, params)
 	}
 	// Apply the datatype's XSD whiteSpace facet (replace for normalizedString,
 	// collapse for everything else here) before lexical validation, so a value
@@ -1825,11 +1864,12 @@ func validateXSDType(typeName, text string, params []*param) int {
 	}
 	// Apply the supported length facets to the whitespace-normalized value for
 	// every applicable XSD datatype, not just xs:string. The length facets are
-	// defined on the value's character count after whiteSpace processing.
-	return validateWithParams(text, params)
+	// defined on the value's length in the units fixed by the datatype (see
+	// facetLength).
+	return validateWithParams(text, typeName, params)
 }
 
-func validateWithParams(value string, params []*param) int {
+func validateWithParams(value, typeName string, params []*param) int {
 	for _, p := range params {
 		switch p.name {
 		case "pattern":
@@ -1837,12 +1877,20 @@ func validateWithParams(value string, params []*param) int {
 			if err != nil || !matched {
 				return -1
 			}
+		case "length":
+			n, err := strconv.Atoi(strings.TrimSpace(p.value))
+			if err != nil {
+				return -1
+			}
+			if facetLength(value, typeName) != n {
+				return -1
+			}
 		case "minLength":
 			n, err := strconv.Atoi(strings.TrimSpace(p.value))
 			if err != nil {
 				return -1
 			}
-			if utf8.RuneCountInString(value) < n {
+			if facetLength(value, typeName) < n {
 				return -1
 			}
 		case "maxLength":
@@ -1850,7 +1898,7 @@ func validateWithParams(value string, params []*param) int {
 			if err != nil {
 				return -1
 			}
-			if utf8.RuneCountInString(value) > n {
+			if facetLength(value, typeName) > n {
 				return -1
 			}
 		}
@@ -1858,9 +1906,70 @@ func validateWithParams(value string, params []*param) int {
 	return 0
 }
 
-// normalizeToken collapses whitespace and trims.
+// facetLength returns the value's length in the units the length/minLength/
+// maxLength facets are defined in for the given XSD datatype:
+//   - list builtins (NMTOKENS, IDREFS, ENTITIES): the number of XML-whitespace
+//     -separated tokens (the list length).
+//   - binary builtins (hexBinary, base64Binary): the number of decoded octets.
+//   - everything else (string family, NMTOKEN, …): the number of characters
+//     (runes) in the value.
+//
+// The value is assumed to have already passed lexical validation for typeName,
+// so the binary decoders below cannot fail for a valid value; on the off chance
+// they do, the raw rune count is returned as a safe fallback.
+func facetLength(value, typeName string) int {
+	switch typeName {
+	case "NMTOKENS", "IDREFS", "ENTITIES":
+		return len(xmlFields(value))
+	case "hexBinary":
+		if n, ok := hexBinaryOctets(value); ok {
+			return n
+		}
+	case "base64Binary":
+		if octets, ok := decodeBase64Octets(value); ok {
+			return len(octets)
+		}
+	}
+	return utf8.RuneCountInString(value)
+}
+
+// hexBinaryOctets returns the decoded octet count of an xs:hexBinary lexical
+// value. Each octet is two hex digits, so for a lexically valid value this is
+// simply len/2.
+func hexBinaryOctets(s string) (int, bool) {
+	s = strings.TrimSpace(s)
+	if len(s)%2 != 0 {
+		return 0, false
+	}
+	if _, err := hex.DecodeString(s); err != nil {
+		return 0, false
+	}
+	return len(s) / 2, true
+}
+
+// decodeBase64Octets decodes an xs:base64Binary lexical value to its octets.
+// XSD permits embedded whitespace, which is stripped before decoding.
+func decodeBase64Octets(s string) ([]byte, bool) {
+	stripped := strings.Map(func(r rune) rune {
+		if isXMLSpace(r) {
+			return -1
+		}
+		return r
+	}, s)
+	decoded, err := base64.StdEncoding.DecodeString(stripped)
+	if err != nil {
+		return nil, false
+	}
+	return decoded, true
+}
+
+// normalizeToken collapses runs of XML whitespace (#x20, #x9, #xA, #xD) into a
+// single space and trims leading/trailing XML whitespace, matching the
+// xs:token whiteSpace=collapse facet. It splits on XML whitespace only (via
+// xmlFields), not arbitrary Unicode whitespace, so NBSP is preserved within a
+// token.
 func normalizeToken(s string) string {
-	return strings.Join(strings.Fields(s), " ")
+	return strings.Join(xmlFields(s), " ")
 }
 
 // isXMLSpace reports whether r is one of the four XML whitespace characters

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1882,7 +1882,8 @@ func validateWithParams(value, typeName string, params []*param) int {
 			if err != nil {
 				return -1
 			}
-			if facetLength(value, typeName) != n {
+			length, ok := facetLength(value, typeName)
+			if !ok || length != n {
 				return -1
 			}
 		case "minLength":
@@ -1890,7 +1891,8 @@ func validateWithParams(value, typeName string, params []*param) int {
 			if err != nil {
 				return -1
 			}
-			if facetLength(value, typeName) < n {
+			length, ok := facetLength(value, typeName)
+			if !ok || length < n {
 				return -1
 			}
 		case "maxLength":
@@ -1898,7 +1900,8 @@ func validateWithParams(value, typeName string, params []*param) int {
 			if err != nil {
 				return -1
 			}
-			if facetLength(value, typeName) > n {
+			length, ok := facetLength(value, typeName)
+			if !ok || length > n {
 				return -1
 			}
 		}
@@ -1907,30 +1910,34 @@ func validateWithParams(value, typeName string, params []*param) int {
 }
 
 // facetLength returns the value's length in the units the length/minLength/
-// maxLength facets are defined in for the given XSD datatype:
+// maxLength facets are defined in for the given XSD datatype, and ok=true when
+// that length is well-defined:
 //   - list builtins (NMTOKENS, IDREFS, ENTITIES): the number of XML-whitespace
 //     -separated tokens (the list length).
 //   - binary builtins (hexBinary, base64Binary): the number of decoded octets.
 //   - everything else (string family, NMTOKEN, …): the number of characters
 //     (runes) in the value.
 //
-// The value is assumed to have already passed lexical validation for typeName,
-// so the binary decoders below cannot fail for a valid value; on the off chance
-// they do, the raw rune count is returned as a safe fallback.
-func facetLength(value, typeName string) int {
+// For the binary builtins the length is measured in decoded octets, so if the
+// value cannot be decoded ok=false is returned and the facet must be treated as
+// unsatisfiable: the rune count of an undecodable binary value is meaningless,
+// and falling back to it would silently compare lengths in the wrong unit. A
+// value that has passed lexical validation for typeName decodes successfully, so
+// this only guards against an undecodable value reaching the facet check.
+func facetLength(value, typeName string) (int, bool) {
 	switch typeName {
 	case "NMTOKENS", "IDREFS", "ENTITIES":
-		return len(xmlFields(value))
+		return len(xmlFields(value)), true
 	case "hexBinary":
-		if n, ok := hexBinaryOctets(value); ok {
-			return n
-		}
+		return hexBinaryOctets(value)
 	case "base64Binary":
-		if octets, ok := decodeBase64Octets(value); ok {
-			return len(octets)
+		octets, ok := decodeBase64Octets(value)
+		if !ok {
+			return 0, false
 		}
+		return len(octets), true
 	}
-	return utf8.RuneCountInString(value)
+	return utf8.RuneCountInString(value), true
 }
 
 // hexBinaryOctets returns the decoded octet count of an xs:hexBinary lexical
@@ -1947,8 +1954,13 @@ func hexBinaryOctets(s string) (int, bool) {
 	return len(s) / 2, true
 }
 
-// decodeBase64Octets decodes an xs:base64Binary lexical value to its octets.
-// XSD permits embedded whitespace, which is stripped before decoding.
+// decodeBase64Octets decodes an xs:base64Binary lexical value to its octets,
+// mirroring the strict decoder used by the xsd/value comparison path so the two
+// agree on what counts as a valid base64Binary. XSD permits embedded whitespace,
+// which is stripped first; the remainder must then be correctly padded and have
+// zero unused trailing bits (Strict()), so unpadded forms such as "TQ" or padded
+// forms with non-zero trailing bits such as "TR==" fail to decode rather than
+// yielding a bogus octet count.
 func decodeBase64Octets(s string) ([]byte, bool) {
 	stripped := strings.Map(func(r rune) rune {
 		if isXMLSpace(r) {
@@ -1956,7 +1968,7 @@ func decodeBase64Octets(s string) ([]byte, bool) {
 		}
 		return r
 	}, s)
-	decoded, err := base64.StdEncoding.DecodeString(stripped)
+	decoded, err := base64.StdEncoding.Strict().DecodeString(stripped)
 	if err != nil {
 		return nil, false
 	}

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1082,8 +1082,10 @@ func (v *validator) matchAttrContent(pat *pattern, text string, elem *helium.Ele
 		// backtracking token matcher, requiring that the whole token sequence
 		// is consumed. Without the full-consumption check, a zeroOrMore would
 		// accept any text (consuming nothing) and a oneOrMore would ignore
-		// trailing non-matching tokens.
-		tokens := strings.Fields(text)
+		// trailing non-matching tokens. Tokenization must split on XML
+		// whitespace only (#x20, #x9, #xA, #xD), not arbitrary Unicode
+		// whitespace, so a value such as "a b" stays a single token.
+		tokens := xmlFields(text)
 		if slices.Contains(v.matchAttrTokensCounts(pat, tokens), len(tokens)) {
 			return 0
 		}
@@ -1754,10 +1756,22 @@ func (v *validator) matchData(pat *pattern, text string) int {
 		case "string":
 			return 0
 		}
-		// A schema may name an XSD datatype (e.g. "integer", "NMTOKEN") without
-		// declaring the XSD datatype library; route recognized names through the
-		// shared XSD validator. Unrecognized names fall through to the failure
-		// below.
+		// Spec note: per RELAX NG, an omitted datatypeLibrary selects the EMPTY
+		// built-in library, which provides ONLY "string" and "token"; XSD
+		// datatypes strictly require datatypeLibrary
+		// "http://www.w3.org/2001/XMLSchema-datatypes". A spec-conformant
+		// processor would reject <data type="integer"/> here.
+		//
+		// We deliberately deviate for libxml2/golden compatibility: libxml2's
+		// RELAX NG engine resolves bare XSD datatype names against its built-in
+		// XSD library, and the established token-matcher unit tests (PR #451)
+		// exercise the group/choice backtracking machinery using bare
+		// <data type="integer"/> and <data type="NMTOKEN"/> schemas. Routing
+		// only RECOGNIZED XSD datatype names through the shared validator keeps
+		// those green while still validating the value (so e.g. an out-of-range
+		// integer is rejected). Crucially, a truly-unknown name such as
+		// type="bogus" is NOT in xsdDatatypeNames and falls through to the
+		// failure below, fixing the original "empty library matches anything" bug.
 		if _, ok := xsdDatatypeNames[dt.name]; ok {
 			return validateXSDType(dt.name, text, pat.params)
 		}
@@ -1809,7 +1823,10 @@ func validateXSDType(typeName, text string, params []*param) int {
 	if value.ValidateBuiltin(text, typeName) != nil {
 		return -1
 	}
-	return 0
+	// Apply the supported length facets to the whitespace-normalized value for
+	// every applicable XSD datatype, not just xs:string. The length facets are
+	// defined on the value's character count after whiteSpace processing.
+	return validateWithParams(text, params)
 }
 
 func validateWithParams(value string, params []*param) int {
@@ -1844,6 +1861,20 @@ func validateWithParams(value string, params []*param) int {
 // normalizeToken collapses whitespace and trims.
 func normalizeToken(s string) string {
 	return strings.Join(strings.Fields(s), " ")
+}
+
+// isXMLSpace reports whether r is one of the four XML whitespace characters
+// (#x20, #x9, #xA, #xD). RELAX NG / XSD list tokenization is defined in terms
+// of these only, unlike strings.Fields which splits on all Unicode whitespace
+// (e.g. NBSP, which must remain part of a token).
+func isXMLSpace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+}
+
+// xmlFields splits s into tokens on XML whitespace only, discarding empty
+// fields. It is the XML-whitespace analogue of strings.Fields.
+func xmlFields(s string) []string {
+	return strings.FieldsFunc(s, isXMLSpace)
 }
 
 // addError adds a validation error (suppressed when inside choice branches).

--- a/relaxng/validate_consistency_test.go
+++ b/relaxng/validate_consistency_test.go
@@ -1,0 +1,274 @@
+package relaxng_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const nbsp = " " // U+00A0 NO-BREAK SPACE: not XML whitespace.
+
+// TestListNBSPTokenize covers item 1 for <list>: list tokenization must split
+// on XML whitespace only (#x20, #x9, #xA, #xD), not arbitrary Unicode
+// whitespace. An NBSP-joined value stays a single token.
+func TestListNBSPTokenize(t *testing.T) {
+	t.Parallel()
+
+	schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <list>
+    <oneOrMore><value>foo</value></oneOrMore>
+  </list>
+</element>`
+
+	t.Run("space-separated is two tokens", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a>foo foo</a>`)
+		require.NoError(t, err, `"foo foo" is two foo tokens`)
+	})
+
+	t.Run("nbsp-separated is one non-matching token", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, "<a>foo"+nbsp+"foo</a>")
+		require.Error(t, err, "NBSP-joined value is a single token, not two foo")
+	})
+}
+
+// TestAttrGroupNBSPTokenize covers item 1 for the attribute <group> path: the
+// patternGroup token list in matchAttrContent must split on XML whitespace
+// only. An NBSP-joined value is a single token.
+func TestAttrGroupNBSPTokenize(t *testing.T) {
+	t.Parallel()
+
+	schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <attribute name="v">
+    <group>
+      <value>foo</value>
+      <value>bar</value>
+    </group>
+  </attribute>
+</element>`
+
+	t.Run("space-separated is two tokens", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a v="foo bar"/>`)
+		require.NoError(t, err, `"foo bar" is two tokens matching the group`)
+	})
+
+	t.Run("nbsp-separated is one non-matching token", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, "<a v=\"foo"+nbsp+"bar\"/>")
+		require.Error(t, err, "NBSP-joined value is a single token, not foo+bar")
+	})
+}
+
+// TestValueTokenNBSP covers item 1 for <value type="token">: the token
+// whiteSpace=collapse normalization must collapse XML whitespace only, leaving
+// NBSP intact so it does not collapse to a single space.
+func TestValueTokenNBSP(t *testing.T) {
+	t.Parallel()
+
+	schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <value type="token">foo bar</value>
+</element>`
+
+	t.Run("collapsible xml whitespace matches", func(t *testing.T) {
+		t.Parallel()
+		// Tabs/newlines collapse to single spaces under whiteSpace=collapse.
+		err := validateWith(t, schema, "<a>foo\t\tbar</a>")
+		require.NoError(t, err, `collapsed "foo\t\tbar" equals "foo bar"`)
+	})
+
+	t.Run("nbsp does not collapse", func(t *testing.T) {
+		t.Parallel()
+		// NBSP is not XML whitespace, so "foo bar" stays distinct from the
+		// expected "foo bar".
+		err := validateWith(t, schema, "<a>foo"+nbsp+"bar</a>")
+		require.Error(t, err, "NBSP value must not collapse to match \"foo bar\"")
+	})
+}
+
+// TestValueUnknownDatatype covers item 2: a <value> with an unknown datatype
+// name (empty library) or an unknown datatypeLibrary must FAIL rather than
+// matching by raw string equality.
+func TestValueUnknownDatatype(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unknown bare type name fails", func(t *testing.T) {
+		t.Parallel()
+		schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <value type="bogus">x</value>
+</element>`
+		err := validateWith(t, schema, `<a>x</a>`)
+		require.Error(t, err, `<value type="bogus"> must not match even on identical text`)
+	})
+
+	t.Run("unknown datatypeLibrary fails", func(t *testing.T) {
+		t.Parallel()
+		schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://example.com/unknown-datatypes">
+  <value type="string">x</value>
+</element>`
+		err := validateWith(t, schema, `<a>x</a>`)
+		require.Error(t, err, "unknown datatypeLibrary must not match by raw equality")
+	})
+
+	t.Run("recognized bare XSD type still matches via value space", func(t *testing.T) {
+		t.Parallel()
+		// Mirrors matchData's documented libxml2-compat fallback: a bare
+		// recognized XSD type name (no datatypeLibrary) routes through the XSD
+		// value path, so "5" and "+5" are value-equal for integer.
+		schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <value type="integer">5</value>
+</element>`
+		err := validateWith(t, schema, `<a>+5</a>`)
+		require.NoError(t, err, `integer value "+5" equals "5"`)
+	})
+}
+
+// TestExactLengthFacet covers item 3: the exact <param name="length"> facet
+// must be enforced (it was previously ignored).
+func TestExactLengthFacet(t *testing.T) {
+	t.Parallel()
+
+	schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <data type="string">
+    <param name="length">3</param>
+  </data>
+</element>`
+
+	t.Run("exact length matches", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a>abc</a>`)
+		require.NoError(t, err, `"abc" has length 3`)
+	})
+
+	t.Run("shorter rejected", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a>ab</a>`)
+		require.Error(t, err, `"ab" violates length 3`)
+	})
+
+	t.Run("longer rejected", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a>abcd</a>`)
+		require.Error(t, err, `"abcd" violates length 3`)
+	})
+}
+
+// TestLengthFacetTokenCount covers item 3: for XSD list builtins (NMTOKENS,
+// IDREFS, ENTITIES) the length facet counts XML-whitespace tokens, not
+// characters.
+func TestLengthFacetTokenCount(t *testing.T) {
+	t.Parallel()
+
+	schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <data type="NMTOKENS">
+    <param name="length">2</param>
+  </data>
+</element>`
+
+	t.Run("two tokens match length 2", func(t *testing.T) {
+		t.Parallel()
+		// "ab cd" is 5 characters but 2 tokens; length is token COUNT.
+		err := validateWith(t, schema, `<a>ab cd</a>`)
+		require.NoError(t, err, `"ab cd" has token-length 2`)
+	})
+
+	t.Run("three tokens rejected", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a>ab cd ef</a>`)
+		require.Error(t, err, `"ab cd ef" has token-length 3, violates length 2`)
+	})
+
+	t.Run("one token rejected", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a>ab</a>`)
+		require.Error(t, err, `"ab" has token-length 1, violates length 2`)
+	})
+}
+
+// TestLengthFacetOctetCount covers item 3: for binary builtins the length facet
+// counts DECODED octets, not lexical characters.
+func TestLengthFacetOctetCount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("hexBinary octet count", func(t *testing.T) {
+		t.Parallel()
+		schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <data type="hexBinary">
+    <param name="length">2</param>
+  </data>
+</element>`
+		// "0A0B" is 4 hex chars decoding to 2 octets.
+		err := validateWith(t, schema, `<a>0A0B</a>`)
+		require.NoError(t, err, `"0A0B" decodes to 2 octets`)
+
+		// "0A" is 1 octet, violates length 2.
+		err = validateWith(t, schema, `<a>0A</a>`)
+		require.Error(t, err, `"0A" decodes to 1 octet, violates length 2`)
+	})
+
+	t.Run("base64Binary octet count", func(t *testing.T) {
+		t.Parallel()
+		schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <data type="base64Binary">
+    <param name="length">3</param>
+  </data>
+</element>`
+		// "Zm9v" decodes to "foo" = 3 octets.
+		err := validateWith(t, schema, `<a>Zm9v</a>`)
+		require.NoError(t, err, `"Zm9v" decodes to 3 octets`)
+
+		// "Zm8=" decodes to "fo" = 2 octets, violates length 3.
+		err = validateWith(t, schema, `<a>Zm8=</a>`)
+		require.Error(t, err, `"Zm8=" decodes to 2 octets, violates length 3`)
+	})
+}
+
+// TestInheritedXSDLibraryResetByEmpty covers item 4: a child datatypeLibrary=""
+// must RESET to the built-in library even under an inherited XSD library, so a
+// bare <data type="integer"/> beneath it is NOT treated as XSD. With the reset,
+// "integer" is an unknown built-in name and any value is rejected.
+func TestInheritedXSDLibraryResetByEmpty(t *testing.T) {
+	t.Parallel()
+
+	schema := `<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <element name="a">
+      <data type="integer" datatypeLibrary=""/>
+    </element>
+  </start>
+</grammar>`
+
+	// datatypeLibrary="" resets to the empty built-in library, which provides
+	// only string/token. "integer" is therefore unknown and must fail.
+	err := validateWith(t, schema, `<a>5</a>`)
+	require.Error(t, err, `datatypeLibrary="" resets to built-in; bare integer must fail`)
+}
+
+// TestInheritedXSDLibraryApplies is the contrast to the reset case: without the
+// child datatypeLibrary="" reset, the inherited XSD library applies and a bare
+// <data type="integer"/> validates against the XSD integer type.
+func TestInheritedXSDLibraryApplies(t *testing.T) {
+	t.Parallel()
+
+	schema := `<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <element name="a">
+      <data type="integer"/>
+    </element>
+  </start>
+</grammar>`
+
+	err := validateWith(t, schema, `<a>5</a>`)
+	require.NoError(t, err, "inherited XSD library validates integer 5")
+
+	err = validateWith(t, schema, `<a>x</a>`)
+	require.Error(t, err, "inherited XSD library rejects non-integer")
+}

--- a/relaxng/validate_consistency_test.go
+++ b/relaxng/validate_consistency_test.go
@@ -227,6 +227,38 @@ func TestLengthFacetOctetCount(t *testing.T) {
 		err = validateWith(t, schema, `<a>Zm8=</a>`)
 		require.Error(t, err, `"Zm8=" decodes to 2 octets, violates length 3`)
 	})
+
+	// Regression for the length-facet decoder bug: a base64Binary value whose
+	// octet length is exactly 1 must satisfy <param name="length">1</param>, and
+	// the facet must never silently fall back to a rune count when decoding
+	// fails. With strict padding required by the xsd/value path, the canonical
+	// length-1 value is the padded "TQ==" (decodes to one octet, "M"); its
+	// unpadded form "TQ" is not a valid base64Binary lexical form and so must be
+	// rejected at lexical validation before the facet is even consulted.
+	t.Run("base64Binary length 1 padding", func(t *testing.T) {
+		t.Parallel()
+		schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <data type="base64Binary">
+    <param name="length">1</param>
+  </data>
+</element>`
+		// Padded "TQ==" decodes to a single octet, satisfying length 1. If the
+		// facet wrongly used the rune count (4) this would fail.
+		err := validateWith(t, schema, `<a>TQ==</a>`)
+		require.NoError(t, err, `"TQ==" decodes to 1 octet, satisfies length 1`)
+
+		// Unpadded "TQ" is not a valid base64Binary lexical form under the strict
+		// xsd/value decoder, so it must fail lexical validation; it must NOT be
+		// accepted via a rune-count length of 2 either.
+		err = validateWith(t, schema, `<a>TQ</a>`)
+		require.Error(t, err, `unpadded "TQ" is not valid base64Binary`)
+
+		// "Zm9v" decodes to 3 octets ("foo"), violating length 1. This exercises
+		// the octet-count length-mismatch path for a strictly-valid value.
+		err = validateWith(t, schema, `<a>Zm9v</a>`)
+		require.Error(t, err, `"Zm9v" decodes to 3 octets, violates length 1`)
+	})
 }
 
 // TestInheritedXSDLibraryResetByEmpty covers item 4: a child datatypeLibrary=""

--- a/relaxng/validate_fixes_test.go
+++ b/relaxng/validate_fixes_test.go
@@ -21,6 +21,19 @@ func TestMatchDataUnknownDatatype(t *testing.T) {
 		require.Error(t, err, `<data type="bogus"/> must not match`)
 	})
 
+	t.Run("unknown datatype library", func(t *testing.T) {
+		t.Parallel()
+		// An explicit, unrecognized datatypeLibrary on <data> must fail closed:
+		// matchData returns -1 for an unknown library rather than matching
+		// everything. This directly discriminates the <data> library path
+		// (the bogus-name case above exercises the unknown built-in NAME path).
+		schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <data type="string" datatypeLibrary="http://example.com/unknown-datatypes"/>
+</element>`
+		err := validateWith(t, schema, `<a>x</a>`)
+		require.Error(t, err, `<data> with an unknown datatypeLibrary must not match`)
+	})
+
 	t.Run("builtin token matches", func(t *testing.T) {
 		t.Parallel()
 		schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">

--- a/relaxng/validate_fixes_test.go
+++ b/relaxng/validate_fixes_test.go
@@ -1,0 +1,127 @@
+package relaxng_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMatchDataUnknownDatatype covers bug 1: <data> against an unknown
+// built-in datatype name (or unknown library) must FAIL, not silently match
+// everything.
+func TestMatchDataUnknownDatatype(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unknown builtin datatype name", func(t *testing.T) {
+		t.Parallel()
+		schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <data type="bogus"/>
+</element>`
+		err := validateWith(t, schema, `<a>anything</a>`)
+		require.Error(t, err, `<data type="bogus"/> must not match`)
+	})
+
+	t.Run("builtin token matches", func(t *testing.T) {
+		t.Parallel()
+		schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <data type="token"/>
+</element>`
+		err := validateWith(t, schema, `<a>anything</a>`)
+		require.NoError(t, err, `<data type="token"/> should match`)
+	})
+}
+
+// TestMatchAttrZeroOrMore covers bug 2: a <zeroOrMore><value> inside an
+// attribute must reject tokens the value doesn't match.
+func TestMatchAttrZeroOrMore(t *testing.T) {
+	t.Parallel()
+
+	schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <attribute name="a">
+    <zeroOrMore>
+      <value>foo</value>
+    </zeroOrMore>
+  </attribute>
+</element>`
+
+	t.Run("empty matches", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a a=""/>`)
+		require.NoError(t, err, `empty should match zeroOrMore`)
+	})
+
+	t.Run("matching tokens match", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a a="foo foo"/>`)
+		require.NoError(t, err, `"foo foo" should match`)
+	})
+
+	t.Run("non-matching token rejected", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a a="bar"/>`)
+		require.Error(t, err, `"bar" must be rejected`)
+	})
+}
+
+// TestMatchAttrOneOrMore covers the patternOneOrMore path in matchAttrContent.
+func TestMatchAttrOneOrMore(t *testing.T) {
+	t.Parallel()
+
+	schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <attribute name="a">
+    <oneOrMore>
+      <value>foo</value>
+    </oneOrMore>
+  </attribute>
+</element>`
+
+	t.Run("matching tokens match", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a a="foo foo"/>`)
+		require.NoError(t, err, `"foo foo" should match`)
+	})
+
+	t.Run("non-matching token rejected", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a a="foo bar"/>`)
+		require.Error(t, err, `"foo bar" must be rejected`)
+	})
+}
+
+// TestValidateWithLengthFacets covers bug 3: minLength/maxLength facets on a
+// <data type="string"> must be enforced.
+func TestValidateWithLengthFacets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("minLength", func(t *testing.T) {
+		t.Parallel()
+		schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <data type="string">
+    <param name="minLength">3</param>
+  </data>
+</element>`
+
+		err := validateWith(t, schema, `<a>abc</a>`)
+		require.NoError(t, err, `"abc" meets minLength 3`)
+
+		err = validateWith(t, schema, `<a>ab</a>`)
+		require.Error(t, err, `"ab" violates minLength 3`)
+	})
+
+	t.Run("maxLength", func(t *testing.T) {
+		t.Parallel()
+		schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <data type="string">
+    <param name="maxLength">3</param>
+  </data>
+</element>`
+
+		err := validateWith(t, schema, `<a>abc</a>`)
+		require.NoError(t, err, `"abc" meets maxLength 3`)
+
+		err = validateWith(t, schema, `<a>abcd</a>`)
+		require.Error(t, err, `"abcd" violates maxLength 3`)
+	})
+}

--- a/relaxng/validate_fixes_test.go
+++ b/relaxng/validate_fixes_test.go
@@ -152,6 +152,51 @@ func TestLengthFacetsNonStringDatatype(t *testing.T) {
 	})
 }
 
+// TestForeignDatatypeLibraryIgnored covers a namespace bug: a foreign-namespaced
+// f:datatypeLibrary attribute must NOT be mistaken for the RELAX NG
+// datatypeLibrary attribute. Foreign attributes are removed during
+// simplification (spec §§4.1, 4.3) before datatypeLibrary inheritance is
+// computed, so a foreign f:datatypeLibrary="" must not reset an inherited XSD
+// library. A genuine unqualified datatypeLibrary="" still resets to the
+// built-in library.
+func TestForeignDatatypeLibraryIgnored(t *testing.T) {
+	t.Parallel()
+
+	const xsdLib = "http://www.w3.org/2001/XMLSchema-datatypes"
+
+	t.Run("foreign datatypeLibrary is ignored", func(t *testing.T) {
+		t.Parallel()
+		// The grammar declares the XSD library. The foreign f:datatypeLibrary=""
+		// on the <data> element must be ignored, so type="integer" still
+		// resolves against the inherited XSD library and validates an integer.
+		schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0"
+    xmlns:f="urn:example:foreign"
+    datatypeLibrary="` + xsdLib + `">
+  <data type="integer" f:datatypeLibrary=""/>
+</element>`
+
+		err := validateWith(t, schema, `<a>42</a>`)
+		require.NoError(t, err, `foreign f:datatypeLibrary="" must not reset the inherited XSD library; integer must validate`)
+
+		err = validateWith(t, schema, `<a>notanint</a>`)
+		require.Error(t, err, `non-integer must still be rejected under the inherited XSD library`)
+	})
+
+	t.Run("unqualified datatypeLibrary empty resets to builtin", func(t *testing.T) {
+		t.Parallel()
+		// A genuine unqualified datatypeLibrary="" resets to the built-in
+		// library, where "integer" is not a recognized datatype, so the bare
+		// integer value must be rejected.
+		schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="` + xsdLib + `">
+  <data type="integer" datatypeLibrary=""/>
+</element>`
+
+		err := validateWith(t, schema, `<a>42</a>`)
+		require.Error(t, err, `unqualified datatypeLibrary="" resets to the built-in library where "integer" is unknown`)
+	})
+}
+
 // TestAttrRepeatXMLWhitespaceTokenize covers issue C: the attribute-repetition
 // token list must split on XML whitespace only (#x20, #x9, #xA, #xD), not all
 // Unicode whitespace. An NBSP-separated value is a single token and must not be

--- a/relaxng/validate_fixes_test.go
+++ b/relaxng/validate_fixes_test.go
@@ -125,3 +125,60 @@ func TestValidateWithLengthFacets(t *testing.T) {
 		require.Error(t, err, `"abcd" violates maxLength 3`)
 	})
 }
+
+// TestLengthFacetsNonStringDatatype covers issue B: minLength/maxLength must be
+// enforced for applicable XSD datatypes beyond xs:string (e.g. xs:token), not
+// just left to lexical validation.
+func TestLengthFacetsNonStringDatatype(t *testing.T) {
+	t.Parallel()
+
+	schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <data type="token">
+    <param name="maxLength">3</param>
+  </data>
+</element>`
+
+	t.Run("within maxLength", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a>abc</a>`)
+		require.NoError(t, err, `token "abc" meets maxLength 3`)
+	})
+
+	t.Run("exceeds maxLength", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a>abcd</a>`)
+		require.Error(t, err, `token "abcd" violates maxLength 3`)
+	})
+}
+
+// TestAttrRepeatXMLWhitespaceTokenize covers issue C: the attribute-repetition
+// token list must split on XML whitespace only (#x20, #x9, #xA, #xD), not all
+// Unicode whitespace. An NBSP-separated value is a single token and must not be
+// treated as two "foo" tokens.
+func TestAttrRepeatXMLWhitespaceTokenize(t *testing.T) {
+	t.Parallel()
+
+	schema := `<element name="a" xmlns="http://relaxng.org/ns/structure/1.0">
+  <attribute name="a">
+    <oneOrMore>
+      <value>foo</value>
+    </oneOrMore>
+  </attribute>
+</element>`
+
+	t.Run("space-separated is two tokens", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<a a="foo foo"/>`)
+		require.NoError(t, err, `"foo foo" is two foo tokens`)
+	})
+
+	t.Run("nbsp-separated is one non-matching token", func(t *testing.T) {
+		t.Parallel()
+		// U+00A0 NO-BREAK SPACE between the two words: XML whitespace
+		// tokenization keeps this as a single token "foo foo", which does
+		// not equal the <value>foo</value>, so validation must fail.
+		err := validateWith(t, schema, "<a a=\"foo foo\"/>")
+		require.Error(t, err, "NBSP-joined value is a single token, not two foo")
+	})
+}


### PR DESCRIPTION
- `matchData` now fails on unknown built-in datatype names and unknown libraries instead of matching any text
- `matchAttrContent` routes attribute `zeroOrMore`/`oneOrMore` through the backtracking token matcher with full-consumption, rejecting non-matching tokens
- `validateWithParams` enforces `minLength`/`maxLength` facets (rune count) on `xs:string`