### PR TITLE
reject nil key source in xmldsig1 verify

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -273,6 +273,7 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
 - Transforms: `Enveloped()`, `C14NTransform(uri)`, `ExcC14NTransform(prefixes...)`
 - Algorithms: RSA-SHA1/SHA256, ECDSA-SHA256/SHA384, HMAC-SHA1/SHA256, Ed25519
 - Digests: SHA-1, SHA-256, SHA-384, SHA-512
+- Errors: `ErrNoKeySource` sentinel — returned by verify when no usable KeySource is configured (nil cfg, untyped-nil, or typed-nil KeySource/func)
 - Files: `xmldsig1.go` (API), `constants.go`, `algorithms.go`, `sign.go`, `verify.go`, `transforms.go`, `keyinfo.go`, `errors.go`
 - Imports: helium, c14n/
 

--- a/xmldsig1/errors.go
+++ b/xmldsig1/errors.go
@@ -46,6 +46,12 @@ var (
 
 	// ErrInvalidSignature is returned when the Signature element is malformed.
 	ErrInvalidSignature = errors.New("xmldsig1: invalid signature structure")
+
+	// ErrNoKeySource is returned when a Verifier was created with a nil
+	// KeySource and verification is attempted. Without a KeySource there is no
+	// way to resolve a verification key, so this is rejected before any key
+	// resolution rather than panicking on a nil dereference.
+	ErrNoKeySource = errors.New("xmldsig1: no key source configured")
 )
 
 // VerificationError provides details about which step of verification failed.

--- a/xmldsig1/keyinfo.go
+++ b/xmldsig1/keyinfo.go
@@ -21,6 +21,12 @@ type KeySource interface {
 type KeySourceFunc func(ctx context.Context, keyInfo *KeyInfoData, alg string) (any, error)
 
 func (f KeySourceFunc) ResolveKey(ctx context.Context, keyInfo *KeyInfoData, alg string) (any, error) {
+	// A typed-nil KeySourceFunc (e.g. var ks KeySourceFunc; NewVerifier(ks))
+	// survives the interface!=nil check in verifySignature, so guard the nil
+	// func here and return a typed error instead of panicking on the call.
+	if f == nil {
+		return nil, ErrNoKeySource
+	}
 	return f(ctx, keyInfo, alg)
 }
 

--- a/xmldsig1/nil_keysource_test.go
+++ b/xmldsig1/nil_keysource_test.go
@@ -1,11 +1,22 @@
 package xmldsig1_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/lestrrat-go/helium/xmldsig1"
 	"github.com/stretchr/testify/require"
 )
+
+// pointerKeySource is a pointer-receiver KeySource used to construct a typed-nil
+// pointer value. A typed-nil pointer carries a concrete type, so the interface
+// is non-nil and survives a plain == nil check; ResolveKey would then be called
+// on a nil receiver.
+type pointerKeySource struct{}
+
+func (*pointerKeySource) ResolveKey(_ context.Context, _ *xmldsig1.KeyInfoData, _ string) (any, error) {
+	return nil, nil
+}
 
 // A nil KeySource must surface a typed error rather than panic on a nil
 // pointer dereference when Verify reaches ResolveKey.
