### PR TITLE
fix xslt3 output def mutation and item serialization

### DIFF
--- a/xslt3/execute_resultdoc.go
+++ b/xslt3/execute_resultdoc.go
@@ -580,8 +580,10 @@ func (ec *execContext) execResultDocument(ctx context.Context, inst *resultDocum
 			if fmtDef, ok := ec.effectiveOutputs()[effectiveFormat]; ok {
 				allMaps = append(allMaps, fmtDef.UseCharacterMaps...)
 				// Also propagate resolved character maps from parameter-document.
+				// Clone the compiled map so the later maps.Copy merge below never
+				// mutates the compiled format's ResolvedCharMap.
 				if len(fmtDef.ResolvedCharMap) > 0 {
-					ec.primaryResolvedCharMap = fmtDef.ResolvedCharMap
+					ec.primaryResolvedCharMap = maps.Clone(fmtDef.ResolvedCharMap)
 				}
 			}
 		}
@@ -893,7 +895,9 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 		base.NormalizationForm = strings.ToUpper(strings.TrimSpace(v))
 	}
 	if len(inst.SuppressIndentation) > 0 {
-		base.SuppressIndentation = inst.SuppressIndentation
+		// Copy the slice so a derived/handler-delivered OutputDef cannot mutate
+		// the compiled instruction's SuppressIndentation backing array.
+		base.SuppressIndentation = append([]string(nil), inst.SuppressIndentation...)
 	}
 	if inst.ItemSeparatorSet {
 		if inst.ItemSeparator != nil {
@@ -908,7 +912,10 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 		}
 	}
 	if inst.BuildTree != nil {
-		base.BuildTree = inst.BuildTree
+		// Copy the pointee so a derived/handler-delivered OutputDef cannot mutate
+		// the compiled instruction's BuildTree value.
+		v := *inst.BuildTree
+		base.BuildTree = &v
 	}
 	return &base, nil
 }
@@ -940,7 +947,7 @@ func (ec *execContext) buildEffectiveOutputDef(ctx context.Context, inst *result
 		return nil, err
 	}
 	if overrides != nil {
-		base = *overrides
+		base = *cloneOutputDef(overrides)
 	}
 	// Resolve character maps from the format and instruction.
 	var allMaps []string

--- a/xslt3/execute_resultdoc.go
+++ b/xslt3/execute_resultdoc.go
@@ -739,16 +739,16 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 	var base OutputDef
 	paramDocOD := ec.getParamDocOutputDef(inst)
 	if paramDocOD != nil {
-		base = *paramDocOD
+		base = *cloneOutputDef(paramDocOD)
 	}
 	// Named format overrides parameter-document.
 	if effectiveFormat != "" {
 		if fmtDef, ok := ec.effectiveOutputs()[effectiveFormat]; ok {
-			base = *fmtDef
+			base = *cloneOutputDef(fmtDef)
 		}
 	} else if paramDocOD == nil {
 		if defDef, ok := ec.effectiveOutputs()[""]; ok {
-			base = *defDef
+			base = *cloneOutputDef(defDef)
 		}
 	}
 
