### PR TITLE
reject multi-item qname and map:merge options args

### DIFF
--- a/xpath3/functions_map.go
+++ b/xpath3/functions_map.go
@@ -47,9 +47,21 @@ func fnMapMerge(_ context.Context, args []Sequence) (Sequence, error) {
 		}
 		key := AtomicValue{TypeName: TypeString, Value: "duplicates"}
 		if val, found := optMap.Get(key); found {
-			s, err := coerceArgToStringRequired(val)
-			if err != nil {
-				return nil, err
+			// Per F&O 3.1, an empty, multi-item, non-string, or unknown
+			// 'duplicates' value is a FOJS0005 error (not XPTY0004).
+			if seqLen(val) != 1 {
+				return nil, &XPathError{Code: errCodeFOJS0005, Message: "map:merge: 'duplicates' option must be a single string"}
+			}
+			av, ok := val.Get(0).(AtomicValue)
+			if !ok {
+				return nil, &XPathError{Code: errCodeFOJS0005, Message: fmt.Sprintf("map:merge: 'duplicates' option must be a string, got %T", val.Get(0))}
+			}
+			if av.TypeName != TypeString && av.TypeName != TypeUntypedAtomic {
+				return nil, &XPathError{Code: errCodeFOJS0005, Message: fmt.Sprintf("map:merge: 'duplicates' option must be a string, got %s", av.TypeName)}
+			}
+			s, ok := av.Value.(string)
+			if !ok {
+				return nil, &XPathError{Code: errCodeFOJS0005, Message: "map:merge: 'duplicates' option must be a string"}
 			}
 			switch s {
 			case duplicatesUseFirst:

--- a/xpath3/functions_map.go
+++ b/xpath3/functions_map.go
@@ -37,25 +37,29 @@ func fnMapMerge(_ context.Context, args []Sequence) (Sequence, error) {
 		if seqLen(args[1]) == 0 {
 			return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "map:merge: options argument must be a map, got empty sequence"}
 		}
+		if seqLen(args[1]) > 1 {
+			return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "map:merge: options argument must be a single map"}
+		}
 		// The options map should contain "duplicates" key
 		optMap, ok := args[1].Get(0).(MapItem)
-		if ok {
-			key := AtomicValue{TypeName: TypeString, Value: "duplicates"}
-			if val, found := optMap.Get(key); found {
-				s, err := coerceArgToStringRequired(val)
-				if err != nil {
-					return nil, err
-				}
-				switch s {
-				case duplicatesUseFirst:
-					duplicates = MergeUseFirst
-				case "use-last":
-					duplicates = MergeUseLast
-				case duplicatesReject:
-					duplicates = MergeReject
-				case "combine":
-					duplicates = MergeCombine
-				}
+		if !ok {
+			return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("map:merge: options argument must be a map, got %T", args[1].Get(0))}
+		}
+		key := AtomicValue{TypeName: TypeString, Value: "duplicates"}
+		if val, found := optMap.Get(key); found {
+			s, err := coerceArgToStringRequired(val)
+			if err != nil {
+				return nil, err
+			}
+			switch s {
+			case duplicatesUseFirst:
+				duplicates = MergeUseFirst
+			case "use-last":
+				duplicates = MergeUseLast
+			case duplicatesReject:
+				duplicates = MergeReject
+			case "combine":
+				duplicates = MergeCombine
 			}
 		}
 	}

--- a/xpath3/functions_map.go
+++ b/xpath3/functions_map.go
@@ -97,14 +97,23 @@ func fnMapMerge(_ context.Context, args []Sequence) (Sequence, error) {
 // FOJS0005 error rather than being silently accepted. A single-item array still
 // flattens to its member via atomization.
 func coerceDuplicatesOption(val Sequence) (string, error) {
-	atoms, err := AtomizeSequence(val)
+	var first AtomicValue
+	count := 0
+	err := atomizeStream(val, func(av AtomicValue) (bool, error) {
+		count++
+		if count == 1 {
+			first = av
+			return true, nil
+		}
+		return false, nil
+	})
 	if err != nil {
 		return "", &XPathError{Code: errCodeFOJS0005, Message: fmt.Sprintf("map:merge: 'duplicates' option must be a single string: %s", err)}
 	}
-	if len(atoms) != 1 {
-		return "", &XPathError{Code: errCodeFOJS0005, Message: fmt.Sprintf("map:merge: 'duplicates' option must be a single string, got sequence of length %d", len(atoms))}
+	if count != 1 {
+		return "", &XPathError{Code: errCodeFOJS0005, Message: fmt.Sprintf("map:merge: 'duplicates' option must be a single string, got sequence of length %d", count)}
 	}
-	av := atoms[0]
+	av := first
 	if av.TypeName != TypeUntypedAtomic &&
 		!isAtomicSubtypeOf(av, TypeString) &&
 		!isAtomicSubtypeOf(av, TypeAnyURI) {

--- a/xpath3/functions_map.go
+++ b/xpath3/functions_map.go
@@ -47,21 +47,14 @@ func fnMapMerge(_ context.Context, args []Sequence) (Sequence, error) {
 		}
 		key := AtomicValue{TypeName: TypeString, Value: "duplicates"}
 		if val, found := optMap.Get(key); found {
-			// Per F&O 3.1, an empty, multi-item, non-string, or unknown
-			// 'duplicates' value is a FOJS0005 error (not XPTY0004).
-			if seqLen(val) != 1 {
-				return nil, &XPathError{Code: errCodeFOJS0005, Message: "map:merge: 'duplicates' option must be a single string"}
-			}
-			av, ok := val.Get(0).(AtomicValue)
-			if !ok {
-				return nil, &XPathError{Code: errCodeFOJS0005, Message: fmt.Sprintf("map:merge: 'duplicates' option must be a string, got %T", val.Get(0))}
-			}
-			if av.TypeName != TypeString && av.TypeName != TypeUntypedAtomic {
-				return nil, &XPathError{Code: errCodeFOJS0005, Message: fmt.Sprintf("map:merge: 'duplicates' option must be a string, got %s", av.TypeName)}
-			}
-			s, ok := av.Value.(string)
-			if !ok {
-				return nil, &XPathError{Code: errCodeFOJS0005, Message: "map:merge: 'duplicates' option must be a string"}
+			// Per F&O 3.1 option conventions, the 'duplicates' value is type
+			// xs:string and is converted with the function conversion rules.
+			// So xs:string subtypes (xs:NCName, ...), xs:anyURI, xs:untypedAtomic,
+			// and a single-item array all coerce to a string. An empty, multi-item,
+			// or non-convertible value is a FOJS0005 error (not XPTY0004).
+			s, convErr := coerceArgToStringRequired(val)
+			if convErr != nil {
+				return nil, &XPathError{Code: errCodeFOJS0005, Message: fmt.Sprintf("map:merge: 'duplicates' option must be a single string: %s", convErr)}
 			}
 			switch s {
 			case duplicatesUseFirst:

--- a/xpath3/functions_map.go
+++ b/xpath3/functions_map.go
@@ -56,10 +56,16 @@ func fnMapMerge(_ context.Context, args []Sequence) (Sequence, error) {
 				duplicates = MergeUseFirst
 			case "use-last":
 				duplicates = MergeUseLast
+			case "use-any":
+				// use-any allows the implementation to pick any value;
+				// reusing use-first behavior is conformant.
+				duplicates = MergeUseFirst
 			case duplicatesReject:
 				duplicates = MergeReject
 			case "combine":
 				duplicates = MergeCombine
+			default:
+				return nil, &XPathError{Code: errCodeFOJS0005, Message: fmt.Sprintf("map:merge: invalid value for 'duplicates' option: %q", s)}
 			}
 		}
 	}

--- a/xpath3/functions_map.go
+++ b/xpath3/functions_map.go
@@ -52,9 +52,9 @@ func fnMapMerge(_ context.Context, args []Sequence) (Sequence, error) {
 			// So xs:string subtypes (xs:NCName, ...), xs:anyURI, xs:untypedAtomic,
 			// and a single-item array all coerce to a string. An empty, multi-item,
 			// or non-convertible value is a FOJS0005 error (not XPTY0004).
-			s, convErr := coerceArgToStringRequired(val)
+			s, convErr := coerceDuplicatesOption(val)
 			if convErr != nil {
-				return nil, &XPathError{Code: errCodeFOJS0005, Message: fmt.Sprintf("map:merge: 'duplicates' option must be a single string: %s", convErr)}
+				return nil, convErr
 			}
 			switch s {
 			case duplicatesUseFirst:
@@ -88,6 +88,33 @@ func fnMapMerge(_ context.Context, args []Sequence) (Sequence, error) {
 		}
 	}
 	return ItemSlice{builder.Build()}, nil
+}
+
+// coerceDuplicatesOption converts the 'duplicates' option value of map:merge to
+// a string. The option is declared as xs:string, so only xs:untypedAtomic,
+// xs:string (and subtypes), and xs:anyURI (and subtypes) are accepted; any other
+// atomic type — even a custom type whose Go payload happens to be a string — is a
+// FOJS0005 error rather than being silently accepted. A single-item array still
+// flattens to its member via atomization.
+func coerceDuplicatesOption(val Sequence) (string, error) {
+	atoms, err := AtomizeSequence(val)
+	if err != nil {
+		return "", &XPathError{Code: errCodeFOJS0005, Message: fmt.Sprintf("map:merge: 'duplicates' option must be a single string: %s", err)}
+	}
+	if len(atoms) != 1 {
+		return "", &XPathError{Code: errCodeFOJS0005, Message: fmt.Sprintf("map:merge: 'duplicates' option must be a single string, got sequence of length %d", len(atoms))}
+	}
+	av := atoms[0]
+	if av.TypeName != TypeUntypedAtomic &&
+		!isAtomicSubtypeOf(av, TypeString) &&
+		!isAtomicSubtypeOf(av, TypeAnyURI) {
+		return "", &XPathError{Code: errCodeFOJS0005, Message: fmt.Sprintf("map:merge: 'duplicates' option must be a string, got %s", av.TypeName)}
+	}
+	s, convErr := atomicToString(av)
+	if convErr != nil {
+		return "", &XPathError{Code: errCodeFOJS0005, Message: fmt.Sprintf("map:merge: 'duplicates' option must be a single string: %s", convErr)}
+	}
+	return s, nil
 }
 
 func fnMapSize(_ context.Context, args []Sequence) (Sequence, error) {

--- a/xpath3/functions_map_test.go
+++ b/xpath3/functions_map_test.go
@@ -100,3 +100,34 @@ func TestMapMergeRejectsInvalidDuplicates(t *testing.T) {
 		})
 	}
 }
+
+// A "duplicates" value that is a custom atomic whose Go payload is a string but
+// whose BaseType is NOT string-derived must still raise FOJS0005. The option is
+// declared as xs:string, so a non-string-based atom is not convertible even when
+// its underlying Go representation happens to be a string.
+func TestMapMergeRejectsNonStringBasedDuplicates(t *testing.T) {
+	t.Parallel()
+
+	doc := mustParseXML(t, "<root/>")
+
+	compiled, err := xpath3.NewCompiler().Compile(
+		`map:merge((map{"a": 1}), map{"duplicates": $dup})`)
+	require.NoError(t, err)
+
+	// A user-defined atomic derived from xs:integer that carries a Go string
+	// payload. The pre-fix coercion accepted any atom with a string payload.
+	dup := xpath3.AtomicValue{
+		TypeName: "Q{urn:x}strishInt",
+		Value:    "use-last",
+		BaseType: xpath3.TypeInteger,
+	}
+	_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Variables(xpath3.VariablesFromMap(map[string]xpath3.Sequence{
+			"dup": xpath3.ItemSlice{dup},
+		})).
+		Evaluate(t.Context(), compiled, doc)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, "FOJS0005", xpErr.Code)
+}

--- a/xpath3/functions_map_test.go
+++ b/xpath3/functions_map_test.go
@@ -31,3 +31,39 @@ func TestMapMergeRejectsNonMapOptions(t *testing.T) {
 		})
 	}
 }
+
+// map:merge's "duplicates" option accepts the F&O 3.1 defined values:
+// use-first, use-last, use-any, combine, reject.
+func TestMapMergeAcceptsDuplicatesOptions(t *testing.T) {
+	t.Parallel()
+
+	doc := mustParseXML(t, "<root/>")
+
+	cases := []string{
+		`map:merge((map{"a": 1}, map{"a": 2}), map{"duplicates": "use-first"})`,
+		`map:merge((map{"a": 1}, map{"a": 2}), map{"duplicates": "use-last"})`,
+		`map:merge((map{"a": 1}, map{"a": 2}), map{"duplicates": "use-any"})`,
+		`map:merge((map{"a": 1}, map{"a": 2}), map{"duplicates": "combine"})`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			_, err := evaluate(t.Context(), doc, expr)
+			require.NoError(t, err, expr)
+		})
+	}
+}
+
+// An invalid "duplicates" option value must raise FOJS0005 rather than being
+// silently accepted.
+func TestMapMergeRejectsInvalidDuplicates(t *testing.T) {
+	t.Parallel()
+
+	doc := mustParseXML(t, "<root/>")
+
+	expr := `map:merge((map{"a": 1}), map{"duplicates": "bogus"})`
+	_, err := evaluate(t.Context(), doc, expr)
+	require.Error(t, err, expr)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, "FOJS0005", xpErr.Code, expr)
+}

