### PR TITLE
fix schematron rule let evaluation order

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -409,7 +409,7 @@ Message content parsed into `[]messagePart`: text literals, `<name path="..."/>`
 2. For each pattern/rule: evaluate `contextExpr` against document root → node set
    - If the context XPath **errors at evaluation**, surface an `XPath error : ...` diagnostic and mark the document invalid (the rule's assertions can't be checked, so it is not silently skipped)
 3. For each context node:
-   - Bind `<let>` variables (accumulated, later lets see earlier ones)
+   - Bind `<let>` variables in **document order** (accumulated, so a later let sees earlier ones, e.g. `<let name="b" value="$a"/>` after `a`). A let whose expression **errors at evaluation** surfaces an `XPath error : ...` diagnostic rather than being silently dropped.
    - Create rule-specific XPath context with variables
 4. For each test:
    - Evaluate XPath, convert to boolean

--- a/schematron/let_order_test.go
+++ b/schematron/let_order_test.go
@@ -1,6 +1,8 @@
 package schematron_test
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	helium "github.com/lestrrat-go/helium"
@@ -37,4 +39,56 @@ func TestRuleLetDocumentOrder(t *testing.T) {
 
 	err = schematron.NewValidator(schema).Validate(ctx, instDoc)
 	require.NoError(t, err, "dependent let b should resolve to a's value, so the assert must pass")
+}
+
+// TestRuleLetEvalErrorFailsValidation verifies that when a matched rule's
+// <let> expression cannot be evaluated, validation fails (returns
+// ErrValidationFailed) even though the rule's assert would otherwise pass.
+// A failing let must not silently let Validate report a "valid" result.
+func TestRuleLetEvalErrorFailsValidation(t *testing.T) {
+	const schemaSrc = `<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://purl.oclc.org/dsdl/schematron">
+  <pattern>
+    <rule context="/root">
+      <let name="x" value="not-a-function()"/>
+      <assert test="true()">always ok</assert>
+    </rule>
+  </pattern>
+</schema>`
+
+	const instanceSrc = `<?xml version="1.0" encoding="UTF-8"?><root/>`
+
+	ctx := t.Context()
+
+	schemaDoc, err := helium.NewParser().Parse(ctx, []byte(schemaSrc))
+	require.NoError(t, err, "parse schema")
+
+	schema, err := schematron.NewCompiler().Compile(ctx, schemaDoc)
+	require.NoError(t, err, "compile schema")
+
+	instDoc, err := helium.NewParser().Parse(ctx, []byte(instanceSrc))
+	require.NoError(t, err, "parse instance")
+
+	// With the default (nil) handler the validation must still fail: a broken
+	// let must not produce a silent "valid" result.
+	err = schematron.NewValidator(schema).Validate(ctx, instDoc)
+	require.ErrorIs(t, err, schematron.ErrValidationFailed, "a matched rule whose let fails to evaluate must fail validation even with the default handler")
+
+	// And the diagnostic must be surfaced to a handler when one is supplied.
+	var captured []string
+	handler := captureHandler{out: &captured}
+	err = schematron.NewValidator(schema).ErrorHandler(handler).Validate(ctx, instDoc)
+	require.ErrorIs(t, err, schematron.ErrValidationFailed, "validation must still fail with a handler attached")
+
+	joined := strings.Join(captured, "\n")
+	require.Contains(t, joined, "XPath error", "the let evaluation error must be surfaced to the handler")
+}
+
+// captureHandler records the string form of every error it receives.
+type captureHandler struct {
+	out *[]string
+}
+
+func (h captureHandler) Handle(_ context.Context, err error) {
+	*h.out = append(*h.out, err.Error())
 }

--- a/schematron/let_order_test.go
+++ b/schematron/let_order_test.go
@@ -1,0 +1,40 @@
+package schematron_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/schematron"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRuleLetDocumentOrder verifies that <let> bindings inside a rule are
+// evaluated in document order, so a later let may depend on an earlier one.
+func TestRuleLetDocumentOrder(t *testing.T) {
+	const schemaSrc = `<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://purl.oclc.org/dsdl/schematron">
+  <pattern>
+    <rule context="/root">
+      <let name="a" value="'ok'"/>
+      <let name="b" value="$a"/>
+      <assert test="$b='ok'">b must equal ok</assert>
+    </rule>
+  </pattern>
+</schema>`
+
+	const instanceSrc = `<?xml version="1.0" encoding="UTF-8"?><root/>`
+
+	ctx := t.Context()
+
+	schemaDoc, err := helium.NewParser().Parse(ctx, []byte(schemaSrc))
+	require.NoError(t, err, "parse schema")
+
+	schema, err := schematron.NewCompiler().Compile(ctx, schemaDoc)
+	require.NoError(t, err, "compile schema")
+
+	instDoc, err := helium.NewParser().Parse(ctx, []byte(instanceSrc))
+	require.NoError(t, err, "parse instance")
+
+	err = schematron.NewValidator(schema).Validate(ctx, instDoc)
+	require.NoError(t, err, "dependent let b should resolve to a's value, so the assert must pass")
+}

