### PR TITLE
detect duplicate named xsd components

### DIFF
--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -61,11 +61,51 @@ type compiler struct {
 	// so the per-compiler importedNS map does not detect the cycle.
 	importDepth    int
 	maxImportDepth int
-	// inRedefine is true while processing the override children of an
-	// xs:redefine. Redefinitions intentionally replace the same-named
-	// component loaded from the redefined schema, so the duplicate-name
-	// checks in parseNamed* must be suppressed in this context.
-	inRedefine bool
+	// redefine is non-nil while processing the override children of an
+	// xs:redefine. It scopes the duplicate-name suppression to the specific
+	// (kind, name) components actually loaded by the redefined schema, each
+	// consumable exactly once, instead of suppressing the check globally.
+	redefine *redefineState
+}
+
+// redefineKind identifies the component category a redefine override targets.
+type redefineKind int
+
+const (
+	redefineKindType redefineKind = iota
+	redefineKindGroup
+	redefineKindAttrGroup
+)
+
+// redefineState scopes duplicate-name suppression during an xs:redefine
+// override loop. phaseAKeys records, per kind, the QNames loaded from the
+// redefined schema (Phase A); each may be replaced by exactly one override.
+// seen records, per kind, the override QNames already consumed so a repeated
+// override of the same name is reported as a duplicate.
+type redefineState struct {
+	phaseAKeys map[redefineKind]map[QName]struct{}
+	seen       map[redefineKind]map[QName]struct{}
+}
+
+// allowsRedefine reports whether an override of the given (kind, name) may
+// replace an existing same-named component. It returns true only the first
+// time a name loaded in Phase A is overridden; a name not loaded in Phase A
+// or a repeated override returns false so the caller reports a duplicate.
+func (c *compiler) allowsRedefine(kind redefineKind, qn QName) bool {
+	if c.redefine == nil {
+		return false
+	}
+	if _, ok := c.redefine.phaseAKeys[kind][qn]; !ok {
+		return false
+	}
+	if _, seen := c.redefine.seen[kind][qn]; seen {
+		return false
+	}
+	if c.redefine.seen[kind] == nil {
+		c.redefine.seen[kind] = make(map[QName]struct{})
+	}
+	c.redefine.seen[kind][qn] = struct{}{}
+	return true
 }
 
 // defaultMaxImportDepth bounds xs:import recursion depth (not a flat

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -108,6 +108,35 @@ func (c *compiler) allowsRedefine(kind redefineKind, qn QName) bool {
 	return true
 }
 