--- a/xpath3/functions_map_test.go
+++ b/xpath3/functions_map_test.go
@@ -1,0 +1,33 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// map:merge's optional second argument is a single map. A non-map options
+// argument (or a multi-item sequence) must raise XPTY0004 rather than being
+// silently ignored.
+func TestMapMergeRejectsNonMapOptions(t *testing.T) {
+	t.Parallel()
+
+	doc := mustParseXML(t, "<root/>")
+
+	cases := []string{
+		`map:merge((map{"a": 1}), "not-a-map")`,
+		`map:merge((map{"a": 1}), 42)`,
+		`map:merge((map{"a": 1}), (map{"duplicates": "use-last"}, map{}))`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			_, err := evaluate(t.Context(), doc, expr)
+			require.Error(t, err, expr)
+			var xpErr *xpath3.XPathError
+			require.ErrorAs(t, err, &xpErr)
+			require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code, expr)
+		})
+	}
+}

--- a/xpath3/functions_map_test.go
+++ b/xpath3/functions_map_test.go
@@ -54,16 +54,26 @@ func TestMapMergeAcceptsDuplicatesOptions(t *testing.T) {
 }
 
 // An invalid "duplicates" option value must raise FOJS0005 rather than being
-// silently accepted.
+// silently accepted. Per F&O 3.1 this covers empty, multi-item, non-string,
+// and unknown values alike.
 func TestMapMergeRejectsInvalidDuplicates(t *testing.T) {
 	t.Parallel()
 
 	doc := mustParseXML(t, "<root/>")
 
-	expr := `map:merge((map{"a": 1}), map{"duplicates": "bogus"})`
-	_, err := evaluate(t.Context(), doc, expr)
-	require.Error(t, err, expr)
-	var xpErr *xpath3.XPathError
-	require.ErrorAs(t, err, &xpErr)
-	require.Equal(t, "FOJS0005", xpErr.Code, expr)
+	cases := []string{
+		`map:merge((map{"a": 1}), map{"duplicates": "bogus"})`,
+		`map:merge((map{"a": 1}), map{"duplicates": 42})`,
+		`map:merge((map{"a": 1}), map{"duplicates": ()})`,
+		`map:merge((map{"a": 1}), map{"duplicates": ("use-first", "use-last")})`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			_, err := evaluate(t.Context(), doc, expr)
+			require.Error(t, err, expr)
+			var xpErr *xpath3.XPathError
+			require.ErrorAs(t, err, &xpErr)
+			require.Equal(t, "FOJS0005", xpErr.Code, expr)
+		})
+	}
 }