--- a/schematron/parse.go
+++ b/schematron/parse.go
@@ -151,10 +151,10 @@ func compileRuleChild(compileCtx context.Context, r *rule, childElem *helium.Ele
 			return
 		}
 		if lb != nil {
-			// Prepend to match libxml2's LIFO ordering: each new let
-			// is inserted at the head of the list, so evaluation
-			// proceeds in reverse-definition order.
-			r.lets = append([]*letBinding{lb}, r.lets...)
+			// Append in document order so each let is bound before any
+			// later let that references it (e.g. <let name="b"
+			// value="$a"/> after <let name="a" .../>).
+			r.lets = append(r.lets, lb)
 		}
 	case "assert":
 		if t := compileTest(compileCtx, childElem, testAssert, schNS, eh); t != nil {

--- a/schematron/schematron_test.go
+++ b/schematron/schematron_test.go
@@ -889,18 +889,19 @@ func TestLetVariableChainedDependency(t *testing.T) {
 		require.Contains(t, got, "y is hello")
 	})
 
-	t.Run("LIFO evaluation order", func(t *testing.T) {
+	t.Run("document order evaluation", func(t *testing.T) {
 		t.Parallel()
-		// libxml2 stores lets in LIFO order. When a is defined first and b
-		// second, the list is [b, a]. b is evaluated first (before a is
-		// registered), so $a in b's expression is NaN. We verify the
-		// observable effect: a=1 is reported correctly.
+		// Lets are evaluated in document order, so a later let may depend on
+		// an earlier one: a is defined first, then b references $a. We assert
+		// the dependent value b=2 (a=1 plus 1). Under the old reversed (LIFO)
+		// order b would be evaluated before a was bound, making $a NaN and
+		// b NaN — so this asserting b's resolved value would fail.
 		schema, errs := compileTestSchema(t, `<schema xmlns="http://purl.oclc.org/dsdl/schematron">
 			<pattern>
 				<rule context="item">
 					<let name="a" value="1"/>
 					<let name="b" value="$a + 1"/>
-					<report test="$a = 1">a=<value-of select="$a"/></report>
+					<report test="$b = 2">b=<value-of select="$b"/></report>
 				</rule>
 			</pattern>
 		</schema>`)
@@ -911,7 +912,7 @@ func TestLetVariableChainedDependency(t *testing.T) {
 
 		collected, err := validateAndCollect(t, schema, doc)
 		require.ErrorIs(t, err, schematron.ErrValidationFailed)
-		require.Contains(t, collectedString(collected), "a=1")
+		require.Contains(t, collectedString(collected), "b=2")
 	})
 }
 

--- a/schematron/validate.go
+++ b/schematron/validate.go
@@ -54,11 +54,17 @@ func validateDocument(ctx context.Context, doc *helium.Document, schema *Schema,
 				ruleEv := ev
 				for _, lb := range r.lets {
 					letResult, err := ruleEv.Evaluate(ctx, lb.expr, node)
-					if err == nil {
-						ruleEv = ruleEv.AdditionalVariables(map[string]any{
-							lb.name: xpathResultToValue(letResult),
-						})
+					if err != nil {
+						// A let whose expression cannot be evaluated must
+						// not be silently dropped: a later let or test that
+						// references it would then break in confusing ways.
+						// Surface the error instead of swallowing it.
+						handler.Handle(ctx, helium.NewLeveledError(fmt.Sprintf("XPath error : %s\n", formatXPathError(err)), helium.ErrorLevelError))
+						continue
 					}
+					ruleEv = ruleEv.AdditionalVariables(map[string]any{
+						lb.name: xpathResultToValue(letResult),
+					})
 				}
 
 				for _, t := range r.tests {

--- a/schematron/validate.go
+++ b/schematron/validate.go
@@ -58,7 +58,12 @@ func validateDocument(ctx context.Context, doc *helium.Document, schema *Schema,
 						// A let whose expression cannot be evaluated must
 						// not be silently dropped: a later let or test that
 						// references it would then break in confusing ways.
-						// Surface the error instead of swallowing it.
+						// Treat this as a validation failure and surface the
+						// error rather than swallowing it -- otherwise an
+						// otherwise-passing rule with a broken let would make
+						// Validate report a false "valid" result (and with a
+						// nil handler the error would be invisible).
+						valid = false
 						handler.Handle(ctx, helium.NewLeveledError(fmt.Sprintf("XPath error : %s\n", formatXPathError(err)), helium.ErrorLevelError))
 						continue
 					}


### PR DESCRIPTION
- Rule `<let>` bindings now evaluate in document order so a later let can reference an earlier one; previously they were prepended (LIFO) and dependent vars broke.
- Surface let-expression evaluation errors instead of silently dropping the binding.