### PR TITLE
fix catalog file uri loading and uri delegation

### DIFF
--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -311,6 +311,55 @@ func TestNextCatalogFileURI(t *testing.T) {
 	require.Equal(t, "file:///downstream/asset.xml", got)
 }
 
+// A downstream catalog reached via a "file:" nextCatalog whose own entry uses a
+// RELATIVE uri must resolve that uri against the catalog's "file:" URI, yielding
+// a "file:" URI — not a bare filesystem path. Regression for the baseURI being
+// overwritten with the decoded local path in loadInternal.
+func TestNextCatalogFileURIRelativeEntry(t *testing.T) {
+	dir := t.TempDir()
+
+	nextPath, err := filepath.Abs(filepath.Join(dir, "next.xml"))
+	require.NoError(t, err)
+
+	// The downstream entry's uri is relative ("asset.xml"); it must resolve
+	// against the downstream catalog's own file: URI.
+	nextXML := `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <uri name="http://example.com/asset" uri="asset.xml"/>
+</catalog>`
+	require.NoError(t, os.WriteFile(nextPath, []byte(nextXML), 0o600))
+
+	// Reference the downstream catalog via a portable file:// URI (see
+	// TestNextCatalogFileURI for the construction rationale).
+	slashPath := filepath.ToSlash(nextPath)
+	if !strings.HasPrefix(slashPath, "/") {
+		slashPath = "/" + slashPath
+	}
+	nextURI := (&url.URL{Scheme: "file", Path: slashPath}).String()
+	rootXML := `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <nextCatalog catalog="` + nextURI + `"/>
+</catalog>`
+	rootPath := filepath.Join(dir, "root.xml")
+	require.NoError(t, os.WriteFile(rootPath, []byte(rootXML), 0o600))
+
+	cat, err := catalog.Load(context.Background(), rootPath)
+	require.NoError(t, err)
+
+	got := cat.ResolveURI(context.Background(), "http://example.com/asset")
+
+	// The relative "asset.xml" must resolve to a file: URI in the same
+	// directory as next.xml, not to the bare local path nextPath's directory.
+	dirSlash := filepath.ToSlash(filepath.Dir(nextPath))
+	if !strings.HasPrefix(dirSlash, "/") {
+		dirSlash = "/" + dirSlash
+	}
+	want := (&url.URL{Scheme: "file", Path: dirSlash + "/asset.xml"}).String()
+	require.Equal(t, want, got)
+	require.True(t, strings.HasPrefix(got, "file:"),
+		"relative downstream uri must resolve to a file: URI, got %q", got)
+}
+
 func TestLoadError(t *testing.T) {
 	_, err := catalog.Load(context.Background(), "/nonexistent/catalog.xml")
 	require.Error(t, err)

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -2,8 +2,10 @@ package catalog_test
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/lestrrat-go/helium/catalog"
@@ -284,9 +286,20 @@ func TestNextCatalogFileURI(t *testing.T) {
 	require.NoError(t, os.WriteFile(nextPath, []byte(nextXML), 0o600))
 
 	// Reference the downstream catalog via a file:// URI (not a bare path).
+	// Build the URI portably: slash-normalize the absolute path and ensure a
+	// leading slash so the authority component is empty. On POSIX nextPath is
+	// "/abs/next.xml" -> "file:///abs/next.xml"; on Windows it is
+	// "C:\...\next.xml" -> "C:/.../next.xml" -> "file:///C:/.../next.xml".
+	// This round-trips through the production catalogFilePath/fileURIPath code
+	// back to nextPath on the current OS.
+	slashPath := filepath.ToSlash(nextPath)
+	if !strings.HasPrefix(slashPath, "/") {
+		slashPath = "/" + slashPath
+	}
+	nextURI := (&url.URL{Scheme: "file", Path: slashPath}).String()
 	rootXML := `<?xml version="1.0"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-  <nextCatalog catalog="file://` + nextPath + `"/>
+  <nextCatalog catalog="` + nextURI + `"/>
 </catalog>`
 	rootPath := filepath.Join(dir, "root.xml")
 	require.NoError(t, os.WriteFile(rootPath, []byte(rootXML), 0o600))

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -268,6 +268,38 @@ func TestResolveURI(t *testing.T) {
 	require.Equal(t, "", got)
 }
 
+// A root catalog whose nextCatalog references a downstream catalog via a
+// "file://" URI must resolve the downstream mapping. The file: URI has to be
+// converted to a local filesystem path before opening.
+func TestNextCatalogFileURI(t *testing.T) {
+	dir, err := os.MkdirTemp(".", ".tmp-nextcatalog-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	nextPath, err := filepath.Abs(filepath.Join(dir, "next.xml"))
+	require.NoError(t, err)
+
+	nextXML := `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <uri name="http://example.com/asset" uri="file:///downstream/asset.xml"/>
+</catalog>`
+	require.NoError(t, os.WriteFile(nextPath, []byte(nextXML), 0o600))
+
+	// Reference the downstream catalog via a file:// URI (not a bare path).
+	rootXML := `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <nextCatalog catalog="file://` + nextPath + `"/>
+</catalog>`
+	rootPath := filepath.Join(dir, "root.xml")
+	require.NoError(t, os.WriteFile(rootPath, []byte(rootXML), 0o600))
+
+	cat, err := catalog.Load(context.Background(), rootPath)
+	require.NoError(t, err)
+
+	got := cat.ResolveURI(context.Background(), "http://example.com/asset")
+	require.Equal(t, "file:///downstream/asset.xml", got)
+}
+
 func TestLoadError(t *testing.T) {
 	_, err := catalog.Load(context.Background(), "/nonexistent/catalog.xml")
 	require.Error(t, err)

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -272,9 +272,7 @@ func TestResolveURI(t *testing.T) {
 // "file://" URI must resolve the downstream mapping. The file: URI has to be
 // converted to a local filesystem path before opening.
 func TestNextCatalogFileURI(t *testing.T) {
-	dir, err := os.MkdirTemp(".", ".tmp-nextcatalog-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	nextPath, err := filepath.Abs(filepath.Join(dir, "next.xml"))
 	require.NoError(t, err)

--- a/catalog/load.go
+++ b/catalog/load.go
@@ -7,11 +7,17 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	helium "github.com/lestrrat-go/helium"
 	icatalog "github.com/lestrrat-go/helium/internal/catalog"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 )
+
+// goosWindows is the runtime.GOOS value for Windows. Drive-letter handling in
+// file: URIs is gated on this so POSIX behavior is never altered.
+const goosWindows = "windows"
 
 // internalLoader implements icatalog.Loader using helium's parser.
 type internalLoader struct {
@@ -106,8 +112,10 @@ func catalogFilePath(ref string) (string, error) {
 
 	// For "file:///abs/path" the host is empty and Path holds the (already
 	// percent-decoded) absolute path. For "file://host/path" a non-localhost
-	// host is not addressable on the local filesystem.
-	if u.Host != "" && u.Host != "localhost" {
+	// host is not addressable on the local filesystem. URI hosts are
+	// case-insensitive, so an empty host and "localhost" in any case both
+	// denote the local machine.
+	if u.Host != "" && !strings.EqualFold(u.Host, "localhost") {
 		return "", fmt.Errorf("catalog: non-local file URI host %q in %q", u.Host, ref)
 	}
 
@@ -116,13 +124,22 @@ func catalogFilePath(ref string) (string, error) {
 
 // fileURIPath converts the (already percent-decoded) path component of a "file:"
 // URI into a local filesystem path. On POSIX an absolute URI path such as
-// "/abs/x" is returned unchanged. On Windows a URI such as "file:///C:/tmp/x"
-// yields a path of "/C:/tmp/x"; the leading slash before the drive letter is
-// stripped ("C:/tmp/x") and slashes are converted to the OS separator.
+// "/abs/x" — including "/C:/tmp/x", which is a legitimate POSIX absolute path —
+// is returned unchanged. On Windows a URI such as "file:///C:/tmp/x" yields a
+// path of "/C:/tmp/x"; the leading slash before the drive letter is stripped
+// ("C:/tmp/x") and slashes are converted to the OS separator.
 func fileURIPath(p string) string {
-	// Detect a Windows drive-letter path of the form "/C:/...": a leading slash
-	// followed by a single ASCII letter and a colon.
-	if len(p) >= 3 && p[0] == '/' && isASCIILetter(p[1]) && p[2] == ':' {
+	return fileURIPathFor(runtime.GOOS, p)
+}
+
+// fileURIPathFor is the OS-parameterized implementation of fileURIPath. The
+// drive-letter slash strip only applies on Windows; on POSIX "/C:/tmp/x" is a
+// valid absolute path and must be left untouched. goos is threaded explicitly
+// so the conversion is deterministically testable on a non-Windows CI host.
+func fileURIPathFor(goos, p string) string {
+	// On Windows, detect a drive-letter path of the form "/C:/...": a leading
+	// slash followed by a single ASCII letter and a colon, and strip the slash.
+	if goos == goosWindows && len(p) >= 3 && p[0] == '/' && isASCIILetter(p[1]) && p[2] == ':' {
 		p = p[1:]
 	}
 	return filepath.FromSlash(p)

--- a/catalog/load.go
+++ b/catalog/load.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -56,7 +57,12 @@ func (l Loader) Load(ctx context.Context, filename string) (*Catalog, error) { /
 }
 
 func loadInternal(ctx context.Context, filename string, eh helium.ErrorHandler) (*icatalog.Catalog, error) {
-	absPath, err := filepath.Abs(filename)
+	path, err := catalogFilePath(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return nil, fmt.Errorf("catalog: failed to resolve path %q: %w", filename, err)
 	}
@@ -67,6 +73,33 @@ func loadInternal(ctx context.Context, filename string, eh helium.ErrorHandler) 
 	}
 
 	return loadFromBytes(ctx, data, absPath, eh)
+}
+
+// catalogFilePath converts a catalog reference into a local filesystem path.
+// Bare paths are returned unchanged. "file:" URIs are parsed and percent-decoded
+// into a local path. Any other URI scheme is unsupported and rejected.
+func catalogFilePath(ref string) (string, error) {
+	if !icatalog.HasScheme(ref) {
+		return ref, nil
+	}
+
+	u, err := url.Parse(ref)
+	if err != nil {
+		return "", fmt.Errorf("catalog: failed to parse URI %q: %w", ref, err)
+	}
+
+	if u.Scheme != "file" {
+		return "", fmt.Errorf("catalog: unsupported URI scheme %q in %q", u.Scheme, ref)
+	}
+
+	// For "file:///abs/path" the host is empty and Path holds the (already
+	// percent-decoded) absolute path. For "file://host/path" a non-localhost
+	// host is not addressable on the local filesystem.
+	if u.Host != "" && u.Host != "localhost" {
+		return "", fmt.Errorf("catalog: non-local file URI host %q in %q", u.Host, ref)
+	}
+
+	return u.Path, nil
 }
 
 func loadFromBytes(ctx context.Context, data []byte, baseURI string, eh helium.ErrorHandler) (*icatalog.Catalog, error) {

--- a/catalog/load.go
+++ b/catalog/load.go
@@ -79,6 +79,18 @@ func loadInternal(ctx context.Context, filename string, eh helium.ErrorHandler) 
 // Bare paths are returned unchanged. "file:" URIs are parsed and percent-decoded
 // into a local path. Any other URI scheme is unsupported and rejected.
 func catalogFilePath(ref string) (string, error) {
+	// A Windows path such as "C:\tmp\catalog.xml", "C:/tmp/catalog.xml", or a
+	// "\\host\share" UNC path must be treated as a local OS path, not as a URI
+	// whose scheme is the drive letter "C". Check this before HasScheme so the
+	// leading "C:" is not mistaken for a scheme.
+	//
+	// filepath.VolumeName only recognizes these forms when running on Windows,
+	// so a portable drive-letter check is needed as well to keep the behavior
+	// consistent (and tested) on the POSIX CI host.
+	if filepath.VolumeName(ref) != "" || hasDriveLetterPrefix(ref) {
+		return ref, nil
+	}
+
 	if !icatalog.HasScheme(ref) {
 		return ref, nil
 	}
@@ -99,7 +111,33 @@ func catalogFilePath(ref string) (string, error) {
 		return "", fmt.Errorf("catalog: non-local file URI host %q in %q", u.Host, ref)
 	}
 
-	return u.Path, nil
+	return fileURIPath(u.Path), nil
+}
+
+// fileURIPath converts the (already percent-decoded) path component of a "file:"
+// URI into a local filesystem path. On POSIX an absolute URI path such as
+// "/abs/x" is returned unchanged. On Windows a URI such as "file:///C:/tmp/x"
+// yields a path of "/C:/tmp/x"; the leading slash before the drive letter is
+// stripped ("C:/tmp/x") and slashes are converted to the OS separator.
+func fileURIPath(p string) string {
+	// Detect a Windows drive-letter path of the form "/C:/...": a leading slash
+	// followed by a single ASCII letter and a colon.
+	if len(p) >= 3 && p[0] == '/' && isASCIILetter(p[1]) && p[2] == ':' {
+		p = p[1:]
+	}
+	return filepath.FromSlash(p)
+}
+
+func isASCIILetter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+// hasDriveLetterPrefix reports whether s begins with a Windows drive-letter
+// prefix such as "C:\" or "C:/". This is checked independently of the host OS
+// so a drive-letter reference is never mistaken for a URI scheme.
+func hasDriveLetterPrefix(s string) bool {
+	return len(s) >= 3 && isASCIILetter(s[0]) && s[1] == ':' &&
+		(s[2] == '\\' || s[2] == '/')
 }
 
 func loadFromBytes(ctx context.Context, data []byte, baseURI string, eh helium.ErrorHandler) (*icatalog.Catalog, error) {

--- a/catalog/load.go
+++ b/catalog/load.go
@@ -63,7 +63,7 @@ func (l Loader) Load(ctx context.Context, filename string) (*Catalog, error) { /
 }
 
 func loadInternal(ctx context.Context, filename string, eh helium.ErrorHandler) (*icatalog.Catalog, error) {
-	path, err := catalogFilePath(filename)
+	path, isFileURI, err := catalogFilePath(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -78,13 +78,28 @@ func loadInternal(ctx context.Context, filename string, eh helium.ErrorHandler) 
 		return nil, fmt.Errorf("catalog: failed to read %q: %w", absPath, err)
 	}
 
-	return loadFromBytes(ctx, data, absPath, eh)
+	// Read from the local filesystem path, but resolve relative URIs in the
+	// catalog against the catalog's URI. When the catalog was referenced via a
+	// "file:" URI, downstream relative URIs must stay in "file:" URI space (so
+	// "asset.xml" in /tmp/catalog.xml resolves to "file:///tmp/asset.xml", not
+	// the bare local path "/tmp/asset.xml"). For a plain OS path input, the
+	// filesystem path itself is the base, preserving the original behavior.
+	baseURI := absPath
+	if isFileURI {
+		baseURI = localPathToFileURI(absPath)
+	}
+
+	return loadFromBytes(ctx, data, baseURI, eh)
 }
 
 // catalogFilePath converts a catalog reference into a local filesystem path.
 // Bare paths are returned unchanged. "file:" URIs are parsed and percent-decoded
 // into a local path. Any other URI scheme is unsupported and rejected.
-func catalogFilePath(ref string) (string, error) {
+//
+// The second return value reports whether ref was a "file:" URI. Callers use it
+// to decide the catalog's baseURI: a "file:" reference keeps relative downstream
+// URIs in "file:" URI space, while a plain OS path resolves them as OS paths.
+func catalogFilePath(ref string) (string, bool, error) {
 	// A Windows path such as "C:\tmp\catalog.xml", "C:/tmp/catalog.xml", or a
 	// "\\host\share" UNC path must be treated as a local OS path, not as a URI
 	// whose scheme is the drive letter "C". Check this before HasScheme so the
@@ -94,20 +109,20 @@ func catalogFilePath(ref string) (string, error) {
 	// so a portable drive-letter check is needed as well to keep the behavior
 	// consistent (and tested) on the POSIX CI host.
 	if filepath.VolumeName(ref) != "" || hasDriveLetterPrefix(ref) {
-		return ref, nil
+		return ref, false, nil
 	}
 
 	if !icatalog.HasScheme(ref) {
-		return ref, nil
+		return ref, false, nil
 	}
 
 	u, err := url.Parse(ref)
 	if err != nil {
-		return "", fmt.Errorf("catalog: failed to parse URI %q: %w", ref, err)
+		return "", false, fmt.Errorf("catalog: failed to parse URI %q: %w", ref, err)
 	}
 
 	if u.Scheme != "file" {
-		return "", fmt.Errorf("catalog: unsupported URI scheme %q in %q", u.Scheme, ref)
+		return "", false, fmt.Errorf("catalog: unsupported URI scheme %q in %q", u.Scheme, ref)
 	}
 
 	// For "file:///abs/path" the host is empty and Path holds the (already
@@ -116,10 +131,23 @@ func catalogFilePath(ref string) (string, error) {
 	// case-insensitive, so an empty host and "localhost" in any case both
 	// denote the local machine.
 	if u.Host != "" && !strings.EqualFold(u.Host, "localhost") {
-		return "", fmt.Errorf("catalog: non-local file URI host %q in %q", u.Host, ref)
+		return "", false, fmt.Errorf("catalog: non-local file URI host %q in %q", u.Host, ref)
 	}
 
-	return fileURIPath(u.Path), nil
+	return fileURIPath(u.Path), true, nil
+}
+
+// localPathToFileURI builds a "file://" URI from an absolute local filesystem
+// path. It is used as the catalog baseURI when the catalog was referenced by a
+// "file:" URI, so relative URIs in the catalog resolve back into "file:" URI
+// space rather than as bare filesystem paths.
+//
+// (&url.URL{Scheme: "file", Path: ...}).String() percent-encodes as needed and,
+// on Windows, converts the OS separator to "/" via filepath.ToSlash, yielding
+// "file:///C:/tmp/catalog.xml". On POSIX the absolute path already uses "/".
+func localPathToFileURI(absPath string) string {
+	u := url.URL{Scheme: "file", Path: filepath.ToSlash(absPath)}
+	return u.String()
 }
 
 // fileURIPath converts the (already percent-decoded) path component of a "file:"

--- a/catalog/load_internal_test.go
+++ b/catalog/load_internal_test.go
@@ -70,9 +70,10 @@ func TestCatalogFilePathDriveLetterIsLocal(t *testing.T) {
 
 	for _, ref := range tests {
 		t.Run(ref, func(t *testing.T) {
-			got, err := catalogFilePath(ref)
+			got, isFileURI, err := catalogFilePath(ref)
 			require.NoError(t, err)
 			require.Equal(t, ref, got)
+			require.False(t, isFileURI)
 		})
 	}
 }
@@ -110,16 +111,17 @@ func TestCatalogFilePathLocalHost(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := catalogFilePath(tc.ref)
+			got, isFileURI, err := catalogFilePath(tc.ref)
 			require.NoError(t, err)
 			require.Equal(t, tc.expect, got)
+			require.True(t, isFileURI)
 		})
 	}
 }
 
 // catalogFilePath must reject a genuinely remote (non-local) host.
 func TestCatalogFilePathRemoteHostRejected(t *testing.T) {
-	_, err := catalogFilePath("file://example.com/etc/xml/catalog.xml")
+	_, _, err := catalogFilePath("file://example.com/etc/xml/catalog.xml")
 	require.Error(t, err)
 }
 
@@ -130,7 +132,8 @@ func TestCatalogFilePathPOSIXDriveLetterStaysAbsolute(t *testing.T) {
 	if runtime.GOOS == goosWindows {
 		t.Skip("POSIX-specific behavior")
 	}
-	got, err := catalogFilePath("file:///C:/tmp/catalog.xml")
+	got, isFileURI, err := catalogFilePath("file:///C:/tmp/catalog.xml")
 	require.NoError(t, err)
 	require.Equal(t, "/C:/tmp/catalog.xml", got)
+	require.True(t, isFileURI)
 }

--- a/catalog/load_internal_test.go
+++ b/catalog/load_internal_test.go
@@ -1,0 +1,63 @@
+package catalog
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fileURIPath must convert a Windows "file:///C:/..." URI path into a
+// drive-letter filesystem path while leaving POSIX absolute paths unchanged.
+// The conversion logic is exercised directly so it runs on Linux CI.
+func TestFileURIPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string // path component of a file: URI
+		expect string
+	}{
+		{
+			name:   "posix absolute path unchanged",
+			path:   "/usr/share/xml/catalog.xml",
+			expect: filepath.FromSlash("/usr/share/xml/catalog.xml"),
+		},
+		{
+			name:   "windows drive letter strips leading slash",
+			path:   "/C:/tmp/catalog.xml",
+			expect: filepath.FromSlash("C:/tmp/catalog.xml"),
+		},
+		{
+			name:   "windows drive letter lowercase",
+			path:   "/d:/data/cat.xml",
+			expect: filepath.FromSlash("d:/data/cat.xml"),
+		},
+		{
+			name:   "non drive colon path unchanged",
+			path:   "/ab:/x",
+			expect: filepath.FromSlash("/ab:/x"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expect, fileURIPath(tc.path))
+		})
+	}
+}
+
+// catalogFilePath must treat a bare Windows drive-letter path as a local OS
+// path rather than rejecting "C" as an unsupported URI scheme.
+func TestCatalogFilePathDriveLetterIsLocal(t *testing.T) {
+	tests := []string{
+		`C:\tmp\catalog.xml`,
+		`C:/tmp/catalog.xml`,
+	}
+
+	for _, ref := range tests {
+		t.Run(ref, func(t *testing.T) {
+			got, err := catalogFilePath(ref)
+			require.NoError(t, err)
+			require.Equal(t, ref, got)
+		})
+	}
+}

--- a/catalog/load_internal_test.go
+++ b/catalog/load_internal_test.go
@@ -2,37 +2,52 @@ package catalog
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// fileURIPath must convert a Windows "file:///C:/..." URI path into a
-// drive-letter filesystem path while leaving POSIX absolute paths unchanged.
-// The conversion logic is exercised directly so it runs on Linux CI.
+// fileURIPathFor must strip the leading slash before a drive letter only on
+// Windows. On POSIX "/C:/tmp/x" is a legitimate absolute path and must be left
+// unchanged. goos is passed explicitly so both branches run deterministically
+// on the Linux CI host.
 func TestFileURIPath(t *testing.T) {
 	tests := []struct {
 		name   string
+		goos   string
 		path   string // path component of a file: URI
 		expect string
 	}{
 		{
 			name:   "posix absolute path unchanged",
+			goos:   "linux",
 			path:   "/usr/share/xml/catalog.xml",
 			expect: filepath.FromSlash("/usr/share/xml/catalog.xml"),
 		},
 		{
+			// Regression: on POSIX "/C:/tmp/..." is an absolute path and the
+			// leading slash must NOT be stripped.
+			name:   "posix drive-letter-like path stays absolute",
+			goos:   "linux",
+			path:   "/C:/tmp/catalog.xml",
+			expect: filepath.FromSlash("/C:/tmp/catalog.xml"),
+		},
+		{
 			name:   "windows drive letter strips leading slash",
+			goos:   goosWindows,
 			path:   "/C:/tmp/catalog.xml",
 			expect: filepath.FromSlash("C:/tmp/catalog.xml"),
 		},
 		{
 			name:   "windows drive letter lowercase",
+			goos:   goosWindows,
 			path:   "/d:/data/cat.xml",
 			expect: filepath.FromSlash("d:/data/cat.xml"),
 		},
 		{
-			name:   "non drive colon path unchanged",
+			name:   "windows non drive colon path unchanged",
+			goos:   goosWindows,
 			path:   "/ab:/x",
 			expect: filepath.FromSlash("/ab:/x"),
 		},
@@ -40,7 +55,7 @@ func TestFileURIPath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expect, fileURIPath(tc.path))
+			require.Equal(t, tc.expect, fileURIPathFor(tc.goos, tc.path))
 		})
 	}
 }
@@ -60,4 +75,62 @@ func TestCatalogFilePathDriveLetterIsLocal(t *testing.T) {
 			require.Equal(t, ref, got)
 		})
 	}
+}
+
+// catalogFilePath must treat the "localhost" host of a file: URI as the local
+// machine regardless of case, since URI hosts are case-insensitive. An empty
+// host denotes the local machine as well.
+func TestCatalogFilePathLocalHost(t *testing.T) {
+	tests := []struct {
+		name   string
+		ref    string
+		expect string
+	}{
+		{
+			name:   "empty host",
+			ref:    "file:///etc/xml/catalog.xml",
+			expect: filepath.FromSlash("/etc/xml/catalog.xml"),
+		},
+		{
+			name:   "lowercase localhost",
+			ref:    "file://localhost/etc/xml/catalog.xml",
+			expect: filepath.FromSlash("/etc/xml/catalog.xml"),
+		},
+		{
+			name:   "uppercase LOCALHOST",
+			ref:    "file://LOCALHOST/etc/xml/catalog.xml",
+			expect: filepath.FromSlash("/etc/xml/catalog.xml"),
+		},
+		{
+			name:   "mixed case LocalHost",
+			ref:    "file://LocalHost/etc/xml/catalog.xml",
+			expect: filepath.FromSlash("/etc/xml/catalog.xml"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := catalogFilePath(tc.ref)
+			require.NoError(t, err)
+			require.Equal(t, tc.expect, got)
+		})
+	}
+}
+
+// catalogFilePath must reject a genuinely remote (non-local) host.
+func TestCatalogFilePathRemoteHostRejected(t *testing.T) {
+	_, err := catalogFilePath("file://example.com/etc/xml/catalog.xml")
+	require.Error(t, err)
+}
+
+// catalogFilePath must keep a POSIX "file:///C:/..." path absolute. The
+// drive-letter slash strip is Windows-only; on POSIX "/C:/tmp/..." is a valid
+// absolute path, so this asserts deterministically on the Linux CI host.
+func TestCatalogFilePathPOSIXDriveLetterStaysAbsolute(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("POSIX-specific behavior")
+	}
+	got, err := catalogFilePath("file:///C:/tmp/catalog.xml")
+	require.NoError(t, err)
+	require.Equal(t, "/C:/tmp/catalog.xml", got)
 }

--- a/internal/catalog/resolve.go
+++ b/internal/catalog/resolve.go
@@ -208,7 +208,7 @@ func (c *Catalog) resolveURI(ctx context.Context, uri string) string {
 				rewrite = e
 				lenRewrite = len(e.Name)
 			}
-		case EntryDelegateURI, EntryDelegateSystem:
+		case EntryDelegateURI:
 			if strings.HasPrefix(uri, e.Name) {
 				haveDelegate++
 			}
@@ -307,13 +307,13 @@ func (c *Catalog) resolveDelegatePublic(ctx context.Context, pubID string) strin
 	return ""
 }
 
-// resolveDelegateURI tries all matching delegateURI and delegateSystem entries.
+// resolveDelegateURI tries all matching delegateURI entries.
 func (c *Catalog) resolveDelegateURI(ctx context.Context, uri string) string {
 	seen := make(map[string]struct{}, MaxDelegates)
 
 	for i := range c.Entries {
 		e := &c.Entries[i]
-		if e.Type != EntryDelegateURI && e.Type != EntryDelegateSystem {
+		if e.Type != EntryDelegateURI {
 			continue
 		}
 		if !strings.HasPrefix(uri, e.Name) {

--- a/internal/catalog/resolve_test.go
+++ b/internal/catalog/resolve_test.go
@@ -77,6 +77,35 @@ func TestResolveURIURNNotFound(t *testing.T) {
 	require.Equal(t, "", got)
 }
 
+// A catalog containing only delegateSystem entries must NOT influence URI
+// resolution. System-identifier delegation belongs to the system-id path only.
+func TestResolveURIIgnoresDelegateSystem(t *testing.T) {
+	t.Parallel()
+
+	delegate := &catalog.Catalog{
+		Entries: []catalog.Entry{
+			{Type: catalog.EntryURI, Name: "http://example.com/asset", URL: "file:///delegated/asset"},
+		},
+	}
+	loader := &countingLoader{
+		counts: make(map[string]*atomic.Int32),
+		cat:    delegate,
+	}
+
+	cat := &catalog.Catalog{
+		Entries: []catalog.Entry{
+			{Type: catalog.EntryDelegateSystem, Name: "http://example.com/", URL: sharedCatalogXML},
+		},
+		Loader: loader,
+		Prefer: catalog.PreferPublic,
+	}
+
+	// delegateSystem must not be consulted for URI resolution.
+	got := cat.ResolveURI(t.Context(), "http://example.com/asset")
+	require.Equal(t, "", got)
+	require.Nil(t, loader.counts[sharedCatalogXML], "delegateSystem must not be loaded during ResolveURI")
+}
+
 // countingLoader is a Loader that counts how many times each URL is loaded.
 type countingLoader struct {
 	counts map[string]*atomic.Int32


### PR DESCRIPTION
- loadInternal now converts `file:` catalog URIs (e.g. nextCatalog) to local paths and rejects other schemes instead of opening them as literal paths
- ResolveURI no longer follows delegateSystem entries; system-id delegation stays in the system-id path only