--- a/xpath3/functions_map_test.go
+++ b/xpath3/functions_map_test.go
@@ -44,6 +44,14 @@ func TestMapMergeAcceptsDuplicatesOptions(t *testing.T) {
 		`map:merge((map{"a": 1}, map{"a": 2}), map{"duplicates": "use-last"})`,
 		`map:merge((map{"a": 1}, map{"a": 2}), map{"duplicates": "use-any"})`,
 		`map:merge((map{"a": 1}, map{"a": 2}), map{"duplicates": "combine"})`,
+		// Per F&O 3.1 option conventions the value is converted with the
+		// function conversion rules, so xs:string subtypes, xs:anyURI, and a
+		// single-item array all coerce to the string policy.
+		`map:merge((map{"a": 1}, map{"a": 2}), map{"duplicates": xs:NCName("use-last")})`,
+		`map:merge((map{"a": 1}, map{"a": 2}), map{"duplicates": xs:anyURI("use-first")})`,
+		`map:merge((map{"a": 1}, map{"a": 2}), map{"duplicates": ["combine"]})`,
+		// reject with no duplicate keys succeeds.
+		`map:merge((map{"a": 1}, map{"b": 2}), map{"duplicates": "reject"})`,
 	}
 	for _, expr := range cases {
 		t.Run(expr, func(t *testing.T) {
@@ -51,6 +59,21 @@ func TestMapMergeAcceptsDuplicatesOptions(t *testing.T) {
 			require.NoError(t, err, expr)
 		})
 	}
+}
+
+// The "reject" duplicates policy raises FOJS0003 when an actual duplicate key
+// is encountered.
+func TestMapMergeRejectDuplicateKey(t *testing.T) {
+	t.Parallel()
+
+	doc := mustParseXML(t, "<root/>")
+
+	expr := `map:merge((map{"a": 1}, map{"a": 2}), map{"duplicates": "reject"})`
+	_, err := evaluate(t.Context(), doc, expr)
+	require.Error(t, err, expr)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, "FOJS0003", xpErr.Code, expr)
 }
 
 // An invalid "duplicates" option value must raise FOJS0005 rather than being

