### PR TITLE
set owner document on CreatePI nodes

### DIFF
--- a/document.go
+++ b/document.go
@@ -379,10 +379,12 @@ func (d *Document) createLiteralAttribute(name, value string, ns *Namespace) *At
 }
 
 func (d *Document) CreatePI(target, data string) *ProcessingInstruction {
-	return &ProcessingInstruction{
+	pi := &ProcessingInstruction{
 		target: target,
 		data:   data,
 	}
+	pi.doc = d
+	return pi
 }
 
 func (d *Document) CreateDTD() (*DTD, error) {

--- a/document_test.go
+++ b/document_test.go
@@ -136,3 +136,10 @@ func TestDocProperties(t *testing.T) {
 		require.False(t, doc.HasProperty(helium.DocWellFormed|helium.DocDTDValid))
 	})
 }
+
+func TestCreatePIOwnerDocument(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "", helium.StandaloneImplicitNo)
+	pi := doc.CreatePI("p", "data")
+	require.Same(t, doc, pi.OwnerDocument(), "PI owner document should be the creating document")
+}


### PR DESCRIPTION
- `Document.CreatePI` now assigns the new PI's owner document, so `OwnerDocument()` returns the creating document instead of nil.