### PR TITLE
fix xpath3 list and dateTimeStamp constructors

### DIFF
--- a/xpath3/cast.go
+++ b/xpath3/cast.go
@@ -133,6 +133,11 @@ func CastAtomic(v AtomicValue, targetType string) (AtomicValue, error) {
 			return AtomicValue{TypeName: TypeDateTime, Value: t}, nil
 		}
 	case TypeDateTimeStamp:
+		// A string source casts directly so a bad lexical reports
+		// xs:dateTimeStamp (not the xs:dateTime fallback target below).
+		if v.TypeName == TypeString {
+			return CastFromString(v.StringVal(), TypeDateTimeStamp)
+		}
 		// xs:dateTimeStamp is xs:dateTime with a required timezone
 		dt, err := CastAtomic(v, TypeDateTime)
 		if err != nil {

--- a/xpath3/cast.go
+++ b/xpath3/cast.go
@@ -47,6 +47,21 @@ func CastAtomic(v AtomicValue, targetType string) (AtomicValue, error) {
 		}
 	}
 
+	// xs:dateTimeStamp carries a mandatory-timezone invariant. AtomicValue is
+	// public and mutable, so a caller can retag a no-timezone xs:dateTime as
+	// TypeDateTimeStamp; enforce the invariant before the identity fast path
+	// rather than trusting the type tag.
+	if targetType == TypeDateTimeStamp && v.TypeName == TypeDateTimeStamp {
+		t, ok := v.Value.(time.Time)
+		if !ok {
+			return AtomicValue{}, &XPathError{Code: errCodeFORG0001, Message: "xs:dateTimeStamp requires a timezone"}
+		}
+		if !HasTimezone(t) {
+			return AtomicValue{}, &XPathError{Code: errCodeFORG0001, Message: "xs:dateTimeStamp requires a timezone"}
+		}
+		return v, nil
+	}
+
 	if v.TypeName == targetType {
 		return v, nil
 	}

