### PR TITLE
enforce xsd identity-constraint xpath and keyref refer

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -167,14 +167,29 @@ engine, which RE2 cannot. A pattern that is not a valid XSD regular expression i
 reported as a schema parser error (`The value '…' is not a valid regular
 expression.`); its `compiledPatterns` entry stays nil and is skipped at validation.
 
-**Compile-time IDC checks:** a malformed `xs:selector`/`xs:field` `@xpath` is a fatal schema parser error (`parseIDConstraint` → `reportIDCXPathError`) rather than a silently-dropped `xpath1.Compile` failure that would disable the whole constraint. After all elements are parsed, `checkKeyRefRefers` (in `compileSchema`) resolves every `xs:keyref/@refer` against a schema-wide set of key/unique constraint names (identity-constraint names share one symbol space, so a keyref may refer to a key/unique on a different element) and raises a fatal error for an unknown/empty refer. At validation time, an IDC whose selector/field XPath fails to evaluate is reported as a validity error (`Failed to evaluate identity-constraint '…'`), not swallowed.
+**Compile-time IDC checks:** a malformed `xs:selector`/`xs:field` `@xpath` is a fatal schema parser error (`parseIDConstraint` → `reportIDCXPathError`) rather than a silently-dropped `xpath1.Compile` failure that would disable the whole constraint. After all elements are parsed, `checkKeyRefRefers` (in `compileSchema`) resolves every `xs:keyref/@refer` against a schema-wide set of key/unique constraint names (identity-constraint names share one symbol space) and raises a fatal error for an unknown/empty refer. The registry is built by `collectAllIDCs`, which walks EVERY element declaration — not just `schema.elements` (globals) — by recursively descending each global element's/type's/named-group's content model (`idcWalker`, with visited sets on `*ElementDecl`/`*ModelGroup`/`*TypeDef` to bound shared/recursive/circular structures), so a keyref (or the key it refers to) declared on a LOCAL element buried in a content model is checked too. **@refer resolution is schema-wide (the symbol space); keyref VALUE resolution is occurrence-scoped** — the two are distinct (see Pass 2 below). At validation time, an IDC whose selector/field XPath fails to evaluate is reported as a validity error (`Failed to evaluate identity-constraint '…'`), not swallowed.
 
 **Pass 2 — Identity Constraints** (`validateIDConstraints` via second `helium.Walk()`):
 - For elements with IDCs (xs:unique, xs:key, xs:keyref):
   1. Evaluate selector XPath → node set
   2. For each selected node, evaluate field XPaths → collect key-sequences
   3. Check unique/key: all key-sequences must be unique
