### PR TITLE
reject invalid minOccurs/maxOccurs in xsd particles

### DIFF
--- a/xsd/check_elements.go
+++ b/xsd/check_elements.go
@@ -179,6 +179,21 @@ func (c *compiler) checkGlobalElement(ctx context.Context, elem *helium.Element)
 	}
 }
 
+// effectiveMinOccurs returns the effective minOccurs value for a particle given
+// the raw minOccurs attribute lexical (empty when unset). An absent or invalid
+// minOccurs defaults to 1, matching XSD's schema-default and libxml2's behavior
+// when deciding whether a maxOccurs of 0 is a legal prohibited particle.
+func effectiveMinOccurs(minOcc string) int {
+	if minOcc == "" {
+		return 1
+	}
+	n, ok := parseNonNegativeOccurs(minOcc, false)
+	if !ok {
+		return 1
+	}
+	return n
+}
+
 // checkLocalElement validates constraints on a local xs:element declaration.
 func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) {
 	if c.filename == "" {
@@ -199,14 +214,17 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		// 3. First ref-restricted attribute (alphabetical)
 		// 4. First child content error
 
-		// maxOccurs must be a non-negative integer (or "unbounded") and >= 1.
+		// maxOccurs must be a non-negative integer (or "unbounded"). A maxOccurs of
+		// 0 is a legal prohibited particle when the effective minOccurs is also 0;
+		// libxml2 only rejects maxOccurs<1 when the effective minOccurs is >= 1
+		// (default minOccurs is 1), reporting the ">= 1" message on maxOccurs.
 		if maxOcc != "" && maxOcc != attrValUnbounded {
 			maxVal, ok := parseNonNegativeOccurs(maxOcc, true)
 			if !ok {
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
 					"'"+maxOcc+"' is not a valid value of the union type 'xs:allNNI'."), helium.ErrorLevelFatal))
 				c.errorCount++
-			} else if maxVal < 1 {
+			} else if maxVal < 1 && effectiveMinOccurs(minOcc) >= 1 {
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
 					"The value must be greater than or equal to 1."), helium.ErrorLevelFatal))
 				c.errorCount++
@@ -223,11 +241,12 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		}
 
 		// minOccurs > maxOccurs check. Skip it when maxOccurs already failed the
-		// >= 1 rule (maxVal < 1); libxml2 reports only the maxOccurs error there.
+		// >= 1 rule (maxVal < 1 with an effective minOccurs >= 1); libxml2 reports
+		// only the maxOccurs error there.
 		if minOcc != "" && maxOcc != "" && maxOcc != attrValUnbounded {
 			minVal, minOK := parseNonNegativeOccurs(minOcc, false)
 			maxVal, maxOK := parseNonNegativeOccurs(maxOcc, true)
-			if minOK && maxOK && maxVal != Unbounded && maxVal >= 1 && minVal > maxVal {
+			if minOK && maxOK && maxVal != Unbounded && !(maxVal < 1 && minVal >= 1) && minVal > maxVal {
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
 					"The value must not be greater than the value of 'maxOccurs'."), helium.ErrorLevelFatal))
 				c.errorCount++
@@ -273,14 +292,17 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		// Matches libxml2 ordering: maxOccurs, not-allowed attrs,
 		// block/final value checks, default+fixed, type/content children.
 
-		// maxOccurs must be a non-negative integer (or "unbounded") and >= 1.
+		// maxOccurs must be a non-negative integer (or "unbounded"). A maxOccurs of
+		// 0 is a legal prohibited particle when the effective minOccurs is also 0;
+		// libxml2 only rejects maxOccurs<1 when the effective minOccurs is >= 1
+		// (default minOccurs is 1), reporting the ">= 1" message on maxOccurs.
 		if maxOcc != "" && maxOcc != attrValUnbounded {
 			maxVal, ok := parseNonNegativeOccurs(maxOcc, true)
 			if !ok {
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
 					"'"+maxOcc+"' is not a valid value of the union type 'xs:allNNI'."), helium.ErrorLevelFatal))
 				c.errorCount++
-			} else if maxVal < 1 {
+			} else if maxVal < 1 && effectiveMinOccurs(minOcc) >= 1 {
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
 					"The value must be greater than or equal to 1."), helium.ErrorLevelFatal))
 				c.errorCount++
@@ -297,11 +319,12 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		}
 
 		// minOccurs > maxOccurs check. Skip it when maxOccurs already failed the
-		// >= 1 rule (maxVal < 1); libxml2 reports only the maxOccurs error there.
+		// >= 1 rule (maxVal < 1 with an effective minOccurs >= 1); libxml2 reports
+		// only the maxOccurs error there.
 		if minOcc != "" && maxOcc != "" && maxOcc != attrValUnbounded {
 			minVal, minOK := parseNonNegativeOccurs(minOcc, false)
 			maxVal, maxOK := parseNonNegativeOccurs(maxOcc, true)
-			if minOK && maxOK && maxVal != Unbounded && maxVal >= 1 && minVal > maxVal {
+			if minOK && maxOK && maxVal != Unbounded && !(maxVal < 1 && minVal >= 1) && minVal > maxVal {
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
 					"The value must not be greater than the value of 'maxOccurs'."), helium.ErrorLevelFatal))
 				c.errorCount++

