### PR TITLE
emit U+FFFD for overflowing html numeric char refs

### DIFF
--- a/html/charref_overflow_test.go
+++ b/html/charref_overflow_test.go
@@ -1,0 +1,48 @@
+package html_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/html"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNumericCharRefOverflow verifies that a numeric character reference whose
+// value overflows a 32-bit integer or exceeds the maximum Unicode code point is
+// mapped to the replacement character U+FFFD per HTML5, rather than being
+// dropped entirely (the buggy behavior treated ParseInt overflow as "no
+// digits" and emitted nothing). Both element-text and attribute-value contexts
+// must produce U+FFFD.
+func TestNumericCharRefOverflow(t *testing.T) {
+	const repl = "�"
+
+	cases := map[string]struct {
+		input string
+		want  string // expected serialized substring containing the U+FFFD site
+	}{
+		// Decimal value far above the 32-bit signed range.
+		"text-decimal-overflow": {"<p>x&#9999999999;y</p>", "<p>x" + repl + "y</p>"},
+		// Hex value just above the max code point (0x10FFFF).
+		"text-hex-above-max": {"<p>x&#x110000;y</p>", "<p>x" + repl + "y</p>"},
+		// Enormous hex value that overflows the accumulator.
+		"text-hex-overflow": {"<p>x&#xFFFFFFFFFF;y</p>", "<p>x" + repl + "y</p>"},
+		// Same in attribute values.
+		"attr-decimal-overflow": {`<p title="x&#9999999999;y">z</p>`, `title="x` + repl + `y"`},
+		"attr-hex-above-max":    {`<p title="x&#x110000;y">z</p>`, `title="x` + repl + `y"`},
+		"attr-hex-overflow":     {`<p title="x&#xFFFFFFFFFF;y">z</p>`, `title="x` + repl + `y"`},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			doc, err := html.NewParser().
+				SuppressErrors(true).
+				SuppressWarnings(true).
+				Parse(t.Context(), []byte(tc.input))
+			require.NoError(t, err, "parse must not error")
+
+			out, err := html.WriteString(doc)
+			require.NoError(t, err, "serialize must not error")
+			require.Contains(t, out, tc.want, "out-of-range numeric char ref must yield U+FFFD: %q", out)
+		})
+	}
+}

--- a/html/parser.go
+++ b/html/parser.go
@@ -862,6 +862,26 @@ func normalizeNumericCharRef(cp int) rune {
 	return rune(cp)
 }
 
+// parseNumericCharRef converts a numeric character reference's digit string
+// (already extracted) into a code point. ok reports whether any digits were
+// present at all; a bare "&#" / "&#x" with no digits yields ok==false so the
+// caller emits nothing. When digits are present but the value overflows or
+// exceeds the maximum Unicode code point, ok is true and cp is forced above the
+// valid range so normalizeNumericCharRef maps it to U+FFFD (per HTML5) rather
+// than being dropped.
+func parseNumericCharRef(digits string, base int) (int, bool) {
+	if digits == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseInt(digits, base, 32)
+	if err != nil {
+		// Out-of-range (overflow) or otherwise unrepresentable in 32 bits:
+		// route to normalizeNumericCharRef via an out-of-range sentinel.
+		return 0x110000, true
+	}
+	return int(v), true
+}
+
 // parseCharRef handles entity references (&name; or &#num; or &#xhex;).
 // Emits the resolved value as a Characters SAX event (entity splitting behavior).
 func (p *parser) parseCharRef() {
@@ -877,18 +897,10 @@ func (p *parser) parseCharRef() {
 		if p.cur.Peek() == 'x' || p.cur.Peek() == 'X' {
 			_ = p.cur.Advance(1) // skip 'x'
 			hexStr := p.parseWhile(isHexDigit)
-			codepoint64, err := strconv.ParseInt(hexStr, 16, 32)
-			if err == nil {
-				codepoint = int(codepoint64)
-				haveDigits = true
-			}
+			codepoint, haveDigits = parseNumericCharRef(hexStr, 16)
 		} else {
 			numStr := p.parseWhile(isDigit)
-			codepoint64, err := strconv.ParseInt(numStr, 10, 32)
-			if err == nil {
-				codepoint = int(codepoint64)
-				haveDigits = true
-			}
+			codepoint, haveDigits = parseNumericCharRef(numStr, 10)
 		}
 		if p.cur.Peek() == ';' {
 			_ = p.cur.Advance(1)
@@ -1363,18 +1375,10 @@ func (p *parser) resolveEntityInAttr() string {
 		if p.cur.Peek() == 'x' || p.cur.Peek() == 'X' {
 			_ = p.cur.Advance(1)
 			hexStr := p.parseWhile(isHexDigit)
-			cp, err := strconv.ParseInt(hexStr, 16, 32)
-			if err == nil {
-				codepoint = int(cp)
-				haveDigits = true
-			}
+			codepoint, haveDigits = parseNumericCharRef(hexStr, 16)
 		} else {
 			numStr := p.parseWhile(isDigit)
-			cp, err := strconv.ParseInt(numStr, 10, 32)
-			if err == nil {
-				codepoint = int(cp)
-				haveDigits = true
-			}
+			codepoint, haveDigits = parseNumericCharRef(numStr, 10)
 		}
 		if p.cur.Peek() == ';' {
 			_ = p.cur.Advance(1)


### PR DESCRIPTION
- Out-of-range/overflowing numeric HTML character refs (e.g. `&#9999999999;`, `&#xFFFFFFFFFF;`) were silently dropped because ParseInt overflow was treated as "no digits"
- Route overflow values through normalizeNumericCharRef so they yield U+FFFD per HTML5, in both element-text and attribute-value paths