### PR TITLE
reject active relative namespace uris in c14n

### DIFF
--- a/c14n/c14n_test.go
+++ b/c14n/c14n_test.go
@@ -348,6 +348,26 @@ func TestRelativeNamespaceURIRejected(t *testing.T) {
 	require.Contains(t, err.Error(), "relative namespace URI")
 }
 
+func TestActiveRelativeNamespaceURIRejected(t *testing.T) {
+	t.Parallel()
+	// A programmatically built DOM may set an *active* namespace with a
+	// relative URI via SetActiveNamespace. This active namespace is emitted
+	// during canonicalization, so the C14N relative-URI check must reject it
+	// even though it was never added as a declared namespace.
+	doc := helium.NewDocument("1.0", "", helium.StandaloneImplicitNo)
+
+	root := doc.CreateElement("root")
+	require.NoError(t, doc.SetDocumentElement(root))
+
+	child := doc.CreateElement("child")
+	require.NoError(t, root.AddChild(child))
+	require.NoError(t, child.SetActiveNamespace("p", "relative/uri"))
+
+	_, err := c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(doc)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "relative namespace URI")
+}
+
 func TestAbsoluteNamespaceURIAccepted(t *testing.T) {
 	t.Parallel()
 	xml := `<?xml version="1.0"?><root xmlns:ok="http://example.com"><child/></root>`

--- a/c14n/canonicalizer.go
+++ b/c14n/canonicalizer.go
@@ -104,16 +104,33 @@ func (c *canonicalizer) processDocument() error {
 	return nil
 }
 
-// checkForRelativeNamespaces checks that no namespace declaration on the
-// element has a relative URI.  The C14N spec requires implementations to
-// report failure when a relative namespace URI is encountered.
+// checkForRelativeNamespaces checks that no namespace on the element has a
+// relative URI.  The C14N spec requires implementations to report failure when
+// a relative namespace URI is encountered. Both declared namespaces
+// (e.Namespaces()) and the element's active namespace (e.Namespace()) are
+// inspected, because canonicalization emits in-scope active namespaces too — a
+// programmatically built DOM can set an active namespace with a relative URI
+// (via SetActiveNamespace) without ever declaring it.
 // Mirrors libxml2's xmlC14NCheckForRelativeNamespaces (c14n.c:1338-1373).
 func checkForRelativeNamespaces(e *helium.Element) error {
+	if err := checkRelativeNamespaceURI(e, e.Namespace()); err != nil {
+		return err
+	}
 	for _, ns := range e.Namespaces() {
-		uri := ns.URI()
-		if uri != "" && !strings.Contains(uri, ":") {
-			return fmt.Errorf("c14n: relative namespace URI %q on element %s", uri, e.Name())
+		if err := checkRelativeNamespaceURI(e, ns); err != nil {
+			return err
 		}
+	}
+	return nil
+}
+
+func checkRelativeNamespaceURI(e *helium.Element, ns *helium.Namespace) error {
+	if ns == nil {
+		return nil
+	}
+	uri := ns.URI()
+	if uri != "" && !strings.Contains(uri, ":") {
+		return fmt.Errorf("c14n: relative namespace URI %q on element %s", uri, e.Name())
 	}
 	return nil
 }


### PR DESCRIPTION
- c14n relative-URI check now also inspects an element's active namespace, not just declared ones, so an active namespace set with a relative URI is rejected as required