--- a/xsd/check_elements.go
+++ b/xsd/check_elements.go
@@ -251,7 +251,7 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		if minPresent && maxPresent && maxOcc != attrValUnbounded {
 			minVal, minOK := parseNonNegativeOccurs(minOcc, false)
 			maxVal, maxOK := parseNonNegativeOccurs(maxOcc, true)
-			if minOK && maxOK && maxVal != Unbounded && !(maxVal < 1 && minVal >= 1) && minVal > maxVal {
+			if minOK && maxOK && maxVal != Unbounded && (maxVal >= 1 || minVal < 1) && minVal > maxVal {
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
 					"The value must not be greater than the value of 'maxOccurs'."), helium.ErrorLevelFatal))
 				c.errorCount++
@@ -329,7 +329,7 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		if minPresent && maxPresent && maxOcc != attrValUnbounded {
 			minVal, minOK := parseNonNegativeOccurs(minOcc, false)
 			maxVal, maxOK := parseNonNegativeOccurs(maxOcc, true)
-			if minOK && maxOK && maxVal != Unbounded && !(maxVal < 1 && minVal >= 1) && minVal > maxVal {
+			if minOK && maxOK && maxVal != Unbounded && (maxVal >= 1 || minVal < 1) && minVal > maxVal {
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
 					"The value must not be greater than the value of 'maxOccurs'."), helium.ErrorLevelFatal))
 				c.errorCount++

--- a/xsd/check_elements.go
+++ b/xsd/check_elements.go
@@ -199,21 +199,35 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		// 3. First ref-restricted attribute (alphabetical)
 		// 4. First child content error
 
-		// maxOccurs must be >= 1.
+		// maxOccurs must be a non-negative integer (or "unbounded") and >= 1.
 		if maxOcc != "" && maxOcc != attrValUnbounded {
-			maxVal := parseOccurs(maxOcc, 1)
-			if maxVal < 1 {
+			maxVal, ok := parseNonNegativeOccurs(maxOcc, true)
+			if !ok {
+				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
+					"'"+maxOcc+"' is not a valid value of the union type 'xs:allNNI'."), helium.ErrorLevelFatal))
+				c.errorCount++
+			} else if maxVal < 1 {
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
 					"The value must be greater than or equal to 1."), helium.ErrorLevelFatal))
 				c.errorCount++
 			}
 		}
 
-		// minOccurs > maxOccurs check.
+		// minOccurs must be a non-negative integer.
+		if minOcc != "" {
+			if _, ok := parseNonNegativeOccurs(minOcc, false); !ok {
+				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
+					"'"+minOcc+"' is not a valid value of the atomic type 'xs:nonNegativeInteger'."), helium.ErrorLevelFatal))
+				c.errorCount++
+			}
+		}
+
+		// minOccurs > maxOccurs check. Skip it when maxOccurs already failed the
+		// >= 1 rule (maxVal < 1); libxml2 reports only the maxOccurs error there.
 		if minOcc != "" && maxOcc != "" && maxOcc != attrValUnbounded {
-			minVal := parseOccurs(minOcc, 1)
-			maxVal := parseOccurs(maxOcc, 1)
-			if minVal > maxVal {
+			minVal, minOK := parseNonNegativeOccurs(minOcc, false)
+			maxVal, maxOK := parseNonNegativeOccurs(maxOcc, true)
+			if minOK && maxOK && maxVal != Unbounded && maxVal >= 1 && minVal > maxVal {
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
 					"The value must not be greater than the value of 'maxOccurs'."), helium.ErrorLevelFatal))
 				c.errorCount++
@@ -259,12 +273,37 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		// Matches libxml2 ordering: maxOccurs, not-allowed attrs,
 		// block/final value checks, default+fixed, type/content children.
 
-		// maxOccurs must be >= 1.
+		// maxOccurs must be a non-negative integer (or "unbounded") and >= 1.
 		if maxOcc != "" && maxOcc != attrValUnbounded {
-			maxVal := parseOccurs(maxOcc, 1)
-			if maxVal < 1 {
+			maxVal, ok := parseNonNegativeOccurs(maxOcc, true)
+			if !ok {
+				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
+					"'"+maxOcc+"' is not a valid value of the union type 'xs:allNNI'."), helium.ErrorLevelFatal))
+				c.errorCount++
+			} else if maxVal < 1 {
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
 					"The value must be greater than or equal to 1."), helium.ErrorLevelFatal))
