### PR TITLE
clamp negative sink buffer size to zero

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -311,7 +311,7 @@ Generic channel-based async event sink.
 - **New[T](ctx, Handler[T], ...Option) → *Sink[T]**
 - **Sink.Handle(ctx, T)** — async send (blocks if buffer full)
 - **Sink.Close()** — drain and stop
-- WithBufferSize(n) — default 256
+- WithBufferSize(n) — default 256; negative values clamped to 0 (unbuffered)
 - Nil-safe: Handle() on nil *Sink is no-op
 - When T=error, satisfies helium.ErrorHandler
 - Files: `sink.go`

--- a/sink/sink.go
+++ b/sink/sink.go
@@ -25,7 +25,8 @@ type config struct {
 	bufSize int
 }
 
-// WithBufferSize sets the channel buffer size. Default is 256.
+// WithBufferSize sets the channel buffer size. Default is 256. Negative
+// values are clamped to 0 (an unbuffered channel).
 func WithBufferSize(n int) Option {
 	return func(c *config) { c.bufSize = n }
 }
@@ -54,6 +55,9 @@ func New[T any](ctx context.Context, handler Handler[T], options ...Option) *Sin
 	cfg := config{bufSize: 256}
 	for _, o := range options {
 		o(&cfg)
+	}
+	if cfg.bufSize < 0 {
+		cfg.bufSize = 0
 	}
 	s := &Sink[T]{
 		ch:      make(chan T, cfg.bufSize),

--- a/sink/sink_test.go
+++ b/sink/sink_test.go
@@ -71,6 +71,31 @@ func TestSinkCloseMultipleTimes(t *testing.T) {
 	require.NoError(t, s.Close())
 }
 
+func TestSinkNegativeBufferSizeDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	var mu sync.Mutex
+	var got []int
+
+	var s *sink.Sink[int]
+	require.NotPanics(t, func() {
+		s = sink.New[int](ctx, sink.HandlerFunc[int](func(_ context.Context, v int) {
+			mu.Lock()
+			got = append(got, v)
+			mu.Unlock()
+		}), sink.WithBufferSize(-1))
+	})
+
+	s.Handle(ctx, 1)
+	s.Handle(ctx, 2)
+	require.NoError(t, s.Close())
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []int{1, 2}, got)
+}
+
 func TestSinkCloseWhileHandleBlockedUnblocksHandle(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- `sink.New` with `WithBufferSize(-1)` panicked in `make(chan ...)`; negatives now clamp to 0 (unbuffered).