--- a/xpath3/functions_qname.go
+++ b/xpath3/functions_qname.go
@@ -137,13 +137,8 @@ func fnNamespaceURIForPrefix(_ context.Context, args []Sequence) (Sequence, erro
 }
 
 func fnResolveQName(_ context.Context, args []Sequence) (Sequence, error) {
-	if seqLen(args[0]) == 0 {
-		return validNilSequence, nil
-	}
-	qnameStr, err := coerceQNameString(args[0], false, false, "resolve-QName: QName argument must be a string")
-	if err != nil {
-		return nil, err
-	}
+	// The element() second argument is required and must be exactly one
+	// element() regardless of whether $qname is empty, so validate it FIRST.
 	if seqLen(args[1]) == 0 {
 		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "resolve-QName: element argument is empty"}
 	}
@@ -157,6 +152,15 @@ func fnResolveQName(_ context.Context, args []Sequence) (Sequence, error) {
 	elem, ok := ni.Node.(*helium.Element)
 	if !ok {
 		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "resolve-QName: expected element node"}
+	}
+
+	// Empty $qname yields the empty sequence (after the element() check).
+	if seqLen(args[0]) == 0 {
+		return validNilSequence, nil
+	}
+	qnameStr, err := coerceQNameString(args[0], false, false, "resolve-QName: QName argument must be a string")
+	if err != nil {
+		return nil, err
 	}
 
 	prefix, local, err := parseLexicalQName(qnameStr)

--- a/xpath3/functions_qname.go
+++ b/xpath3/functions_qname.go
@@ -212,23 +212,37 @@ func parseLexicalQName(qname string) (string, string, error) {
 	return prefix, local, nil
 }
 