@@ -919,12 +919,12 @@ func (ec *execContext) buildEffectiveOutputDef(ctx context.Context, inst *result
 	var base OutputDef
 	// Start with parameter-document defaults (lowest priority).
 	if pd := ec.getParamDocOutputDef(inst); pd != nil {
-		base = *pd
+		base = *cloneOutputDef(pd)
 	}
 	// Named format overrides parameter-document.
 	if formatName != "" {
 		if fmtDef, ok := ec.effectiveOutputs()[formatName]; ok {
-			base = *fmtDef
+			base = *cloneOutputDef(fmtDef)
 		}
 	}
 	if base.Method == "" && method != "" {

--- a/xslt3/execute_transform.go
+++ b/xslt3/execute_transform.go
@@ -516,7 +516,10 @@ func executeTransform(ctx context.Context, source *helium.Document, ss *Styleshe
 		if outDef == nil {
 			outDef = &OutputDef{Method: methodXML, Encoding: lexicon.EncodingUTF8U}
 		}
-		ov := ec.primaryOutputOverrides
+		// Clone the overrides so the pointer/slice/map fields merged below are
+		// independent allocations; the terminal outDef (exposed via
+		// ResolvedOutputDef and handlers) must not alias shared override state.
+		ov := cloneOutputDef(ec.primaryOutputOverrides)
 		if ov.Method != "" {
 			outDef.Method = ov.Method
 			outDef.MethodExplicit = true

--- a/xslt3/execute_transform.go
+++ b/xslt3/execute_transform.go
@@ -13,8 +13,9 @@ import (
 	"github.com/lestrrat-go/helium/xsd"
 )
 
-// cloneOutputDef returns a shallow copy of an OutputDef with deep-copied map
-// fields. Returns nil if src is nil.
+// cloneOutputDef returns a deep copy of an OutputDef. All pointer, slice, and
+// map fields are freshly allocated so that mutating the clone (or the original)
+// never affects the other. Returns nil if src is nil.
 func cloneOutputDef(src *OutputDef) *OutputDef {
 	if src == nil {
 		return nil
@@ -32,6 +33,22 @@ func cloneOutputDef(src *OutputDef) *OutputDef {
 	}
 	if src.SuppressIndentation != nil {
 		cp.SuppressIndentation = append([]string(nil), src.SuppressIndentation...)
+	}
+	if src.IncludeContentType != nil {
+		v := *src.IncludeContentType
+		cp.IncludeContentType = &v
+	}
+	if src.ItemSeparator != nil {
+		v := *src.ItemSeparator
+		cp.ItemSeparator = &v
+	}
+	if src.EscapeURIAttributes != nil {
+		v := *src.EscapeURIAttributes
+		cp.EscapeURIAttributes = &v
+	}
+	if src.BuildTree != nil {
+		v := *src.BuildTree
+		cp.BuildTree = &v
 	}
 	return &cp
 }

--- a/xslt3/invocation.go
+++ b/xslt3/invocation.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/xpath3"
@@ -93,21 +94,51 @@ type invocationConfig struct {
 	traceWriter         io.Writer
 	globalContextSelect string // XPath for global context item (evaluated post-strip-space)
 
-	// resolvedOutputDef is set after executeTransform completes.
-	// It contains the effective output definition for the primary result,
-	// including runtime overrides from xsl:result-document.
-	resolvedOutputDef *OutputDef
+	// resolved holds the effective output definition for the primary result
+	// after a terminal method (Do/Serialize/WriteTo) completes. It is stored
+	// behind a pointer with its own mutex so that concurrent terminal-method
+	// calls on the same Invocation value (which share this *invocationConfig)
+	// do not race when recording/reading the resolved output def.
+	resolved *resolvedOutputState
+}
+
+// resolvedOutputState guards the effective output definition recorded by a
+// terminal method. The mutex lives behind a pointer so copying
+// invocationConfig (in clone) never copies a lock.
+type resolvedOutputState struct {
+	mu  sync.Mutex
+	def *OutputDef
+}
+
+// store records the resolved primary output def. It deep-clones so the stored
+// snapshot is independent of the per-call transformConfig.
+func (r *resolvedOutputState) store(def *OutputDef) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.def = cloneOutputDef(def)
+}
+
+// snapshot returns an independent clone of the recorded output def, or nil if
+// no terminal method has recorded one yet.
+func (r *resolvedOutputState) snapshot() *OutputDef {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return cloneOutputDef(r.def)
 }
 
 func newInvocation(ss *Stylesheet, kind invocationKind) Invocation {
-	return Invocation{cfg: &invocationConfig{ss: ss, kind: kind}}
+	return Invocation{cfg: &invocationConfig{ss: ss, kind: kind, resolved: &resolvedOutputState{}}}
 }
 
 func (inv Invocation) clone() Invocation {
 	if inv.cfg == nil {
-		return Invocation{cfg: &invocationConfig{}}
+		return Invocation{cfg: &invocationConfig{resolved: &resolvedOutputState{}}}
 	}
 	cp := *inv.cfg
+	// A cloned invocation is a distinct invocation; give it its own resolved
+	// slot so recording a terminal result on the clone never writes through
+	// to the source invocation's shared state.
+	cp.resolved = &resolvedOutputState{}
 	return Invocation{cfg: &cp}
 }
 
@@ -317,7 +348,7 @@ func (inv Invocation) Do(ctx context.Context) (*helium.Document, error) {
 	}
 	tcfg := inv.toTransformConfig()
 	doc, err := executeTransform(ctx, inv.cfg.source, inv.cfg.ss, tcfg)
-	inv.cfg.resolvedOutputDef = tcfg.resolvedOutputDef
+	inv.cfg.resolved.store(tcfg.resolvedOutputDef)
 	return doc, err
 }
 
@@ -326,7 +357,12 @@ func (inv Invocation) Do(ctx context.Context) (*helium.Document, error) {
 // It includes runtime overrides from xsl:result-document targeting the
 // primary output. Returns nil if no terminal method has been called yet.
 func (inv Invocation) ResolvedOutputDef() *OutputDef {
-	return inv.cfg.resolvedOutputDef
+	if inv.cfg == nil || inv.cfg.resolved == nil {
+		return nil
+	}
+	// Return an independent snapshot so callers cannot mutate shared state and
+	// so concurrent terminal-method calls remain safe.
+	return inv.cfg.resolved.snapshot()
 }
 
 // Serialize executes the transformation and returns the serialized result.
@@ -347,7 +383,7 @@ func (inv Invocation) WriteTo(ctx context.Context, w io.Writer) error {
 	}
 	tcfg := inv.toTransformConfig()
 	resultDoc, err := executeTransform(ctx, inv.cfg.source, inv.cfg.ss, tcfg)
-	inv.cfg.resolvedOutputDef = tcfg.resolvedOutputDef
+	inv.cfg.resolved.store(tcfg.resolvedOutputDef)
 	if err != nil {
 		return err
 	}

--- a/xslt3/output.go
+++ b/xslt3/output.go
@@ -187,6 +187,10 @@ func SerializeResult(w io.Writer, doc *helium.Document, outDef *OutputDef) error
 func serializeResult(w io.Writer, doc *helium.Document, outDef *OutputDef, charMaps ...map[rune]string) error {
 	if outDef == nil {
 		outDef = defaultOutputDef()
+	} else {
+		// Clone so html/xhtml auto-detection below never mutates the
+		// caller-supplied OutputDef (it may be shared/reused).
+		outDef = cloneOutputDef(outDef)
 	}
 
 	// XSLT 3.0 §20: When no output method is explicitly specified, auto-detect

--- a/xslt3/output_fixes_test.go
+++ b/xslt3/output_fixes_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// mutatedMarker is a sentinel written into derived/snapshot OutputDef fields to
+// prove that mutating them never reaches compiled or shared stylesheet state.
+const mutatedMarker = "MUTATED"
+
 // A-003: serializeResult must not mutate the caller-supplied OutputDef during
 // html/xhtml auto-detection. Reusing one OutputDef{Method:"xml"} across an
 // <html> doc and a non-html doc must not turn the second into HTML output.
@@ -66,7 +70,7 @@ func TestDefaultOutputDefReturnsClone(t *testing.T) {
 
 	// Mutating the returned def — scalar and pointee — must not affect internal state.
 	d1.Method = "html"
-	*d1.ItemSeparator = "MUTATED"
+	*d1.ItemSeparator = mutatedMarker
 	*d1.BuildTree = false
 
 	d3 := ss.DefaultOutputDef()
@@ -96,13 +100,107 @@ func TestResolvedOutputDefIsSnapshot(t *testing.T) {
 
 	// Mutating the snapshot — scalar and pointee — must not affect a later read.
 	r1.Method = "html"
-	*r1.ItemSeparator = "MUTATED"
+	*r1.ItemSeparator = mutatedMarker
 
 	r2 := inv.ResolvedOutputDef()
 	require.NotNil(t, r2)
 	require.Equal(t, "xml", r2.Method, "ResolvedOutputDef must return an independent snapshot")
 	require.NotNil(t, r2.ItemSeparator)
 	require.Equal(t, "|", *r2.ItemSeparator, "mutating snapshot *ItemSeparator must not affect a later read")
+}
+
+// W01: a ResultDocumentHandler must receive an OutputDef whose pointer/slice/map
+// fields are independent of the compiled stylesheet. Mutating those fields from
+// the handler must not corrupt the compiled named format shared across runs.
+type captureResultDocHandler struct {
+	outDef *xslt3.OutputDef
+}
+
+func (h *captureResultDocHandler) HandleResultDocument(_ string, _ *helium.Document, outDef *xslt3.OutputDef) error {
+	h.outDef = outDef
+	return nil
+}
+
+func TestResultDocumentHandlerOutputDefIsIsolated(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output name="fmt" method="xml" item-separator="|" build-tree="yes"
+              suppress-indentation="a b"/>
+  <xsl:template match="/">
+    <xsl:result-document href="secondary.xml" format="fmt"><secondary/></xsl:result-document>
+    <out/>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	run := func() *xslt3.OutputDef {
+		h := &captureResultDocHandler{}
+		_, err := ss.Transform(parseTransformSource(t)).ResultDocumentHandler(h).Do(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, h.outDef, "handler must receive an OutputDef")
+		return h.outDef
+	}
+
+	first := run()
+	require.NotNil(t, first.ItemSeparator)
+	require.Equal(t, "|", *first.ItemSeparator)
+	require.NotNil(t, first.BuildTree)
+	require.True(t, *first.BuildTree)
+	require.Equal(t, []string{"a", "b"}, first.SuppressIndentation)
+
+	// Mutate every pointer/slice/map field on the delivered def.
+	*first.ItemSeparator = mutatedMarker
+	*first.BuildTree = false
+	first.SuppressIndentation[0] = mutatedMarker
+	first.SuppressIndentation = append(first.SuppressIndentation, "MUTATED2")
+	if first.ResolvedCharMap == nil {
+		first.ResolvedCharMap = map[rune]string{}
+	}
+	first.ResolvedCharMap['x'] = mutatedMarker
+
+	// A second run must observe the original compiled values, proving the first
+	// delivered def did not alias compiled/shared state.
+	second := run()
+	require.NotNil(t, second.ItemSeparator)
+	require.Equal(t, "|", *second.ItemSeparator, "compiled item-separator must be unaffected")
+	require.NotNil(t, second.BuildTree)
+	require.True(t, *second.BuildTree, "compiled build-tree must be unaffected")
+	require.Equal(t, []string{"a", "b"}, second.SuppressIndentation, "compiled suppress-indentation must be unaffected")
+	require.Empty(t, second.ResolvedCharMap, "compiled char map must be unaffected")
+}
+
+// W01: a primary xsl:result-document delivers its effective output def via
+// ResolvedOutputDef. Mutating that snapshot's pointer/slice/map fields must not
+// corrupt the compiled stylesheet across runs.
+func TestPrimaryResultDocumentResolvedOutputDefIsIsolated(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" item-separator="|" build-tree="yes"/>
+  <xsl:template match="/">
+    <xsl:result-document item-separator=";"><out/></xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	run := func() *xslt3.OutputDef {
+		inv := ss.Transform(parseTransformSource(t))
+		_, err := inv.Do(t.Context())
+		require.NoError(t, err)
+		r := inv.ResolvedOutputDef()
+		require.NotNil(t, r)
+		return r
+	}
+
+	first := run()
+	require.NotNil(t, first.ItemSeparator)
+	require.Equal(t, ";", *first.ItemSeparator, "result-document override must apply")
+
+	*first.ItemSeparator = mutatedMarker
+	if first.BuildTree != nil {
+		*first.BuildTree = false
+	}
+
+	second := run()
+	require.NotNil(t, second.ItemSeparator)
+	require.Equal(t, ";", *second.ItemSeparator, "compiled/override state must be unaffected across runs")
 }
 
 // A-006 race: concurrent Serialize/ResolvedOutputDef on the SAME Invocation

--- a/xslt3/output_fixes_test.go
+++ b/xslt3/output_fixes_test.go
@@ -1,0 +1,140 @@
+package xslt3_test
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xslt3"
+	"github.com/stretchr/testify/require"
+)
+
+// A-003: serializeResult must not mutate the caller-supplied OutputDef during
+// html/xhtml auto-detection. Reusing one OutputDef{Method:"xml"} across an
+// <html> doc and a non-html doc must not turn the second into HTML output.
+func TestSerializeResultDoesNotMutateOutputDef(t *testing.T) {
+	parse := func(src string) *helium.Document {
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+		require.NoError(t, err)
+		return doc
+	}
+
+	outDef := &xslt3.OutputDef{Method: "xml"}
+
+	htmlDoc := parse(`<html><body><br/></body></html>`)
+	var htmlBuf strings.Builder
+	require.NoError(t, xslt3.SerializeResult(&htmlBuf, htmlDoc, outDef))
+
+	// outDef must still be xml-method after auto-detecting HTML.
+	require.Equal(t, "xml", outDef.Method, "outDef.Method must not be mutated")
+	require.False(t, outDef.OmitDeclaration, "outDef.OmitDeclaration must not be mutated")
+
+	xmlDoc := parse(`<root><br/></root>`)
+	var xmlBuf strings.Builder
+	require.NoError(t, xslt3.SerializeResult(&xmlBuf, xmlDoc, outDef))
+
+	// The second (non-html) doc must serialize as XML, not HTML.
+	out := xmlBuf.String()
+	require.Contains(t, out, "<br/>", "second doc must be XML-serialized with self-closing br")
+	require.NotContains(t, out, "<br>", "second doc must not be HTML-serialized")
+}
+
+// A-002 / A-004: DefaultOutputDef must return a deep clone, not the internal
+// pointer. Mutating the clone — including its pointer fields — must never reach
+// through to the stylesheet's internal state.
+func TestDefaultOutputDefReturnsClone(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" item-separator="|" build-tree="yes"/>
+  <xsl:template match="/"><out/></xsl:template>
+</xsl:stylesheet>`)
+
+	d1 := ss.DefaultOutputDef()
+	require.NotNil(t, d1)
+	d2 := ss.DefaultOutputDef()
+	require.NotNil(t, d2)
+	require.NotSame(t, d1, d2, "DefaultOutputDef must return a fresh clone each call")
+
+	// The pointer fields must themselves be fresh allocations, not aliases.
+	require.NotNil(t, d1.ItemSeparator)
+	require.NotNil(t, d2.ItemSeparator)
+	require.NotSame(t, d1.ItemSeparator, d2.ItemSeparator, "ItemSeparator pointer must be deep-cloned")
+	require.NotNil(t, d1.BuildTree)
+	require.NotNil(t, d2.BuildTree)
+	require.NotSame(t, d1.BuildTree, d2.BuildTree, "BuildTree pointer must be deep-cloned")
+
+	// Mutating the returned def — scalar and pointee — must not affect internal state.
+	d1.Method = "html"
+	*d1.ItemSeparator = "MUTATED"
+	*d1.BuildTree = false
+
+	d3 := ss.DefaultOutputDef()
+	require.Equal(t, "xml", d3.Method, "mutating a returned def must not corrupt internal state")
+	require.NotNil(t, d3.ItemSeparator)
+	require.Equal(t, "|", *d3.ItemSeparator, "mutating clone *ItemSeparator must not corrupt internal state")
+	require.NotNil(t, d3.BuildTree)
+	require.True(t, *d3.BuildTree, "mutating clone *BuildTree must not corrupt internal state")
+}
+
+// A-006: Do/WriteTo must not mutate the shared invocationConfig; ResolvedOutputDef
+// must return an independent deep-cloned snapshot.
+func TestResolvedOutputDefIsSnapshot(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" item-separator="|"/>
+  <xsl:template match="/"><out/></xsl:template>
+</xsl:stylesheet>`)
+
+	inv := ss.Transform(parseTransformSource(t))
+	_, err := inv.Do(t.Context())
+	require.NoError(t, err)
+
+	r1 := inv.ResolvedOutputDef()
+	require.NotNil(t, r1)
+	require.NotNil(t, r1.ItemSeparator)
+
+	// Mutating the snapshot — scalar and pointee — must not affect a later read.
+	r1.Method = "html"
+	*r1.ItemSeparator = "MUTATED"
+
+	r2 := inv.ResolvedOutputDef()
+	require.NotNil(t, r2)
+	require.Equal(t, "xml", r2.Method, "ResolvedOutputDef must return an independent snapshot")
+	require.NotNil(t, r2.ItemSeparator)
+	require.Equal(t, "|", *r2.ItemSeparator, "mutating snapshot *ItemSeparator must not affect a later read")
+}
+
+// A-006 race: concurrent Serialize/ResolvedOutputDef on the SAME Invocation
+// value must be safe. Run under -race to catch data races on the shared config.
+func TestConcurrentSerializeAndResolvedOutputDef(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" item-separator="|"/>
+  <xsl:template match="/"><out/></xsl:template>
+</xsl:stylesheet>`)
+
+	inv := ss.Transform(parseTransformSource(t))
+	ctx := t.Context()
+
+	const n = 16
+	var wg sync.WaitGroup
+	wg.Add(n * 2)
+	for range n {
+		go func() {
+			defer wg.Done()
+			_, err := inv.Serialize(ctx)
+			require.NoError(t, err)
+		}()
+		go func() {
+			defer wg.Done()
+			// Reading the resolved def concurrently with Serialize must not race.
+			_ = inv.ResolvedOutputDef()
+		}()
+	}
+	wg.Wait()
+
+	out, err := inv.Serialize(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "<out/>")
+}

--- a/xslt3/stylesheet.go
+++ b/xslt3/stylesheet.go
@@ -155,7 +155,7 @@ func (s *Stylesheet) DefaultOutputDef() *OutputDef {
 	if s == nil {
 		return nil
 	}
-	return s.outputs[""]
+	return cloneOutputDef(s.outputs[""])
 }
 
 // defaultItemSeparator returns the item-separator from the default output


### PR DESCRIPTION
- clone OutputDef in serializeResult/DefaultOutputDef/ResolvedOutputDef so auto-detect and reuse no longer mutate shared/caller defs
- serialize captured primary items via SerializeItems for method=json/adaptive (and build-tree=no) in WriteTo and fn:transform