+				c.errorCount++
+			}
+		}
+
+		// minOccurs must be a non-negative integer.
+		if minOcc != "" {
+			if _, ok := parseNonNegativeOccurs(minOcc, false); !ok {
+				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
+					"'"+minOcc+"' is not a valid value of the atomic type 'xs:nonNegativeInteger'."), helium.ErrorLevelFatal))
+				c.errorCount++
+			}
+		}
+
+		// minOccurs > maxOccurs check. Skip it when maxOccurs already failed the
+		// >= 1 rule (maxVal < 1); libxml2 reports only the maxOccurs error there.
+		if minOcc != "" && maxOcc != "" && maxOcc != attrValUnbounded {
+			minVal, minOK := parseNonNegativeOccurs(minOcc, false)
+			maxVal, maxOK := parseNonNegativeOccurs(maxOcc, true)
+			if minOK && maxOK && maxVal != Unbounded && maxVal >= 1 && minVal > maxVal {
+				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
+					"The value must not be greater than the value of 'maxOccurs'."), helium.ErrorLevelFatal))
 				c.errorCount++
 			}
 		}

--- a/xsd/check_elements.go
+++ b/xsd/check_elements.go
@@ -206,6 +206,11 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 
 	minOcc := getAttr(elem, attrMinOccurs)
 	maxOcc := getAttr(elem, attrMaxOccurs)