+// coerceQNameString atomizes a QName string argument with streaming and a
+// max-one cap on the ATOMIZED result, then enforces the string/anyURI/
+// untypedAtomic rules. Atomizing first (rather than checking item cardinality
+// up front) means a single array/list item that atomizes to multiple values is
+// rejected as XPTY0004 (a cardinality error), not FOTY0013. Streaming stops
+// once a second atom appears.
 func coerceQNameString(seq Sequence, allowEmpty, allowAnyURI bool, message string) (string, error) {
-	switch seqLen(seq) {
-	case 0:
+	var first AtomicValue
+	count := 0
+	err := atomizeStream(seq, func(av AtomicValue) (bool, error) {
+		count++
+		if count == 1 {
+			first = av
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	if count == 0 {
 		if allowEmpty {
 			return "", nil
 		}
 		return "", &XPathError{Code: lexicon.ErrXPTY0004, Message: message}
-	case 1:
-	default:
+	}
+	if count > 1 {
 		return "", &XPathError{Code: lexicon.ErrXPTY0004, Message: message}
 	}
 
-	a, err := AtomizeItem(seq.Get(0))
-	if err != nil {
-		return "", err
-	}
-	switch a.TypeName {
+	switch first.TypeName {
 	case TypeString, TypeUntypedAtomic:
 	case TypeAnyURI:
 		if !allowAnyURI {
@@ -238,9 +252,9 @@ func coerceQNameString(seq Sequence, allowEmpty, allowAnyURI bool, message strin
 		return "", &XPathError{Code: lexicon.ErrXPTY0004, Message: message}
 	}
 
-	s, ok := a.Value.(string)
+	s, ok := first.Value.(string)
 	if !ok {
-		return "", fmt.Errorf("xpath3: internal error: expected string for %s", a.TypeName)
+		return "", fmt.Errorf("xpath3: internal error: expected string for %s", first.TypeName)
 	}
 	return s, nil
 }

--- a/xpath3/functions_qname.go
+++ b/xpath3/functions_qname.go
@@ -48,6 +48,9 @@ func fnPrefixFromQName(_ context.Context, args []Sequence) (Sequence, error) {
 	if seqLen(args[0]) == 0 {
 		return validNilSequence, nil
 	}
+	if seqLen(args[0]) > 1 {
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "fn:prefix-from-QName expects a single QName"}
+	}
 	a, err := AtomizeItem(args[0].Get(0))
 	if err != nil {
 		return nil, err
@@ -67,6 +70,9 @@ func fnLocalNameFromQName(_ context.Context, args []Sequence) (Sequence, error) 
 	if seqLen(args[0]) == 0 {
 		return validNilSequence, nil
 	}
+	if seqLen(args[0]) > 1 {
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "fn:local-name-from-QName expects a single QName"}
+	}
 	a, err := AtomizeItem(args[0].Get(0))
 	if err != nil {
 		return nil, err
@@ -81,6 +87,9 @@ func fnLocalNameFromQName(_ context.Context, args []Sequence) (Sequence, error) 
 func fnNamespaceURIFromQName(_ context.Context, args []Sequence) (Sequence, error) {
 	if seqLen(args[0]) == 0 {
 		return validNilSequence, nil
+	}
+	if seqLen(args[0]) > 1 {
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "fn:namespace-uri-from-QName expects a single QName"}
 	}
 	a, err := AtomizeItem(args[0].Get(0))
 	if err != nil {
@@ -125,6 +134,9 @@ func fnResolveQName(_ context.Context, args []Sequence) (Sequence, error) {
 	}
 	if seqLen(args[1]) == 0 {
 		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "resolve-QName: element argument is empty"}
+	}
+	if seqLen(args[1]) > 1 {
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "resolve-QName: expects a single element"}
 	}
 	ni, ok := args[1].Get(0).(NodeItem)
 	if !ok {
@@ -216,6 +228,9 @@ func coerceQNameString(seq Sequence, allowEmpty, allowAnyURI bool, message strin
 func fnInScopePrefixes(_ context.Context, args []Sequence) (Sequence, error) {
 	if seqLen(args[0]) == 0 {
 		return validNilSequence, nil
+	}
+	if seqLen(args[0]) > 1 {
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "fn:in-scope-prefixes expects a single element"}
 	}
 	ni, ok := args[0].Get(0).(NodeItem)
 	if !ok {

--- a/xpath3/functions_qname.go
+++ b/xpath3/functions_qname.go
@@ -44,20 +44,46 @@ func fnQName(_ context.Context, args []Sequence) (Sequence, error) {
 	}), nil
 }
 
+// atomizeQNameArg atomizes a QName-accessor argument and enforces 0-or-1
+// cardinality on the ATOMIZED result, so that a single array/list item that
+// atomizes to multiple values is rejected as XPTY0004 (not FOTY0013). It
+// stops atomization early once a second atom appears. The returned bool is
+// true when the atomized sequence is empty (applicable result is the empty
+// sequence); otherwise the returned AtomicValue is the single xs:QName.
+func atomizeQNameArg(seq Sequence, fname string) (AtomicValue, bool, error) {
+	var first AtomicValue
+	count := 0
+	err := atomizeStream(seq, func(av AtomicValue) (bool, error) {
+		count++
+		if count == 1 {
+			first = av
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return AtomicValue{}, false, err
+	}
+	if count == 0 {
+		return AtomicValue{}, true, nil
+	}
+	if count > 1 {
+		return AtomicValue{}, false, &XPathError{Code: lexicon.ErrXPTY0004, Message: fname + " expects a single QName"}
+	}
+	first = PromoteSchemaType(first)
+	if first.TypeName != TypeQName {
+		return AtomicValue{}, false, &XPathError{Code: lexicon.ErrXPTY0004, Message: "expected QName"}
+	}
+	return first, false, nil
+}
+
 func fnPrefixFromQName(_ context.Context, args []Sequence) (Sequence, error) {
-	if seqLen(args[0]) == 0 {
-		return validNilSequence, nil
-	}
-	if seqLen(args[0]) > 1 {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "fn:prefix-from-QName expects a single QName"}
-	}
-	a, err := AtomizeItem(args[0].Get(0))
+	a, empty, err := atomizeQNameArg(args[0], "fn:prefix-from-QName")
 	if err != nil {
 		return nil, err
 	}
-	a = PromoteSchemaType(a)
-	if a.TypeName != TypeQName {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "expected QName"}
+	if empty {
+		return validNilSequence, nil
 	}
 	qv := a.QNameVal()
 	if qv.Prefix == "" {
@@ -67,37 +93,23 @@ func fnPrefixFromQName(_ context.Context, args []Sequence) (Sequence, error) {
 }
 
 func fnLocalNameFromQName(_ context.Context, args []Sequence) (Sequence, error) {
-	if seqLen(args[0]) == 0 {
-		return validNilSequence, nil
-	}
-	if seqLen(args[0]) > 1 {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "fn:local-name-from-QName expects a single QName"}
-	}
-	a, err := AtomizeItem(args[0].Get(0))
+	a, empty, err := atomizeQNameArg(args[0], "fn:local-name-from-QName")
 	if err != nil {
 		return nil, err
 	}
-	a = PromoteSchemaType(a)
-	if a.TypeName != TypeQName {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "expected QName"}
+	if empty {
+		return validNilSequence, nil
 	}
 	return ItemSlice{AtomicValue{TypeName: TypeNCName, Value: a.QNameVal().Local}}, nil
 }
 
 func fnNamespaceURIFromQName(_ context.Context, args []Sequence) (Sequence, error) {
-	if seqLen(args[0]) == 0 {
-		return validNilSequence, nil
-	}
-	if seqLen(args[0]) > 1 {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "fn:namespace-uri-from-QName expects a single QName"}
-	}
-	a, err := AtomizeItem(args[0].Get(0))
+	a, empty, err := atomizeQNameArg(args[0], "fn:namespace-uri-from-QName")
 	if err != nil {
 		return nil, err
 	}
-	a = PromoteSchemaType(a)
-	if a.TypeName != TypeQName {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "expected QName"}
+	if empty {
+		return validNilSequence, nil
 	}
 	return SingleAtomic(AtomicValue{TypeName: TypeAnyURI, Value: a.QNameVal().URI}), nil
 }
@@ -107,8 +119,8 @@ func fnNamespaceURIForPrefix(_ context.Context, args []Sequence) (Sequence, erro
 	if err != nil {
 		return nil, err
 	}
-	if seqLen(args[1]) == 0 {
-		return validNilSequence, nil
+	if seqLen(args[1]) != 1 {
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "fn:namespace-uri-for-prefix expects a single element"}
 	}
 	ni, ok := args[1].Get(0).(NodeItem)
 	if !ok {
@@ -226,10 +238,7 @@ func coerceQNameString(seq Sequence, allowEmpty, allowAnyURI bool, message strin
 }
 
 func fnInScopePrefixes(_ context.Context, args []Sequence) (Sequence, error) {
-	if seqLen(args[0]) == 0 {
-		return validNilSequence, nil
-	}
-	if seqLen(args[0]) > 1 {
+	if seqLen(args[0]) != 1 {
 		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "fn:in-scope-prefixes expects a single element"}
 	}
 	ni, ok := args[0].Get(0).(NodeItem)

--- a/xpath3/functions_qname.go
+++ b/xpath3/functions_qname.go
@@ -22,11 +22,11 @@ func init() {
 }
 
 func fnQName(_ context.Context, args []Sequence) (Sequence, error) {
-	uri, err := coerceQNameString(args[0], true, true, "fn:QName namespace argument must be a string")
+	uri, err := coerceQNameString(args[0], true, "fn:QName namespace argument must be a string")
 	if err != nil {
 		return nil, err
 	}
-	qname, err := coerceQNameString(args[1], false, false, "fn:QName QName argument must be a string")
+	qname, err := coerceQNameString(args[1], false, "fn:QName QName argument must be a string")
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func fnNamespaceURIForPrefix(_ context.Context, args []Sequence) (Sequence, erro
 	if err != nil {
 		return nil, err
 	}
-	prefix, err := coerceQNameString(args[0], true, false, "fn:namespace-uri-for-prefix prefix argument must be a string")
+	prefix, err := coerceQNameString(args[0], true, "fn:namespace-uri-for-prefix prefix argument must be a string")
 	if err != nil {
 		return nil, err
 	}
@@ -158,13 +158,16 @@ func fnResolveQName(_ context.Context, args []Sequence) (Sequence, error) {
 		return nil, err
 	}
 
-	// Empty $qname yields the empty sequence (after the element() check).
-	if seqLen(args[0]) == 0 {
-		return validNilSequence, nil
-	}
-	qnameStr, err := coerceQNameString(args[0], false, false, "resolve-QName: QName argument must be a string")
+	// Empty $qname yields the empty sequence (after the element() check). The
+	// argument is atomized first so that a single empty array/list item (which
+	// atomizes to the empty sequence) is treated as empty, while a literal ""
+	// remains a non-empty lexical QName reaching parseLexicalQName.
+	qnameStr, empty, err := coerceOptionalQNameString(args[0], "resolve-QName: QName argument must be a string")
 	if err != nil {
 		return nil, err
+	}
+	if empty {
+		return validNilSequence, nil
 	}
 
 	prefix, local, err := parseLexicalQName(qnameStr)
@@ -218,7 +221,27 @@ func parseLexicalQName(qname string) (string, string, error) {
 // up front) means a single array/list item that atomizes to multiple values is
 // rejected as XPTY0004 (a cardinality error), not FOTY0013. Streaming stops
 // once a second atom appears.
-func coerceQNameString(seq Sequence, allowEmpty, allowAnyURI bool, message string) (string, error) {
+func coerceQNameString(seq Sequence, allowEmpty bool, message string) (string, error) {
+	s, empty, err := coerceOptionalQNameString(seq, message)
+	if err != nil {
+		return "", err
+	}
+	if empty {
+		if allowEmpty {
+			return "", nil
+		}
+		return "", &XPathError{Code: lexicon.ErrXPTY0004, Message: message}
+	}
+	return s, nil
+}
+
+// coerceOptionalQNameString atomizes a QName string argument the same way as
+// coerceQNameString but distinguishes an ATOMIZED-empty result (returning the
+// empty bool) from a non-empty lexical value. A single empty array/list item
+// that atomizes to the empty sequence yields empty=true (so callers may return
+// the empty sequence), while a literal "" reaches the lexical path with
+// empty=false. Streaming stops once a second atom appears.
+func coerceOptionalQNameString(seq Sequence, message string) (string, bool, error) {
 	var first AtomicValue
 	count := 0
 	err := atomizeStream(seq, func(av AtomicValue) (bool, error) {
@@ -230,33 +253,32 @@ func coerceQNameString(seq Sequence, allowEmpty, allowAnyURI bool, message strin
 		return false, nil
 	})
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	if count == 0 {
-		if allowEmpty {
-			return "", nil
-		}
-		return "", &XPathError{Code: lexicon.ErrXPTY0004, Message: message}
+		return "", true, nil
 	}
 	if count > 1 {
-		return "", &XPathError{Code: lexicon.ErrXPTY0004, Message: message}
+		return "", false, &XPathError{Code: lexicon.ErrXPTY0004, Message: message}
 	}
 
-	switch first.TypeName {
-	case TypeString, TypeUntypedAtomic:
-	case TypeAnyURI:
-		if !allowAnyURI {
-			return "", &XPathError{Code: lexicon.ErrXPTY0004, Message: message}
-		}
+	// Every QName-string parameter is typed xs:string?, so accept any xs:string
+	// subtype (e.g. xs:NCName), xs:untypedAtomic, and xs:anyURI (which promotes
+	// to xs:string under function conversion).
+	first = PromoteSchemaType(first)
+	switch {
+	case isAtomicSubtypeOf(first, TypeString):
+	case first.TypeName == TypeUntypedAtomic:
+	case first.TypeName == TypeAnyURI:
 	default:
-		return "", &XPathError{Code: lexicon.ErrXPTY0004, Message: message}
+		return "", false, &XPathError{Code: lexicon.ErrXPTY0004, Message: message}
 	}
 
 	s, ok := first.Value.(string)
 	if !ok {
-		return "", fmt.Errorf("xpath3: internal error: expected string for %s", first.TypeName)
+		return "", false, fmt.Errorf("xpath3: internal error: expected string for %s", first.TypeName)
 	}
-	return s, nil
+	return s, false, nil
 }
 
 func fnInScopePrefixes(_ context.Context, args []Sequence) (Sequence, error) {

--- a/xpath3/functions_qname.go
+++ b/xpath3/functions_qname.go
@@ -115,20 +115,15 @@ func fnNamespaceURIFromQName(_ context.Context, args []Sequence) (Sequence, erro
 }
 
 func fnNamespaceURIForPrefix(_ context.Context, args []Sequence) (Sequence, error) {
-	prefix, err := coerceQNameString(args[0], true, false, "fn:namespace-uri-for-prefix prefix argument must be a string")
+	// The element() second argument is required and must be exactly one
+	// element() regardless of the first argument, so validate it FIRST.
+	elem, err := requireSingleElement(args[1], "fn:namespace-uri-for-prefix")
 	if err != nil {
 		return nil, err
 	}
-	if seqLen(args[1]) != 1 {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "fn:namespace-uri-for-prefix expects a single element"}
-	}
-	ni, ok := args[1].Get(0).(NodeItem)
-	if !ok {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "expected element node"}
-	}
-	elem, ok := ni.Node.(*helium.Element)
-	if !ok {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "expected element node"}
+	prefix, err := coerceQNameString(args[0], true, false, "fn:namespace-uri-for-prefix prefix argument must be a string")
+	if err != nil {
+		return nil, err
 	}
 	if ns := helium.LookupNSByPrefix(elem, prefix); ns != nil {
 		return SingleAtomic(AtomicValue{TypeName: TypeAnyURI, Value: ns.URI()}), nil
@@ -136,22 +131,31 @@ func fnNamespaceURIForPrefix(_ context.Context, args []Sequence) (Sequence, erro
 	return validNilSequence, nil
 }
 
-func fnResolveQName(_ context.Context, args []Sequence) (Sequence, error) {
-	// The element() second argument is required and must be exactly one
-	// element() regardless of whether $qname is empty, so validate it FIRST.
-	if seqLen(args[1]) == 0 {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "resolve-QName: element argument is empty"}
+// requireSingleElement validates a required element() argument: it must be
+// exactly one node and that node must be a *helium.Element. This is validated
+// before any sibling argument is coerced so an invalid element() arg yields
+// XPTY0004 rather than an error from atomizing the other argument.
+func requireSingleElement(seq Sequence, fname string) (*helium.Element, error) {
+	if seqLen(seq) != 1 {
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fname + ": expects a single element"}
 	}
-	if seqLen(args[1]) > 1 {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "resolve-QName: expects a single element"}
-	}
-	ni, ok := args[1].Get(0).(NodeItem)
+	ni, ok := seq.Get(0).(NodeItem)
 	if !ok {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "resolve-QName: expected element node"}
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fname + ": expected element node"}
 	}
 	elem, ok := ni.Node.(*helium.Element)
 	if !ok {
-		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: "resolve-QName: expected element node"}
+		return nil, &XPathError{Code: lexicon.ErrXPTY0004, Message: fname + ": expected element node"}
+	}
+	return elem, nil
+}
+
+func fnResolveQName(_ context.Context, args []Sequence) (Sequence, error) {
+	// The element() second argument is required and must be exactly one
+	// element() regardless of whether $qname is empty, so validate it FIRST.
+	elem, err := requireSingleElement(args[1], "resolve-QName")
+	if err != nil {
+		return nil, err
 	}
 
 	// Empty $qname yields the empty sequence (after the element() check).

--- a/xpath3/functions_qname_test.go
+++ b/xpath3/functions_qname_test.go
@@ -58,6 +58,30 @@ func TestQNameElementArgRequiresSingleton(t *testing.T) {
 	}
 }
 
+// namespace-uri-for-prefix must validate its required singleton element()
+// (args[1]) BEFORE coercing the prefix (args[0]). An invalid element() arg with
+// an array-typed prefix must raise XPTY0004 (from the element check), not
+// FOTY0013 (which array atomization of the prefix would otherwise raise first).
+func TestNamespaceURIForPrefixElementArgValidatedFirst(t *testing.T) {
+	t.Parallel()
+
+	doc := mustParseXML(t, `<root xmlns:p="urn:p"><a/><b/></root>`)
+
+	cases := []string{
+		`namespace-uri-for-prefix(["p","q"], ())`,
+		`namespace-uri-for-prefix(["p","q"], //root/*)`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			_, err := evaluate(t.Context(), doc, expr)
+			require.Error(t, err, expr)
+			var xpErr *xpath3.XPathError
+			require.ErrorAs(t, err, &xpErr)
+			require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code, expr)
+		})
+	}
+}
+
 // resolve-QName's second argument is a REQUIRED singleton element(). An empty,
 // multi-element, or non-element second argument must raise XPTY0004 even when
 // the first ($qname) argument is the empty sequence.

--- a/xpath3/functions_qname_test.go
+++ b/xpath3/functions_qname_test.go
@@ -129,3 +129,28 @@ func TestQNameAccessorsArrayArgRejected(t *testing.T) {
 		})
 	}
 }
+
+// The string-typed argument of namespace-uri-for-prefix and resolve-QName must
+// atomize first, so a single array argument that atomizes to multiple values is
+// a cardinality error (XPTY0004), not FOTY0013. The element() second argument is
+// valid here so the failure comes from the string argument's cardinality, not
+// the element check.
+func TestQNameStringArgArrayRejected(t *testing.T) {
+	t.Parallel()
+
+	doc := mustParseXML(t, `<root xmlns:p="urn:p"><a/><b/></root>`)
+
+	cases := []string{
+		`namespace-uri-for-prefix(["p","q"], /root)`,
+		`resolve-QName(["p:a","q:b"], /root)`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			_, err := evaluate(t.Context(), doc, expr)
+			require.Error(t, err, expr)
+			var xpErr *xpath3.XPathError
+			require.ErrorAs(t, err, &xpErr)
+			require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code, expr)
+		})
+	}
+}

--- a/xpath3/functions_qname_test.go
+++ b/xpath3/functions_qname_test.go
@@ -58,6 +58,30 @@ func TestQNameElementArgRequiresSingleton(t *testing.T) {
 	}
 }
 
+// resolve-QName's second argument is a REQUIRED singleton element(). An empty,
+// multi-element, or non-element second argument must raise XPTY0004 even when
+// the first ($qname) argument is the empty sequence.
+func TestResolveQNameElementArgValidatedFirst(t *testing.T) {
+	t.Parallel()
+
+	doc := mustParseXML(t, `<root xmlns:p="urn:p"><a/><b/></root>`)
+
+	cases := []string{
+		`resolve-QName((), ())`,
+		`resolve-QName((), //root/*)`,
+		`resolve-QName((), "x")`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			_, err := evaluate(t.Context(), doc, expr)
+			require.Error(t, err, expr)
+			var xpErr *xpath3.XPathError
+			require.ErrorAs(t, err, &xpErr)
+			require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code, expr)
+		})
+	}
+}
+
 // A single array/list argument that atomizes to multiple values must raise
 // XPTY0004 (a cardinality error), not FOTY0013. The accessors must atomize
 // the argument first and then enforce 0-or-1 cardinality on the result.

--- a/xpath3/functions_qname_test.go
+++ b/xpath3/functions_qname_test.go
@@ -33,3 +33,51 @@ func TestQNameFunctionsRejectMultiItemArg(t *testing.T) {
 		})
 	}
 }