@@ -40,6 +51,23 @@ func TestTypedNilKeySourceFunc(t *testing.T) {
 	doc := mustParseXML(t, nilKeySourceSigDoc)
 
 	var ks xmldsig1.KeySourceFunc // typed nil
+
+	require.NotPanics(t, func() {
+		_, err := xmldsig1.NewVerifier(ks).Verify(t.Context(), doc)
+		require.Error(t, err)
+		require.ErrorIs(t, err, xmldsig1.ErrNoKeySource)
+	})
+}
+
+// A typed-nil POINTER KeySource (e.g. var ks *pointerKeySource;
+// NewVerifier(ks)) yields a non-nil interface whose underlying value is nil, so
+// a plain cfg.keySource == nil check misses it and ResolveKey would panic on
+// the nil receiver. verifySignature must detect this via isNilKeySource and
+// return a typed error instead.
+func TestTypedNilPointerKeySource(t *testing.T) {
+	doc := mustParseXML(t, nilKeySourceSigDoc)
+
+	var ks *pointerKeySource // typed-nil pointer
 
 	require.NotPanics(t, func() {
 		_, err := xmldsig1.NewVerifier(ks).Verify(t.Context(), doc)

--- a/xmldsig1/nil_keysource_test.go
+++ b/xmldsig1/nil_keysource_test.go
@@ -32,3 +32,47 @@ func TestNilKeySource(t *testing.T) {
 		require.ErrorIs(t, err, xmldsig1.ErrNoKeySource)
 	})
 }
+
+// A typed-nil KeySourceFunc passes the interface!=nil check in verifySignature
+// (the interface carries a concrete type), so ResolveKey must guard the nil
+// func itself and return a typed error rather than panic on the nil call.
+func TestTypedNilKeySourceFunc(t *testing.T) {
+	doc := mustParseXML(t, nilKeySourceSigDoc)
+
+	var ks xmldsig1.KeySourceFunc // typed nil
+
+	require.NotPanics(t, func() {
+		_, err := xmldsig1.NewVerifier(ks).Verify(t.Context(), doc)
+		require.Error(t, err)
+		require.ErrorIs(t, err, xmldsig1.ErrNoKeySource)
+	})
+}
+
+// A zero-value Verifier{} constructed directly (bypassing NewVerifier) has a
+// nil cfg. Verify/VerifyElement must surface a typed error rather than panic on
+// the nil cfg dereference inside verifySignature.
+func TestZeroValueVerifier(t *testing.T) {
+	doc := mustParseXML(t, nilKeySourceSigDoc)
+
+	require.NotPanics(t, func() {
+		_, err := xmldsig1.Verifier{}.Verify(t.Context(), doc)
+		require.Error(t, err)
+		require.ErrorIs(t, err, xmldsig1.ErrNoKeySource)
+	})
+}
+
+// nilKeySourceSigDoc is a minimal document carrying a single ds:Signature so
+// the verify path reaches the key-resolution step.
+const nilKeySourceSigDoc = `<doc xmlns:ds="http://www.w3.org/2000/09/xmldsig#">` +
+	`<ds:Signature>` +
+	`<ds:SignedInfo>` +
+	`<ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>` +
+	`<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>` +
+	`<ds:Reference URI="">` +
+	`<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>` +
+	`<ds:DigestValue>AAAA</ds:DigestValue>` +
+	`</ds:Reference>` +
+	`</ds:SignedInfo>` +
+	`<ds:SignatureValue>AAAA</ds:SignatureValue>` +
+	`</ds:Signature>` +
+	`</doc>`

--- a/xmldsig1/nil_keysource_test.go
+++ b/xmldsig1/nil_keysource_test.go
@@ -15,10 +15,11 @@ import (
 type pointerKeySource struct{}
 
 func (*pointerKeySource) ResolveKey(_ context.Context, _ *xmldsig1.KeyInfoData, _ string) (any, error) {
-	// Unreachable in this test: a typed-nil *pointerKeySource is detected by
-	// isNilKeySource before ResolveKey is ever called. Return the package
-	// sentinel so a nil value is never paired with a nil error (nilnil lint).
-	return nil, xmldsig1.ErrNoKeySource
+	// Must be unreachable in TestTypedNilPointerKeySource: a typed-nil
+	// *pointerKeySource is detected by isNilKeySource before ResolveKey is ever
+	// called. Panic here so the test fails loudly if the isNilKeySource guard is
+	// removed and ResolveKey is invoked on the nil receiver.
+	panic("typed-nil *pointerKeySource ResolveKey should not be called")
 }
 
 // A nil KeySource must surface a typed error rather than panic on a nil

--- a/xmldsig1/nil_keysource_test.go
+++ b/xmldsig1/nil_keysource_test.go
@@ -15,7 +15,10 @@ import (
 type pointerKeySource struct{}
 
 func (*pointerKeySource) ResolveKey(_ context.Context, _ *xmldsig1.KeyInfoData, _ string) (any, error) {
-	return nil, nil
+	// Unreachable in this test: a typed-nil *pointerKeySource is detected by
+	// isNilKeySource before ResolveKey is ever called. Return the package
+	// sentinel so a nil value is never paired with a nil error (nilnil lint).
+	return nil, xmldsig1.ErrNoKeySource
 }
 
 // A nil KeySource must surface a typed error rather than panic on a nil

--- a/xmldsig1/nil_keysource_test.go
+++ b/xmldsig1/nil_keysource_test.go
@@ -1,0 +1,34 @@
+package xmldsig1_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xmldsig1"
+	"github.com/stretchr/testify/require"
+)
+
+// A nil KeySource must surface a typed error rather than panic on a nil
+// pointer dereference when Verify reaches ResolveKey.
+func TestNilKeySource(t *testing.T) {
+	const sigDoc = `<doc xmlns:ds="http://www.w3.org/2000/09/xmldsig#">` +
+		`<ds:Signature>` +
+		`<ds:SignedInfo>` +
+		`<ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>` +
+		`<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>` +
+		`<ds:Reference URI="">` +
+		`<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>` +
+		`<ds:DigestValue>AAAA</ds:DigestValue>` +
+		`</ds:Reference>` +
+		`</ds:SignedInfo>` +
+		`<ds:SignatureValue>AAAA</ds:SignatureValue>` +
+		`</ds:Signature>` +
+		`</doc>`
+
+	doc := mustParseXML(t, sigDoc)
+
+	require.NotPanics(t, func() {
+		_, err := xmldsig1.NewVerifier(nil).Verify(t.Context(), doc)
+		require.Error(t, err)
+		require.ErrorIs(t, err, xmldsig1.ErrNoKeySource)
+	})
+}

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -32,10 +32,12 @@ type parsedTransform struct {
 }
 
 func verifySignature(ctx context.Context, cfg *verifierConfig, doc *helium.Document, sigElem *helium.Element) (*VerifyResult, error) {
-	// A nil KeySource (e.g. NewVerifier(nil)) cannot resolve a key. Reject it
-	// up front so a config-controlled nil returns a typed error instead of
-	// panicking on a nil dereference inside ResolveKey below.
-	if cfg.keySource == nil {
+	// A zero-value Verifier{} constructed directly (bypassing NewVerifier) has
+	// a nil cfg, and a nil KeySource (e.g. NewVerifier(nil)) cannot resolve a
+	// key. Reject both up front so these config-controlled cases return a typed
+	// error instead of panicking on a nil dereference here or inside ResolveKey
+	// below.
+	if cfg == nil || cfg.keySource == nil {
 		return nil, ErrNoKeySource
 	}
 

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -4,10 +4,30 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 
 	helium "github.com/lestrrat-go/helium"
 )
+
+// isNilKeySource reports whether a KeySource is effectively nil. A plain
+// `cfg.keySource == nil` only catches an untyped-nil interface; a typed-nil
+// pointer (e.g. `var ks *myKeySource; NewVerifier(ks)`) yields a non-nil
+// interface whose underlying value is nil, so calling ResolveKey on it would
+// panic on the nil-receiver dereference. Detect that case reflectively for any
+// nil-capable underlying kind.
+func isNilKeySource(ks KeySource) bool {
+	if ks == nil {
+		return true
+	}
+	v := reflect.ValueOf(ks)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Chan, reflect.Func, reflect.Slice, reflect.Interface:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
 
 // parsedSignature holds the parsed structure of a ds:Signature element.
 type parsedSignature struct {
@@ -34,10 +54,11 @@ type parsedTransform struct {
 func verifySignature(ctx context.Context, cfg *verifierConfig, doc *helium.Document, sigElem *helium.Element) (*VerifyResult, error) {
 	// A zero-value Verifier{} constructed directly (bypassing NewVerifier) has
 	// a nil cfg, and a nil KeySource (e.g. NewVerifier(nil)) cannot resolve a
-	// key. Reject both up front so these config-controlled cases return a typed
-	// error instead of panicking on a nil dereference here or inside ResolveKey
-	// below.
-	if cfg == nil || cfg.keySource == nil {
+	// key. isNilKeySource also catches a typed-nil pointer KeySource, whose
+	// non-nil interface would otherwise slip past a plain == nil check and panic
+	// inside ResolveKey below. Reject all of these up front so config-controlled
+	// cases return a typed error instead of panicking on a nil dereference.
+	if cfg == nil || isNilKeySource(cfg.keySource) {
 		return nil, ErrNoKeySource
 	}
 

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -22,7 +22,7 @@ func isNilKeySource(ks KeySource) bool {
 	}
 	v := reflect.ValueOf(ks)
 	switch v.Kind() {
-	case reflect.Ptr, reflect.Map, reflect.Chan, reflect.Func, reflect.Slice, reflect.Interface:
+	case reflect.Pointer, reflect.Map, reflect.Chan, reflect.Func, reflect.Slice, reflect.Interface:
 		return v.IsNil()
 	default:
 		return false

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -32,6 +32,13 @@ type parsedTransform struct {
 }
 
 func verifySignature(ctx context.Context, cfg *verifierConfig, doc *helium.Document, sigElem *helium.Element) (*VerifyResult, error) {
+	// A nil KeySource (e.g. NewVerifier(nil)) cannot resolve a key. Reject it
+	// up front so a config-controlled nil returns a typed error instead of
+	// panicking on a nil dereference inside ResolveKey below.
+	if cfg.keySource == nil {
+		return nil, ErrNoKeySource
+	}
+
 	parsed, err := parseSignatureElement(sigElem)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- `NewVerifier(nil).Verify` returned a nil-deref panic on `ResolveKey`; now returns typed `ErrNoKeySource`.