-  4. Check keyref: all key-sequences must exist in referenced constraint table
+  4. Check keyref: all key-sequences must exist in referenced constraint table.
+     **Keyref tables are OCCURRENCE-SCOPED** (XSD identity-constraint scope,
+     matching xmllint): the key/unique tables a keyref resolves against are those
+     built for the SAME host-element OCCURRENCE that declares the keyref
+     (`validateIDConstraints` builds a per-occurrence `keyTables map[QName]*idcTable`
+     and resolves that occurrence's keyrefs against it after every key/unique on
+     the occurrence is evaluated, so a keyref declared before its key still
+     resolves). A keyref whose referenced key/unique is declared on a DIFFERENT
+     element (a sibling, or a repeating host's other occurrence) resolves against
+     an EMPTY key space → every key-sequence is a "no match" failure. This is
+     deliberate: two sibling occurrences of a repeating host never leak key spaces
+     into each other (a doc-wide merged table would falsely accept a cross-scope
+     reference), and a key on a sibling element is out of the keyref's scope just
+     as xmllint enforces. Note this means a genuine cross-host keyref (key on
+     element A, keyref on element B≠A) is conservatively rejected — xmllint rejects
+     it too, so there are no false accepts.
   - Field presence (cvc-identity-constraint.4.2.1): an `xs:key` requires every
     field to evaluate to a node for each selected node; an absent field is a
     validity error (`Not all fields of key identity-constraint '…' evaluate to a

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -167,6 +167,8 @@ engine, which RE2 cannot. A pattern that is not a valid XSD regular expression i
 reported as a schema parser error (`The value '…' is not a valid regular
 expression.`); its `compiledPatterns` entry stays nil and is skipped at validation.
 
+**Compile-time IDC checks:** a malformed `xs:selector`/`xs:field` `@xpath` is a fatal schema parser error (`parseIDConstraint` → `reportIDCXPathError`) rather than a silently-dropped `xpath1.Compile` failure that would disable the whole constraint. After all elements are parsed, `checkKeyRefRefers` (in `compileSchema`) resolves every `xs:keyref/@refer` against a schema-wide set of key/unique constraint names (identity-constraint names share one symbol space, so a keyref may refer to a key/unique on a different element) and raises a fatal error for an unknown/empty refer. At validation time, an IDC whose selector/field XPath fails to evaluate is reported as a validity error (`Failed to evaluate identity-constraint '…'`), not swallowed.
+
 **Pass 2 — Identity Constraints** (`validateIDConstraints` via second `helium.Walk()`):
 - For elements with IDCs (xs:unique, xs:key, xs:keyref):
   1. Evaluate selector XPath → node set

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -342,10 +342,18 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 // refer to a key/unique declared on a different element; the prior per-host
 // resolution missed those and any typo'd or missing refer silently disabled the
 // keyref. A failure here is reported as a fatal schema parser error.
+//
+// The registry is built from ALL identity-constraints in the schema, not just
+// those on GLOBAL element declarations: a keyref (or the key/unique it refers
+// to) declared on a LOCAL element declaration buried in a content model must be
+// checked too. collectAllIDCs walks every global element/type/group content
+// model recursively (with a visited set) to reach those local hosts.
 func (c *compiler) checkKeyRefRefers(ctx context.Context) {
 	if c.filename == "" {
 		return
 	}
+
+	idcs := c.collectAllIDCs()
 
 	// Build the set of all declared key/unique constraint QNames. Identity
 	// constraints live in the schema's target namespace, so a keyref may refer to
@@ -353,39 +361,112 @@ func (c *compiler) checkKeyRefRefers(ctx context.Context) {
 	// {namespace}local identity, not local name only (a local-name match could
 	// bind the wrong constraint when two namespaces share a local name).
 	keyNames := make(map[QName]struct{})
-	for _, edecl := range c.schema.elements {
-		for _, idc := range edecl.IDCs {
-			if idc.Kind == IDCKey || idc.Kind == IDCUnique {
-				keyNames[idc.QName] = struct{}{}
-			}
+	for _, idc := range idcs {
+		if idc.Kind == IDCKey || idc.Kind == IDCUnique {
+			keyNames[idc.QName] = struct{}{}
 		}
 	}
 
-	for _, edecl := range c.schema.elements {
-		for _, idc := range edecl.IDCs {
-			if idc.Kind != IDCKeyRef {
-				continue
-			}
-			// An unbound @refer prefix was already reported as fatal at parse time.
-			if idc.referUnbound {
-				continue
-			}
-			if idc.Refer == "" {
-				msg := fmt.Sprintf("The keyref identity-constraint '%s' has no 'refer' attribute naming a key or unique.", idc.Name)
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(
-					schemaParserErrorAttr(c.filename, idc.Line, elemKeyRef, elemKeyRef, attrRefer, msg),
-					helium.ErrorLevelFatal))
-				c.errorCount++
-				continue
-			}
-			if _, ok := keyNames[idc.ReferQName]; ok {
-				continue
-			}
-			msg := fmt.Sprintf("The keyref identity-constraint '%s' references the unknown key or unique '%s'.", idc.Name, idc.Refer)
+	for _, idc := range idcs {
+		if idc.Kind != IDCKeyRef {
+			continue
+		}
+		// An unbound @refer prefix was already reported as fatal at parse time.
+		if idc.referUnbound {
+			continue
+		}
+		if idc.Refer == "" {
+			msg := fmt.Sprintf("The keyref identity-constraint '%s' has no 'refer' attribute naming a key or unique.", idc.Name)
 			c.errorHandler.Handle(ctx, helium.NewLeveledError(
 				schemaParserErrorAttr(c.filename, idc.Line, elemKeyRef, elemKeyRef, attrRefer, msg),
 				helium.ErrorLevelFatal))
 			c.errorCount++
+			continue
+		}
+		if _, ok := keyNames[idc.ReferQName]; ok {
+			continue
+		}
+		msg := fmt.Sprintf("The keyref identity-constraint '%s' references the unknown key or unique '%s'.", idc.Name, idc.Refer)
+		c.errorHandler.Handle(ctx, helium.NewLeveledError(
+			schemaParserErrorAttr(c.filename, idc.Line, elemKeyRef, elemKeyRef, attrRefer, msg),
+			helium.ErrorLevelFatal))
+		c.errorCount++
+	}
+}
+
+// collectAllIDCs returns every identity-constraint declared anywhere in the
+// schema, including those on LOCAL element declarations nested inside content
+// models. It seeds the walk from all global element declarations, named types,
+// and named model groups, then descends each content model recursively. Visited
+// sets on *ElementDecl, *ModelGroup, and *TypeDef bound the walk so shared
+// group particles, recursive types, and circular references are each traversed
+// once.
+func (c *compiler) collectAllIDCs() []*IDConstraint {
+	w := &idcWalker{
+		elems:  make(map[*ElementDecl]struct{}),
+		groups: make(map[*ModelGroup]struct{}),
+		types:  make(map[*TypeDef]struct{}),
+	}
+	for _, edecl := range c.schema.elements {
+		w.walkElement(edecl)
+	}
+	for _, td := range c.schema.types {
+		w.walkType(td)
+	}
+	for _, mg := range c.schema.groups {
+		w.walkGroup(mg)
+	}
+	return w.idcs
+}
+
+// idcWalker accumulates identity-constraints while recursively descending
+// element declarations, types, and model groups, tracking visited nodes to
+// terminate on shared/recursive/circular structures.
+type idcWalker struct {
+	idcs   []*IDConstraint
+	elems  map[*ElementDecl]struct{}
+	groups map[*ModelGroup]struct{}
+	types  map[*TypeDef]struct{}
+}
+
+func (w *idcWalker) walkElement(edecl *ElementDecl) {
+	if edecl == nil {
+		return
+	}
+	if _, seen := w.elems[edecl]; seen {
+		return
+	}
+	w.elems[edecl] = struct{}{}
+	w.idcs = append(w.idcs, edecl.IDCs...)
+	w.walkType(edecl.Type)
+}
+
+func (w *idcWalker) walkType(td *TypeDef) {
+	if td == nil {
+		return
+	}
+	if _, seen := w.types[td]; seen {
+		return
+	}
+	w.types[td] = struct{}{}
+	w.walkGroup(td.ContentModel)
+	w.walkType(td.BaseType)
+}
+
+func (w *idcWalker) walkGroup(mg *ModelGroup) {
+	if mg == nil {
+		return
+	}
+	if _, seen := w.groups[mg]; seen {
+		return
+	}
+	w.groups[mg] = struct{}{}
+	for _, p := range mg.Particles {
+		switch term := p.Term.(type) {
+		case *ElementDecl:
+			w.walkElement(term)
+		case *ModelGroup:
+			w.walkGroup(term)
 		}
 	}
 }

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -6,7 +6,6 @@ import (
 	"io/fs"
 	"sort"
 	"strconv"
-	"strings"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/iofs"
@@ -348,12 +347,16 @@ func (c *compiler) checkKeyRefRefers(ctx context.Context) {
 		return
 	}
 
-	// Build the set of all declared key/unique constraint local names.
-	keyNames := make(map[string]struct{})
+	// Build the set of all declared key/unique constraint QNames. Identity
+	// constraints live in the schema's target namespace, so a keyref may refer to
+	// a key/unique declared on a DIFFERENT element; matching must be by full
+	// {namespace}local identity, not local name only (a local-name match could
+	// bind the wrong constraint when two namespaces share a local name).
+	keyNames := make(map[QName]struct{})
 	for _, edecl := range c.schema.elements {
 		for _, idc := range edecl.IDCs {
 			if idc.Kind == IDCKey || idc.Kind == IDCUnique {
-				keyNames[idc.Name] = struct{}{}
+				keyNames[idc.QName] = struct{}{}
 			}
 		}
 	}
@@ -363,13 +366,11 @@ func (c *compiler) checkKeyRefRefers(ctx context.Context) {
 			if idc.Kind != IDCKeyRef {
 				continue
 			}
-			// Resolve a possibly-qualified refer to its local part, matching the
-			// validation-time lookup which compares on local name.
-			referLocal := idc.Refer
-			if i := strings.IndexByte(referLocal, ':'); i >= 0 {
-				referLocal = referLocal[i+1:]
+			// An unbound @refer prefix was already reported as fatal at parse time.
+			if idc.referUnbound {
+				continue
 			}
-			if referLocal == "" {
+			if idc.Refer == "" {
 				msg := fmt.Sprintf("The keyref identity-constraint '%s' has no 'refer' attribute naming a key or unique.", idc.Name)
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(
 					schemaParserErrorAttr(c.filename, idc.Line, elemKeyRef, elemKeyRef, attrRefer, msg),
@@ -377,7 +378,7 @@ func (c *compiler) checkKeyRefRefers(ctx context.Context) {
 				c.errorCount++
 				continue
 			}
-			if _, ok := keyNames[referLocal]; ok {
+			if _, ok := keyNames[idc.ReferQName]; ok {
 				continue
 			}
 			msg := fmt.Sprintf("The keyref identity-constraint '%s' references the unknown key or unique '%s'.", idc.Name, idc.Refer)

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"sort"
 	"strconv"
+	"strings"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/iofs"
@@ -327,7 +328,65 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 		c.checkFinalOnSubstGroups(ctx)
 	}
 
+	// Resolve every xs:keyref/@refer against the schema-wide registry of
+	// key/unique constraints. An unresolved refer must be a fatal schema error:
+	// otherwise the keyref is silently skipped at validation time and referential
+	// integrity is never enforced.
+	c.checkKeyRefRefers(ctx)
+
 	return c.schema, nil
+}
+
+// checkKeyRefRefers verifies that every xs:keyref/@refer names a key or unique
+// identity-constraint that exists somewhere in the schema. The XSD scope rules
+// place all identity-constraint names in a single symbol space, so a keyref may
+// refer to a key/unique declared on a different element; the prior per-host
+// resolution missed those and any typo'd or missing refer silently disabled the
+// keyref. A failure here is reported as a fatal schema parser error.
+func (c *compiler) checkKeyRefRefers(ctx context.Context) {
+	if c.filename == "" {
+		return
+	}
+
+	// Build the set of all declared key/unique constraint local names.
+	keyNames := make(map[string]struct{})
+	for _, edecl := range c.schema.elements {
+		for _, idc := range edecl.IDCs {
+			if idc.Kind == IDCKey || idc.Kind == IDCUnique {
+				keyNames[idc.Name] = struct{}{}
+			}
+		}
+	}
+
+	for _, edecl := range c.schema.elements {
+		for _, idc := range edecl.IDCs {
+			if idc.Kind != IDCKeyRef {
+				continue
+			}
+			// Resolve a possibly-qualified refer to its local part, matching the
+			// validation-time lookup which compares on local name.
+			referLocal := idc.Refer
+			if i := strings.IndexByte(referLocal, ':'); i >= 0 {
+				referLocal = referLocal[i+1:]
+			}
+			if referLocal == "" {
+				msg := fmt.Sprintf("The keyref identity-constraint '%s' has no 'refer' attribute naming a key or unique.", idc.Name)
+				c.errorHandler.Handle(ctx, helium.NewLeveledError(
+					schemaParserErrorAttr(c.filename, idc.Line, elemKeyRef, elemKeyRef, attrRefer, msg),
+					helium.ErrorLevelFatal))
+				c.errorCount++
+				continue
+			}
+			if _, ok := keyNames[referLocal]; ok {
+				continue
+			}
+			msg := fmt.Sprintf("The keyref identity-constraint '%s' references the unknown key or unique '%s'.", idc.Name, idc.Refer)
+			c.errorHandler.Handle(ctx, helium.NewLeveledError(
+				schemaParserErrorAttr(c.filename, idc.Line, elemKeyRef, elemKeyRef, attrRefer, msg),
+				helium.ErrorLevelFatal))
+			c.errorCount++
+		}
+	}
 }
 
 // parseSchemaChildren parses the children of an xs:schema element.

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -481,7 +481,7 @@ func (c *compiler) parseIDConstraints(ctx context.Context, elem *helium.Element)
 }
 
 // parseIDConstraint parses a single xs:key, xs:keyref, or xs:unique declaration.
-func (c *compiler) parseIDConstraint(_ context.Context, elem *helium.Element, kind IDCKind) *IDConstraint {
+func (c *compiler) parseIDConstraint(ctx context.Context, elem *helium.Element, kind IDCKind) *IDConstraint {
 	name := getAttr(elem, attrName)
 	if name == "" {
 		return nil
@@ -490,10 +490,15 @@ func (c *compiler) parseIDConstraint(_ context.Context, elem *helium.Element, ki
 		Name:       name,
 		Kind:       kind,
 		Namespaces: collectNSContext(elem),
+		Line:       elem.Line(),
 	}
 	if kind == IDCKeyRef {
 		idc.Refer = getAttr(elem, attrRefer)
 	}
+	// fieldLines tracks the source line of each <field>, parallel to idc.Fields,
+	// so a malformed field XPath is reported against the right element.
+	var selectorLine int
+	var fieldLines []int
 	for child := range helium.Children(elem) {
 		if child.Type() != helium.ElementNode {
 			continue
@@ -505,27 +510,61 @@ func (c *compiler) parseIDConstraint(_ context.Context, elem *helium.Element, ki
 		switch {
 		case isXSDElement(ce, elemSelector):
 			idc.Selector = getAttr(ce, attrXPath)
+			selectorLine = ce.Line()
 		case isXSDElement(ce, elemField):
 			idc.Fields = append(idc.Fields, getAttr(ce, attrXPath))
+			fieldLines = append(fieldLines, ce.Line())
 		}
 	}
 
-	// Pre-compile selector XPath expression.
+	// Pre-compile selector XPath expression. A malformed selector XPath is a
+	// fatal schema error: leaving SelectorExpr nil would silently disable the
+	// whole constraint (the field-level uniqueness/keyref checks would never
+	// run), so an invalid schema must fail to compile rather than validate
+	// documents as if no constraint were present.
 	if idc.Selector != "" {
 		compiled, err := xpath1.Compile(idc.Selector)
-		if err == nil {
+		if err != nil {
+			c.reportIDCXPathError(ctx, elemSelector, selectorLine, idc.Selector, err)
+		} else {
 			idc.SelectorExpr = compiled
 		}
 	}
 
-	// Pre-compile field XPath expressions.
+	// Pre-compile field XPath expressions. A malformed field XPath is likewise
+	// fatal: with FieldExprs[i] nil the field would fall back to a per-validation
+	// recompile that also fails and is currently swallowed, again disabling the
+	// constraint.
 	idc.FieldExprs = make([]*xpath1.Expression, len(idc.Fields))
 	for i, f := range idc.Fields {
 		compiled, err := xpath1.Compile(f)
-		if err == nil {
-			idc.FieldExprs[i] = compiled
+		if err != nil {
+			line := 0
+			if i < len(fieldLines) {
+				line = fieldLines[i]
+			}
+			c.reportIDCXPathError(ctx, elemField, line, f, err)
+			continue
 		}
+		idc.FieldExprs[i] = compiled
 	}
 
 	return idc
+}
+
+// reportIDCXPathError reports a malformed identity-constraint selector/field
+// XPath as a fatal schema compilation error. kind is elemSelector or elemField.
+func (c *compiler) reportIDCXPathError(ctx context.Context, kind string, line int, xpath string, cause error) {
+	if c.filename == "" {
+		return
+	}
+	noun := "selector"
+	if kind == elemField {
+		noun = "field"
+	}
+	msg := fmt.Sprintf("The %s XPath '%s' is not a valid %s expression: %s.", noun, xpath, noun, cause)
+	c.errorHandler.Handle(ctx, helium.NewLeveledError(
+		schemaParserErrorAttr(c.filename, line, kind, kind, attrXPath, msg),
+		helium.ErrorLevelFatal))
+	c.errorCount++
 }

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -488,7 +488,7 @@ func (c *compiler) parseIDConstraint(ctx context.Context, elem *helium.Element, 
 		return nil
 	}
 	idc := &IDConstraint{
-		Name:       name,
+		Name: name,
 		// The name attribute is an NCName; the constraint's identity is the
 		// QName {targetNamespace}name (XSD identity-constraints live in the
 		// schema's target namespace).
@@ -576,9 +576,7 @@ func (c *compiler) resolveIDCReferQName(ctx context.Context, elem *helium.Elemen
 		// An empty @refer is reported by checkKeyRefRefers.
 		return QName{}, false
 	}
-	if i := strings.IndexByte(refer, ':'); i >= 0 {
-		prefix := refer[:i]
-		local := refer[i+1:]
+	if prefix, local, found := strings.Cut(refer, ":"); found {
 		ns := lookupNS(elem, prefix)
 		if ns == "" && prefix != "" {
 			msg := fmt.Sprintf("The keyref identity-constraint '%s' has a 'refer' attribute '%s' whose namespace prefix '%s' is not bound.", idc.Name, refer, prefix)

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -3,6 +3,7 @@ package xsd
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
@@ -488,12 +489,23 @@ func (c *compiler) parseIDConstraint(ctx context.Context, elem *helium.Element, 
 	}
 	idc := &IDConstraint{
 		Name:       name,
+		// The name attribute is an NCName; the constraint's identity is the
+		// QName {targetNamespace}name (XSD identity-constraints live in the
+		// schema's target namespace).
+		QName:      QName{Local: name, NS: c.schema.targetNamespace},
 		Kind:       kind,
 		Namespaces: collectNSContext(elem),
 		Line:       elem.Line(),
 	}
 	if kind == IDCKeyRef {
 		idc.Refer = getAttr(elem, attrRefer)
+		// @refer is a QName; resolve it namespace-aware against the constraint
+		// element's in-scope namespaces. An empty refer or an unbound prefix is a
+		// fatal schema error (reported later by checkKeyRefRefers, which also
+		// verifies the referenced constraint exists). Store the resolved QName so
+		// validation can look the target up by full identity rather than by local
+		// name only.
+		idc.ReferQName, idc.referUnbound = c.resolveIDCReferQName(ctx, elem, idc)
 	}
 	// fieldLines tracks the source line of each <field>, parallel to idc.Fields,
 	// so a malformed field XPath is reported against the right element.
@@ -550,6 +562,42 @@ func (c *compiler) parseIDConstraint(ctx context.Context, elem *helium.Element, 
 	}
 
 	return idc
+}
+
+// resolveIDCReferQName resolves an xs:keyref/@refer QName against the constraint
+// element's in-scope namespaces. An unprefixed refer resolves to the in-scope
+// default namespace (falling back to the schema's target namespace), matching how
+// other XSD QName-valued attributes (@type, @ref) are resolved. A prefixed refer
+// whose prefix is not bound in scope is a fatal schema error; the returned bool
+// reports that so checkKeyRefRefers can suppress its own "unknown key" diagnostic.
+func (c *compiler) resolveIDCReferQName(ctx context.Context, elem *helium.Element, idc *IDConstraint) (QName, bool) {
+	refer := idc.Refer
+	if refer == "" {
+		// An empty @refer is reported by checkKeyRefRefers.
+		return QName{}, false
+	}
+	if i := strings.IndexByte(refer, ':'); i >= 0 {
+		prefix := refer[:i]
+		local := refer[i+1:]
+		ns := lookupNS(elem, prefix)
+		if ns == "" && prefix != "" {
+			msg := fmt.Sprintf("The keyref identity-constraint '%s' has a 'refer' attribute '%s' whose namespace prefix '%s' is not bound.", idc.Name, refer, prefix)
+			if c.filename != "" {
+				c.errorHandler.Handle(ctx, helium.NewLeveledError(
+					schemaParserErrorAttr(c.filename, idc.Line, elemKeyRef, elemKeyRef, attrRefer, msg),
+					helium.ErrorLevelFatal))
+				c.errorCount++
+			}
+			return QName{}, true
+		}
+		return QName{Local: local, NS: ns}, false
+	}
+	// Unprefixed: use the in-scope default namespace, else the target namespace.
+	ns := c.schema.targetNamespace
+	if defNS := lookupNS(elem, ""); defNS != "" {
+		ns = defNS
+	}
+	return QName{Local: refer, NS: ns}, false
 }
 
 // reportIDCXPathError reports a malformed identity-constraint selector/field

--- a/xsd/schema.go
+++ b/xsd/schema.go
@@ -171,6 +171,7 @@ type IDConstraint struct {
 	Fields     []string          // XPath field expressions
 	Refer      string            // for keyref: the name of the referenced key/unique
 	Namespaces map[string]string // prefix → URI from the schema document (for XPath evaluation)
+	Line       int               // source line of the constraint element (for error reporting)
 
 	SelectorExpr *xpath1.Expression   // pre-compiled selector XPath
 	FieldExprs   []*xpath1.Expression // pre-compiled field XPaths (parallel to Fields)

--- a/xsd/schema.go
+++ b/xsd/schema.go
@@ -166,7 +166,7 @@ const (
 // IDConstraint represents an xs:unique, xs:key, or xs:keyref identity constraint.
 type IDConstraint struct {
 	Name       string
-	QName      QName             // namespace-qualified constraint name ({targetNamespace}Name)
+	QName      QName // namespace-qualified constraint name ({targetNamespace}Name)
 	Kind       IDCKind
 	Selector   string            // XPath selector expression
 	Fields     []string          // XPath field expressions

--- a/xsd/schema.go
+++ b/xsd/schema.go
@@ -166,15 +166,19 @@ const (
 // IDConstraint represents an xs:unique, xs:key, or xs:keyref identity constraint.
 type IDConstraint struct {
 	Name       string
+	QName      QName             // namespace-qualified constraint name ({targetNamespace}Name)
 	Kind       IDCKind
 	Selector   string            // XPath selector expression
 	Fields     []string          // XPath field expressions
-	Refer      string            // for keyref: the name of the referenced key/unique
+	Refer      string            // for keyref: the lexical refer QName as written
+	ReferQName QName             // for keyref: the resolved {ns}local of the referenced key/unique
 	Namespaces map[string]string // prefix → URI from the schema document (for XPath evaluation)
 	Line       int               // source line of the constraint element (for error reporting)
 
 	SelectorExpr *xpath1.Expression   // pre-compiled selector XPath
 	FieldExprs   []*xpath1.Expression // pre-compiled field XPaths (parallel to Fields)
+
+	referUnbound bool // for keyref: @refer used a prefix not bound in scope (already reported)
 }
 
 // DerivationKind describes how a type is derived from its base.

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -431,6 +431,24 @@ type validationContext struct {
 	// descending the declared content model, so an IDC field whose type is
 	// contributed by xsi:type is canonicalized in the correct value space.
 	actualElemType map[*helium.Element]*TypeDef
+
+	// idcKeyEntries accumulates the key-sequences of every evaluated key/unique
+	// constraint during the IDC walk, keyed by the constraint's full QName
+	// identity. Entries are APPENDED (not overwritten) so a constraint whose host
+	// element occurs multiple times contributes all of its key-sequences. keyref
+	// resolution consults this AFTER the whole document is walked, so a keyref can
+	// reference a key/unique declared on a DIFFERENT element (XSD places all
+	// identity-constraint names in one symbol space). keyrefPending holds the
+	// pending keyref tables to check against it.
+	idcKeyEntries map[QName][]idcEntry
+	keyrefPending []pendingKeyRef
+}
+
+// pendingKeyRef is an evaluated keyref table awaiting cross-element resolution
+// against the document-level key/unique tables.
+type pendingKeyRef struct {
+	idc   *IDConstraint
+	table *idcTable
 }
 
 func newValidationContext(schema *Schema, cfg *validateConfig, filename string, handler helium.ErrorHandler) *validationContext {
@@ -440,6 +458,7 @@ func newValidationContext(schema *Schema, cfg *validateConfig, filename string, 
 		filename:       filename,
 		errorHandler:   handler,
 		actualElemType: make(map[*helium.Element]*TypeDef),
+		idcKeyEntries:  make(map[QName][]idcEntry),
 	}
 }
 
@@ -577,6 +596,13 @@ func validateDocument(ctx context.Context, doc *helium.Document, schema *Schema,
 		}
 		return nil
 	}))
+
+	// Resolve keyref constraints AFTER the whole document is walked, so a keyref
+	// can match a key/unique declared on a different element (cross-element refs
+	// would otherwise hit a nil ref-table and be silently skipped).
+	if err := vc.checkPendingKeyRefs(ctx); err != nil {
+		valid = false
+	}
 
 	return valid
 }

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -431,21 +431,12 @@ type validationContext struct {
 	// descending the declared content model, so an IDC field whose type is
 	// contributed by xsi:type is canonicalized in the correct value space.
 	actualElemType map[*helium.Element]*TypeDef
-
-	// idcKeyEntries accumulates the key-sequences of every evaluated key/unique
-	// constraint during the IDC walk, keyed by the constraint's full QName
-	// identity. Entries are APPENDED (not overwritten) so a constraint whose host
-	// element occurs multiple times contributes all of its key-sequences. keyref
-	// resolution consults this AFTER the whole document is walked, so a keyref can
-	// reference a key/unique declared on a DIFFERENT element (XSD places all
-	// identity-constraint names in one symbol space). keyrefPending holds the
-	// pending keyref tables to check against it.
-	idcKeyEntries map[QName][]idcEntry
-	keyrefPending []pendingKeyRef
 }
 
-// pendingKeyRef is an evaluated keyref table awaiting cross-element resolution
-// against the document-level key/unique tables.
+// pendingKeyRef is an evaluated keyref table awaiting resolution against the
+// key/unique tables built for the SAME host-element occurrence (XSD
+// identity-constraint scope), once every key/unique on that occurrence has been
+// evaluated.
 type pendingKeyRef struct {
 	idc   *IDConstraint
 	table *idcTable
@@ -458,7 +449,6 @@ func newValidationContext(schema *Schema, cfg *validateConfig, filename string, 
 		filename:       filename,
 		errorHandler:   handler,
 		actualElemType: make(map[*helium.Element]*TypeDef),
-		idcKeyEntries:  make(map[QName][]idcEntry),
 	}
 }
 
@@ -596,13 +586,6 @@ func validateDocument(ctx context.Context, doc *helium.Document, schema *Schema,
 		}
 		return nil
 	}))
-
-	// Resolve keyref constraints AFTER the whole document is walked, so a keyref
-	// can match a key/unique declared on a different element (cross-element refs
-	// would otherwise hit a nil ref-table and be silently skipped).
-	if err := vc.checkPendingKeyRefs(ctx); err != nil {
-		valid = false
-	}
 
 	return valid
 }

--- a/xsd/validate_idc.go
+++ b/xsd/validate_idc.go
@@ -37,8 +37,21 @@ func (vc *validationContext) validateIDConstraints(ctx context.Context, elem *he
 	}
 
 	// Evaluate all constraints declared on this element and collect their
-	// key-sequence tables.
+	// key-sequence tables. The tables are scoped to THIS element OCCURRENCE: an
+	// xs:key/xs:unique table built here is visible only to keyrefs declared on the
+	// SAME occurrence. This matches the XSD identity-constraint scope (and
+	// xmllint): a keyref resolves against the key table built for its own host
+	// occurrence, so two sibling occurrences of a repeating host never leak key
+	// spaces into each other.
 	var lastErr error
+
+	// keyTables holds this occurrence's evaluated key/unique tables, indexed by
+	// the constraint's full QName identity, for resolving same-occurrence keyrefs.
+	keyTables := make(map[QName]*idcTable)
+	// keyRefs collects this occurrence's keyrefs to resolve after every key/unique
+	// on the same occurrence has been evaluated (a keyref may be declared before
+	// the key it refers to in document order).
+	var keyRefs []pendingKeyRef
 
 	for _, idc := range edecl.IDCs {
 		// Use the schema's namespace context for XPath evaluation.
@@ -69,18 +82,17 @@ func (vc *validationContext) validateIDConstraints(ctx context.Context, elem *he
 		}
 
 		if idc.Kind == IDCKeyRef {
-			// Defer keyref checks until the whole document is walked: a keyref may
-			// reference a key/unique declared on a DIFFERENT element, whose table is
-			// not yet available here.
-			vc.keyrefPending = append(vc.keyrefPending, pendingKeyRef{idc: idc, table: table})
+			// Defer keyref resolution until every key/unique on this occurrence is
+			// evaluated, so a keyref declared before its key (document order) still
+			// resolves.
+			keyRefs = append(keyRefs, pendingKeyRef{idc: idc, table: table})
 			continue
 		}
 
 		// Register the key/unique key-sequences under the constraint's full QName
-		// identity for cross-element keyref resolution. Appending (rather than
-		// overwriting) keeps every occurrence's key-sequences when the host element
-		// repeats.
-		vc.idcKeyEntries[idc.QName] = append(vc.idcKeyEntries[idc.QName], table.keys...)
+		// identity, scoped to THIS occurrence, for same-occurrence keyref
+		// resolution.
+		keyTables[idc.QName] = table
 
 		// Check unique/key uniqueness immediately.
 		if err := vc.checkUniqueness(ctx, table, idc); err != nil {
@@ -88,29 +100,22 @@ func (vc *validationContext) validateIDConstraints(ctx context.Context, elem *he
 		}
 	}
 
-	return lastErr
-}
-
-// checkPendingKeyRefs resolves every deferred keyref against the document-level
-// key/unique tables collected during the IDC walk. Resolution is by the keyref's
-// resolved @refer QName (namespace + local), so cross-element references are
-// enforced and a local-name collision across namespaces cannot bind the wrong
-// constraint. An unresolved refer (missing table) is rejected at schema compile
-// time, so a nil ref-table here means the referenced element simply did not
-// appear in the instance: that is an empty key space, against which any non-empty
-// keyref is a "no match" failure.
-func (vc *validationContext) checkPendingKeyRefs(ctx context.Context) error {
-	var lastErr error
-	for _, pending := range vc.keyrefPending {
-		// idcKeyEntries holds every key-sequence the referenced key/unique produced
-		// across the document (possibly empty if its host element never appeared).
-		// An empty ref space means any non-empty keyref is a "no match" failure,
-		// which checkKeyRef reports — never a silent skip.
-		refTable := &idcTable{idc: pending.idc, keys: vc.idcKeyEntries[pending.idc.ReferQName]}
+	// Resolve this occurrence's keyrefs against the key/unique tables built for
+	// the SAME occurrence. A keyref whose referenced key/unique is NOT declared on
+	// this host occurrence resolves against an empty key space, so every non-empty
+	// key-sequence is a "no match" failure — matching xmllint, which rejects a
+	// keyref that names a key declared on a different element (the referenced key
+	// is out of the keyref's scope).
+	for _, pending := range keyRefs {
+		refTable := keyTables[pending.idc.ReferQName]
+		if refTable == nil {
+			refTable = &idcTable{idc: pending.idc}
+		}
 		if err := vc.checkKeyRef(ctx, pending.table, refTable, pending.idc); err != nil {
 			lastErr = err
 		}
 	}
+
 	return lastErr
 }
 

--- a/xsd/validate_idc.go
+++ b/xsd/validate_idc.go
@@ -36,8 +36,8 @@ func (vc *validationContext) validateIDConstraints(ctx context.Context, elem *he
 		return nil
 	}
 
-	// Phase 1: Evaluate all constraints and collect key-sequence tables.
-	tables := make(map[string]*idcTable, len(edecl.IDCs))
+	// Evaluate all constraints declared on this element and collect their
+	// key-sequence tables.
 	var lastErr error
 
 	for _, idc := range edecl.IDCs {
@@ -55,7 +55,6 @@ func (vc *validationContext) validateIDConstraints(ctx context.Context, elem *he
 			lastErr = err
 			continue
 		}
-		tables[idc.Name] = table
 
 		// A key with an absent field was already reported during
 		// evaluation; surface it as a validation failure.
@@ -69,40 +68,49 @@ func (vc *validationContext) validateIDConstraints(ctx context.Context, elem *he
 			lastErr = fmt.Errorf("field evaluates to more than one node")
 		}
 
-		// Check unique/key constraints immediately.
-		if idc.Kind == IDCUnique || idc.Kind == IDCKey {
-			if err := vc.checkUniqueness(ctx, table, idc); err != nil {
-				lastErr = err
-			}
-		}
-	}
-
-	// Phase 2: Check keyref constraints against referenced key/unique tables.
-	for _, idc := range edecl.IDCs {
-		if idc.Kind != IDCKeyRef {
-			continue
-		}
-		table := tables[idc.Name]
-		if table == nil {
+		if idc.Kind == IDCKeyRef {
+			// Defer keyref checks until the whole document is walked: a keyref may
+			// reference a key/unique declared on a DIFFERENT element, whose table is
+			// not yet available here.
+			vc.keyrefPending = append(vc.keyrefPending, pendingKeyRef{idc: idc, table: table})
 			continue
 		}
 
-		// Find the referenced key/unique constraint.
-		referName := idc.Refer
-		// Handle qualified refer names (prefix:local).
-		if idx := strings.IndexByte(referName, ':'); idx >= 0 {
-			referName = referName[idx+1:]
-		}
-		refTable := tables[referName]
-		if refTable == nil {
-			continue
-		}
+		// Register the key/unique key-sequences under the constraint's full QName
+		// identity for cross-element keyref resolution. Appending (rather than
+		// overwriting) keeps every occurrence's key-sequences when the host element
+		// repeats.
+		vc.idcKeyEntries[idc.QName] = append(vc.idcKeyEntries[idc.QName], table.keys...)
 
-		if err := vc.checkKeyRef(ctx, table, refTable, idc); err != nil {
+		// Check unique/key uniqueness immediately.
+		if err := vc.checkUniqueness(ctx, table, idc); err != nil {
 			lastErr = err
 		}
 	}
 
+	return lastErr
+}
+
+// checkPendingKeyRefs resolves every deferred keyref against the document-level
+// key/unique tables collected during the IDC walk. Resolution is by the keyref's
+// resolved @refer QName (namespace + local), so cross-element references are
+// enforced and a local-name collision across namespaces cannot bind the wrong
+// constraint. An unresolved refer (missing table) is rejected at schema compile
+// time, so a nil ref-table here means the referenced element simply did not
+// appear in the instance: that is an empty key space, against which any non-empty
+// keyref is a "no match" failure.
+func (vc *validationContext) checkPendingKeyRefs(ctx context.Context) error {
+	var lastErr error
+	for _, pending := range vc.keyrefPending {
+		// idcKeyEntries holds every key-sequence the referenced key/unique produced
+		// across the document (possibly empty if its host element never appeared).
+		// An empty ref space means any non-empty keyref is a "no match" failure,
+		// which checkKeyRef reports — never a silent skip.
+		refTable := &idcTable{idc: pending.idc, keys: vc.idcKeyEntries[pending.idc.ReferQName]}
+		if err := vc.checkKeyRef(ctx, pending.table, refTable, pending.idc); err != nil {
+			lastErr = err
+		}
+	}
 	return lastErr
 }
 
@@ -151,14 +159,19 @@ func (vc *validationContext) evaluateIDC(ctx context.Context, ev xpath1.Evaluato
 			} else {
 				compiled, compErr := xpath1.Compile(fieldXPath)
 				if compErr != nil {
-					allPresent = false
-					break
+					// A field XPath that fails to compile must NOT be swallowed:
+					// marking the field absent silently drops the selected node from
+					// the constraint, so a unique/keyref could miss a duplicate or a
+					// dangling reference. Surface it like the selector path.
+					return nil, fmt.Errorf("xsd: IDC field XPath %q failed to compile: %w", fieldXPath, compErr)
 				}
 				fieldResult, err = ev.Evaluate(ctx, compiled, node)
 			}
 			if err != nil {
-				allPresent = false
-				break
+				// A field XPath that compiles but fails at evaluation (e.g. an
+				// unknown function) must likewise surface as an error rather than
+				// being silently treated as an absent field.
+				return nil, fmt.Errorf("xsd: IDC field XPath %q failed to evaluate: %w", fieldXPath, err)
 			}
 
 			var value string

--- a/xsd/validate_idc.go
+++ b/xsd/validate_idc.go
@@ -45,6 +45,14 @@ func (vc *validationContext) validateIDConstraints(ctx context.Context, elem *he
 		ev := xpath1.NewEvaluator().AdditionalNamespaces(idc.Namespaces)
 		table, err := vc.evaluateIDC(ctx, ev, elem, edecl, idc)
 		if err != nil {
+			// A selector/field XPath that fails to compile or evaluate must NOT be
+			// swallowed: doing so silently disables the constraint and lets an
+			// otherwise-invalid document validate. Report it as a validity error.
+			// (Malformed XPaths are also rejected at schema compile time, so this
+			// path normally fires only on a genuine evaluation failure.)
+			msg := fmt.Sprintf("Failed to evaluate identity-constraint '%s': %s", idc.Name, err)
+			vc.reportValidityError(ctx, vc.filename, elem.Line(), elemDisplayName(elem), msg)
+			lastErr = err
 			continue
 		}
 		tables[idc.Name] = table

--- a/xsd/validate_idc_errors_test.go
+++ b/xsd/validate_idc_errors_test.go
@@ -1,0 +1,249 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIDCMalformedXPath covers the case where an identity constraint's selector
+// or field XPath is not a valid XPath expression. Previously the compile error
+// was silently dropped, leaving the constraint disabled at validation time so a
+// schema with a duplicate key would wrongly validate. A malformed selector/field
+// XPath must now be a fatal schema compilation error.
+func TestIDCMalformedXPath(t *testing.T) {
+	t.Parallel()
+
+	compileErrors := func(t *testing.T, schemaXML string) string {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, err = xsd.NewCompiler().Label("test.xsd").ErrorHandler(collector).Compile(t.Context(), doc)
+		require.NoError(t, err)
+		_, errors := partitionCompileErrors(collector.Errors())
+		return errors
+	}
+
+	t.Run("malformed selector xpath", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="id" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="itemKey">
+      <xs:selector xpath="["/>
+      <xs:field xpath="@id"/>
+    </xs:unique>
+  </xs:element>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, schemaXML), "is not a valid selector")
+	})
+
+	t.Run("malformed field xpath", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="id" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="itemKey">
+      <xs:selector xpath="item"/>
+      <xs:field xpath="@"/>
+    </xs:unique>
+  </xs:element>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, schemaXML), "is not a valid field")
+	})
+
+	t.Run("valid xpath compiles clean", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="id" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="itemKey">
+      <xs:selector xpath="item"/>
+      <xs:field xpath="@id"/>
+    </xs:unique>
+  </xs:element>
+</xs:schema>`
+		require.Empty(t, compileErrors(t, schemaXML))
+	})
+}
+
+// TestIDCKeyRefUnresolvedRefer covers an xs:keyref whose @refer names a
+// key/unique constraint that does not exist. Previously such a keyref was
+// silently skipped at validation time, so referential integrity was not
+// enforced. The unresolved @refer must now be a fatal schema compilation error.
+func TestIDCKeyRefUnresolvedRefer(t *testing.T) {
+	t.Parallel()
+
+	compileErrors := func(t *testing.T, schemaXML string) string {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, err = xsd.NewCompiler().Label("test.xsd").ErrorHandler(collector).Compile(t.Context(), doc)
+		require.NoError(t, err)
+		_, errors := partitionCompileErrors(collector.Errors())
+		return errors
+	}
+
+	t.Run("keyref refers to missing key", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="ref" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:keyref name="itemRef" refer="missingKey">
+      <xs:selector xpath="item"/>
+      <xs:field xpath="@ref"/>
+    </xs:keyref>
+  </xs:element>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, schemaXML), "missingKey")
+	})
+
+	t.Run("keyref refers to existing key compiles clean", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="id" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="ref" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="to" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="itemKey">
+      <xs:selector xpath="item"/>
+      <xs:field xpath="@id"/>
+    </xs:key>
+    <xs:keyref name="itemRef" refer="itemKey">
+      <xs:selector xpath="ref"/>
+      <xs:field xpath="@to"/>
+    </xs:keyref>
+  </xs:element>
+</xs:schema>`
+		require.Empty(t, compileErrors(t, schemaXML))
+	})
+}
+
+// TestIDCWorkingKeyRefValidation confirms that a valid schema with a working
+// unique/key/keyref still validates conforming instances and rejects
+// non-conforming ones, ensuring the compile-time checks do not break the
+// validation-time enforcement path.
+func TestIDCWorkingKeyRefValidation(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="id" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="ref" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="to" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="itemKey">
+      <xs:selector xpath="item"/>
+      <xs:field xpath="@id"/>
+    </xs:key>
+    <xs:keyref name="itemRef" refer="itemKey">
+      <xs:selector xpath="ref"/>
+      <xs:field xpath="@to"/>
+    </xs:keyref>
+  </xs:element>
+</xs:schema>`
+
+	compile := func(t *testing.T) xsd.Validator {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		s, err := xsd.NewCompiler().ErrorHandler(collector).Compile(t.Context(), doc)
+		require.NoError(t, err)
+		_, compileErrors := partitionCompileErrors(collector.Errors())
+		require.Empty(t, compileErrors, "unexpected compile errors")
+		return xsd.NewValidator(s)
+	}
+
+	t.Run("matching keyref validates", func(t *testing.T) {
+		t.Parallel()
+		v := compile(t)
+		doc, err := helium.NewParser().Parse(t.Context(),
+			[]byte(`<root><item id="a"/><item id="b"/><ref to="a"/></root>`))
+		require.NoError(t, err)
+		var errs string
+		err = validateWithOutput(t, v, doc, &errs)
+		require.NoError(t, err, "expected valid, got: %s", errs)
+	})
+
+	t.Run("dangling keyref fails", func(t *testing.T) {
+		t.Parallel()
+		v := compile(t)
+		doc, err := helium.NewParser().Parse(t.Context(),
+			[]byte(`<root><item id="a"/><ref to="missing"/></root>`))
+		require.NoError(t, err)
+		var errs string
+		err = validateWithOutput(t, v, doc, &errs)
+		require.Error(t, err)
+		require.Contains(t, errs, "No match found")
+	})
+
+	t.Run("duplicate key fails", func(t *testing.T) {
+		t.Parallel()
+		v := compile(t)
+		doc, err := helium.NewParser().Parse(t.Context(),
+			[]byte(`<root><item id="a"/><item id="a"/></root>`))
+		require.NoError(t, err)
+		var errs string
+		err = validateWithOutput(t, v, doc, &errs)
+		require.Error(t, err)
+		require.Contains(t, errs, "Duplicate key-sequence")
+	})
+}