+
+// namespace-uri-for-prefix and in-scope-prefixes take a REQUIRED singleton
+// element() second/first argument. An empty sequence or a multi-element
+// sequence must raise XPTY0004, not be silently accepted.
+func TestQNameElementArgRequiresSingleton(t *testing.T) {
+	t.Parallel()
+
+	doc := mustParseXML(t, `<root xmlns:p="urn:p"><a/><b/></root>`)
+
+	cases := []string{
+		`namespace-uri-for-prefix("p", ())`,
+		`namespace-uri-for-prefix("p", //root/*)`,
+		`in-scope-prefixes(())`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			_, err := evaluate(t.Context(), doc, expr)
+			require.Error(t, err, expr)
+			var xpErr *xpath3.XPathError
+			require.ErrorAs(t, err, &xpErr)
+			require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code, expr)
+		})
+	}
+}
+
+// A single array/list argument that atomizes to multiple values must raise
+// XPTY0004 (a cardinality error), not FOTY0013. The accessors must atomize
+// the argument first and then enforce 0-or-1 cardinality on the result.
+func TestQNameAccessorsArrayArgRejected(t *testing.T) {
+	t.Parallel()
+
+	doc := mustParseXML(t, `<root xmlns:p="urn:p"><a/><b/></root>`)
+
+	cases := []string{
+		`prefix-from-QName([QName("urn:p", "p:a"), QName("urn:p", "p:b")])`,
+		`local-name-from-QName([QName("urn:p", "p:a"), QName("urn:p", "p:b")])`,
+		`namespace-uri-from-QName([QName("urn:p", "p:a"), QName("urn:p", "p:b")])`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			_, err := evaluate(t.Context(), doc, expr)
+			require.Error(t, err, expr)
+			var xpErr *xpath3.XPathError
+			require.ErrorAs(t, err, &xpErr)
+			require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code, expr)
+		})
+	}
+}