+// consumeRedefineTarget validates a redefine override's (kind, name) against
+// the Phase-A key set and consumes it, BEFORE the override child is parsed and
+// regardless of whether the name currently exists in the schema map. It reports
+// a duplicate (and returns false) when the target was not loaded in Phase A or
+// has already been consumed by an earlier override; otherwise it marks the name
+// consumed and returns true so the caller may parse the override. This closes
+// the gap where allowsRedefine only ran under the existing-name branch, letting
+// an override of a name ABSENT from the redefined schema be accepted silently.
+func (c *compiler) consumeRedefineTarget(ctx context.Context, elem *helium.Element, kind redefineKind, qn QName, component, kindDesc string) bool {
+	if c.allowsRedefine(kind, qn) {
+		return true
+	}
+	c.reportDuplicateComponent(ctx, elem, component, kindDesc, qn)
+	return false
+}
+
+// redefineConsumed reports whether the override of (kind, name) was already
+// validated and consumed by the redefine override loop (consumeRedefineTarget).
+// The named-component parsers consult it so a pre-authorized override does not
+// re-trigger their own duplicate-name report, while a non-redefine duplicate
+// (c.redefine == nil, or a name the loop did not consume) still reports.
+func (c *compiler) redefineConsumed(kind redefineKind, qn QName) bool {
+	if c.redefine == nil {
+		return false
+	}
+	_, ok := c.redefine.seen[kind][qn]
+	return ok
+}
+
 // defaultMaxImportDepth bounds xs:import recursion depth (not a flat
 // import count), so a modest value is enough to terminate adversarial
 // namespace-cycling chains while leaving generous headroom for real

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -61,6 +61,11 @@ type compiler struct {
 	// so the per-compiler importedNS map does not detect the cycle.
 	importDepth    int
 	maxImportDepth int
+	// inRedefine is true while processing the override children of an
+	// xs:redefine. Redefinitions intentionally replace the same-named
+	// component loaded from the redefined schema, so the duplicate-name
+	// checks in parseNamed* must be suppressed in this context.
+	inRedefine bool
 }
 
 // defaultMaxImportDepth bounds xs:import recursion depth (not a flat

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -30,6 +30,11 @@ type compiler struct {
 	globalElemSources map[*ElementDecl]elemRefSource
 	// source info for type definitions, used in duplicate attribute errors
 	typeDefSources map[*TypeDef]typeDefSource
+	// typeKinds records, per registered named type QName, whether it was
+	// declared via xs:simpleType or xs:complexType. Both share schema.types,
+	// but redefine must distinguish them so a Phase-A simpleType cannot be
+	// consumed by a complexType override of the same name (and vice versa).
+	typeKinds map[QName]redefineKind
 	// unresolved item type references for list types
 	itemTypeRefs map[*TypeDef]QName
 	// unresolved union member type references
@@ -72,7 +77,12 @@ type compiler struct {
 type redefineKind int
 
 const (
-	redefineKindType redefineKind = iota
+	// redefineKindSimpleType and redefineKindComplexType are tracked
+	// separately so a Phase-A simpleType cannot be consumed by a complexType
+	// override of the same name (or vice versa). They share the same
+	// schema.types map but are distinct redefine targets.
+	redefineKindSimpleType redefineKind = iota
+	redefineKindComplexType
 	redefineKindGroup
 	redefineKindAttrGroup
 )
@@ -209,6 +219,7 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 		attrGroupRefs:            make(map[*TypeDef][]QName),
 		globalElemSources:        make(map[*ElementDecl]elemRefSource),
 		typeDefSources:           make(map[*TypeDef]typeDefSource),
+		typeKinds:                make(map[QName]redefineKind),
 		itemTypeRefs:             make(map[*TypeDef]QName),
 		chameleonEligible:        make(map[any]struct{}),
 		attrRefs:                 make(map[*AttrUse]QName),

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -205,6 +205,29 @@ func (c *compiler) loadInclude(ctx context.Context, location string, includeElem
 	return err
 }
 
+// snapshotKeys captures the current key set of a component map so a later
+// delta (newKeysSince) can isolate the keys added between two points.
+func snapshotKeys[V any](m map[QName]V) map[QName]struct{} {
+	keys := make(map[QName]struct{}, len(m))
+	for qn := range m {
+		keys[qn] = struct{}{}
+	}
+	return keys
+}
+
+// newKeysSince returns the keys present in m but absent from before, i.e. the
+// components added since the snapshot was taken.
+func newKeysSince[V any](m map[QName]V, before map[QName]struct{}) map[QName]struct{} {
+	added := make(map[QName]struct{})
+	for qn := range m {
+		if _, existed := before[qn]; existed {
+			continue
+		}
+		added[qn] = struct{}{}
+	}
+	return added
+}
+
 // loadRedefine loads a schema via xs:redefine and processes override children.
 // It works like xs:include (merging original declarations) but then applies
 // redefinitions for complexType, simpleType, group, and attributeGroup children.
@@ -266,6 +289,15 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 		c.includeFile = schemaDisplayLoc(c.filename, location)
 	}
 
+	// Snapshot the component-name sets per kind BEFORE Phase A. The including
+	// (main) schema's root declarations are already registered at this point,
+	// so taking the snapshot after Phase A would wrongly treat pre-existing
+	// main-schema components as redefinable. Only names ACTUALLY loaded from the
+	// redefined schema (afterKeys - beforeKeys) may be overridden.
+	beforeTypes := snapshotKeys(c.schema.types)
+	beforeGroups := snapshotKeys(c.schema.groups)
+	beforeAttrGroups := snapshotKeys(c.schema.attrGroups)
+
 	// Parse the included schema's declarations into the current compiler.
 	if err := c.parseSchemaChildren(ctx, incRoot); err != nil {
 		c.schema.elemFormQualified = savedElemForm
@@ -277,24 +309,16 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 	}
 
 	// Phase B: Process redefine children (overrides). Each override may replace
-	// the same-named component loaded in Phase A exactly once. Snapshot the
-	// Phase-A keys per kind so the duplicate-name checks are suppressed only for
-	// those specific names, consumed once each — not globally. An override that
-	// targets a name not loaded in Phase A, or repeats a name, is reported as a
-	// duplicate.
+	// the same-named component loaded in Phase A exactly once. Compute the
+	// Phase-A keys per kind as (afterKeys - beforeKeys) so the duplicate-name
+	// checks are suppressed only for the components actually loaded by the
+	// redefined schema, consumed once each — not globally and not for
+	// pre-existing main-schema components. An override that targets a name not
+	// loaded in Phase A, or repeats a name, is reported as a duplicate.
 	phaseAKeys := map[redefineKind]map[QName]struct{}{
-		redefineKindType:      make(map[QName]struct{}, len(c.schema.types)),
-		redefineKindGroup:     make(map[QName]struct{}, len(c.schema.groups)),
-		redefineKindAttrGroup: make(map[QName]struct{}, len(c.schema.attrGroups)),
-	}
-	for qn := range c.schema.types {
-		phaseAKeys[redefineKindType][qn] = struct{}{}
-	}
-	for qn := range c.schema.groups {
-		phaseAKeys[redefineKindGroup][qn] = struct{}{}
-	}
-	for qn := range c.schema.attrGroups {
-		phaseAKeys[redefineKindAttrGroup][qn] = struct{}{}
+		redefineKindType:      newKeysSince(c.schema.types, beforeTypes),
+		redefineKindGroup:     newKeysSince(c.schema.groups, beforeGroups),
+		redefineKindAttrGroup: newKeysSince(c.schema.attrGroups, beforeAttrGroups),
 	}
 	c.redefine = &redefineState{
 		phaseAKeys: phaseAKeys,
@@ -318,6 +342,12 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 				continue
 			}
 			qn := QName{Local: name, NS: c.schema.targetNamespace}
+			// Validate and consume the override target before any parse side
+			// effects: it must name a type loaded from the redefined schema
+			// (Phase A) and may be overridden only once.
+			if !c.consumeRedefineTarget(ctx, elem, redefineKindType, qn, "complexType", "A global type definition") {
+				continue
+			}
 			origType := c.schema.types[qn]
 			if err := c.parseNamedComplexType(ctx, elem); err != nil {
 				c.schema.elemFormQualified = savedElemForm
@@ -344,6 +374,9 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 				continue
 			}
 			qn := QName{Local: name, NS: c.schema.targetNamespace}
+			if !c.consumeRedefineTarget(ctx, elem, redefineKindType, qn, "simpleType", "A global type definition") {
+				continue
+			}
 			origType := c.schema.types[qn]
 			if err := c.parseNamedSimpleType(ctx, elem); err != nil {
 				c.schema.elemFormQualified = savedElemForm
@@ -367,6 +400,9 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 				continue
 			}
 			qn := QName{Local: name, NS: c.schema.targetNamespace}
+			if !c.consumeRedefineTarget(ctx, elem, redefineKindGroup, qn, "group", "A global model group definition") {
+				continue
+			}
 			origGroup := c.schema.groups[qn]
 			// Snapshot existing groupRefs keys.
 			existingRefs := make(map[*ModelGroup]bool, len(c.groupRefs))
@@ -403,9 +439,9 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 			// This case writes c.schema.attrGroups directly (bypassing
 			// parseNamedAttributeGroup), so enforce the redefine duplicate rule
 			// here: the override must target a Phase-A attribute group and may
-			// consume it only once.
-			if _, exists := c.schema.attrGroups[qn]; exists && !c.allowsRedefine(redefineKindAttrGroup, qn) {
-				c.reportDuplicateComponent(ctx, elem, "attributeGroup", "A global attribute group definition", qn)
+			// consume it only once. A target absent from Phase A or repeated is
+			// reported and skipped.
+			if !c.consumeRedefineTarget(ctx, elem, redefineKindAttrGroup, qn, "attributeGroup", "A global attribute group definition") {
 				continue
 			}
 			origAttrs := c.schema.attrGroups[qn]

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -315,10 +315,26 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 	// redefined schema, consumed once each — not globally and not for
 	// pre-existing main-schema components. An override that targets a name not
 	// loaded in Phase A, or repeats a name, is reported as a duplicate.
+	// Split the newly-loaded type keys by declared kind so a Phase-A simpleType
+	// is only redefinable by a simpleType override (and likewise for complex).
+	newTypes := newKeysSince(c.schema.types, beforeTypes)
+	phaseASimpleTypes := make(map[QName]struct{})
+	phaseAComplexTypes := make(map[QName]struct{})
+	for qn := range newTypes {
+		switch c.typeKinds[qn] {
+		case redefineKindComplexType:
+			phaseAComplexTypes[qn] = struct{}{}
+		default:
+			// simpleType (and builtin/anySimpleType fallbacks) are treated as
+			// simple; only an xs:simpleType override may consume them.
+			phaseASimpleTypes[qn] = struct{}{}
+		}
+	}
 	phaseAKeys := map[redefineKind]map[QName]struct{}{
-		redefineKindType:      newKeysSince(c.schema.types, beforeTypes),
-		redefineKindGroup:     newKeysSince(c.schema.groups, beforeGroups),
-		redefineKindAttrGroup: newKeysSince(c.schema.attrGroups, beforeAttrGroups),
+		redefineKindSimpleType:  phaseASimpleTypes,
+		redefineKindComplexType: phaseAComplexTypes,
+		redefineKindGroup:       newKeysSince(c.schema.groups, beforeGroups),
+		redefineKindAttrGroup:   newKeysSince(c.schema.attrGroups, beforeAttrGroups),
 	}
 	c.redefine = &redefineState{
 		phaseAKeys: phaseAKeys,
@@ -345,7 +361,7 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 			// Validate and consume the override target before any parse side
 			// effects: it must name a type loaded from the redefined schema
 			// (Phase A) and may be overridden only once.
-			if !c.consumeRedefineTarget(ctx, elem, redefineKindType, qn, "complexType", "A global type definition") {
+			if !c.consumeRedefineTarget(ctx, elem, redefineKindComplexType, qn, "complexType", "A global type definition") {
 				continue
 			}
 			origType := c.schema.types[qn]
@@ -374,7 +390,7 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 				continue
 			}
 			qn := QName{Local: name, NS: c.schema.targetNamespace}
-			if !c.consumeRedefineTarget(ctx, elem, redefineKindType, qn, "simpleType", "A global type definition") {
+			if !c.consumeRedefineTarget(ctx, elem, redefineKindSimpleType, qn, "simpleType", "A global type definition") {
 				continue
 			}
 			origType := c.schema.types[qn]
@@ -565,6 +581,7 @@ func (c *compiler) loadImport(ctx context.Context, location, ns string, importEl
 		attrGroupRefs:            make(map[*TypeDef][]QName),
 		globalElemSources:        make(map[*ElementDecl]elemRefSource),
 		typeDefSources:           make(map[*TypeDef]typeDefSource),
+		typeKinds:                make(map[QName]redefineKind),
 		itemTypeRefs:             make(map[*TypeDef]QName),
 		chameleonEligible:        make(map[any]struct{}),
 		attrRefs:                 make(map[*AttrUse]QName),

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -276,11 +276,31 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 		return err
 	}
 
-	// Phase B: Process redefine children (overrides). Redefinitions replace
-	// the same-named components loaded in Phase A, so the duplicate-name checks
-	// in parseNamed* must be suppressed for this loop.
-	c.inRedefine = true
-	defer func() { c.inRedefine = false }()
+	// Phase B: Process redefine children (overrides). Each override may replace
+	// the same-named component loaded in Phase A exactly once. Snapshot the
+	// Phase-A keys per kind so the duplicate-name checks are suppressed only for
+	// those specific names, consumed once each — not globally. An override that
+	// targets a name not loaded in Phase A, or repeats a name, is reported as a
+	// duplicate.
+	phaseAKeys := map[redefineKind]map[QName]struct{}{
+		redefineKindType:      make(map[QName]struct{}, len(c.schema.types)),
+		redefineKindGroup:     make(map[QName]struct{}, len(c.schema.groups)),
+		redefineKindAttrGroup: make(map[QName]struct{}, len(c.schema.attrGroups)),
+	}
+	for qn := range c.schema.types {
+		phaseAKeys[redefineKindType][qn] = struct{}{}
+	}
+	for qn := range c.schema.groups {
+		phaseAKeys[redefineKindGroup][qn] = struct{}{}
+	}
+	for qn := range c.schema.attrGroups {
+		phaseAKeys[redefineKindAttrGroup][qn] = struct{}{}
+	}
+	c.redefine = &redefineState{
+		phaseAKeys: phaseAKeys,
+		seen:       make(map[redefineKind]map[QName]struct{}),
+	}
+	defer func() { c.redefine = nil }()
 	for child := range helium.Children(redefineElem) {
 		if child.Type() != helium.ElementNode {
 			continue
@@ -380,6 +400,14 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 				continue
 			}
 			qn := QName{Local: name, NS: c.schema.targetNamespace}
+			// This case writes c.schema.attrGroups directly (bypassing
+			// parseNamedAttributeGroup), so enforce the redefine duplicate rule
+			// here: the override must target a Phase-A attribute group and may
+			// consume it only once.
+			if _, exists := c.schema.attrGroups[qn]; exists && !c.allowsRedefine(redefineKindAttrGroup, qn) {
+				c.reportDuplicateComponent(ctx, elem, "attributeGroup", "A global attribute group definition", qn)
+				continue
+			}
 			origAttrs := c.schema.attrGroups[qn]
 			// Build the new attribute list manually, expanding self-references
 			// inline. parseNamedAttributeGroup only collects xs:attribute children

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -276,7 +276,11 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 		return err
 	}
 
-	// Phase B: Process redefine children (overrides).
+	// Phase B: Process redefine children (overrides). Redefinitions replace
+	// the same-named components loaded in Phase A, so the duplicate-name checks
+	// in parseNamed* must be suppressed for this loop.
+	c.inRedefine = true
+	defer func() { c.inRedefine = false }()
 	for child := range helium.Children(redefineElem) {
 		if child.Type() != helium.ElementNode {
 			continue

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -341,6 +341,12 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 		seen:       make(map[redefineKind]map[QName]struct{}),
 	}
 	defer func() { c.redefine = nil }()
+
+	// The override children below come from the REDEFINING (main) schema, not
+	// the redefined (base) schema loaded in Phase A. Restore c.includeFile to
+	// the redefining file's label so duplicate-override diagnostics report the
+	// correct source file and line; Phase A above needed the base label.
+	c.includeFile = savedIncludeFile
 	for child := range helium.Children(redefineElem) {
 		if child.Type() != helium.ElementNode {
 			continue

--- a/xsd/duplicate_component_test.go
+++ b/xsd/duplicate_component_test.go
@@ -8,25 +8,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// compileErrorsExact compiles schemaXML under the label "test.xsd", closes the
+// ErrorCollector before reading (so the async sink is fully drained and the read
+// is not flaky), and returns the concatenated fatal compile-error output. The
+// label fallback (top-level duplicate keeps the "test.xsd" prefix instead of
+// starting with ":line:") is exercised by the exact-output assertions below.
+func compileErrorsExact(t *testing.T, schemaXML string) string {
+	t.Helper()
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+	require.NoError(t, err)
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	_, err = xsd.NewCompiler().Label("test.xsd").ErrorHandler(collector).Compile(t.Context(), doc)
+	require.NoError(t, err)
+	require.NoError(t, collector.Close())
+	_, errors := partitionCompileErrors(collector.Errors())
+	return errors
+}
+
 // TestDuplicateNamedComponent verifies that two global components sharing the
 // same name (simpleType, complexType, model group, or attributeGroup) are
-// reported as a fatal schema parser error instead of silently overwriting the
-// first definition.
+// reported as a single fatal schema parser error — with the correct file-label
+// prefix and no extra follow-on diagnostics — instead of silently overwriting
+// the first definition.
 func TestDuplicateNamedComponent(t *testing.T) {
 	t.Parallel()
-
-	const wantMsg = "does already exist"
-
-	compileErrors := func(t *testing.T, schemaXML string) string {
-		t.Helper()
-		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
-		require.NoError(t, err)
-		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
-		_, err = xsd.NewCompiler().Label("test.xsd").ErrorHandler(collector).Compile(t.Context(), doc)
-		require.NoError(t, err)
-		_, errors := partitionCompileErrors(collector.Errors())
-		return errors
-	}
 
 	t.Run("duplicate simpleType", func(t *testing.T) {
 		t.Parallel()
@@ -38,7 +43,9 @@ func TestDuplicateNamedComponent(t *testing.T) {
     <xs:restriction base="xs:int"/>
   </xs:simpleType>
 </xs:schema>`
-		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
+		require.Equal(t,
+			"test.xsd:5: element simpleType: Schemas parser error : Element '{http://www.w3.org/2001/XMLSchema}simpleType': A global type definition ''T does already exist.\n",
+			compileErrorsExact(t, schemaXML))
 	})
 
 	t.Run("duplicate complexType", func(t *testing.T) {
@@ -51,7 +58,9 @@ func TestDuplicateNamedComponent(t *testing.T) {
     <xs:sequence/>
   </xs:complexType>
 </xs:schema>`
-		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
+		require.Equal(t,
+			"test.xsd:5: element complexType: Schemas parser error : Element '{http://www.w3.org/2001/XMLSchema}complexType': A global type definition ''T does already exist.\n",
+			compileErrorsExact(t, schemaXML))
 	})
 
 	t.Run("duplicate group", func(t *testing.T) {
@@ -68,7 +77,9 @@ func TestDuplicateNamedComponent(t *testing.T) {
     </xs:sequence>
   </xs:group>
 </xs:schema>`
-		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
+		require.Equal(t,
+			"test.xsd:7: element group: Schemas parser error : Element '{http://www.w3.org/2001/XMLSchema}group': A global model group definition ''G does already exist.\n",
+			compileErrorsExact(t, schemaXML))
 	})
 
 	t.Run("duplicate attributeGroup", func(t *testing.T) {
@@ -81,7 +92,9 @@ func TestDuplicateNamedComponent(t *testing.T) {
     <xs:attribute name="b" type="xs:string"/>
   </xs:attributeGroup>
 </xs:schema>`
-		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
+		require.Equal(t,
+			"test.xsd:5: element attributeGroup: Schemas parser error : Element '{http://www.w3.org/2001/XMLSchema}attributeGroup': A global attribute group definition ''AG does already exist.\n",
+			compileErrorsExact(t, schemaXML))
 	})
 
 	t.Run("duplicate global attribute", func(t *testing.T) {
@@ -90,6 +103,19 @@ func TestDuplicateNamedComponent(t *testing.T) {
   <xs:attribute name="A" type="xs:string"/>
   <xs:attribute name="A" type="xs:int"/>
 </xs:schema>`
-		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
+		require.Equal(t,
+			"test.xsd:3: element attribute: Schemas parser error : Element '{http://www.w3.org/2001/XMLSchema}attribute': A global attribute declaration ''A does already exist.\n",
+			compileErrorsExact(t, schemaXML))
+	})
+
+	t.Run("duplicate global element", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="E" type="xs:string"/>
+  <xs:element name="E" type="xs:int"/>
+</xs:schema>`
+		require.Equal(t,
+			"test.xsd:3: element element: Schemas parser error : Element '{http://www.w3.org/2001/XMLSchema}element': A global element declaration ''E does already exist.\n",
+			compileErrorsExact(t, schemaXML))
 	})
 }

--- a/xsd/duplicate_component_test.go
+++ b/xsd/duplicate_component_test.go
@@ -1,0 +1,86 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDuplicateNamedComponent verifies that two global components sharing the
+// same name (simpleType, complexType, model group, or attributeGroup) are
+// reported as a fatal schema parser error instead of silently overwriting the
+// first definition.
+func TestDuplicateNamedComponent(t *testing.T) {
+	t.Parallel()
+
+	const wantMsg = "does already exist"
+
+	compileErrors := func(t *testing.T, schemaXML string) string {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, err = xsd.NewCompiler().Label("test.xsd").ErrorHandler(collector).Compile(t.Context(), doc)
+		require.NoError(t, err)
+		_, errors := partitionCompileErrors(collector.Errors())
+		return errors
+	}
+
+	t.Run("duplicate simpleType", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="T">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:simpleType name="T">
+    <xs:restriction base="xs:int"/>
+  </xs:simpleType>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
+	})
+
+	t.Run("duplicate complexType", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="T">
+    <xs:sequence/>
+  </xs:complexType>
+  <xs:complexType name="T">
+    <xs:sequence/>
+  </xs:complexType>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
+	})
+
+	t.Run("duplicate group", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="G">
+    <xs:sequence>
+      <xs:element name="a" type="xs:string"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="G">
+    <xs:sequence>
+      <xs:element name="b" type="xs:string"/>
+    </xs:sequence>
+  </xs:group>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
+	})
+
+	t.Run("duplicate attributeGroup", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attributeGroup name="AG">
+    <xs:attribute name="a" type="xs:string"/>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="AG">
+    <xs:attribute name="b" type="xs:string"/>
+  </xs:attributeGroup>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
+	})
+}

--- a/xsd/duplicate_component_test.go
+++ b/xsd/duplicate_component_test.go
@@ -83,4 +83,13 @@ func TestDuplicateNamedComponent(t *testing.T) {
 </xs:schema>`
 		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
 	})
+
+	t.Run("duplicate global attribute", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attribute name="A" type="xs:string"/>
+  <xs:attribute name="A" type="xs:int"/>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
+	})
 }

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -375,6 +375,15 @@ func (c *compiler) parseGlobalAttribute(ctx context.Context, elem *helium.Elemen
 	au := c.readAttributeUseDecl(ctx, elem, attrUseReadOptions{
 		name: QName{Local: name, NS: c.schema.targetNamespace},
 	})
+
+	// Check for a duplicate global attribute declaration. xs:redefine never
+	// targets global attributes, so (mirroring the other named components) only
+	// suppress the report when processing redefine overrides.
+	if _, exists := c.schema.globalAttrs[au.Name]; exists && c.redefine == nil {
+		c.reportDuplicateComponent(ctx, elem, "attribute", "A global attribute declaration", au.Name)
+		return
+	}
+
 	c.schema.globalAttrs[au.Name] = au
 }
 

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -274,21 +274,29 @@ func (c *compiler) parseGlobalElement(ctx context.Context, elem *helium.Element)
 
 	// Check for duplicate global element declarations.
 	if _, exists := c.schema.elements[decl.Name]; exists {
-		qnDisplay := "'" + decl.Name.NS + "'" + decl.Name.Local
-		if decl.Name.NS != "" {
-			qnDisplay = "'{" + decl.Name.NS + "}" + decl.Name.Local + "'"
-		}
-		source := c.includeFile
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(source, elem.Line(),
-			elem.LocalName(), "element",
-			"A global element declaration "+qnDisplay+" does already exist."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.reportDuplicateComponent(ctx, elem, "element", "A global element declaration", decl.Name)
 		return nil
 	}
 
 	c.globalElemSources[decl] = elemRefSource{elemName: name, line: elem.Line()}
 	c.schema.elements[decl.Name] = decl
 	return nil
+}
+
+// reportDuplicateComponent emits the schema-parser error for a redeclared
+// global component (element, type, model group, or attribute group). component
+// is the XSD element name used in the error prefix (e.g. "element", "type");
+// kind is the descriptive phrase (e.g. "A global element declaration").
+func (c *compiler) reportDuplicateComponent(ctx context.Context, elem *helium.Element, component, kind string, name QName) {
+	qnDisplay := "'" + name.NS + "'" + name.Local
+	if name.NS != "" {
+		qnDisplay = "'{" + name.NS + "}" + name.Local + "'"
+	}
+	source := c.includeFile
+	c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(source, elem.Line(),
+		elem.LocalName(), component,
+		kind+" "+qnDisplay+" does already exist."), helium.ErrorLevelFatal))
+	c.errorCount++
 }
 
 func (c *compiler) parseLocalElement(ctx context.Context, elem *helium.Element) (*Particle, error) {

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -257,6 +257,15 @@ func (c *compiler) parseGlobalElement(ctx context.Context, elem *helium.Element)
 		return nil
 	}
 
+	// Check for a duplicate global element declaration BEFORE reading the decl
+	// body, so a rejected declaration records no type/element refs that would
+	// produce unrelated follow-on errors.
+	declName := QName{Local: name, NS: c.schema.targetNamespace}
+	if _, exists := c.schema.elements[declName]; exists {
+		c.reportDuplicateComponent(ctx, elem, "element", "A global element declaration", declName)
+		return nil
+	}
+
 	decl, err := c.readElementDecl(ctx, elem, elementDeclReadOptions{
 		name:                   name,
 		namespace:              c.schema.targetNamespace,
@@ -270,12 +279,6 @@ func (c *compiler) parseGlobalElement(ctx context.Context, elem *helium.Element)
 	})
 	if err != nil {
 		return err
-	}
-
-	// Check for duplicate global element declarations.
-	if _, exists := c.schema.elements[decl.Name]; exists {
-		c.reportDuplicateComponent(ctx, elem, "element", "A global element declaration", decl.Name)
-		return nil
 	}
 
 	c.globalElemSources[decl] = elemRefSource{elemName: name, line: elem.Line()}
@@ -292,7 +295,14 @@ func (c *compiler) reportDuplicateComponent(ctx context.Context, elem *helium.El
 	if name.NS != "" {
 		qnDisplay = "'{" + name.NS + "}" + name.Local + "'"
 	}
+	// A duplicate inside an xs:include/xs:redefine reports against that file
+	// (c.includeFile); a top-level (main-schema) duplicate has no includeFile,
+	// so fall back to the compiler's own filename label so the diagnostic keeps
+	// its path prefix instead of starting with ":line:".
 	source := c.includeFile
+	if source == "" {
+		source = c.filename
+	}
 	c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(source, elem.Line(),
 		elem.LocalName(), component,
 		kind+" "+qnDisplay+" does already exist."), helium.ErrorLevelFatal))
@@ -372,19 +382,23 @@ func (c *compiler) parseGlobalAttribute(ctx context.Context, elem *helium.Elemen
 		return
 	}
 	// Global attributes are always in the target namespace (per spec).
-	au := c.readAttributeUseDecl(ctx, elem, attrUseReadOptions{
-		name: QName{Local: name, NS: c.schema.targetNamespace},
-	})
+	qn := QName{Local: name, NS: c.schema.targetNamespace}
 
-	// Check for a duplicate global attribute declaration. xs:redefine never
-	// targets global attributes, so (mirroring the other named components) only
-	// suppress the report when processing redefine overrides.
-	if _, exists := c.schema.globalAttrs[au.Name]; exists && c.redefine == nil {
-		c.reportDuplicateComponent(ctx, elem, "attribute", "A global attribute declaration", au.Name)
+	// Check for a duplicate global attribute declaration BEFORE parsing the body,
+	// so a rejected declaration records no type/constraint refs that would
+	// produce unrelated follow-on errors. xs:redefine never targets global
+	// attributes, so (mirroring the other named components) only suppress the
+	// report when processing redefine overrides.
+	if _, exists := c.schema.globalAttrs[qn]; exists && c.redefine == nil {
+		c.reportDuplicateComponent(ctx, elem, "attribute", "A global attribute declaration", qn)
 		return
 	}
 
-	c.schema.globalAttrs[au.Name] = au
+	au := c.readAttributeUseDecl(ctx, elem, attrUseReadOptions{
+		name: qn,
+	})
+
+	c.schema.globalAttrs[qn] = au
 }
 
 func (c *compiler) parseAttributeUse(ctx context.Context, elem *helium.Element) *AttrUse {

--- a/xsd/read_particles.go
+++ b/xsd/read_particles.go
@@ -38,6 +38,13 @@ func (c *compiler) parseNamedGroup(ctx context.Context, elem *helium.Element) er
 			return err
 		}
 		qn := QName{Local: name, NS: c.schema.targetNamespace}
+		// Redefinitions intentionally replace the same-named group loaded from
+		// the redefined schema, so suppress the check while processing
+		// xs:redefine overrides.
+		if _, exists := c.schema.groups[qn]; exists && !c.inRedefine {
+			c.reportDuplicateComponent(ctx, elem, "group", "A global model group definition", qn)
+			return nil
+		}
 		c.schema.groups[qn] = mg
 		return nil
 	}
@@ -51,6 +58,13 @@ func (c *compiler) parseNamedAttributeGroup(ctx context.Context, elem *helium.El
 	}
 
 	qn := QName{Local: name, NS: c.schema.targetNamespace}
+	// Redefinitions intentionally replace the same-named attribute group
+	// loaded from the redefined schema, so suppress the check while processing
+	// xs:redefine overrides.
+	if _, exists := c.schema.attrGroups[qn]; exists && !c.inRedefine {
+		c.reportDuplicateComponent(ctx, elem, "attributeGroup", "A global attribute group definition", qn)
+		return nil
+	}
 	var attrs []*AttrUse
 	for child := range helium.Children(elem) {
 		if child.Type() != helium.ElementNode {

--- a/xsd/read_particles.go
+++ b/xsd/read_particles.go
@@ -13,6 +13,17 @@ func (c *compiler) parseNamedGroup(ctx context.Context, elem *helium.Element) er
 		return fmt.Errorf("xsd: named group missing name")
 	}
 
+	qn := QName{Local: name, NS: c.schema.targetNamespace}
+
+	// Check for a duplicate model group BEFORE parsing the compositor body, so a
+	// rejected component records no group references that would produce unrelated
+	// follow-on errors. An xs:redefine override that was validated and consumed
+	// by the redefine loop is pre-authorized and skips the report.
+	if _, exists := c.schema.groups[qn]; exists && !c.redefineConsumed(redefineKindGroup, qn) {
+		c.reportDuplicateComponent(ctx, elem, "group", "A global model group definition", qn)
+		return nil
+	}
+
 	// A named group has exactly one child compositor (sequence, choice, or all).
 	for child := range helium.Children(elem) {
 		if child.Type() != helium.ElementNode {
@@ -36,13 +47,6 @@ func (c *compiler) parseNamedGroup(ctx context.Context, elem *helium.Element) er
 		mg, err := c.parseModelGroup(ctx, ce, compositor)
 		if err != nil {
 			return err
-		}
-		qn := QName{Local: name, NS: c.schema.targetNamespace}
-		// An xs:redefine override that was validated and consumed by the redefine
-		// loop is pre-authorized and skips the report.
-		if _, exists := c.schema.groups[qn]; exists && !c.redefineConsumed(redefineKindGroup, qn) {
-			c.reportDuplicateComponent(ctx, elem, "group", "A global model group definition", qn)
-			return nil
 		}
 		c.schema.groups[qn] = mg
 		return nil

--- a/xsd/read_particles.go
+++ b/xsd/read_particles.go
@@ -38,10 +38,9 @@ func (c *compiler) parseNamedGroup(ctx context.Context, elem *helium.Element) er
 			return err
 		}
 		qn := QName{Local: name, NS: c.schema.targetNamespace}
-		// Redefinitions intentionally replace the same-named group loaded from
-		// the redefined schema, so suppress the check while processing
-		// xs:redefine overrides.
-		if _, exists := c.schema.groups[qn]; exists && !c.inRedefine {
+		// An xs:redefine override may replace the same-named group loaded from
+		// the redefined schema exactly once.
+		if _, exists := c.schema.groups[qn]; exists && !c.allowsRedefine(redefineKindGroup, qn) {
 			c.reportDuplicateComponent(ctx, elem, "group", "A global model group definition", qn)
 			return nil
 		}
@@ -58,10 +57,9 @@ func (c *compiler) parseNamedAttributeGroup(ctx context.Context, elem *helium.El
 	}
 
 	qn := QName{Local: name, NS: c.schema.targetNamespace}
-	// Redefinitions intentionally replace the same-named attribute group
-	// loaded from the redefined schema, so suppress the check while processing
-	// xs:redefine overrides.
-	if _, exists := c.schema.attrGroups[qn]; exists && !c.inRedefine {
+	// An xs:redefine override may replace the same-named attribute group
+	// loaded from the redefined schema exactly once.
+	if _, exists := c.schema.attrGroups[qn]; exists && !c.allowsRedefine(redefineKindAttrGroup, qn) {
 		c.reportDuplicateComponent(ctx, elem, "attributeGroup", "A global attribute group definition", qn)
 		return nil
 	}

--- a/xsd/read_particles.go
+++ b/xsd/read_particles.go
@@ -38,9 +38,9 @@ func (c *compiler) parseNamedGroup(ctx context.Context, elem *helium.Element) er
 			return err
 		}
 		qn := QName{Local: name, NS: c.schema.targetNamespace}
-		// An xs:redefine override may replace the same-named group loaded from
-		// the redefined schema exactly once.
-		if _, exists := c.schema.groups[qn]; exists && !c.allowsRedefine(redefineKindGroup, qn) {
+		// An xs:redefine override that was validated and consumed by the redefine
+		// loop is pre-authorized and skips the report.
+		if _, exists := c.schema.groups[qn]; exists && !c.redefineConsumed(redefineKindGroup, qn) {
 			c.reportDuplicateComponent(ctx, elem, "group", "A global model group definition", qn)
 			return nil
 		}
@@ -57,9 +57,9 @@ func (c *compiler) parseNamedAttributeGroup(ctx context.Context, elem *helium.El
 	}
 
 	qn := QName{Local: name, NS: c.schema.targetNamespace}
-	// An xs:redefine override may replace the same-named attribute group
-	// loaded from the redefined schema exactly once.
-	if _, exists := c.schema.attrGroups[qn]; exists && !c.allowsRedefine(redefineKindAttrGroup, qn) {
+	// An xs:redefine override that was validated and consumed by the redefine
+	// loop is pre-authorized and skips the report.
+	if _, exists := c.schema.attrGroups[qn]; exists && !c.redefineConsumed(redefineKindAttrGroup, qn) {
 		c.reportDuplicateComponent(ctx, elem, "attributeGroup", "A global attribute group definition", qn)
 		return nil
 	}

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -17,20 +17,23 @@ func (c *compiler) parseNamedComplexType(ctx context.Context, elem *helium.Eleme
 		return fmt.Errorf("xsd: named complexType missing name")
 	}
 
+	qn := QName{Local: name, NS: c.schema.targetNamespace}
+
+	// Check for a duplicate global type BEFORE parsing the body, so a rejected
+	// component leaves no stale refs/state behind that would produce unrelated
+	// follow-on errors. An xs:redefine override that was validated and consumed
+	// by the redefine loop is pre-authorized and skips the report.
+	if _, exists := c.schema.types[qn]; exists && !c.redefineConsumed(redefineKindComplexType, qn) {
+		c.reportDuplicateComponent(ctx, elem, "complexType", "A global type definition", qn)
+		return nil
+	}
+
 	td, err := c.parseComplexType(ctx, elem)
 	if err != nil {
 		return err
 	}
-	td.Name = QName{Local: name, NS: c.schema.targetNamespace}
+	td.Name = qn
 	td.Abstract = getAttr(elem, attrAbstract) == attrValTrue
-
-	// Check for a duplicate global type. An xs:redefine override that was
-	// validated and consumed by the redefine loop is pre-authorized and skips
-	// the report.
-	if _, exists := c.schema.types[td.Name]; exists && !c.redefineConsumed(redefineKindType, td.Name) {
-		c.reportDuplicateComponent(ctx, elem, "complexType", "A global type definition", td.Name)
-		return nil
-	}
 
 	// Parse final attribute with schema default.
 	if hasAttr(elem, attrFinal) {
@@ -41,6 +44,7 @@ func (c *compiler) parseNamedComplexType(ctx context.Context, elem *helium.Eleme
 	}
 
 	c.typeDefSources[td] = typeDefSource{line: elem.Line(), isLocal: false}
+	c.typeKinds[td.Name] = redefineKindComplexType
 	c.schema.types[td.Name] = td
 	return nil
 }
@@ -51,19 +55,22 @@ func (c *compiler) parseNamedSimpleType(ctx context.Context, elem *helium.Elemen
 		return fmt.Errorf("xsd: named simpleType missing name")
 	}
 
+	qn := QName{Local: name, NS: c.schema.targetNamespace}
+
+	// Check for a duplicate global type BEFORE parsing the body, so a rejected
+	// component leaves no stale refs/state behind that would produce unrelated
+	// follow-on errors. An xs:redefine override that was validated and consumed
+	// by the redefine loop is pre-authorized and skips the report.
+	if _, exists := c.schema.types[qn]; exists && !c.redefineConsumed(redefineKindSimpleType, qn) {
+		c.reportDuplicateComponent(ctx, elem, "simpleType", "A global type definition", qn)
+		return nil
+	}
+
 	td, err := c.parseSimpleType(ctx, elem)
 	if err != nil {
 		return err
 	}
-	td.Name = QName{Local: name, NS: c.schema.targetNamespace}
-
-	// Check for a duplicate global type. An xs:redefine override that was
-	// validated and consumed by the redefine loop is pre-authorized and skips
-	// the report.
-	if _, exists := c.schema.types[td.Name]; exists && !c.redefineConsumed(redefineKindType, td.Name) {
-		c.reportDuplicateComponent(ctx, elem, "simpleType", "A global type definition", td.Name)
-		return nil
-	}
+	td.Name = qn
 
 	// Parse final attribute with schema default.
 	if hasAttr(elem, attrFinal) {
@@ -74,6 +81,7 @@ func (c *compiler) parseNamedSimpleType(ctx context.Context, elem *helium.Elemen
 	}
 
 	c.typeDefSources[td] = typeDefSource{line: elem.Line(), isLocal: false}
+	c.typeKinds[td.Name] = redefineKindSimpleType
 	c.schema.types[td.Name] = td
 	return nil
 }

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -24,9 +24,10 @@ func (c *compiler) parseNamedComplexType(ctx context.Context, elem *helium.Eleme
 	td.Name = QName{Local: name, NS: c.schema.targetNamespace}
 	td.Abstract = getAttr(elem, attrAbstract) == attrValTrue
 
-	// Check for a duplicate global type. An xs:redefine override may replace
-	// the same-named type loaded from the redefined schema exactly once.
-	if _, exists := c.schema.types[td.Name]; exists && !c.allowsRedefine(redefineKindType, td.Name) {
+	// Check for a duplicate global type. An xs:redefine override that was
+	// validated and consumed by the redefine loop is pre-authorized and skips
+	// the report.
+	if _, exists := c.schema.types[td.Name]; exists && !c.redefineConsumed(redefineKindType, td.Name) {
 		c.reportDuplicateComponent(ctx, elem, "complexType", "A global type definition", td.Name)
 		return nil
 	}
@@ -56,9 +57,10 @@ func (c *compiler) parseNamedSimpleType(ctx context.Context, elem *helium.Elemen
 	}
 	td.Name = QName{Local: name, NS: c.schema.targetNamespace}
 
-	// Check for a duplicate global type. An xs:redefine override may replace
-	// the same-named type loaded from the redefined schema exactly once.
-	if _, exists := c.schema.types[td.Name]; exists && !c.allowsRedefine(redefineKindType, td.Name) {
+	// Check for a duplicate global type. An xs:redefine override that was
+	// validated and consumed by the redefine loop is pre-authorized and skips
+	// the report.
+	if _, exists := c.schema.types[td.Name]; exists && !c.redefineConsumed(redefineKindType, td.Name) {
 		c.reportDuplicateComponent(ctx, elem, "simpleType", "A global type definition", td.Name)
 		return nil
 	}

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -24,6 +24,14 @@ func (c *compiler) parseNamedComplexType(ctx context.Context, elem *helium.Eleme
 	td.Name = QName{Local: name, NS: c.schema.targetNamespace}
 	td.Abstract = getAttr(elem, attrAbstract) == attrValTrue
 
+	// Check for a duplicate global type. Redefinitions intentionally replace
+	// the same-named type loaded from the redefined schema, so suppress the
+	// check while processing xs:redefine overrides.
+	if _, exists := c.schema.types[td.Name]; exists && !c.inRedefine {
+		c.reportDuplicateComponent(ctx, elem, "complexType", "A global type definition", td.Name)
+		return nil
+	}
+
 	// Parse final attribute with schema default.
 	if hasAttr(elem, attrFinal) {
 		td.Final = parseElemFinalFlags(getAttr(elem, attrFinal))
@@ -48,6 +56,14 @@ func (c *compiler) parseNamedSimpleType(ctx context.Context, elem *helium.Elemen
 		return err
 	}
 	td.Name = QName{Local: name, NS: c.schema.targetNamespace}
+
+	// Check for a duplicate global type. Redefinitions intentionally replace
+	// the same-named type loaded from the redefined schema, so suppress the
+	// check while processing xs:redefine overrides.
+	if _, exists := c.schema.types[td.Name]; exists && !c.inRedefine {
+		c.reportDuplicateComponent(ctx, elem, "simpleType", "A global type definition", td.Name)
+		return nil
+	}
 
 	// Parse final attribute with schema default.
 	if hasAttr(elem, attrFinal) {

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -24,10 +24,9 @@ func (c *compiler) parseNamedComplexType(ctx context.Context, elem *helium.Eleme
 	td.Name = QName{Local: name, NS: c.schema.targetNamespace}
 	td.Abstract = getAttr(elem, attrAbstract) == attrValTrue
 
-	// Check for a duplicate global type. Redefinitions intentionally replace
-	// the same-named type loaded from the redefined schema, so suppress the
-	// check while processing xs:redefine overrides.
-	if _, exists := c.schema.types[td.Name]; exists && !c.inRedefine {
+	// Check for a duplicate global type. An xs:redefine override may replace
+	// the same-named type loaded from the redefined schema exactly once.
+	if _, exists := c.schema.types[td.Name]; exists && !c.allowsRedefine(redefineKindType, td.Name) {
 		c.reportDuplicateComponent(ctx, elem, "complexType", "A global type definition", td.Name)
 		return nil
 	}
@@ -57,10 +56,9 @@ func (c *compiler) parseNamedSimpleType(ctx context.Context, elem *helium.Elemen
 	}
 	td.Name = QName{Local: name, NS: c.schema.targetNamespace}
 
-	// Check for a duplicate global type. Redefinitions intentionally replace
-	// the same-named type loaded from the redefined schema, so suppress the
-	// check while processing xs:redefine overrides.
-	if _, exists := c.schema.types[td.Name]; exists && !c.inRedefine {
+	// Check for a duplicate global type. An xs:redefine override may replace
+	// the same-named type loaded from the redefined schema exactly once.
+	if _, exists := c.schema.types[td.Name]; exists && !c.allowsRedefine(redefineKindType, td.Name) {
 		c.reportDuplicateComponent(ctx, elem, "simpleType", "A global type definition", td.Name)
 		return nil
 	}

--- a/xsd/xsd_test.go
+++ b/xsd/xsd_test.go
@@ -1213,6 +1213,84 @@ func TestRedefine(t *testing.T) {
 			require.Empty(t, compileErrors(t, mainPath))
 		})
 	}
+
+	// crossKindRejected covers a redefine override whose component KIND differs
+	// from the Phase-A component it names. A Phase-A simpleType may only be
+	// overridden by a simpleType (and a complexType by a complexType); a
+	// cross-kind override (simpleType→complexType or complexType→simpleType) must
+	// be rejected as a single duplicate-name error with no follow-on diagnostics.
+	// The override element is on line 4 of each main schema (line 1 xml decl,
+	// line 2 xs:schema, line 3 xs:redefine, line 4 the override).
+	crossKindRejected := []struct {
+		name        string
+		baseFile    string
+		base        string
+		mainFile    string
+		main        string
+		overrideTag string // xsd element name of the rejected override
+		compDesc    string // descriptive phrase in the diagnostic
+	}{
+		{
+			name:     "simpleType_redefined_by_complexType",
+			baseFile: "base-xkind-st.xsd",
+			base: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="T">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+</xs:schema>`,
+			mainFile: "main-xkind-st.xsd",
+			main: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base-xkind-st.xsd">
+    <xs:complexType name="T">
+      <xs:sequence><xs:element name="a" type="xs:string"/></xs:sequence>
+    </xs:complexType>
+  </xs:redefine>
+  <xs:element name="root" type="T"/>
+</xs:schema>`,
+			overrideTag: "complexType",
+			compDesc:    "A global type definition",
+		},
+		{
+			name:     "complexType_redefined_by_simpleType",
+			baseFile: "base-xkind-ct.xsd",
+			base: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="T">
+    <xs:sequence><xs:element name="a" type="xs:string"/></xs:sequence>
+  </xs:complexType>
+</xs:schema>`,
+			mainFile: "main-xkind-ct.xsd",
+			main: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base-xkind-ct.xsd">
+    <xs:simpleType name="T">
+      <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+  </xs:redefine>
+  <xs:element name="root" type="T"/>
+</xs:schema>`,
+			overrideTag: "simpleType",
+			compDesc:    "A global type definition",
+		},
+	}
+
+	for _, tc := range crossKindRejected {
+		t.Run("cross_kind_rejected_"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			writeFile(t, tc.baseFile, tc.base)
+			mainPath := writeFile(t, tc.mainFile, tc.main)
+			// The diagnostic file label is the redefined schema's resolved
+			// location (schemaDisplayLoc). CompileFile labels the main schema by
+			// its basename, so Dir is "." and the location resolves to the bare
+			// base-schema file name.
+			want := tc.baseFile + ":4: element " + tc.overrideTag +
+				": Schemas parser error : Element '{http://www.w3.org/2001/XMLSchema}" + tc.overrideTag +
+				"': " + tc.compDesc + " ''T does already exist.\n"
+			require.Equal(t, want, compileErrors(t, mainPath))
+		})
+	}
 }
 
 func TestFacetConsistency(t *testing.T) {

--- a/xsd/xsd_test.go
+++ b/xsd/xsd_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -803,10 +804,18 @@ func TestRedefine(t *testing.T) {
 		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
 		_, err := xsd.NewCompiler().ErrorHandler(collector).CompileFile(t.Context(), xsdPath)
 		require.NoError(t, err)
-		_ = collector.Close()
+		require.NoError(t, collector.Close())
 		_, errors := partitionCompileErrors(collector.Errors())
 		return errors
 	}
+
+	// Descriptive phrases used by the duplicate-component diagnostic, keyed by
+	// the redefinable component kind, shared by the exact-assertion tables below.
+	const (
+		descType      = "A global type definition"
+		descGroup     = "A global model group definition"
+		descAttrGroup = "A global attribute group definition"
+	)
 
 	t.Run("single_redefine_compiles_clean", func(t *testing.T) {
 		t.Parallel()
@@ -858,7 +867,15 @@ func TestRedefine(t *testing.T) {
   <xs:element name="code" type="codeType"/>
 </xs:schema>`)
 
-		require.Contains(t, compileErrors(t, mainPath), "does already exist")
+		// The second override (line 9) is the duplicate. CompileFile assigns no
+		// label, so the redefining file resolves to "(string)" — confirming the
+		// override-child diagnostic carries the redefining file's label (not the
+		// redefined base file's), with the duplicate override's line and exactly
+		// one error.
+		want := "(string):9: element simpleType: Schemas parser error : " +
+			"Element '{http://www.w3.org/2001/XMLSchema}simpleType': " +
+			"A global type definition ''codeType does already exist.\n"
+		require.Equal(t, want, compileErrors(t, mainPath))
 	})
 
 	// dupOverrideKinds covers duplicate override children for each redefinable
@@ -871,9 +888,15 @@ func TestRedefine(t *testing.T) {
 		base     string
 		mainFile string
 		main     string
+		line     int    // line of the duplicate (second) override child
+		compName string // expected component local name in the diagnostic
+		compDesc string // descriptive phrase in the diagnostic
 	}{
 		{
 			name:     "complexType",
+			line:     11,
+			compName: "ctType",
+			compDesc: descType,
 			baseFile: "base-dup-ct.xsd",
 			base: `<?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
@@ -905,6 +928,9 @@ func TestRedefine(t *testing.T) {
 		},
 		{
 			name:     "group",
+			line:     10,
+			compName: "grp",
+			compDesc: descGroup,
 			baseFile: "base-dup-grp.xsd",
 			base: `<?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
@@ -936,6 +962,9 @@ func TestRedefine(t *testing.T) {
 		},
 		{
 			name:     "attributeGroup",
+			line:     8,
+			compName: "ag",
+			compDesc: descAttrGroup,
 			baseFile: "base-dup-ag.xsd",
 			base: `<?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
@@ -968,7 +997,16 @@ func TestRedefine(t *testing.T) {
 			t.Parallel()
 			writeFile(t, tc.baseFile, tc.base)
 			mainPath := writeFile(t, tc.mainFile, tc.main)
-			require.Contains(t, compileErrors(t, mainPath), "does already exist")
+			// The duplicate override child belongs to the REDEFINING (main)
+			// schema, so its diagnostic must carry that file's label, not the
+			// redefined base file's. CompileFile assigns no label, so the
+			// redefining file resolves to "(string)". Assert the exact single
+			// error: correct label, the duplicate override's line, and no
+			// follow-on diagnostics.
+			want := "(string):" + strconv.Itoa(tc.line) + ": element " + tc.name +
+				": Schemas parser error : Element '{http://www.w3.org/2001/XMLSchema}" + tc.name +
+				"': " + tc.compDesc + " ''" + tc.compName + " does already exist.\n"
+			require.Equal(t, want, compileErrors(t, mainPath))
 		})
 	}
 
@@ -982,9 +1020,13 @@ func TestRedefine(t *testing.T) {
 		base     string
 		mainFile string
 		main     string
+		line     int    // line of the absent-target override child
+		compDesc string // descriptive phrase in the diagnostic
 	}{
 		{
 			name:     "simpleType",
+			line:     7,
+			compDesc: descType,
 			baseFile: "base-absent-st.xsd",
 			base: `<?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
@@ -1010,6 +1052,8 @@ func TestRedefine(t *testing.T) {
 		},
 		{
 			name:     "complexType",
+			line:     7,
+			compDesc: descType,
 			baseFile: "base-absent-ct.xsd",
 			base: `<?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
@@ -1037,6 +1081,8 @@ func TestRedefine(t *testing.T) {
 		},
 		{
 			name:     "group",
+			line:     7,
+			compDesc: descGroup,
 			baseFile: "base-absent-grp.xsd",
 			base: `<?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
@@ -1065,6 +1111,8 @@ func TestRedefine(t *testing.T) {
 		},
 		{
 			name:     "attributeGroup",
+			line:     7,
+			compDesc: descAttrGroup,
 			baseFile: "base-absent-ag.xsd",
 			base: `<?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
@@ -1096,7 +1144,15 @@ func TestRedefine(t *testing.T) {
 			t.Parallel()
 			writeFile(t, tc.baseFile, tc.base)
 			mainPath := writeFile(t, tc.mainFile, tc.main)
-			require.Contains(t, compileErrors(t, mainPath), "does already exist")
+			// The override targets "localOnly", a component present only in the
+			// REDEFINING (main) schema (absent from the redefined base). It must
+			// be rejected with the redefining file's label (CompileFile assigns
+			// none, so "(string)"), the override child's line, and exactly one
+			// error with no follow-on diagnostics.
+			want := "(string):" + strconv.Itoa(tc.line) + ": element " + tc.name +
+				": Schemas parser error : Element '{http://www.w3.org/2001/XMLSchema}" + tc.name +
+				"': " + tc.compDesc + " ''localOnly does already exist.\n"
+			require.Equal(t, want, compileErrors(t, mainPath))
 		})
 	}
 
@@ -1250,7 +1306,7 @@ func TestRedefine(t *testing.T) {
   <xs:element name="root" type="T"/>
 </xs:schema>`,
 			overrideTag: "complexType",
-			compDesc:    "A global type definition",
+			compDesc:    descType,
 		},
 		{
 			name:     "complexType_redefined_by_simpleType",
@@ -1272,7 +1328,7 @@ func TestRedefine(t *testing.T) {
   <xs:element name="root" type="T"/>
 </xs:schema>`,
 			overrideTag: "simpleType",
-			compDesc:    "A global type definition",
+			compDesc:    descType,
 		},
 	}
 
@@ -1281,11 +1337,12 @@ func TestRedefine(t *testing.T) {
 			t.Parallel()
 			writeFile(t, tc.baseFile, tc.base)
 			mainPath := writeFile(t, tc.mainFile, tc.main)
-			// The diagnostic file label is the redefined schema's resolved
-			// location (schemaDisplayLoc). CompileFile labels the main schema by
-			// its basename, so Dir is "." and the location resolves to the bare
-			// base-schema file name.
-			want := tc.baseFile + ":4: element " + tc.overrideTag +
+			// The override child belongs to the REDEFINING (main) schema, so its
+			// cross-kind rejection diagnostic carries that file's label, not the
+			// redefined base file's. CompileFile assigns no label, so the
+			// redefining file resolves to "(string)". The override is on line 4
+			// (line 1 xml decl, 2 xs:schema, 3 xs:redefine, 4 the override).
+			want := "(string):4: element " + tc.overrideTag +
 				": Schemas parser error : Element '{http://www.w3.org/2001/XMLSchema}" + tc.overrideTag +
 				"': " + tc.compDesc + " ''T does already exist.\n"
 			require.Equal(t, want, compileErrors(t, mainPath))

--- a/xsd/xsd_test.go
+++ b/xsd/xsd_test.go
@@ -860,6 +860,359 @@ func TestRedefine(t *testing.T) {
 
 		require.Contains(t, compileErrors(t, mainPath), "does already exist")
 	})
+
+	// dupOverrideKinds covers duplicate override children for each redefinable
+	// component kind. Two override children naming the same Phase-A component
+	// must be rejected: the first consumes the Phase-A name, the second is a
+	// duplicate.
+	dupOverrideKinds := []struct {
+		name     string
+		baseFile string
+		base     string
+		mainFile string
+		main     string
+	}{
+		{
+			name:     "complexType",
+			baseFile: "base-dup-ct.xsd",
+			base: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="ctType">
+    <xs:sequence><xs:element name="a" type="xs:string"/></xs:sequence>
+  </xs:complexType>
+</xs:schema>`,
+			mainFile: "main-dup-ct.xsd",
+			main: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base-dup-ct.xsd">
+    <xs:complexType name="ctType">
+      <xs:complexContent>
+        <xs:extension base="ctType">
+          <xs:sequence><xs:element name="b" type="xs:string"/></xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="ctType">
+      <xs:complexContent>
+        <xs:extension base="ctType">
+          <xs:sequence><xs:element name="c" type="xs:string"/></xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:redefine>
+  <xs:element name="root" type="ctType"/>
+</xs:schema>`,
+		},
+		{
+			name:     "group",
+			baseFile: "base-dup-grp.xsd",
+			base: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="grp">
+    <xs:sequence><xs:element name="a" type="xs:string"/></xs:sequence>
+  </xs:group>
+</xs:schema>`,
+			mainFile: "main-dup-grp.xsd",
+			main: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base-dup-grp.xsd">
+    <xs:group name="grp">
+      <xs:sequence>
+        <xs:group ref="grp"/>
+        <xs:element name="b" type="xs:string"/>
+      </xs:sequence>
+    </xs:group>
+    <xs:group name="grp">
+      <xs:sequence>
+        <xs:group ref="grp"/>
+        <xs:element name="c" type="xs:string"/>
+      </xs:sequence>
+    </xs:group>
+  </xs:redefine>
+  <xs:element name="root">
+    <xs:complexType><xs:group ref="grp"/></xs:complexType>
+  </xs:element>
+</xs:schema>`,
+		},
+		{
+			name:     "attributeGroup",
+			baseFile: "base-dup-ag.xsd",
+			base: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attributeGroup name="ag">
+    <xs:attribute name="a" type="xs:string"/>
+  </xs:attributeGroup>
+</xs:schema>`,
+			mainFile: "main-dup-ag.xsd",
+			main: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base-dup-ag.xsd">
+    <xs:attributeGroup name="ag">
+      <xs:attributeGroup ref="ag"/>
+      <xs:attribute name="b" type="xs:string"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="ag">
+      <xs:attributeGroup ref="ag"/>
+      <xs:attribute name="c" type="xs:string"/>
+    </xs:attributeGroup>
+  </xs:redefine>
+  <xs:element name="root">
+    <xs:complexType><xs:attributeGroup ref="ag"/></xs:complexType>
+  </xs:element>
+</xs:schema>`,
+		},
+	}
+
+	for _, tc := range dupOverrideKinds {
+		t.Run("duplicate_override_"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			writeFile(t, tc.baseFile, tc.base)
+			mainPath := writeFile(t, tc.mainFile, tc.main)
+			require.Contains(t, compileErrors(t, mainPath), "does already exist")
+		})
+	}
+
+	// absentTargetKinds covers a redefine override naming a component that is
+	// ABSENT from the redefined schema (but present in the INCLUDING schema). It
+	// must be rejected: only components loaded from the redefined file (Phase A)
+	// are redefinable, not pre-existing main-schema declarations.
+	absentTargetKinds := []struct {
+		name     string
+		baseFile string
+		base     string
+		mainFile string
+		main     string
+	}{
+		{
+			name:     "simpleType",
+			baseFile: "base-absent-st.xsd",
+			base: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="baseOnly">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+</xs:schema>`,
+			mainFile: "main-absent-st.xsd",
+			main: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="localOnly">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:redefine schemaLocation="base-absent-st.xsd">
+    <xs:simpleType name="localOnly">
+      <xs:restriction base="localOnly">
+        <xs:maxLength value="5"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:redefine>
+  <xs:element name="root" type="localOnly"/>
+</xs:schema>`,
+		},
+		{
+			name:     "complexType",
+			baseFile: "base-absent-ct.xsd",
+			base: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="baseOnly">
+    <xs:sequence><xs:element name="a" type="xs:string"/></xs:sequence>
+  </xs:complexType>
+</xs:schema>`,
+			mainFile: "main-absent-ct.xsd",
+			main: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="localOnly">
+    <xs:sequence><xs:element name="a" type="xs:string"/></xs:sequence>
+  </xs:complexType>
+  <xs:redefine schemaLocation="base-absent-ct.xsd">
+    <xs:complexType name="localOnly">
+      <xs:complexContent>
+        <xs:extension base="localOnly">
+          <xs:sequence><xs:element name="b" type="xs:string"/></xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:redefine>
+  <xs:element name="root" type="localOnly"/>
+</xs:schema>`,
+		},
+		{
+			name:     "group",
+			baseFile: "base-absent-grp.xsd",
+			base: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="baseOnly">
+    <xs:sequence><xs:element name="a" type="xs:string"/></xs:sequence>
+  </xs:group>
+</xs:schema>`,
+			mainFile: "main-absent-grp.xsd",
+			main: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="localOnly">
+    <xs:sequence><xs:element name="a" type="xs:string"/></xs:sequence>
+  </xs:group>
+  <xs:redefine schemaLocation="base-absent-grp.xsd">
+    <xs:group name="localOnly">
+      <xs:sequence>
+        <xs:group ref="localOnly"/>
+        <xs:element name="b" type="xs:string"/>
+      </xs:sequence>
+    </xs:group>
+  </xs:redefine>
+  <xs:element name="root">
+    <xs:complexType><xs:group ref="localOnly"/></xs:complexType>
+  </xs:element>
+</xs:schema>`,
+		},
+		{
+			name:     "attributeGroup",
+			baseFile: "base-absent-ag.xsd",
+			base: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attributeGroup name="baseOnly">
+    <xs:attribute name="a" type="xs:string"/>
+  </xs:attributeGroup>
+</xs:schema>`,
+			mainFile: "main-absent-ag.xsd",
+			main: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attributeGroup name="localOnly">
+    <xs:attribute name="a" type="xs:string"/>
+  </xs:attributeGroup>
+  <xs:redefine schemaLocation="base-absent-ag.xsd">
+    <xs:attributeGroup name="localOnly">
+      <xs:attributeGroup ref="localOnly"/>
+      <xs:attribute name="b" type="xs:string"/>
+    </xs:attributeGroup>
+  </xs:redefine>
+  <xs:element name="root">
+    <xs:complexType><xs:attributeGroup ref="localOnly"/></xs:complexType>
+  </xs:element>
+</xs:schema>`,
+		},
+	}
+
+	for _, tc := range absentTargetKinds {
+		t.Run("absent_target_rejected_"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			writeFile(t, tc.baseFile, tc.base)
+			mainPath := writeFile(t, tc.mainFile, tc.main)
+			require.Contains(t, compileErrors(t, mainPath), "does already exist")
+		})
+	}
+
+	// validSingleKinds covers a single valid redefine of each kind compiling
+	// clean — the positive counterpart to the duplicate/absent rejections.
+	validSingleKinds := []struct {
+		name     string
+		baseFile string
+		base     string
+		mainFile string
+		main     string
+	}{
+		{
+			name:     "complexType",
+			baseFile: "base-valid-ct.xsd",
+			base: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="ctType">
+    <xs:sequence><xs:element name="a" type="xs:string"/></xs:sequence>
+  </xs:complexType>
+</xs:schema>`,
+			mainFile: "main-valid-ct.xsd",
+			main: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base-valid-ct.xsd">
+    <xs:complexType name="ctType">
+      <xs:complexContent>
+        <xs:extension base="ctType">
+          <xs:sequence><xs:element name="b" type="xs:string"/></xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:redefine>
+  <xs:element name="root" type="ctType"/>
+</xs:schema>`,
+		},
+		{
+			name:     "simpleType",
+			baseFile: "base-valid-st.xsd",
+			base: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="stType">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+</xs:schema>`,
+			mainFile: "main-valid-st.xsd",
+			main: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base-valid-st.xsd">
+    <xs:simpleType name="stType">
+      <xs:restriction base="stType">
+        <xs:maxLength value="5"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:redefine>
+  <xs:element name="root" type="stType"/>
+</xs:schema>`,
+		},
+		{
+			name:     "group",
+			baseFile: "base-valid-grp.xsd",
+			base: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="grp">
+    <xs:sequence><xs:element name="a" type="xs:string"/></xs:sequence>
+  </xs:group>
+</xs:schema>`,
+			mainFile: "main-valid-grp.xsd",
+			main: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base-valid-grp.xsd">
+    <xs:group name="grp">
+      <xs:sequence>
+        <xs:group ref="grp"/>
+        <xs:element name="b" type="xs:string"/>
+      </xs:sequence>
+    </xs:group>
+  </xs:redefine>
+  <xs:element name="root">
+    <xs:complexType><xs:group ref="grp"/></xs:complexType>
+  </xs:element>
+</xs:schema>`,
+		},
+		{
+			name:     "attributeGroup",
+			baseFile: "base-valid-ag.xsd",
+			base: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attributeGroup name="ag">
+    <xs:attribute name="a" type="xs:string"/>
+  </xs:attributeGroup>
+</xs:schema>`,
+			mainFile: "main-valid-ag.xsd",
+			main: `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base-valid-ag.xsd">
+    <xs:attributeGroup name="ag">
+      <xs:attributeGroup ref="ag"/>
+      <xs:attribute name="b" type="xs:string"/>
+    </xs:attributeGroup>
+  </xs:redefine>
+  <xs:element name="root">
+    <xs:complexType><xs:attributeGroup ref="ag"/></xs:complexType>
+  </xs:element>
+</xs:schema>`,
+		},
+	}
+
+	for _, tc := range validSingleKinds {
+		t.Run("valid_single_"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			writeFile(t, tc.baseFile, tc.base)
+			mainPath := writeFile(t, tc.mainFile, tc.main)
+			require.Empty(t, compileErrors(t, mainPath))
+		})
+	}
 }
 
 func TestFacetConsistency(t *testing.T) {

--- a/xsd/xsd_test.go
+++ b/xsd/xsd_test.go
@@ -797,6 +797,69 @@ func TestRedefine(t *testing.T) {
 <code xmlns="http://example.com/ns">VeryLongCodeValue</code>`)
 		require.Error(t, err)
 	})
+
+	compileErrors := func(t *testing.T, xsdPath string) string {
+		t.Helper()
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, err := xsd.NewCompiler().ErrorHandler(collector).CompileFile(t.Context(), xsdPath)
+		require.NoError(t, err)
+		_ = collector.Close()
+		_, errors := partitionCompileErrors(collector.Errors())
+		return errors
+	}
+
+	t.Run("single_redefine_compiles_clean", func(t *testing.T) {
+		t.Parallel()
+		writeFile(t, "base-single.xsd", `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="codeType">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+</xs:schema>`)
+
+		mainPath := writeFile(t, "main-single.xsd", `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base-single.xsd">
+    <xs:simpleType name="codeType">
+      <xs:restriction base="codeType">
+        <xs:maxLength value="10"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:redefine>
+  <xs:element name="code" type="codeType"/>
+</xs:schema>`)
+
+		require.Empty(t, compileErrors(t, mainPath))
+	})
+
+	t.Run("duplicate_override_children_reported", func(t *testing.T) {
+		t.Parallel()
+		writeFile(t, "base-dup-override.xsd", `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="codeType">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+</xs:schema>`)
+
+		mainPath := writeFile(t, "main-dup-override.xsd", `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base-dup-override.xsd">
+    <xs:simpleType name="codeType">
+      <xs:restriction base="codeType">
+        <xs:maxLength value="10"/>
+      </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="codeType">
+      <xs:restriction base="codeType">
+        <xs:maxLength value="5"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:redefine>
+  <xs:element name="code" type="codeType"/>
+</xs:schema>`)
+
+		require.Contains(t, compileErrors(t, mainPath), "does already exist")
+	})
 }
 
 func TestFacetConsistency(t *testing.T) {


### PR DESCRIPTION
- Report a fatal schema error when two global simpleTypes, complexTypes, model groups, or attributeGroups share a name, instead of silently overwriting the first.
- Suppress the check inside xs:redefine override processing, which legitimately replaces same-named components.