--- a/xsd/validate_idc_keyref_scope_test.go
+++ b/xsd/validate_idc_keyref_scope_test.go
@@ -1,0 +1,242 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// compileXSD compiles a schema and returns the validator plus the fatal
+// compile-error string (empty when the schema compiled clean).
+func compileXSD(t *testing.T, schemaXML string) (xsd.Validator, string) {
+	t.Helper()
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+	require.NoError(t, err)
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	s, err := xsd.NewCompiler().Label("test.xsd").ErrorHandler(collector).Compile(t.Context(), doc)
+	require.NoError(t, err)
+	_, errors := partitionCompileErrors(collector.Errors())
+	if errors != "" {
+		return xsd.Validator{}, errors
+	}
+	return xsd.NewValidator(s), ""
+}
+
+// TestIDCFieldXPathEvalError covers a field XPath that COMPILES but fails at
+// evaluation (e.g. an unknown function). Previously the evaluation error was
+// swallowed — the field was treated as absent and the selected node silently
+// dropped from the constraint, so a unique/keyref could miss a violation. The
+// failure must now surface as a validity error.
+func TestIDCFieldXPathEvalError(t *testing.T) {
+	t.Parallel()
+
+	// "bogusfn(.)" parses and compiles in xpath1 but errors at Evaluate with
+	// ErrUnknownFunction. The selector still selects the two <item> nodes.
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="id" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="itemKey">
+      <xs:selector xpath="item"/>
+      <xs:field xpath="bogusfn(.)"/>
+    </xs:unique>
+  </xs:element>
+</xs:schema>`
+
+	v, compileErrs := compileXSD(t, schemaXML)
+	require.Empty(t, compileErrs, "schema should compile clean; the failure is at evaluation")
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item id="a"/><item id="b"/></root>`))
+	require.NoError(t, err)
+
+	var errs string
+	err = validateWithOutput(t, v, doc, &errs)
+	require.Error(t, err, "a failing field XPath must surface as a validation error, not be swallowed")
+	require.Contains(t, errs, "itemKey")
+}
+
+// TestIDCCrossElementKeyRef confirms that a keyref whose referenced key lives on
+// a DIFFERENT element is actually enforced. Previously validation only consulted
+// the keyref host element's own tables, so a cross-element refer hit a nil
+// ref-table and was silently skipped — a dangling reference wrongly validated.
+func TestIDCCrossElementKeyRef(t *testing.T) {
+	t.Parallel()
+
+	// "productKey" is declared on the GLOBAL element <products>; "orderRef" is
+	// declared on the GLOBAL element <orders>. The two constraints live on
+	// different (globally-declared) elements, so resolving the keyref requires the
+	// document-level cross-element key table.
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="catalog">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="products"/>
+        <xs:element ref="orders"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="products">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="product" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="id" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="productKey">
+      <xs:selector xpath="product"/>
+      <xs:field xpath="@id"/>
+    </xs:key>
+  </xs:element>
+  <xs:element name="orders">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="order" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="product" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:keyref name="orderRef" refer="productKey">
+      <xs:selector xpath="order"/>
+      <xs:field xpath="@product"/>
+    </xs:keyref>
+  </xs:element>
+</xs:schema>`
+
+	v, compileErrs := compileXSD(t, schemaXML)
+	require.Empty(t, compileErrs, "cross-element keyref should compile clean")
+
+	t.Run("matching cross-element keyref validates", func(t *testing.T) {
+		t.Parallel()
+		doc, err := helium.NewParser().Parse(t.Context(),
+			[]byte(`<catalog><products><product id="a"/><product id="b"/></products><orders><order product="a"/></orders></catalog>`))
+		require.NoError(t, err)
+		var errs string
+		err = validateWithOutput(t, v, doc, &errs)
+		require.NoError(t, err, "expected valid, got: %s", errs)
+	})
+
+	t.Run("dangling cross-element keyref fails", func(t *testing.T) {
+		t.Parallel()
+		doc, err := helium.NewParser().Parse(t.Context(),
+			[]byte(`<catalog><products><product id="a"/></products><orders><order product="missing"/></orders></catalog>`))
+		require.NoError(t, err)
+		var errs string
+		err = validateWithOutput(t, v, doc, &errs)
+		require.Error(t, err, "a dangling cross-element keyref must be rejected, not silently skipped")
+		require.Contains(t, errs, "No match found")
+	})
+}
+
+// TestIDCKeyRefUnboundReferPrefix covers an xs:keyref/@refer that uses a
+// namespace prefix not bound in scope. @refer is a QName, so an unbound prefix is
+// a fatal schema compilation error rather than being silently accepted (which the
+// previous local-name-only matching did).
+func TestIDCKeyRefUnboundReferPrefix(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="id" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="ref" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="to" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="itemKey">
+      <xs:selector xpath="item"/>
+      <xs:field xpath="@id"/>
+    </xs:key>
+    <xs:keyref name="itemRef" refer="bogus:itemKey">
+      <xs:selector xpath="ref"/>
+      <xs:field xpath="@to"/>
+    </xs:keyref>
+  </xs:element>
+</xs:schema>`
+
+	_, compileErrs := compileXSD(t, schemaXML)
+	require.NotEmpty(t, compileErrs, "an unbound @refer prefix must be a fatal schema error")
+	require.Contains(t, compileErrs, "bogus")
+}
+
+// TestIDCSameNamespaceKeyRef confirms that a valid same-target-namespace keyref
+// (prefixed @refer resolving through the schema's namespace context) still
+// compiles and enforces referential integrity after the namespace-aware refer
+// resolution change.
+func TestIDCSameNamespaceKeyRef(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:t="urn:test" targetNamespace="urn:test" elementFormDefault="qualified">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="id" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="ref" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="to" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="itemKey">
+      <xs:selector xpath="t:item"/>
+      <xs:field xpath="@id"/>
+    </xs:key>
+    <xs:keyref name="itemRef" refer="t:itemKey">
+      <xs:selector xpath="t:ref"/>
+      <xs:field xpath="@to"/>
+    </xs:keyref>
+  </xs:element>
+</xs:schema>`
+
+	v, compileErrs := compileXSD(t, schemaXML)
+	require.Empty(t, compileErrs, "valid prefixed same-namespace keyref should compile clean")
+
+	t.Run("matching validates", func(t *testing.T) {
+		t.Parallel()
+		doc, err := helium.NewParser().Parse(t.Context(),
+			[]byte(`<root xmlns="urn:test"><item id="a"/><item id="b"/><ref to="a"/></root>`))
+		require.NoError(t, err)
+		var errs string
+		err = validateWithOutput(t, v, doc, &errs)
+		require.NoError(t, err, "expected valid, got: %s", errs)
+	})
+
+	t.Run("dangling fails", func(t *testing.T) {
+		t.Parallel()
+		doc, err := helium.NewParser().Parse(t.Context(),
+			[]byte(`<root xmlns="urn:test"><item id="a"/><ref to="missing"/></root>`))
+		require.NoError(t, err)
+		var errs string
+		err = validateWithOutput(t, v, doc, &errs)
+		require.Error(t, err)
+		require.Contains(t, errs, "No match found")
+	})
+}

--- a/xsd/validate_idc_keyref_scope_test.go
+++ b/xsd/validate_idc_keyref_scope_test.go
@@ -65,17 +65,21 @@ func TestIDCFieldXPathEvalError(t *testing.T) {
 	require.Contains(t, errs, "itemKey")
 }
 
-// TestIDCCrossElementKeyRef confirms that a keyref whose referenced key lives on
-// a DIFFERENT element is actually enforced. Previously validation only consulted
-// the keyref host element's own tables, so a cross-element refer hit a nil
-// ref-table and was silently skipped — a dangling reference wrongly validated.
-func TestIDCCrossElementKeyRef(t *testing.T) {
+// TestIDCCrossElementKeyRefOutOfScope verifies the XSD identity-constraint scope
+// rule for a keyref whose referenced key is declared on a DIFFERENT element. The
+// keyref's referenced key/unique must be in the keyref host occurrence's scope;
+// a key declared on a SIBLING element is NOT, so every key-sequence is a "no
+// match" failure — even when an equal value exists under the sibling key. This
+// matches xmllint, which rejects BOTH the "matching" and the dangling instance
+// here. (A doc-wide merged key table would falsely accept the first.) The schema
+// itself still COMPILES: @refer resolves in the schema-wide identity-constraint
+// symbol space; only value resolution is occurrence-scoped.
+func TestIDCCrossElementKeyRefOutOfScope(t *testing.T) {
 	t.Parallel()
 
 	// "productKey" is declared on the GLOBAL element <products>; "orderRef" is
-	// declared on the GLOBAL element <orders>. The two constraints live on
-	// different (globally-declared) elements, so resolving the keyref requires the
-	// document-level cross-element key table.
+	// declared on the GLOBAL element <orders>. They live on different elements, so
+	// the key is out of the keyref's scope.
 	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="catalog">
     <xs:complexType>
@@ -118,16 +122,19 @@ func TestIDCCrossElementKeyRef(t *testing.T) {
 </xs:schema>`
 
 	v, compileErrs := compileXSD(t, schemaXML)
-	require.Empty(t, compileErrs, "cross-element keyref should compile clean")
+	require.Empty(t, compileErrs, "cross-element keyref should compile clean (refer resolves in the symbol space)")
 
-	t.Run("matching cross-element keyref validates", func(t *testing.T) {
+	t.Run("out-of-scope key does not satisfy keyref", func(t *testing.T) {
 		t.Parallel()
+		// An equal value DOES exist under the sibling productKey, but it is out of
+		// the orderRef scope, so xmllint (and helium) reject it.
 		doc, err := helium.NewParser().Parse(t.Context(),
 			[]byte(`<catalog><products><product id="a"/><product id="b"/></products><orders><order product="a"/></orders></catalog>`))
 		require.NoError(t, err)
 		var errs string
 		err = validateWithOutput(t, v, doc, &errs)
-		require.NoError(t, err, "expected valid, got: %s", errs)
+		require.Error(t, err, "a key on a sibling element is out of the keyref scope and must not satisfy it")
+		require.Contains(t, errs, "No match found")
 	})
 
 	t.Run("dangling cross-element keyref fails", func(t *testing.T) {
@@ -239,4 +246,165 @@ func TestIDCSameNamespaceKeyRef(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, errs, "No match found")
 	})
+}
+
+// TestIDCKeyRefOccurrenceScope is the regression test for the leak that the
+// document-level key table introduced: a key/unique declared on a REPEATING host
+// element must be scoped to each occurrence, so a keyref on a later occurrence
+// cannot satisfy itself using an earlier occurrence's keys. xmllint rejects the
+// cross-occurrence case; a doc-wide merged table would falsely accept it. The
+// host <group> is a GLOBAL element referenced with maxOccurs="unbounded", which
+// is the path pass-2 IDC evaluation actually walks.
+func TestIDCKeyRefOccurrenceScope(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="group" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="id" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="ref" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="r" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="itemKey">
+      <xs:selector xpath="item"/>
+      <xs:field xpath="@id"/>
+    </xs:key>
+    <xs:keyref name="itemRef" refer="itemKey">
+      <xs:selector xpath="ref"/>
+      <xs:field xpath="@r"/>
+    </xs:keyref>
+  </xs:element>
+</xs:schema>`
+
+	v, compileErrs := compileXSD(t, schemaXML)
+	require.Empty(t, compileErrs, "repeated-host keyref schema should compile clean")
+
+	t.Run("each occurrence satisfies its own keyref", func(t *testing.T) {
+		t.Parallel()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root>
+  <group><item id="a"/><ref r="a"/></group>
+  <group><item id="b"/><ref r="b"/></group>
+</root>`))
+		require.NoError(t, err)
+		var errs string
+		err = validateWithOutput(t, v, doc, &errs)
+		require.NoError(t, err, "expected valid, got: %s", errs)
+	})
+
+	t.Run("cross-occurrence key does not leak", func(t *testing.T) {
+		t.Parallel()
+		// group2's ref points to group1's item key — out of group2's scope.
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root>
+  <group><item id="a"/><ref r="a"/></group>
+  <group><item id="b"/><ref r="a"/></group>
+</root>`))
+		require.NoError(t, err)
+		var errs string
+		err = validateWithOutput(t, v, doc, &errs)
+		require.Error(t, err, "a later occurrence must not reuse an earlier occurrence's keys")
+		require.Contains(t, errs, "No match found for key-sequence ['a'] of keyref 'itemRef'.")
+	})
+}
+
+// TestIDCLocalKeyRefMissingRefer is the regression test for finding #2: a keyref
+// declared on a LOCAL element declaration (buried inside a content model) with a
+// @refer that names no existing key/unique must be a fatal schema compile error.
+// The prior registry scanned only GLOBAL element declarations, so a local keyref's
+// dangling refer was never checked and the constraint was silently disabled.
+func TestIDCLocalKeyRefMissingRefer(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="child">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="ref" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="r" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+          <xs:keyref name="danglingRef" refer="nonexistentKey">
+            <xs:selector xpath="ref"/>
+            <xs:field xpath="@r"/>
+          </xs:keyref>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+	_, compileErrs := compileXSD(t, schemaXML)
+	require.NotEmpty(t, compileErrs, "a local keyref with a missing refer must be a fatal schema error")
+	require.Contains(t, compileErrs, "nonexistentKey")
+}
+
+// TestIDCLocalKeyRefCrossLocalKey confirms the registry also reaches a key/unique
+// declared on a LOCAL element when validating a local keyref's @refer: a local
+// keyref referring to a key on another local element compiles clean (the refer
+// resolves), exercising the recursive content-model walk in collectAllIDCs.
+func TestIDCLocalKeyRefCrossLocalKey(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="items">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="item" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="id" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+          <xs:key name="localItemKey">
+            <xs:selector xpath="item"/>
+            <xs:field xpath="@id"/>
+          </xs:key>
+        </xs:element>
+        <xs:element name="refs">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="ref" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="r" type="xs:string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+          <xs:keyref name="localRef" refer="localItemKey">
+            <xs:selector xpath="ref"/>
+            <xs:field xpath="@r"/>
+          </xs:keyref>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+	_, compileErrs := compileXSD(t, schemaXML)
+	require.Empty(t, compileErrs, "a local keyref referring to a local key must compile clean")
 }


### PR DESCRIPTION
- Fail schema compilation on a malformed xs:selector/xs:field XPath instead of silently disabling the constraint.
- Resolve every xs:keyref/@refer against a schema-wide key/unique registry and reject an unknown refer at compile time.
- Surface IDC selector/field evaluation errors as validity errors rather than swallowing them.