+	// Detect presence with hasAttr so an explicitly empty minOccurs="" /
+	// maxOccurs="" is validated (and rejected as an invalid lexical) instead of
+	// being treated as absent, matching xmllint.
+	minPresent := hasAttr(elem, attrMinOccurs)
+	maxPresent := hasAttr(elem, attrMaxOccurs)
 
 	if ref != "" {
 		// Matches libxml2 ordering for ref elements (src-element 2.2):
@@ -218,7 +223,7 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		// 0 is a legal prohibited particle when the effective minOccurs is also 0;
 		// libxml2 only rejects maxOccurs<1 when the effective minOccurs is >= 1
 		// (default minOccurs is 1), reporting the ">= 1" message on maxOccurs.
-		if maxOcc != "" && maxOcc != attrValUnbounded {
+		if maxPresent && maxOcc != attrValUnbounded {
 			maxVal, ok := parseNonNegativeOccurs(maxOcc, true)
 			if !ok {
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
@@ -232,7 +237,7 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		}
 
 		// minOccurs must be a non-negative integer.
-		if minOcc != "" {
+		if minPresent {
 			if _, ok := parseNonNegativeOccurs(minOcc, false); !ok {
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
 					"'"+minOcc+"' is not a valid value of the atomic type 'xs:nonNegativeInteger'."), helium.ErrorLevelFatal))
@@ -243,7 +248,7 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		// minOccurs > maxOccurs check. Skip it when maxOccurs already failed the
 		// >= 1 rule (maxVal < 1 with an effective minOccurs >= 1); libxml2 reports
 		// only the maxOccurs error there.
-		if minOcc != "" && maxOcc != "" && maxOcc != attrValUnbounded {
+		if minPresent && maxPresent && maxOcc != attrValUnbounded {
 			minVal, minOK := parseNonNegativeOccurs(minOcc, false)
 			maxVal, maxOK := parseNonNegativeOccurs(maxOcc, true)
 			if minOK && maxOK && maxVal != Unbounded && !(maxVal < 1 && minVal >= 1) && minVal > maxVal {
@@ -296,7 +301,7 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		// 0 is a legal prohibited particle when the effective minOccurs is also 0;
 		// libxml2 only rejects maxOccurs<1 when the effective minOccurs is >= 1
 		// (default minOccurs is 1), reporting the ">= 1" message on maxOccurs.
-		if maxOcc != "" && maxOcc != attrValUnbounded {
+		if maxPresent && maxOcc != attrValUnbounded {
 			maxVal, ok := parseNonNegativeOccurs(maxOcc, true)
 			if !ok {
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
@@ -310,7 +315,7 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		}
 
 		// minOccurs must be a non-negative integer.
-		if minOcc != "" {
+		if minPresent {
 			if _, ok := parseNonNegativeOccurs(minOcc, false); !ok {
 				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
 					"'"+minOcc+"' is not a valid value of the atomic type 'xs:nonNegativeInteger'."), helium.ErrorLevelFatal))
@@ -321,7 +326,7 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		// minOccurs > maxOccurs check. Skip it when maxOccurs already failed the
 		// >= 1 rule (maxVal < 1 with an effective minOccurs >= 1); libxml2 reports
 		// only the maxOccurs error there.
-		if minOcc != "" && maxOcc != "" && maxOcc != attrValUnbounded {
+		if minPresent && maxPresent && maxOcc != attrValUnbounded {
 			minVal, minOK := parseNonNegativeOccurs(minOcc, false)
 			maxVal, maxOK := parseNonNegativeOccurs(maxOcc, true)
 			if minOK && maxOK && maxVal != Unbounded && !(maxVal < 1 && minVal >= 1) && minVal > maxVal {

--- a/xsd/occurs_validation_test.go
+++ b/xsd/occurs_validation_test.go
@@ -126,6 +126,27 @@ func TestOccursValidation(t *testing.T) {
 		require.Contains(t, compileErrors(t, schemaXML), wantNonNegInt)
 	})
 
+	// A group reference can also appear directly under xs:complexType (without an
+	// enclosing compositor). That branch lives in read_types.go rather than
+	// read_particles.go and formerly used the non-validating occurs parser, so a
+	// negative minOccurs was silently accepted while xmllint rejects it.
+	t.Run("rejects on direct group reference under complexType", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="g">
+    <xs:sequence>
+      <xs:element name="child" type="xs:string"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:group ref="g" minOccurs="-1"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, schemaXML), wantNonNegInt)
+	})
+
 	// Valid occurs forms must still compile cleanly, including unbounded and
 	// minOccurs=0 (optional) and maxOccurs=0 (prohibited particle).
 	t.Run("accepts valid occurs", func(t *testing.T) {

--- a/xsd/occurs_validation_test.go
+++ b/xsd/occurs_validation_test.go
@@ -32,6 +32,7 @@ func TestOccursValidation(t *testing.T) {
 		wantNonNegInt = "is not a valid value of the atomic type 'xs:nonNegativeInteger'"
 		wantAllNNI    = "is not a valid value of the union type 'xs:allNNI'"
 		wantMinGtMax  = "The value must not be greater than the value of 'maxOccurs'"
+		wantMaxGteOne = "The value must be greater than or equal to 1"
 	)
 
 	t.Run("rejects", func(t *testing.T) {
@@ -154,6 +155,184 @@ func TestOccursValidation(t *testing.T) {
   </xs:element>
 </xs:schema>`
 		require.Contains(t, compileErrors(t, schemaXML), wantNonNegInt)
+	})
+
+	// An explicitly empty occurs attribute (minOccurs="" / maxOccurs="") is an
+	// invalid lexical, not an absent attribute. Before the fix presence was
+	// detected with value!="" so empty strings were silently treated as absent
+	// and defaulted; xmllint rejects them. These run across every particle kind.
+	t.Run("rejects empty occurs", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct {
+			name    string
+			schema  string
+			wantMsg string
+		}{
+			{
+				name:    "element empty minOccurs",
+				wantMsg: wantNonNegInt,
+				schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root"><xs:complexType><xs:sequence>
+    <xs:element name="child" type="xs:string" minOccurs=""/>
+  </xs:sequence></xs:complexType></xs:element>
+</xs:schema>`,
+			},
+			{
+				name:    "element empty maxOccurs",
+				wantMsg: wantAllNNI,
+				schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root"><xs:complexType><xs:sequence>
+    <xs:element name="child" type="xs:string" maxOccurs=""/>
+  </xs:sequence></xs:complexType></xs:element>
+</xs:schema>`,
+			},
+			{
+				name:    "sequence empty minOccurs",
+				wantMsg: wantNonNegInt,
+				schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root"><xs:complexType>
+    <xs:sequence minOccurs=""><xs:element name="child" type="xs:string"/></xs:sequence>
+  </xs:complexType></xs:element>
+</xs:schema>`,
+			},
+			{
+				name:    "sequence empty maxOccurs",
+				wantMsg: wantAllNNI,
+				schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root"><xs:complexType>
+    <xs:sequence maxOccurs=""><xs:element name="child" type="xs:string"/></xs:sequence>
+  </xs:complexType></xs:element>
+</xs:schema>`,
+			},
+			{
+				name:    "any empty maxOccurs",
+				wantMsg: wantAllNNI,
+				schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root"><xs:complexType><xs:sequence>
+    <xs:any maxOccurs=""/>
+  </xs:sequence></xs:complexType></xs:element>
+</xs:schema>`,
+			},
+			{
+				name:    "group ref empty minOccurs",
+				wantMsg: wantNonNegInt,
+				schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="g"><xs:sequence><xs:element name="child" type="xs:string"/></xs:sequence></xs:group>
+  <xs:element name="root"><xs:complexType><xs:sequence>
+    <xs:group ref="g" minOccurs=""/>
+  </xs:sequence></xs:complexType></xs:element>
+</xs:schema>`,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				require.Contains(t, compileErrors(t, tc.schema), tc.wantMsg)
+			})
+		}
+	})
+
+	// maxOccurs=0 with an absent minOccurs (effective default minOccurs=1) is a
+	// content model that requires the particle yet forbids it: xmllint reports the
+	// "maxOccurs >= 1" diagnostic. Before the fix non-element particles only
+	// enforced min<=max when minOccurs was explicitly present, so these compiled.
+	t.Run("rejects default-min maxOccurs zero", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct {
+			name   string
+			schema string
+		}{
+			{
+				name: "element absent min",
+				schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root"><xs:complexType><xs:sequence>
+    <xs:element name="child" type="xs:string" maxOccurs="0"/>
+  </xs:sequence></xs:complexType></xs:element>
+</xs:schema>`,
+			},
+			{
+				name: "element explicit min one",
+				schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root"><xs:complexType><xs:sequence>
+    <xs:element name="child" type="xs:string" minOccurs="1" maxOccurs="0"/>
+  </xs:sequence></xs:complexType></xs:element>
+</xs:schema>`,
+			},
+			{
+				name: "sequence absent min",
+				schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root"><xs:complexType>
+    <xs:sequence maxOccurs="0"><xs:element name="child" type="xs:string"/></xs:sequence>
+  </xs:complexType></xs:element>
+</xs:schema>`,
+			},
+			{
+				name: "any absent min",
+				schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root"><xs:complexType><xs:sequence>
+    <xs:any maxOccurs="0"/>
+  </xs:sequence></xs:complexType></xs:element>
+</xs:schema>`,
+			},
+			{
+				name: "group ref absent min",
+				schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="g"><xs:sequence><xs:element name="child" type="xs:string"/></xs:sequence></xs:group>
+  <xs:element name="root"><xs:complexType><xs:sequence>
+    <xs:group ref="g" maxOccurs="0"/>
+  </xs:sequence></xs:complexType></xs:element>
+</xs:schema>`,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				errs := compileErrors(t, tc.schema)
+				require.Contains(t, errs, wantMaxGteOne)
+				// xmllint reports only the maxOccurs error here, not a duplicate
+				// min>max diagnostic.
+				require.NotContains(t, errs, wantMinGtMax)
+			})
+		}
+	})
+
+	// minOccurs=0 maxOccurs=0 is a legal prohibited particle on every particle
+	// kind (not just xs:element); it must compile cleanly.
+	t.Run("accepts prohibited particle on all kinds", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct {
+			name   string
+			schema string
+		}{
+			{
+				name: "sequence",
+				schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root"><xs:complexType>
+    <xs:sequence minOccurs="0" maxOccurs="0"><xs:element name="child" type="xs:string"/></xs:sequence>
+  </xs:complexType></xs:element>
+</xs:schema>`,
+			},
+			{
+				name: "any",
+				schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root"><xs:complexType><xs:sequence>
+    <xs:any minOccurs="0" maxOccurs="0"/>
+  </xs:sequence></xs:complexType></xs:element>
+</xs:schema>`,
+			},
+			{
+				name: "group ref",
+				schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="g"><xs:sequence><xs:element name="child" type="xs:string"/></xs:sequence></xs:group>
+  <xs:element name="root"><xs:complexType><xs:sequence>
+    <xs:group ref="g" minOccurs="0" maxOccurs="0"/>
+  </xs:sequence></xs:complexType></xs:element>
+</xs:schema>`,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				require.Empty(t, compileErrors(t, tc.schema))
+			})
+		}
 	})
 
 	// Valid occurs forms must still compile cleanly, including unbounded and

--- a/xsd/occurs_validation_test.go
+++ b/xsd/occurs_validation_test.go
@@ -46,6 +46,15 @@ func TestOccursValidation(t *testing.T) {
 			{name: "non-integer minOccurs", occurs: `minOccurs="abc"`, wantMsg: wantNonNegInt},
 			{name: "non-integer maxOccurs", occurs: `maxOccurs="abc"`, wantMsg: wantAllNNI},
 			{name: "min greater than max", occurs: `minOccurs="3" maxOccurs="2"`, wantMsg: wantMinGtMax},
+			// xs:nonNegativeInteger / xs:allNNI have no leading sign: "+0", "+1"
+			// and "-0" are invalid lexical forms even though strconv.Atoi would
+			// parse them. libxml2 rejects all three.
+			{name: "plus-zero minOccurs", occurs: `minOccurs="+0"`, wantMsg: wantNonNegInt},
+			{name: "plus-one minOccurs", occurs: `minOccurs="+1"`, wantMsg: wantNonNegInt},
+			{name: "minus-zero minOccurs", occurs: `minOccurs="-0"`, wantMsg: wantNonNegInt},
+			{name: "plus-zero maxOccurs", occurs: `maxOccurs="+0"`, wantMsg: wantAllNNI},
+			{name: "plus-one maxOccurs", occurs: `maxOccurs="+1"`, wantMsg: wantAllNNI},
+			{name: "minus-zero maxOccurs", occurs: `maxOccurs="-0"`, wantMsg: wantAllNNI},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
@@ -160,6 +169,10 @@ func TestOccursValidation(t *testing.T) {
 			{name: "unbounded", occurs: `maxOccurs="unbounded"`},
 			{name: "range", occurs: `minOccurs="0" maxOccurs="5"`},
 			{name: "zero to unbounded", occurs: `minOccurs="0" maxOccurs="unbounded"`},
+			// maxOccurs=0 is a legal prohibited particle when minOccurs is also 0;
+			// libxml2 compiles this without error (only rejects maxOccurs<1 when
+			// the effective minOccurs is >= 1).
+			{name: "prohibited particle", occurs: `minOccurs="0" maxOccurs="0"`},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()

--- a/xsd/occurs_validation_test.go
+++ b/xsd/occurs_validation_test.go
@@ -1,0 +1,158 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOccursValidation verifies that minOccurs/maxOccurs are parsed as
+// non-negative integers (maxOccurs additionally allowing "unbounded") and that
+// negative values, non-integer values, and minOccurs > maxOccurs are reported
+// as fatal schema parser errors at compile time. Before the fix a value such as
+// minOccurs="-1" was silently accepted, producing a too-permissive content
+// model that let a missing required child validate.
+func TestOccursValidation(t *testing.T) {
+	t.Parallel()
+
+	compileErrors := func(t *testing.T, schemaXML string) string {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, err = xsd.NewCompiler().Label("test.xsd").ErrorHandler(collector).Compile(t.Context(), doc)
+		require.NoError(t, err)
+		_, errors := partitionCompileErrors(collector.Errors())
+		return errors
+	}
+
+	const (
+		wantNonNegInt = "is not a valid value of the atomic type 'xs:nonNegativeInteger'"
+		wantAllNNI    = "is not a valid value of the union type 'xs:allNNI'"
+		wantMinGtMax  = "The value must not be greater than the value of 'maxOccurs'"
+	)
+
+	t.Run("rejects", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct {
+			name    string
+			occurs  string
+			wantMsg string
+		}{
+			{name: "negative minOccurs", occurs: `minOccurs="-1"`, wantMsg: wantNonNegInt},
+			{name: "negative maxOccurs", occurs: `maxOccurs="-2"`, wantMsg: wantAllNNI},
+			{name: "non-integer minOccurs", occurs: `minOccurs="abc"`, wantMsg: wantNonNegInt},
+			{name: "non-integer maxOccurs", occurs: `maxOccurs="abc"`, wantMsg: wantAllNNI},
+			{name: "min greater than max", occurs: `minOccurs="3" maxOccurs="2"`, wantMsg: wantMinGtMax},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="child" type="xs:string" ` + tc.occurs + `/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+				require.Contains(t, compileErrors(t, schemaXML), tc.wantMsg)
+			})
+		}
+	})
+
+	// The bug also surfaces on the compositor (sequence/choice/all) particle
+	// itself and on any/group references, which checkLocalElement never covered.
+	t.Run("rejects on compositor particle", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence minOccurs="-1">
+        <xs:element name="child" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, schemaXML), wantNonNegInt)
+	})
+
+	t.Run("rejects on choice min greater than max", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:choice minOccurs="5" maxOccurs="2">
+        <xs:element name="child" type="xs:string"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, schemaXML), wantMinGtMax)
+	})
+
+	t.Run("rejects on any wildcard", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:any maxOccurs="-3"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, schemaXML), wantAllNNI)
+	})
+
+	t.Run("rejects on group reference", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="g">
+    <xs:sequence>
+      <xs:element name="child" type="xs:string"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:group ref="g" minOccurs="-1"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, schemaXML), wantNonNegInt)
+	})
+
+	// Valid occurs forms must still compile cleanly, including unbounded and
+	// minOccurs=0 (optional) and maxOccurs=0 (prohibited particle).
+	t.Run("accepts valid occurs", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct {
+			name   string
+			occurs string
+		}{
+			{name: "default", occurs: ``},
+			{name: "minOccurs zero", occurs: `minOccurs="0"`},
+			{name: "unbounded", occurs: `maxOccurs="unbounded"`},
+			{name: "range", occurs: `minOccurs="0" maxOccurs="5"`},
+			{name: "zero to unbounded", occurs: `minOccurs="0" maxOccurs="unbounded"`},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="child" type="xs:string" ` + tc.occurs + `/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+				require.Empty(t, compileErrors(t, schemaXML))
+			})
+		}
+	})
+}

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -69,7 +69,7 @@ func isASCIIDigits(s string) bool {
 	if s == "" {
 		return false
 	}
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		if s[i] < '0' || s[i] > '9' {
 			return false
 		}

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -3,6 +3,7 @@ package xsd
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
@@ -36,6 +37,77 @@ func parseParticleOccurs(elem *helium.Element) (int, int) {
 		maxOccurs = parseOccurs(v, 1)
 	}
 	return minOccurs, maxOccurs
+}
+
+// parseNonNegativeOccurs parses an occurs attribute value as a non-negative
+// integer. maxOccurs (allowMax) may additionally be the literal "unbounded",
+// represented by the Unbounded sentinel. ok is false when the lexical value is
+// not a valid non-negative integer (or "unbounded" when permitted); callers
+// report a schema error in that case rather than silently accepting a bogus
+// occurrence count.
+func parseNonNegativeOccurs(s string, allowMax bool) (int, bool) {
+	if allowMax && s == attrValUnbounded {
+		return Unbounded, true
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// validateOccursAttrs validates the minOccurs/maxOccurs attributes of a
+// non-element particle (model group, group reference, wildcard). It rejects
+// negative or non-integer values and enforces minOccurs <= maxOccurs, reporting
+// libxml2-style schema parser errors via the compiler's error handler.
+//
+// xs:element particles are validated by checkLocalElement to preserve the
+// libxml2 diagnostic ordering golden tests depend on; this method deliberately
+// skips them.
+func (c *compiler) validateOccursAttrs(ctx context.Context, elem *helium.Element) {
+	if c.filename == "" {
+		return
+	}
+
+	line := elem.Line()
+	local := elem.LocalName()
+	xsdElem := local
+
+	minSet := false
+	minVal := 1
+	if v := getAttr(elem, attrMinOccurs); v != "" {
+		n, ok := parseNonNegativeOccurs(v, false)
+		if !ok {
+			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, xsdElem, attrMinOccurs,
+				"'"+v+"' is not a valid value of the atomic type 'xs:nonNegativeInteger'."), helium.ErrorLevelFatal))
+			c.errorCount++
+		} else {
+			minSet = true
+			minVal = n
+		}
+	}
+
+	maxSet := false
+	maxVal := 1
+	if v := getAttr(elem, attrMaxOccurs); v != "" {
+		n, ok := parseNonNegativeOccurs(v, true)
+		if !ok {
+			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, xsdElem, attrMaxOccurs,
+				"'"+v+"' is not a valid value of the union type 'xs:allNNI'."), helium.ErrorLevelFatal))
+			c.errorCount++
+		} else {
+			maxSet = true
+			maxVal = n
+		}
+	}
+
+	// minOccurs must not exceed maxOccurs (Unbounded is treated as +inf, so it
+	// can never be exceeded).
+	if minSet && maxSet && maxVal != Unbounded && minVal > maxVal {
+		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, xsdElem, attrMinOccurs,
+			"The value must not be greater than the value of 'maxOccurs'."), helium.ErrorLevelFatal))
+		c.errorCount++
+	}
 }
 
 func readDefaultOrFixed(elem *helium.Element) (*string, *string) {
@@ -366,6 +438,7 @@ func (c *compiler) parseLocalElement(ctx context.Context, elem *helium.Element) 
 }
 
 func (c *compiler) parseWildcard(ctx context.Context, elem *helium.Element) *Particle {
+	c.validateOccursAttrs(ctx, elem)
 	minOcc, maxOcc := parseParticleOccurs(elem)
 	wc := c.readWildcard(ctx, elem)
 	return &Particle{

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -79,12 +79,18 @@ func isASCIIDigits(s string) bool {
 
 // validateOccursAttrs validates the minOccurs/maxOccurs attributes of a
 // non-element particle (model group, group reference, wildcard). It rejects
-// negative or non-integer values and enforces minOccurs <= maxOccurs, reporting
-// libxml2-style schema parser errors via the compiler's error handler.
+// negative, signed, non-integer, and empty occurrence values, applies the
+// effective-default minOccurs=1 so a maxOccurs of 0 with an absent or >=1
+// minOccurs is rejected with the "maxOccurs >= 1" diagnostic, and enforces
+// minOccurs <= maxOccurs. Errors are reported as libxml2-style schema parser
+// errors via the compiler's error handler.
 //
 // xs:element particles are validated by checkLocalElement to preserve the
 // libxml2 diagnostic ordering golden tests depend on; this method deliberately
 // skips them.
+//
+// Presence is detected with hasAttr (not value!=""), so an explicitly empty
+// minOccurs="" / maxOccurs="" is validated and rejected, matching xmllint.
 func (c *compiler) validateOccursAttrs(ctx context.Context, elem *helium.Element) {
 	if c.filename == "" {
 		return
@@ -94,37 +100,59 @@ func (c *compiler) validateOccursAttrs(ctx context.Context, elem *helium.Element
 	local := elem.LocalName()
 	xsdElem := local
 
-	minSet := false
-	minVal := 1
-	if v := getAttr(elem, attrMinOccurs); v != "" {
+	minPresent := hasAttr(elem, attrMinOccurs)
+	maxPresent := hasAttr(elem, attrMaxOccurs)
+
+	minVal, minOK := 1, true
+	if minPresent {
+		v := getAttr(elem, attrMinOccurs)
 		n, ok := parseNonNegativeOccurs(v, false)
 		if !ok {
+			minOK = false
 			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, xsdElem, attrMinOccurs,
 				"'"+v+"' is not a valid value of the atomic type 'xs:nonNegativeInteger'."), helium.ErrorLevelFatal))
 			c.errorCount++
 		} else {
-			minSet = true
 			minVal = n
 		}
 	}
 
-	maxSet := false
-	maxVal := 1
-	if v := getAttr(elem, attrMaxOccurs); v != "" {
+	maxVal, maxOK := 1, true
+	if maxPresent {
+		v := getAttr(elem, attrMaxOccurs)
 		n, ok := parseNonNegativeOccurs(v, true)
 		if !ok {
+			maxOK = false
 			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, xsdElem, attrMaxOccurs,
 				"'"+v+"' is not a valid value of the union type 'xs:allNNI'."), helium.ErrorLevelFatal))
 			c.errorCount++
 		} else {
-			maxSet = true
 			maxVal = n
 		}
 	}
 
+	// maxOccurs must be >= 1 unless the effective minOccurs is 0 (a legal
+	// prohibited particle, minOccurs=0 maxOccurs=0). The effective minOccurs is 1
+	// when minOccurs is absent or invalid, so maxOccurs=0 with an absent/explicit
+	// min>=1 is rejected with the ">= 1" diagnostic.
+	maxBelowOne := false
+	if maxOK && maxVal != Unbounded && maxVal < 1 {
+		effMin := 1
+		if minPresent && minOK {
+			effMin = minVal
+		}
+		if effMin >= 1 {
+			maxBelowOne = true
+			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, xsdElem, attrMaxOccurs,
+				"The value must be greater than or equal to 1."), helium.ErrorLevelFatal))
+			c.errorCount++
+		}
+	}
+
 	// minOccurs must not exceed maxOccurs (Unbounded is treated as +inf, so it
-	// can never be exceeded).
-	if minSet && maxSet && maxVal != Unbounded && minVal > maxVal {
+	// can never be exceeded). Suppress this when the ">= 1" rule already fired on
+	// maxOccurs; libxml2 reports only the maxOccurs error there.
+	if minPresent && maxPresent && minOK && maxOK && maxVal != Unbounded && !maxBelowOne && minVal > maxVal {
 		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, xsdElem, attrMinOccurs,
 			"The value must not be greater than the value of 'maxOccurs'."), helium.ErrorLevelFatal))
 		c.errorCount++

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -49,11 +49,32 @@ func parseNonNegativeOccurs(s string, allowMax bool) (int, bool) {
 	if allowMax && s == attrValUnbounded {
 		return Unbounded, true
 	}
+	// xs:nonNegativeInteger has no leading sign: a leading '+' or '-' (including
+	// "+0"/"-0") is not a valid lexical form. strconv.Atoi would accept these, so
+	// reject any non-digit character before converting.
+	if !isASCIIDigits(s) {
+		return 0, false
+	}
 	n, err := strconv.Atoi(s)
 	if err != nil || n < 0 {
 		return 0, false
 	}
 	return n, true
+}
+
+// isASCIIDigits reports whether s is a non-empty run of ASCII digits ('0'-'9')
+// with no sign, whitespace, or other characters. This matches the lexical space
+// of xs:nonNegativeInteger as XSD/libxml2 enforce it for occurrence counts.
+func isASCIIDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // validateOccursAttrs validates the minOccurs/maxOccurs attributes of a

--- a/xsd/read_particles.go
+++ b/xsd/read_particles.go
@@ -86,6 +86,7 @@ func (c *compiler) parseNamedAttributeGroup(ctx context.Context, elem *helium.El
 }
 
 func (c *compiler) parseModelGroup(ctx context.Context, elem *helium.Element, compositor ModelGroupKind) (*ModelGroup, error) {
+	c.validateOccursAttrs(ctx, elem)
 	minOccurs, maxOccurs := parseParticleOccurs(elem)
 	mg := &ModelGroup{
 		Compositor: compositor,
@@ -144,6 +145,7 @@ func (c *compiler) parseModelGroup(ctx context.Context, elem *helium.Element, co
 		case isXSDElement(ce, elemGroup):
 			ref := getAttr(ce, attrRef)
 			if ref != "" {
+				c.validateOccursAttrs(ctx, ce)
 				placeholderMin, placeholderMax := parseParticleOccurs(ce)
 				// Group reference — create a placeholder model group.
 				placeholder := &ModelGroup{

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -133,13 +133,9 @@ func (c *compiler) parseComplexType(ctx context.Context, elem *helium.Element) (
 		case isXSDElement(ce, elemGroup):
 			ref := getAttr(ce, attrRef)
 			if ref != "" {
-				placeholder := &ModelGroup{MinOccurs: 1, MaxOccurs: 1}
-				if v := getAttr(ce, "minOccurs"); v != "" {
-					placeholder.MinOccurs = parseOccurs(v, 1)
-				}
-				if v := getAttr(ce, "maxOccurs"); v != "" {
-					placeholder.MaxOccurs = parseOccurs(v, 1)
-				}
+				c.validateOccursAttrs(ctx, ce)
+				placeholderMin, placeholderMax := parseParticleOccurs(ce)
+				placeholder := &ModelGroup{MinOccurs: placeholderMin, MaxOccurs: placeholderMax}
 				qn := c.resolveQName(ctx, ce, ref)
 				c.groupRefs[placeholder] = qn
 				td.ContentModel = placeholder


### PR DESCRIPTION
- parse minOccurs/maxOccurs as non-negative integers (maxOccurs also allows "unbounded"), rejecting negatives and non-integers at compile time
- enforce minOccurs <= maxOccurs across elements, group refs, choice/sequence/all, and any wildcards instead of silently building a too-permissive content model