--- a/xpath3/cast.go
+++ b/xpath3/cast.go
@@ -123,6 +123,10 @@ func CastAtomic(v AtomicValue, targetType string) (AtomicValue, error) {
 		if v.TypeName == TypeString {
 			return CastFromString(v.StringVal(), TypeDateTime)
 		}
+		if v.TypeName == TypeDateTimeStamp {
+			// xs:dateTimeStamp is a subtype of xs:dateTime
+			return AtomicValue{TypeName: TypeDateTime, Value: v.TimeVal()}, nil
+		}
 		if v.TypeName == TypeDate {
 			t := v.TimeVal()
 			return AtomicValue{TypeName: TypeDateTime, Value: t}, nil

--- a/xpath3/cast.go
+++ b/xpath3/cast.go
@@ -115,7 +115,8 @@ func CastAtomic(v AtomicValue, targetType string) (AtomicValue, error) {
 		if v.TypeName == TypeString {
 			return CastFromString(v.StringVal(), TypeDate)
 		}
-		if v.TypeName == TypeDateTime {
+		// xs:dateTimeStamp is a subtype of xs:dateTime, so it casts to xs:date too.
+		if v.TypeName == TypeDateTime || v.TypeName == TypeDateTimeStamp {
 			t := v.TimeVal()
 			return AtomicValue{TypeName: TypeDate, Value: time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())}, nil
 		}
@@ -146,7 +147,8 @@ func CastAtomic(v AtomicValue, targetType string) (AtomicValue, error) {
 		if v.TypeName == TypeString {
 			return CastFromString(v.StringVal(), TypeTime)
 		}
-		if v.TypeName == TypeDateTime {
+		// xs:dateTimeStamp is a subtype of xs:dateTime, so it casts to xs:time too.
+		if v.TypeName == TypeDateTime || v.TypeName == TypeDateTimeStamp {
 			t := v.TimeVal()
 			loc := t.Location()
 			if !HasTimezone(t) {
@@ -316,6 +318,20 @@ func CastFromString(s string, targetType string) (AtomicValue, error) {
 			return AtomicValue{}, castError(s, targetType)
 		}
 		return AtomicValue{TypeName: TypeDateTime, Value: t}, nil
+	case TypeDateTimeStamp:
+		// xs:dateTimeStamp is xs:dateTime with a mandatory timezone.
+		t, err := parseXSDDateTime(s)
+		if err != nil {
+			var xe *XPathError
+			if errors.As(err, &xe) {
+				return AtomicValue{}, xe
+			}
+			return AtomicValue{}, castError(s, targetType)
+		}
+		if !HasTimezone(t) {
+			return AtomicValue{}, &XPathError{Code: errCodeFORG0001, Message: "xs:dateTimeStamp requires a timezone"}
+		}
+		return AtomicValue{TypeName: TypeDateTimeStamp, Value: t}, nil
 	case TypeTime:
 		t, err := parseXSDTime(s)
 		if err != nil {

--- a/xpath3/cast.go
+++ b/xpath3/cast.go
@@ -12,6 +12,10 @@ import (
 	"github.com/lestrrat-go/helium/internal/lexicon"
 )
 
+// msgDateTimeStampTimezone is the FORG0001 message for an xs:dateTimeStamp
+// value that is missing its mandatory timezone.
+const msgDateTimeStampTimezone = "xs:dateTimeStamp requires a timezone"
+
 // isIntegerDerived returns true if the type is xs:integer or one of its derived types.
 func isIntegerDerived(typeName string) bool {
 	switch typeName {
@@ -38,6 +42,26 @@ func isAbstractCastTarget(typeName string) bool {
 		typeName == TypeNOTATION
 }
 
+// validateDateTimeStampSource enforces the xs:dateTimeStamp invariant on a
+// source value before it is cast to a date/time subtype. AtomicValue is public
+// and mutable, so a caller can retag a no-timezone or non-time value as
+// TypeDateTimeStamp; the subtype cast paths call TimeVal() unconditionally and
+// would panic on such a value. Validate the source is a time.Time carrying a
+// timezone, rejecting otherwise with a structured FORG0001 error.
+func validateDateTimeStampSource(v AtomicValue) error {
+	if v.TypeName != TypeDateTimeStamp {
+		return nil
+	}
+	t, ok := v.Value.(time.Time)
+	if !ok {
+		return &XPathError{Code: errCodeFORG0001, Message: msgDateTimeStampTimezone}
+	}
+	if !HasTimezone(t) {
+		return &XPathError{Code: errCodeFORG0001, Message: msgDateTimeStampTimezone}
+	}
+	return nil
+}
+
 // CastAtomic casts an AtomicValue to the target type.
 func CastAtomic(v AtomicValue, targetType string) (AtomicValue, error) {
 	if isAbstractCastTarget(targetType) {
@@ -54,10 +78,10 @@ func CastAtomic(v AtomicValue, targetType string) (AtomicValue, error) {
 	if targetType == TypeDateTimeStamp && v.TypeName == TypeDateTimeStamp {
 		t, ok := v.Value.(time.Time)
 		if !ok {
-			return AtomicValue{}, &XPathError{Code: errCodeFORG0001, Message: "xs:dateTimeStamp requires a timezone"}
+			return AtomicValue{}, &XPathError{Code: errCodeFORG0001, Message: msgDateTimeStampTimezone}
 		}
 		if !HasTimezone(t) {
-			return AtomicValue{}, &XPathError{Code: errCodeFORG0001, Message: "xs:dateTimeStamp requires a timezone"}
+			return AtomicValue{}, &XPathError{Code: errCodeFORG0001, Message: msgDateTimeStampTimezone}
 		}
 		return v, nil
 	}
@@ -132,6 +156,9 @@ func CastAtomic(v AtomicValue, targetType string) (AtomicValue, error) {
 		}
 		// xs:dateTimeStamp is a subtype of xs:dateTime, so it casts to xs:date too.
 		if v.TypeName == TypeDateTime || v.TypeName == TypeDateTimeStamp {
+			if err := validateDateTimeStampSource(v); err != nil {
+				return AtomicValue{}, err
+			}
 			t := v.TimeVal()
 			return AtomicValue{TypeName: TypeDate, Value: time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())}, nil
 		}
@@ -141,6 +168,9 @@ func CastAtomic(v AtomicValue, targetType string) (AtomicValue, error) {
 		}
 		if v.TypeName == TypeDateTimeStamp {
 			// xs:dateTimeStamp is a subtype of xs:dateTime
+			if err := validateDateTimeStampSource(v); err != nil {
+				return AtomicValue{}, err
+			}
 			return AtomicValue{TypeName: TypeDateTime, Value: v.TimeVal()}, nil
 		}
 		if v.TypeName == TypeDate {
@@ -159,7 +189,7 @@ func CastAtomic(v AtomicValue, targetType string) (AtomicValue, error) {
 			return AtomicValue{}, err
 		}
 		if !HasTimezone(dt.TimeVal()) {
-			return AtomicValue{}, &XPathError{Code: errCodeFORG0001, Message: "xs:dateTimeStamp requires a timezone"}
+			return AtomicValue{}, &XPathError{Code: errCodeFORG0001, Message: msgDateTimeStampTimezone}
 		}
 		dt.TypeName = TypeDateTimeStamp
 		return dt, nil
@@ -169,6 +199,9 @@ func CastAtomic(v AtomicValue, targetType string) (AtomicValue, error) {
 		}
 		// xs:dateTimeStamp is a subtype of xs:dateTime, so it casts to xs:time too.
 		if v.TypeName == TypeDateTime || v.TypeName == TypeDateTimeStamp {
+			if err := validateDateTimeStampSource(v); err != nil {
+				return AtomicValue{}, err
+			}
 			t := v.TimeVal()
 			loc := t.Location()
 			if !HasTimezone(t) {
@@ -349,7 +382,7 @@ func CastFromString(s string, targetType string) (AtomicValue, error) {
 			return AtomicValue{}, castError(s, targetType)
 		}
 		if !HasTimezone(t) {
-			return AtomicValue{}, &XPathError{Code: errCodeFORG0001, Message: "xs:dateTimeStamp requires a timezone"}
+			return AtomicValue{}, &XPathError{Code: errCodeFORG0001, Message: msgDateTimeStampTimezone}
 		}
 		return AtomicValue{TypeName: TypeDateTimeStamp, Value: t}, nil
 	case TypeTime:

--- a/xpath3/cast.go
+++ b/xpath3/cast.go
@@ -183,6 +183,20 @@ func CastAtomic(v AtomicValue, targetType string) (AtomicValue, error) {
 		if v.TypeName == TypeString {
 			return CastFromString(v.StringVal(), TypeDateTimeStamp)
 		}
+		// xs:dateTime and xs:date sources carry a time.Time payload, but
+		// AtomicValue is public and mutable so a caller can retag a non-time
+		// value. Validate the payload with a comma-ok assertion before any
+		// TimeVal()/recursive cast, which would otherwise panic.
+		if v.TypeName == TypeDateTime || v.TypeName == TypeDate {
+			t, ok := v.Value.(time.Time)
+			if !ok {
+				return AtomicValue{}, &XPathError{Code: errCodeFORG0001, Message: msgDateTimeStampTimezone}
+			}
+			if !HasTimezone(t) {
+				return AtomicValue{}, &XPathError{Code: errCodeFORG0001, Message: msgDateTimeStampTimezone}
+			}
+			return AtomicValue{TypeName: TypeDateTimeStamp, Value: t}, nil
+		}
 		// xs:dateTimeStamp is xs:dateTime with a required timezone
 		dt, err := CastAtomic(v, TypeDateTime)
 		if err != nil {

--- a/xpath3/cast_datetime.go
+++ b/xpath3/cast_datetime.go
@@ -17,6 +17,9 @@ func castToGType(v AtomicValue, targetType string, format func(time.Time) string
 	switch v.TypeName {
 	case TypeDateTime, TypeDateTimeStamp, TypeDate:
 		// xs:dateTimeStamp is a subtype of xs:dateTime.
+		if err := validateDateTimeStampSource(v); err != nil {
+			return AtomicValue{}, err
+		}
 		return AtomicValue{TypeName: targetType, Value: format(v.TimeVal())}, nil
 	case TypeString, TypeUntypedAtomic:
 		return CastFromString(v.StringVal(), targetType)

--- a/xpath3/cast_datetime.go
+++ b/xpath3/cast_datetime.go
@@ -15,7 +15,8 @@ import (
 // castToGType casts a date/dateTime value to a Gregorian partial type.
 func castToGType(v AtomicValue, targetType string, format func(time.Time) string) (AtomicValue, error) {
 	switch v.TypeName {
-	case TypeDateTime, TypeDate:
+	case TypeDateTime, TypeDateTimeStamp, TypeDate:
+		// xs:dateTimeStamp is a subtype of xs:dateTime.
 		return AtomicValue{TypeName: targetType, Value: format(v.TimeVal())}, nil
 	case TypeString, TypeUntypedAtomic:
 		return CastFromString(v.StringVal(), targetType)

--- a/xpath3/cast_test.go
+++ b/xpath3/cast_test.go
@@ -401,6 +401,10 @@ func TestCastMalformedDateTimeStamp(t *testing.T) {
 		xpath3.TypeDate,
 		xpath3.TypeTime,
 		xpath3.TypeGYear,
+		xpath3.TypeGYearMonth,
+		xpath3.TypeGMonth,
+		xpath3.TypeGMonthDay,
+		xpath3.TypeGDay,
 	}
 
 	for _, src := range []struct {

--- a/xpath3/cast_test.go
+++ b/xpath3/cast_test.go
@@ -381,6 +381,49 @@ func TestDurationParsing(t *testing.T) {
 	}
 }
 
+// TestCastMalformedDateTimeStamp verifies that casting a malformed or retagged
+// xs:dateTimeStamp (AtomicValue is public and mutable) to a date/time subtype
+// reports a structured FORG0001 error instead of panicking. The subtype paths
+// call TimeVal() unconditionally, so a non-time.Time or no-timezone value must
+// be rejected up front.
+func TestCastMalformedDateTimeStamp(t *testing.T) {
+	// Source #1: TypeDateTimeStamp tag over a non-time.Time value.
+	notTime := xpath3.AtomicValue{TypeName: xpath3.TypeDateTimeStamp, Value: "not a time"}
+
+	// Source #2: TypeDateTimeStamp tag over a no-timezone time.Time, which
+	// violates the mandatory-timezone invariant.
+	noTZ, err := xpath3.CastFromString("2000-01-01T00:00:00", xpath3.TypeDateTime)
+	require.NoError(t, err)
+	noTZStamp := xpath3.AtomicValue{TypeName: xpath3.TypeDateTimeStamp, Value: noTZ.Value}
+
+	targets := []string{
+		xpath3.TypeDateTime,
+		xpath3.TypeDate,
+		xpath3.TypeTime,
+		xpath3.TypeGYear,
+	}
+
+	for _, src := range []struct {
+		name string
+		v    xpath3.AtomicValue
+	}{
+		{"non-time value", notTime},
+		{"no-timezone value", noTZStamp},
+	} {
+		for _, target := range targets {
+			t.Run(src.name+" to "+target, func(t *testing.T) {
+				require.NotPanics(t, func() {
+					_, err := xpath3.CastAtomic(src.v, target)
+					require.Error(t, err)
+					var xerr *xpath3.XPathError
+					require.True(t, errors.As(err, &xerr), "error must be *xpath3.XPathError, got %T: %v", err, err)
+					require.Equal(t, "FORG0001", xerr.Code)
+				})
+			})
+		}
+	}
+}
+
 func mustParseDateTime(s string) any {
 	v, err := xpath3.CastFromString(s, xpath3.TypeDateTime)
 	if err != nil {

--- a/xpath3/cast_test.go
+++ b/xpath3/cast_test.go
@@ -428,6 +428,31 @@ func TestCastMalformedDateTimeStamp(t *testing.T) {
 	}
 }
 
+// TestCastToDateTimeStampMalformedSource verifies that casting a non-time.Time
+// xs:dateTime or xs:date source (AtomicValue is public and mutable) TO
+// xs:dateTimeStamp reports a structured FORG0001 error instead of panicking.
+// The dateTimeStamp target path routes such sources through TimeVal()/recursive
+// casts that assume a time.Time payload.
+func TestCastToDateTimeStampMalformedSource(t *testing.T) {
+	for _, src := range []struct {
+		name string
+		v    xpath3.AtomicValue
+	}{
+		{"non-time dateTime", xpath3.AtomicValue{TypeName: xpath3.TypeDateTime, Value: "not a time"}},
+		{"non-time date", xpath3.AtomicValue{TypeName: xpath3.TypeDate, Value: "not a time"}},
+	} {
+		t.Run(src.name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				_, err := xpath3.CastAtomic(src.v, xpath3.TypeDateTimeStamp)
+				require.Error(t, err)
+				var xerr *xpath3.XPathError
+				require.True(t, errors.As(err, &xerr), "error must be *xpath3.XPathError, got %T: %v", err, err)
+				require.Equal(t, "FORG0001", xerr.Code)
+			})
+		})
+	}
+}
+
 func mustParseDateTime(s string) any {
 	v, err := xpath3.CastFromString(s, xpath3.TypeDateTime)
 	if err != nil {

--- a/xpath3/cast_test.go
+++ b/xpath3/cast_test.go
@@ -1,6 +1,7 @@
 package xpath3_test
 
 import (
+	"errors"
 	"math"
 	"math/big"
 	"testing"
@@ -291,6 +292,40 @@ func TestCastAtomic(t *testing.T) {
 		_, err := xpath3.CastAtomic(v, xpath3.TypeBoolean)
 		require.Error(t, err)
 	})
+
+	// AtomicValue is public and mutable, so a caller can retag a no-timezone
+	// xs:dateTime as xs:dateTimeStamp. CastAtomic to xs:dateTimeStamp must
+	// enforce the mandatory-timezone invariant even on the same-type fast path.
+	t.Run("dateTimeStamp identity enforces timezone", func(t *testing.T) {
+		t.Run("missing timezone rejected", func(t *testing.T) {
+			v := xpath3.AtomicValue{TypeName: xpath3.TypeDateTimeStamp, Value: mustParseDateTime("2024-03-15T10:30:00")}
+			_, err := xpath3.CastAtomic(v, xpath3.TypeDateTimeStamp)
+			require.Error(t, err)
+			require.Equal(t, "FORG0001", castErrorCode(t, err))
+		})
+
+		t.Run("with timezone accepted", func(t *testing.T) {
+			v := xpath3.AtomicValue{TypeName: xpath3.TypeDateTimeStamp, Value: mustParseDateTime("2024-03-15T10:30:00Z")}
+			result, err := xpath3.CastAtomic(v, xpath3.TypeDateTimeStamp)
+			require.NoError(t, err)
+			require.Equal(t, v, result)
+		})
+
+		t.Run("non-time value rejected", func(t *testing.T) {
+			v := xpath3.AtomicValue{TypeName: xpath3.TypeDateTimeStamp, Value: "not-a-time"}
+			_, err := xpath3.CastAtomic(v, xpath3.TypeDateTimeStamp)
+			require.Error(t, err)
+			require.Equal(t, "FORG0001", castErrorCode(t, err))
+		})
+	})
+}
+
+// castErrorCode extracts the structured XPathError code from a CastAtomic error.
+func castErrorCode(t *testing.T, err error) string {
+	t.Helper()
+	var xerr *xpath3.XPathError
+	require.True(t, errors.As(err, &xerr), "error must be *xpath3.XPathError, got %T: %v", err, err)
+	return xerr.Code
 }
 
 func TestAtomicToString(t *testing.T) {

--- a/xpath3/functions_constructors.go
+++ b/xpath3/functions_constructors.go
@@ -240,8 +240,8 @@ func makeXSTokenList(listType, itemType string, tokenRe *regexp.Regexp) func(con
 		s = strings.TrimSpace(s)
 		if s == "" {
 			return nil, &XPathError{
-				Code:    "FORG0001",
-				Message: fmt.Sprintf("cannot cast empty string to %s", itemType),
+				Code:    errCodeFORG0001,
+				Message: fmt.Sprintf("cannot cast empty string to %s", listType),
 			}
 		}
 		tokens := strings.Fields(s)

--- a/xpath3/functions_constructors.go
+++ b/xpath3/functions_constructors.go
@@ -410,8 +410,6 @@ func hasValidGregorianYearDigits(y string) bool {
 	return len(y) == 4 || y[0] != '0'
 }
 
-var reDateTimeStampTZ = regexp.MustCompile(`[+-]\d{2}:\d{2}$`)
-
 func makeXSDateTimeStamp() func(context.Context, []Sequence) (Sequence, error) {
 	return func(_ context.Context, args []Sequence) (Sequence, error) {
 		a, empty, err := atomizeConstructorArg(args[0], TypeDateTimeStamp)
@@ -421,22 +419,13 @@ func makeXSDateTimeStamp() func(context.Context, []Sequence) (Sequence, error) {
 		if empty {
 			return nil, nil
 		}
-		// Cast to dateTime first
-		dt, err := CastAtomic(a, TypeDateTime)
+		// CastAtomic handles whitespace-trimmed string/date/dateTime inputs,
+		// same-type identity, and the mandatory-timezone rule for dateTimeStamp.
+		dts, err := CastAtomic(a, TypeDateTimeStamp)
 		if err != nil {
 			return nil, err
 		}
-		// dateTimeStamp requires a timezone — check the whitespace-collapsed
-		// lexical form so legal padded values are not rejected.
-		s, _ := atomicToString(a)
-		s = collapseWhitespace(s)
-		if !strings.HasSuffix(s, "Z") && !reDateTimeStampTZ.MatchString(s) {
-			return nil, &XPathError{
-				Code:    errCodeFORG0001,
-				Message: "xs:dateTimeStamp requires a timezone",
-			}
-		}
-		return SingleAtomic(AtomicValue{TypeName: TypeDateTimeStamp, Value: dt.Value}), nil
+		return SingleAtomic(dts), nil
 	}
 }
 

--- a/xpath3/functions_constructors.go
+++ b/xpath3/functions_constructors.go
@@ -224,12 +224,12 @@ func makeXSStringRestriction(typeName string, validate *regexp.Regexp) func(cont
 // makeXSTokenList returns a constructor for xs:NMTOKENS or xs:IDREFS (whitespace-separated list).
 func makeXSTokenList(itemType string, tokenRe *regexp.Regexp) func(context.Context, []Sequence) (Sequence, error) {
 	return func(_ context.Context, args []Sequence) (Sequence, error) {
-		if seqLen(args[0]) == 0 {
-			return nil, nil
-		}
-		a, err := AtomizeItem(args[0].Get(0))
+		a, empty, err := atomizeConstructorArg(args[0], itemType)
 		if err != nil {
 			return nil, err
+		}
+		if empty {
+			return nil, nil
 		}
 		s, err := atomicToString(a)
 		if err != nil {
@@ -426,8 +426,10 @@ func makeXSDateTimeStamp() func(context.Context, []Sequence) (Sequence, error) {
 		if err != nil {
 			return nil, err
 		}
-		// dateTimeStamp requires a timezone — check the string representation
+		// dateTimeStamp requires a timezone — check the whitespace-collapsed
+		// lexical form so legal padded values are not rejected.
 		s, _ := atomicToString(a)
+		s = collapseWhitespace(s)
 		if !strings.HasSuffix(s, "Z") && !reDateTimeStampTZ.MatchString(s) {
 			return nil, &XPathError{
 				Code:    errCodeFORG0001,

--- a/xpath3/functions_constructors.go
+++ b/xpath3/functions_constructors.go
@@ -87,9 +87,9 @@ func init() {
 	}
 
 	// List types — split by whitespace, produce sequence of item type values
-	registerNS(NSXS, "NMTOKENS", 1, 1, makeXSTokenList(TypeNMTOKEN, reNMTOKEN))
-	registerNS(NSXS, "IDREFS", 1, 1, makeXSTokenList(TypeIDREF, reNCName))
-	registerNS(NSXS, "ENTITIES", 1, 1, makeXSTokenList(TypeENTITY, reNCName))
+	registerNS(NSXS, "NMTOKENS", 1, 1, makeXSTokenList(TypeNMTOKENS, TypeNMTOKEN, reNMTOKEN))
+	registerNS(NSXS, "IDREFS", 1, 1, makeXSTokenList(TypeIDREFS, TypeIDREF, reNCName))
+	registerNS(NSXS, "ENTITIES", 1, 1, makeXSTokenList(TypeENTITIES, TypeENTITY, reNCName))
 
 	// Gregorian date part types
 	for _, entry := range []struct {
@@ -222,9 +222,11 @@ func makeXSStringRestriction(typeName string, validate *regexp.Regexp) func(cont
 }
 
 // makeXSTokenList returns a constructor for xs:NMTOKENS or xs:IDREFS (whitespace-separated list).
-func makeXSTokenList(itemType string, tokenRe *regexp.Regexp) func(context.Context, []Sequence) (Sequence, error) {
+// listType (e.g. xs:NMTOKENS) drives the cardinality/type error message; itemType
+// (e.g. xs:NMTOKEN) drives per-token validation and result construction.
+func makeXSTokenList(listType, itemType string, tokenRe *regexp.Regexp) func(context.Context, []Sequence) (Sequence, error) {
 	return func(_ context.Context, args []Sequence) (Sequence, error) {
-		a, empty, err := atomizeConstructorArg(args[0], itemType)
+		a, empty, err := atomizeConstructorArg(args[0], listType)
 		if err != nil {
 			return nil, err
 		}
@@ -430,21 +432,22 @@ func makeXSDateTimeStamp() func(context.Context, []Sequence) (Sequence, error) {
 }
 
 func atomizeConstructorArg(seq Sequence, typeName string) (AtomicValue, bool, error) {
-	// Atomize FIRST, then enforce singleton cardinality on the atomized result.
-	// An argument may be an array that flattens to zero, one, or many atomic
-	// values; cardinality must be judged on the atomized count, not the raw
-	// sequence length. We stop after the second atom so a >1 case raises
-	// XPTY0004 here rather than letting a later member's atomization error
-	// (e.g. FOTY0013 from a map) surface instead.
+	// Atomize the whole argument FIRST, then enforce singleton cardinality on
+	// the atomized result. An argument may be an array that flattens to zero,
+	// one, or many atomic values; cardinality must be judged on the atomized
+	// count, not the raw sequence length. Per function-conversion semantics, an
+	// item that cannot be atomized (a map/function → FOTY0013) must surface that
+	// error even when it appears after the second atom, so we atomize to
+	// completion rather than short-circuiting; XPTY0004 cardinality applies only
+	// when atomization succeeds and yields more than one atom.
 	var first AtomicValue
 	var count int
 	err := atomizeStream(seq, func(av AtomicValue) (bool, error) {
 		count++
 		if count == 1 {
 			first = av
-			return true, nil
 		}
-		return false, nil
+		return true, nil
 	})
 	if err != nil {
 		return AtomicValue{}, false, err

--- a/xpath3/functions_constructors.go
+++ b/xpath3/functions_constructors.go
@@ -250,7 +250,7 @@ func makeXSTokenList(listType, itemType string, tokenRe *regexp.Regexp) func(con
 			if !tokenRe.MatchString(tok) {
 				return nil, &XPathError{
 					Code:    errCodeFORG0001,
-					Message: fmt.Sprintf("invalid token %q in %s", tok, itemType),
+					Message: fmt.Sprintf("invalid token %q in %s", tok, listType),
 				}
 			}
 			result[i] = AtomicValue{TypeName: itemType, Value: tok}

--- a/xpath3/functions_constructors.go
+++ b/xpath3/functions_constructors.go
@@ -441,20 +441,35 @@ func makeXSDateTimeStamp() func(context.Context, []Sequence) (Sequence, error) {
 }
 
 func atomizeConstructorArg(seq Sequence, typeName string) (AtomicValue, bool, error) {
-	if seqLen(seq) == 0 {
+	// Atomize FIRST, then enforce singleton cardinality on the atomized result.
+	// An argument may be an array that flattens to zero, one, or many atomic
+	// values; cardinality must be judged on the atomized count, not the raw
+	// sequence length. We stop after the second atom so a >1 case raises
+	// XPTY0004 here rather than letting a later member's atomization error
+	// (e.g. FOTY0013 from a map) surface instead.
+	var first AtomicValue
+	var count int
+	err := atomizeStream(seq, func(av AtomicValue) (bool, error) {
+		count++
+		if count == 1 {
+			first = av
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return AtomicValue{}, false, err
+	}
+	if count == 0 {
 		return AtomicValue{}, true, nil
 	}
-	if seq.Len() > 1 {
+	if count > 1 {
 		return AtomicValue{}, false, &XPathError{
 			Code:    lexicon.ErrXPTY0004,
 			Message: fmt.Sprintf("%s constructor requires a singleton argument", typeName),
 		}
 	}
-	a, err := AtomizeItem(seq.Get(0))
-	if err != nil {
-		return AtomicValue{}, false, err
-	}
-	return a, false, nil
+	return first, false, nil
 }
 
 func fnXSError(_ context.Context, args []Sequence) (Sequence, error) {

--- a/xpath3/functions_constructors_test.go
+++ b/xpath3/functions_constructors_test.go
@@ -58,6 +58,43 @@ func TestXSTokenListCardinality(t *testing.T) {
 		}
 	})
 
+	t.Run("non-atomizable later item surfaces FOTY0013", func(t *testing.T) {
+		// A map cannot be atomized (FOTY0013). The whole argument is atomized
+		// FIRST, so the un-atomizable item must surface its error even when it
+		// appears after the second member — it must NOT be masked by the
+		// XPTY0004 cardinality error.
+		for _, expr := range []string{
+			`xs:NMTOKENS(["a", "b", map{"x":"y"}])`,
+			`xs:IDREFS(["a", "b", map{"x":"y"}])`,
+			`xs:ENTITIES(["a", "b", map{"x":"y"}])`,
+		} {
+			t.Run(expr, func(t *testing.T) {
+				requireXPathErrorCode(t, doc, expr, "FOTY0013")
+			})
+		}
+	})
+
+	t.Run("cardinality error names the list type", func(t *testing.T) {
+		// The XPTY0004 message must name the list type (e.g. xs:NMTOKENS),
+		// not the per-token item type (xs:NMTOKEN).
+		for _, tc := range []struct {
+			expr     string
+			listType string
+		}{
+			{`xs:NMTOKENS(("a", "b"))`, "xs:NMTOKENS"},
+			{`xs:IDREFS(("a", "b"))`, "xs:IDREFS"},
+			{`xs:ENTITIES(("a", "b"))`, "xs:ENTITIES"},
+		} {
+			t.Run(tc.expr, func(t *testing.T) {
+				compiled, err := xpath3.NewCompiler().Compile(tc.expr)
+				require.NoError(t, err)
+				_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.listType)
+			})
+		}
+	})
+
 	t.Run("empty array returns empty (not an error)", func(t *testing.T) {
 		compiled, err := xpath3.NewCompiler().Compile(`count(xs:NMTOKENS([]))`)
 		require.NoError(t, err)

--- a/xpath3/functions_constructors_test.go
+++ b/xpath3/functions_constructors_test.go
@@ -123,3 +123,32 @@ func TestXSDateTimeStampWhitespace(t *testing.T) {
 		require.Contains(t, err.Error(), "FORG0001")
 	})
 }
+
+// TestXSDateTimeStampSubtype verifies that xs:dateTimeStamp is a subtype of
+// xs:dateTime: the constructor is idempotent for its own type, and xs:dateTime
+// accepts an xs:dateTimeStamp value (subtype substitutability).
+func TestXSDateTimeStampSubtype(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	t.Run("dateTimeStamp of dateTimeStamp is idempotent", func(t *testing.T) {
+		compiled, err := xpath3.NewCompiler().Compile(`xs:dateTimeStamp(xs:dateTimeStamp("2000-01-01T00:00:00Z")) eq xs:dateTimeStamp("2000-01-01T00:00:00Z")`)
+		require.NoError(t, err)
+		result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, err)
+		seq := result.Sequence()
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.True(t, av.BooleanVal())
+	})
+
+	t.Run("dateTime accepts a dateTimeStamp value", func(t *testing.T) {
+		compiled, err := xpath3.NewCompiler().Compile(`xs:dateTime(xs:dateTimeStamp("2000-01-01T00:00:00Z")) eq xs:dateTime("2000-01-01T00:00:00Z")`)
+		require.NoError(t, err)
+		result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, err)
+		seq := result.Sequence()
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.True(t, av.BooleanVal())
+	})
+}

--- a/xpath3/functions_constructors_test.go
+++ b/xpath3/functions_constructors_test.go
@@ -95,6 +95,28 @@ func TestXSTokenListCardinality(t *testing.T) {
 		}
 	})
 
+	t.Run("empty string error names the list type", func(t *testing.T) {
+		// An empty lexical list (e.g. xs:NMTOKENS("")) is a cast failure whose
+		// message must name the LIST type (xs:NMTOKENS), not the per-token item
+		// type (xs:NMTOKEN).
+		for _, tc := range []struct {
+			expr     string
+			listType string
+		}{
+			{`xs:NMTOKENS("")`, "xs:NMTOKENS"},
+			{`xs:IDREFS("")`, "xs:IDREFS"},
+			{`xs:ENTITIES("")`, "xs:ENTITIES"},
+		} {
+			t.Run(tc.expr, func(t *testing.T) {
+				compiled, err := xpath3.NewCompiler().Compile(tc.expr)
+				require.NoError(t, err)
+				_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.listType)
+			})
+		}
+	})
+
 	t.Run("empty array returns empty (not an error)", func(t *testing.T) {
 		compiled, err := xpath3.NewCompiler().Compile(`count(xs:NMTOKENS([]))`)
 		require.NoError(t, err)

--- a/xpath3/functions_constructors_test.go
+++ b/xpath3/functions_constructors_test.go
@@ -117,6 +117,28 @@ func TestXSTokenListCardinality(t *testing.T) {
 		}
 	})
 
+	t.Run("invalid token error names the list type", func(t *testing.T) {
+		// A token that fails per-item validation (e.g. a malformed NMTOKEN)
+		// is a cast failure whose message must name the LIST type
+		// (xs:NMTOKENS), not the per-token item type (xs:NMTOKEN).
+		for _, tc := range []struct {
+			expr     string
+			listType string
+		}{
+			{`xs:NMTOKENS("a ;")`, "xs:NMTOKENS"},
+			{`xs:IDREFS("1")`, "xs:IDREFS"},
+			{`xs:ENTITIES("1")`, "xs:ENTITIES"},
+		} {
+			t.Run(tc.expr, func(t *testing.T) {
+				compiled, err := xpath3.NewCompiler().Compile(tc.expr)
+				require.NoError(t, err)
+				_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.listType)
+			})
+		}
+	})
+
 	t.Run("empty array returns empty (not an error)", func(t *testing.T) {
 		compiled, err := xpath3.NewCompiler().Compile(`count(xs:NMTOKENS([]))`)
 		require.NoError(t, err)

--- a/xpath3/functions_constructors_test.go
+++ b/xpath3/functions_constructors_test.go
@@ -151,4 +151,49 @@ func TestXSDateTimeStampSubtype(t *testing.T) {
 		av := seq.Get(0).(xpath3.AtomicValue)
 		require.True(t, av.BooleanVal())
 	})
+
+	t.Run("date accepts a dateTimeStamp value", func(t *testing.T) {
+		compiled, err := xpath3.NewCompiler().Compile(`xs:date(xs:dateTimeStamp("2000-01-01T00:00:00Z")) eq xs:date("2000-01-01Z")`)
+		require.NoError(t, err)
+		result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, err)
+		seq := result.Sequence()
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.True(t, av.BooleanVal())
+	})
+
+	t.Run("time accepts a dateTimeStamp value", func(t *testing.T) {
+		compiled, err := xpath3.NewCompiler().Compile(`xs:time(xs:dateTimeStamp("2000-01-01T00:00:00Z")) eq xs:time("00:00:00Z")`)
+		require.NoError(t, err)
+		result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, err)
+		seq := result.Sequence()
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.True(t, av.BooleanVal())
+	})
+}
+
+// TestXSDateTimeStampNodeValue verifies that xs:dateTimeStamp accepts an
+// atomized node value (xs:untypedAtomic). A node whose text content is a valid
+// dateTimeStamp lexical with a timezone succeeds; a node missing the mandatory
+// timezone fails with FORG0001.
+func TestXSDateTimeStampNodeValue(t *testing.T) {
+	t.Run("node value with timezone accepted", func(t *testing.T) {
+		doc := mustParseXML(t, "<root>2000-01-01T00:00:00Z</root>")
+		compiled, err := xpath3.NewCompiler().Compile(`xs:dateTimeStamp(/root) eq xs:dateTimeStamp("2000-01-01T00:00:00Z")`)
+		require.NoError(t, err)
+		result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, err)
+		seq := result.Sequence()
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.True(t, av.BooleanVal())
+	})
+
+	t.Run("node value without timezone rejected", func(t *testing.T) {
+		doc := mustParseXML(t, "<root>2000-01-01T00:00:00</root>")
+		requireXPathErrorCode(t, doc, `xs:dateTimeStamp(/root)`, "FORG0001")
+	})
 }

--- a/xpath3/functions_constructors_test.go
+++ b/xpath3/functions_constructors_test.go
@@ -1,11 +1,26 @@
 package xpath3_test
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/xpath3"
 	"github.com/stretchr/testify/require"
 )
+
+// requireXPathErrorCode evaluates expr and asserts it fails with a structured
+// XPathError whose Code is exactly want.
+func requireXPathErrorCode(t *testing.T, doc helium.Node, expr, want string) {
+	t.Helper()
+	compiled, err := xpath3.NewCompiler().Compile(expr)
+	require.NoError(t, err)
+	_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+	require.Error(t, err)
+	var xerr *xpath3.XPathError
+	require.True(t, errors.As(err, &xerr), "error must be *xpath3.XPathError, got %T: %v", err, err)
+	require.Equal(t, want, xerr.Code)
+}
 
 // TestXSTokenListCardinality verifies that the list constructors
 // xs:NMTOKENS / xs:IDREFS / xs:ENTITIES enforce a single atomized
@@ -29,6 +44,31 @@ func TestXSTokenListCardinality(t *testing.T) {
 		}
 	})
 
+	t.Run("array atomizing to multiple values rejected", func(t *testing.T) {
+		// An array argument that ATOMIZES to more than one value must be
+		// rejected with XPTY0004 (a cardinality error), not FOTY0013.
+		for _, expr := range []string{
+			`xs:NMTOKENS(["a", "b"])`,
+			`xs:IDREFS(["a", "b"])`,
+			`xs:ENTITIES(["a", "b"])`,
+		} {
+			t.Run(expr, func(t *testing.T) {
+				requireXPathErrorCode(t, doc, expr, "XPTY0004")
+			})
+		}
+	})
+
+	t.Run("empty array returns empty (not an error)", func(t *testing.T) {
+		compiled, err := xpath3.NewCompiler().Compile(`count(xs:NMTOKENS([]))`)
+		require.NoError(t, err)
+		result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, err)
+		seq := result.Sequence()
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.Equal(t, int64(0), av.IntegerVal())
+	})
+
 	t.Run("single whitespace-separated arg splits into tokens", func(t *testing.T) {
 		compiled, err := xpath3.NewCompiler().Compile(`count(xs:NMTOKENS("a b c")) eq 3`)
 		require.NoError(t, err)
@@ -39,6 +79,23 @@ func TestXSTokenListCardinality(t *testing.T) {
 		av := seq.Get(0).(xpath3.AtomicValue)
 		require.True(t, av.BooleanVal())
 	})
+}
+
+// TestXSScalarConstructorArrayCardinality verifies that scalar constructors,
+// which share atomizeConstructorArg with the list constructors, reject an
+// array argument that atomizes to more than one value with XPTY0004 rather
+// than FOTY0013.
+func TestXSScalarConstructorArrayCardinality(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	for _, expr := range []string{
+		`xs:string(["a", "b"])`,
+		`xs:dateTimeStamp(["2000-01-01T00:00:00Z", "2001-01-01T00:00:00Z"])`,
+	} {
+		t.Run(expr, func(t *testing.T) {
+			requireXPathErrorCode(t, doc, expr, "XPTY0004")
+		})
+	}
 }
 
 // TestXSDateTimeStampWhitespace verifies that xs:dateTimeStamp accepts a

--- a/xpath3/functions_constructors_test.go
+++ b/xpath3/functions_constructors_test.go
@@ -175,6 +175,25 @@ func TestXSDateTimeStampSubtype(t *testing.T) {
 	})
 }
 
+// TestXSDateTimeStampInvalidString verifies that an invalid string lexical
+// passed to xs:dateTimeStamp reports FORG0001 naming xs:dateTimeStamp rather
+// than the xs:dateTime fallback target.
+func TestXSDateTimeStampInvalidString(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	t.Run("invalid string names xs:dateTimeStamp", func(t *testing.T) {
+		compiled, err := xpath3.NewCompiler().Compile(`xs:dateTimeStamp("not-a-date")`)
+		require.NoError(t, err)
+		_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.Error(t, err)
+		var xerr *xpath3.XPathError
+		require.True(t, errors.As(err, &xerr), "error must be *xpath3.XPathError, got %T: %v", err, err)
+		require.Equal(t, "FORG0001", xerr.Code)
+		require.Contains(t, xerr.Error(), "xs:dateTimeStamp")
+		require.NotContains(t, xerr.Error(), "xs:dateTime\"")
+	})
+}
+
 // TestXSDateTimeStampNodeValue verifies that xs:dateTimeStamp accepts an
 // atomized node value (xs:untypedAtomic). A node whose text content is a valid
 // dateTimeStamp lexical with a timezone succeeds; a node missing the mandatory

--- a/xpath3/functions_constructors_test.go
+++ b/xpath3/functions_constructors_test.go
@@ -1,0 +1,68 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// TestXSTokenListCardinality verifies that the list constructors
+// xs:NMTOKENS / xs:IDREFS / xs:ENTITIES enforce a single atomized
+// argument and reject a sequence of more than one item with XPTY0004.
+func TestXSTokenListCardinality(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	t.Run("multiple items rejected", func(t *testing.T) {
+		for _, expr := range []string{
+			`xs:NMTOKENS(("a", "b"))`,
+			`xs:IDREFS(("a", "b"))`,
+			`xs:ENTITIES(("a", "b"))`,
+		} {
+			t.Run(expr, func(t *testing.T) {
+				compiled, err := xpath3.NewCompiler().Compile(expr)
+				require.NoError(t, err)
+				_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "XPTY0004")
+			})
+		}
+	})
+
+	t.Run("single whitespace-separated arg splits into tokens", func(t *testing.T) {
+		compiled, err := xpath3.NewCompiler().Compile(`count(xs:NMTOKENS("a b c")) eq 3`)
+		require.NoError(t, err)
+		result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, err)
+		seq := result.Sequence()
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.True(t, av.BooleanVal())
+	})
+}
+
+// TestXSDateTimeStampWhitespace verifies that xs:dateTimeStamp accepts a
+// lexical value with leading/trailing whitespace, since whitespace is
+// collapsed before the timezone is checked.
+func TestXSDateTimeStampWhitespace(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	t.Run("whitespace-padded value accepted", func(t *testing.T) {
+		compiled, err := xpath3.NewCompiler().Compile(`xs:dateTimeStamp(" 2000-01-01T00:00:00Z ") eq xs:dateTimeStamp("2000-01-01T00:00:00Z")`)
+		require.NoError(t, err)
+		result, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, err)
+		seq := result.Sequence()
+		require.Equal(t, 1, seq.Len())
+		av := seq.Get(0).(xpath3.AtomicValue)
+		require.True(t, av.BooleanVal())
+	})
+
+	t.Run("missing timezone still rejected", func(t *testing.T) {
+		compiled, err := xpath3.NewCompiler().Compile(`xs:dateTimeStamp(" 2000-01-01T00:00:00 ")`)
+		require.NoError(t, err)
+		_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(t.Context(), compiled, doc)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "FORG0001")
+	})
+}


### PR DESCRIPTION
- xs:NMTOKENS/xs:IDREFS/xs:ENTITIES now enforce a singleton argument (XPTY0004) instead of silently dropping extra items
- xs:dateTimeStamp collapses whitespace before the timezone check so legal padded values are no longer rejected