--- a/xpath3/functions_qname_test.go
+++ b/xpath3/functions_qname_test.go
@@ -130,6 +130,49 @@ func TestQNameAccessorsArrayArgRejected(t *testing.T) {
 	}
 }
 
+// resolve-QName's $qname argument is xs:string?, so an empty sequence — or a
+// single empty array/list item that atomizes to the empty sequence — must yield
+// the empty sequence, not XPTY0004. The element() second argument is valid here.
+func TestResolveQNameEmptyQNameArgYieldsEmpty(t *testing.T) {
+	t.Parallel()
+
+	doc := mustParseXML(t, `<root xmlns:p="urn:p"><a/><b/></root>`)
+
+	cases := []string{
+		`resolve-QName((), /root)`,
+		`resolve-QName([], /root)`,
+		`resolve-QName(array{}, /root)`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			result, err := evaluate(t.Context(), doc, expr)
+			require.NoError(t, err, expr)
+			// An empty sequence surfaces as a nil Sequence.
+			require.Nil(t, result.Sequence(), expr)
+		})
+	}
+}
+
+// QName-string parameters are typed xs:string?, so function-conversion inputs
+// like xs:NCName("local") and xs:anyURI("p") (which are valid for an xs:string
+// parameter) must be accepted, not rejected as XPTY0004.
+func TestQNameStringArgAcceptsStringSubtypes(t *testing.T) {
+	t.Parallel()
+
+	doc := mustParseXML(t, `<root xmlns:p="urn:p"><a/><b/></root>`)
+
+	cases := []string{
+		`local-name-from-QName(resolve-QName(xs:NCName("local"), /root))`,
+		`namespace-uri-for-prefix(xs:anyURI("p"), /root)`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			_, err := evaluate(t.Context(), doc, expr)
+			require.NoError(t, err, expr)
+		})
+	}
+}
+
 // The string-typed argument of namespace-uri-for-prefix and resolve-QName must
 // atomize first, so a single array argument that atomizes to multiple values is
 // a cardinality error (XPTY0004), not FOTY0013. The element() second argument is

