### PR TITLE
fix dtd element decl lookup key in GetElementDesc

### DIFF
--- a/dtd.go
+++ b/dtd.go
@@ -243,8 +243,15 @@ func (dtd *DTD) LookupNotation(name string) (*Notation, bool) {
 }
 
 func (dtd *DTD) GetElementDesc(name string) (*ElementDecl, bool) {
-	ret, ok := dtd.elements[name]
-	return ret, ok
+	// Element decls are registered under a "name:prefix" key with the QName
+	// split into local name and prefix (see AddElementDecl). Split the same
+	// way here so a QName lookup composes the identical key.
+	var prefix string
+	if i := strings.IndexByte(name, ':'); i > -1 {
+		prefix = name[:i]
+		name = name[i+1:]
+	}
+	return dtd.LookupElement(name, prefix)
 }
 
 // AttributesForElement returns all attribute declarations for the named element.

--- a/dtd_elemdecl_test.go
+++ b/dtd_elemdecl_test.go
@@ -1,0 +1,54 @@
+package helium
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/enum"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetElementDescKey verifies that an element declaration registered via
+// AddElementDecl can be retrieved through GetElementDesc using the same QName.
+// Registration keys decls as "name:prefix"; GetElementDesc must compose the
+// lookup key the same way instead of using the raw QName.
+func TestGetElementDescKey(t *testing.T) {
+	t.Run("unprefixed", func(t *testing.T) {
+		dtd := newDTD()
+		content, err := newElementContent("", ElementContentPCDATA)
+		require.NoError(t, err)
+		_, err = dtd.AddElementDecl("r", enum.MixedElementType, content)
+		require.NoError(t, err)
+
+		decl, ok := dtd.GetElementDesc("r")
+		require.True(t, ok, "GetElementDesc must find the registered decl")
+		require.Equal(t, enum.MixedElementType, decl.decltype)
+	})
+	t.Run("prefixed", func(t *testing.T) {
+		dtd := newDTD()
+		_, err := dtd.AddElementDecl("foo:bar", enum.EmptyElementType, nil)
+		require.NoError(t, err)
+
+		decl, ok := dtd.GetElementDesc("foo:bar")
+		require.True(t, ok, "GetElementDesc must find the prefixed decl by QName")
+		require.Equal(t, enum.EmptyElementType, decl.decltype)
+	})
+}
+
+// TestIsMixedElementWhitespace exercises the mixed-content whitespace path that
+// relies on GetElementDesc: a mixed-content element must report IsMixedElement
+// true so whitespace inside it is not misclassified as ignorable.
+func TestIsMixedElementWhitespace(t *testing.T) {
+	doc := NewDocument("1.0", "UTF-8", StandaloneExplicitNo)
+	dtd := newDTD()
+	dtd.doc = doc
+	doc.intSubset = dtd
+
+	content, err := newElementContent("", ElementContentPCDATA)
+	require.NoError(t, err)
+	_, err = dtd.AddElementDecl("r", enum.MixedElementType, content)
+	require.NoError(t, err)
+
+	mixed, err := doc.IsMixedElement("r")
+	require.NoError(t, err)
+	require.True(t, mixed, "mixed-content element must be reported as mixed")
+}


### PR DESCRIPTION
- GetElementDesc now splits the QName into local name and prefix and composes the same "name:prefix" key used at registration, so element decls (including mixed-content) are found instead of misclassified as ignorable whitespace