### PR TITLE
treat undeclared general entity as fatal

### DIFF
--- a/parser_entity_ref.go
+++ b/parser_entity_ref.go
@@ -654,7 +654,7 @@ func (pctx *parserCtx) parseEntityRef(ctx context.Context) (ent *Entity, err err
 	}
 
 	if ent == nil {
-		if pctx.standalone == StandaloneExplicitYes || (!pctx.hasExternalSubset && pctx.hasPERefs) {
+		if pctx.standalone == StandaloneExplicitYes || (!pctx.hasExternalSubset && !pctx.hasPERefs) {
 			return nil, pctx.error(ctx, ErrUndeclaredEntity)
 		}
 		if err := pctx.warning(ctx, "Entity '%s' not defined", name); err != nil {

--- a/parser_entity_test.go
+++ b/parser_entity_test.go
@@ -201,6 +201,17 @@ func TestPredefinedEntityRedeclaration(t *testing.T) {
 	})
 }
 
+func TestUndeclaredEntityFatal(t *testing.T) {
+	t.Parallel()
+
+	// An undeclared general entity reference, with no DTD/external subset
+	// and no parameter-entity references, is a fatal well-formedness error.
+	xml := `<r>&bogus;</r>`
+
+	_, err := helium.NewParser().Parse(t.Context(), []byte(xml))
+	require.Error(t, err, "undeclared entity with no DTD must be fatal")
+}
+
 func TestEntityDepthLimit(t *testing.T) {
 	// Build deeply nested entity references (depth > 40).
 	var dtd strings.Builder

--- a/parser_entity_test.go
+++ b/parser_entity_test.go
@@ -1,6 +1,7 @@
 package helium_test
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -208,8 +209,14 @@ func TestUndeclaredEntityFatal(t *testing.T) {
 	// and no parameter-entity references, is a fatal well-formedness error.
 	xml := `<r>&bogus;</r>`
 
-	_, err := helium.NewParser().Parse(t.Context(), []byte(xml))
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(xml))
 	require.Error(t, err, "undeclared entity with no DTD must be fatal")
+	require.Nil(t, doc, "no document should be returned on a fatal error")
+	require.ErrorIs(t, err, helium.ErrUndeclaredEntity, "error must be the undeclared-entity sentinel")
+
+	var pe helium.ErrParseError
+	require.True(t, errors.As(err, &pe), "error must be an ErrParseError")
+	require.Equal(t, helium.ErrorLevelFatal, pe.Level, "undeclared entity must be a fatal-level error")
 }
 
 func TestEntityDepthLimit(t *testing.T) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -433,18 +433,22 @@ func TestParseExternalEntity(t *testing.T) {
 ]>
 <doc>&ext;</doc>`
 
-	// Provide a ResolveEntity handler that returns inline content
-	s := sax.New()
-	s.SetOnResolveEntity(sax.ResolveEntityFunc(func(_ context.Context, publicID, systemID string) (sax.ParseInput, error) {
-		if systemID == "ext.xml" {
-			return newStringParseInput("<inner>hello</inner>", systemID), nil
-		}
-		return nil, sax.ErrHandlerUnspecified
-	}))
+	// The external entity is declared in the internal subset and its content is
+	// served through the configured FS, exercising the default resolution path.
+	fsys := fstest.MapFS{
+		"ext.xml": &fstest.MapFile{Data: []byte("<inner>hello</inner>")},
+	}
 
-	p := helium.NewParser().SAXHandler(s).SubstituteEntities(true)
-	_, err := p.Parse(t.Context(), []byte(input))
+	p := helium.NewParser().SubstituteEntities(true).FS(fsys)
+	doc, err := p.Parse(t.Context(), []byte(input))
 	require.NoError(t, err, "Parse with external entity should succeed")
+	require.NotNil(t, doc, "external entity parse should produce a document")
+
+	var buf bytes.Buffer
+	require.NoError(t, helium.NewWriter().WriteTo(&buf, doc))
+	out := buf.String()
+	require.Contains(t, out, "<inner", "external entity element should be expanded into the document")
+	require.Contains(t, out, ">hello</inner>", "external entity content should be expanded into the document")
 }
 
 // stringParseInput implements sax.ParseInput for testing.


### PR DESCRIPTION
- fix inverted condition in `parseEntityRef`: undeclared general entity with no external subset and no PE refs is now fatal, matching sibling sites
- `<r>&bogus;</r>` (no DTD) is now a fatal well-formedness error instead of being silently turned into an entity-ref node
- rewrite `TestParseExternalEntity` to use the default handler + FS so it genuinely resolves the external entity (it previously passed vacuously on the bug)