--- a/xpath3/functions_qname_test.go
+++ b/xpath3/functions_qname_test.go
@@ -1,0 +1,35 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// The QName-accessor functions take a singleton xs:QName? (or element() for the
+// node-based ones). A 2-item argument must raise XPTY0004, not silently use the
+// first item.
+func TestQNameFunctionsRejectMultiItemArg(t *testing.T) {
+	t.Parallel()
+
+	doc := mustParseXML(t, `<root xmlns:p="urn:p"><a/><b/></root>`)
+
+	cases := []string{
+		`prefix-from-QName((QName("urn:p", "p:a"), QName("urn:p", "p:b")))`,
+		`local-name-from-QName((QName("urn:p", "p:a"), QName("urn:p", "p:b")))`,
+		`namespace-uri-from-QName((QName("urn:p", "p:a"), QName("urn:p", "p:b")))`,
+		`resolve-QName("p:a", //root/*)`,
+		`in-scope-prefixes(//root/*)`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			_, err := evaluate(t.Context(), doc, expr)
+			require.Error(t, err, expr)
+			var xpErr *xpath3.XPathError
+			require.ErrorAs(t, err, &xpErr)
+			require.Equal(t, lexicon.ErrXPTY0004, xpErr.Code, expr)
+		})
+	}
+}

--- a/xpath3/xpath3_test.go
+++ b/xpath3/xpath3_test.go
@@ -539,7 +539,11 @@ func TestPublicStringArgsRejectMultiItemSequence(t *testing.T) {
 		{"array-sort", `array:sort([2, 1], ("http://www.w3.org/2005/xpath-functions/collation/codepoint", "dup"))`},
 		{"distinct-values-collation", `distinct-values((1, 2), ("http://www.w3.org/2005/xpath-functions/collation/codepoint", "dup"))`},
 		{"format-number", `format-number(1, "0", ("fmt", "other"))`},
-		{"map-merge", `map:merge((map{"a": 1}), map{"duplicates": ("use-first", "reject")})`},
+		// NOTE: map:merge's "duplicates" option is intentionally absent here. A
+		// multi-item (or empty/non-string/unknown) "duplicates" value is a
+		// FOJS0005 error per F&O 3.1, not the generic XPTY0004 string-cardinality
+		// error this test covers. That behavior is asserted in
+		// TestMapMergeRejectsInvalidDuplicates (functions_map_test.go).
 		{"error-description", `error((), ("a", "b"))`},
 		{"trace-label", `trace(1, ("a", "b"))`},
 	}


### PR DESCRIPTION
- QName accessors (`prefix/local-name/namespace-uri-from-QName`, `resolve-QName`, `in-scope-prefixes`) now raise XPTY0004 on a >1-item argument instead of silently using item 0
- `map:merge` raises XPTY0004 when the options argument is a non-map or multi-item sequence instead of silently ignoring it