### PR TITLE
guard docorder cache with a mutex

### DIFF
--- a/internal/xpath/docorder.go
+++ b/internal/xpath/docorder.go
@@ -24,15 +24,8 @@ type DocOrderCache struct {
 	rootCache map[helium.Node]helium.Node
 }
 
-// cachedRoot returns the DocumentRoot for n, using the rootCache to avoid
-// repeated parent-chain walks.
-func (c *DocOrderCache) cachedRoot(n helium.Node) helium.Node {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.cachedRootLocked(n)
-}
-
-// cachedRootLocked is the body of cachedRoot; the caller must hold c.mu.
+// cachedRootLocked returns the DocumentRoot for n, using the rootCache to
+// avoid repeated parent-chain walks. The caller must hold c.mu.
 func (c *DocOrderCache) cachedRootLocked(n helium.Node) helium.Node {
 	if c.rootCache == nil {
 		c.rootCache = make(map[helium.Node]helium.Node)

--- a/internal/xpath/docorder.go
+++ b/internal/xpath/docorder.go
@@ -2,6 +2,7 @@ package xpath
 
 import (
 	"sort"
+	"sync"
 
 	helium "github.com/lestrrat-go/helium"
 )
@@ -13,7 +14,11 @@ type docIndex struct {
 
 // DocOrderCache caches document-order positions for nodes grouped by
 // document root. Built lazily on first use and shared across an evaluation.
+//
+// A single DocOrderCache may be shared across concurrent Evaluate calls, so all
+// access to its maps is guarded by mu.
 type DocOrderCache struct {
+	mu        sync.Mutex
 	documents map[helium.Node]docIndex
 	// rootCache caches DocumentRoot results to avoid repeated parent-chain walks.
 	rootCache map[helium.Node]helium.Node
@@ -22,6 +27,13 @@ type DocOrderCache struct {
 // cachedRoot returns the DocumentRoot for n, using the rootCache to avoid
 // repeated parent-chain walks.
 func (c *DocOrderCache) cachedRoot(n helium.Node) helium.Node {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.cachedRootLocked(n)
+}
+
+// cachedRootLocked is the body of cachedRoot; the caller must hold c.mu.
+func (c *DocOrderCache) cachedRootLocked(n helium.Node) helium.Node {
 	if c.rootCache == nil {
 		c.rootCache = make(map[helium.Node]helium.Node)
 	}
@@ -42,18 +54,25 @@ type sortKey struct {
 
 // computeSortKey returns the precomputed sort key for a node.
 func (c *DocOrderCache) computeSortKey(n helium.Node) sortKey {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.computeSortKeyLocked(n)
+}
+
+// computeSortKeyLocked is the body of computeSortKey; the caller must hold c.mu.
+func (c *DocOrderCache) computeSortKeyLocked(n helium.Node) sortKey {
 	if n.Type() == helium.NamespaceNode {
 		parent := n.Parent()
 		if parent == nil {
 			return sortKey{docOrder: -1, position: -1}
 		}
-		pk := c.computeSortKey(parent)
+		pk := c.computeSortKeyLocked(parent)
 		if pk.position < 0 {
 			return sortKey{docOrder: -1, position: -1}
 		}
 		return sortKey{docOrder: pk.docOrder, position: pk.position + 1}
 	}
-	root := c.cachedRoot(n)
+	root := c.cachedRootLocked(n)
 	index, ok := c.documents[root]
 	if !ok {
 		return sortKey{docOrder: -1, position: -1}
@@ -76,12 +95,19 @@ func (c *DocOrderCache) computeSortKey(n helium.Node) sortKey {
 // are deduplicated by {parent, prefix} in DeduplicateNodes/MergeNodeSets,
 // so duplicates from different union branches are already eliminated.
 func (c *DocOrderCache) Position(n helium.Node) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.positionLocked(n)
+}
+
+// positionLocked is the body of Position; the caller must hold c.mu.
+func (c *DocOrderCache) positionLocked(n helium.Node) int {
 	if n.Type() == helium.NamespaceNode {
 		parent := n.Parent()
 		if parent == nil {
 			return -1
 		}
-		parentPos := c.Position(parent)
+		parentPos := c.positionLocked(parent)
 		if parentPos < 0 {
 			return -1
 		}
@@ -90,7 +116,7 @@ func (c *DocOrderCache) Position(n helium.Node) int {
 		// left by stride-2 indexing in indexWalk.
 		return parentPos + 1
 	}
-	root := c.cachedRoot(n)
+	root := c.cachedRootLocked(n)
 	index, ok := c.documents[root]
 	if !ok {
 		return -1
@@ -105,6 +131,8 @@ func (c *DocOrderCache) Position(n helium.Node) int {
 // BuildFrom populates the cache by walking the tree rooted at root.
 // No-op if that root is already indexed.
 func (c *DocOrderCache) BuildFrom(root helium.Node) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	root = DocumentRoot(root)
 	if c.documents == nil {
 		c.documents = make(map[helium.Node]docIndex)
@@ -156,11 +184,13 @@ func (c *DocOrderCache) indexWalk(cur helium.Node, positions map[helium.Node]int
 // A negative result means a comes before b, a positive result means a comes
 // after b, and zero means their indexed positions are equal or unknown.
 func (c *DocOrderCache) Compare(a, b helium.Node) int {
-	ra := c.cachedRoot(a)
-	rb := c.cachedRoot(b)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ra := c.cachedRootLocked(a)
+	rb := c.cachedRootLocked(b)
 	if ra == rb {
-		pa := c.Position(a)
-		pb := c.Position(b)
+		pa := c.positionLocked(a)
+		pb := c.positionLocked(b)
 		switch {
 		case pa < pb:
 			return -1

--- a/xpath3/docorder_race_test.go
+++ b/xpath3/docorder_race_test.go
@@ -10,7 +10,7 @@ import (
 
 // A single DocOrderCache shared across concurrent Evaluate calls must not race
 // on its internal maps. Run under `go test -race` to catch concurrent map
-// writes in BuildFrom/computeSortKey/cachedRoot.
+// writes in BuildFrom/computeSortKey/cachedRootLocked.
 func TestDocOrderCache_ConcurrentEvaluate(t *testing.T) {
 	const xml = `<root>
 		<a><b/><c/></a>
@@ -32,10 +32,10 @@ func TestDocOrderCache_ConcurrentEvaluate(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
 	errs := make([]error, goroutines)
-	for i := 0; i < goroutines; i++ {
+	for i := range goroutines {
 		go func(idx int) {
 			defer wg.Done()
-			for j := 0; j < 50; j++ {
+			for range 50 {
 				_, evalErr := eval.Evaluate(t.Context(), compiled, doc)
 				if evalErr != nil {
 					errs[idx] = evalErr

--- a/xpath3/docorder_race_test.go
+++ b/xpath3/docorder_race_test.go
@@ -1,0 +1,52 @@
+package xpath3_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// A single DocOrderCache shared across concurrent Evaluate calls must not race
+// on its internal maps. Run under `go test -race` to catch concurrent map
+// writes in BuildFrom/computeSortKey/cachedRoot.
+func TestDocOrderCache_ConcurrentEvaluate(t *testing.T) {
+	const xml = `<root>
+		<a><b/><c/></a>
+		<a><b/><c/></a>
+		<a><b/><c/></a>
+	</root>`
+
+	doc := mustParseXML(t, xml)
+
+	// A union expression forces document-order deduplication/sorting, which
+	// drives the DocOrderCache map mutations.
+	compiled, err := xpath3.NewCompiler().Compile("//b | //c | //a")
+	require.NoError(t, err)
+
+	cache := xpath3.NewDocOrderCache()
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).DocOrderCache(cache)
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errs := make([]error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				_, evalErr := eval.Evaluate(t.Context(), compiled, doc)
+				if evalErr != nil {
+					errs[idx] = evalErr
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for _, e := range errs {
+		require.NoError(t, e)
+	}
+}


### PR DESCRIPTION
- Add a sync.Mutex to internal/xpath DocOrderCache and guard all map reads/writes (BuildFrom, Position, computeSortKey, cachedRoot, Compare)
- Fixes a concurrent map write race when one DocOrderCache is shared across concurrent xpath3 Evaluate calls
- Add a -race test running concurrent Evaluate calls over a shared cache