### PR TITLE
reject invalid xpointer child index and trailing shorthand

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -8,13 +8,14 @@ internal/cli/heliumcmd → helium, c14n, relaxng, schematron, xsd, xinclude, xpa
 shim           → helium, stream, enum, internal/encoding, internal/xmlchar
 xinclude       → helium, xpointer
                   → xpath1 (via xpointer)
+                  → internal/xmlchar (via xpointer)
                   → internal/encoding
 xpath3         → helium, internal/xpath, internal/lexicon, internal/icu, internal/unparsedtext, internal/strcursor, internal/sequence, internal/xsdregex
 xslt3          → helium, xpath3, xsd, html, internal/lexicon, internal/sequence, internal/xpathstream, xslt3/internal/elements
 xsd            → helium, xpath1, internal/lexicon, internal/xsd/value, internal/xsdregex
 relaxng        → helium, internal/lexicon, internal/iofs, internal/xsd/value
 schematron     → helium, xpath1
-xpointer       → helium, xpath1
+xpointer       → helium, xpath1, internal/xmlchar
 c14n           → helium
 xmldsig1       → helium, c14n, internal/lexicon
 xmlenc1        → helium
@@ -50,7 +51,7 @@ c14n, xpath1, xpath3, html, catalog, relaxng, stream, xmlenc1
 xmldsig1 (root + c14n + internal/lexicon)
 
 ## Composition layer (depends on processing)
-xsd (root + xpath1 + internal/lexicon), xpointer (root + xpath1), schematron (root + xpath1), xinclude (root + xpointer), xslt3 (root + xpath3 + xsd + html + internal/elements), shim (root + stream)
+xsd (root + xpath1 + internal/lexicon), xpointer (root + xpath1 + internal/xmlchar), schematron (root + xpath1), xinclude (root + xpointer), xslt3 (root + xpath3 + xsd + html + internal/elements), shim (root + stream)
 
 ## Application layer
 internal/cli/heliumcmd (CLI implementation)

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -203,7 +203,7 @@ XPointer expression evaluation with scheme cascading.
 - Schemes: xpointer(), xpath1() → XPath; element(/1/2/3) → child-sequence; xmlns() → ns binding; shorthand → ID lookup
 - Multiple scheme parts left-to-right; first non-empty result wins
 - Files: `xpointer.go`
-- Imports: helium, xpath1/
+- Imports: helium, xpath1/, internal/xmlchar/
 
 ## schematron/
 

--- a/xpointer/xpointer.go
+++ b/xpointer/xpointer.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	helium "github.com/lestrrat-go/helium"
@@ -303,6 +304,7 @@ func evaluateElement(doc *helium.Document, body string) ([]helium.Node, error) {
 	if parts[0] != "" && !xmlchar.IsValidNCName(parts[0]) {
 		return nil, fmt.Errorf("xpointer: invalid element() id %q (not an NCName)", parts[0])
 	}
+	childIndexes := make([]int, 0, len(parts)-1)
 	for _, part := range parts[1:] {
 		if part == "" {
 			return nil, fmt.Errorf("xpointer: empty child-sequence segment in element() scheme (trailing or doubled %q)", "/")
@@ -310,6 +312,11 @@ func evaluateElement(doc *helium.Document, body string) ([]helium.Node, error) {
 		if !isChildIndex(part) {
 			return nil, fmt.Errorf("xpointer: invalid child index %q in element() scheme (must match [1-9][0-9]*)", part)
 		}
+		idx, err := childIndexValue(part)
+		if err != nil {
+			return nil, err
+		}
+		childIndexes = append(childIndexes, idx)
 	}
 
 	var cur helium.Node = doc
@@ -323,8 +330,7 @@ func evaluateElement(doc *helium.Document, body string) ([]helium.Node, error) {
 		cur = elem
 	}
 
-	for _, part := range parts[1:] {
-		childIdx := atoiChildIndex(part) // already validated above
+	for _, childIdx := range childIndexes {
 		cur = nthElementChild(cur, childIdx)
 		if cur == nil {
 			return nil, nil
@@ -356,15 +362,18 @@ func isChildIndex(s string) bool {
 	return true
 }
 
-// atoiChildIndex converts a child-sequence index already validated by
-// isChildIndex into an int. The grammar guarantees only ASCII digits, so the
-// conversion cannot fail.
-func atoiChildIndex(s string) int {
-	n := 0
-	for i := range len(s) {
-		n = n*10 + int(s[i]-'0')
+// childIndexValue converts a child-sequence index already validated by
+// isChildIndex into an int. isChildIndex guarantees the lexical form, but an
+// arbitrarily long digit string can still exceed the platform int range (e.g.
+// "18446744073709551617"). strconv.Atoi reports such a value as a range error,
+// which we surface as a syntax error rather than letting the index wrap around
+// and silently select the wrong node.
+func childIndexValue(s string) (int, error) {
+	idx, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("xpointer: child index %q in element() scheme is out of range", s)
 	}
-	return n
+	return idx, nil
 }
 
 // nthElementChild returns the n-th element child (1-based) of the given node.

--- a/xpointer/xpointer.go
+++ b/xpointer/xpointer.go
@@ -6,10 +6,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 	"github.com/lestrrat-go/helium/xpath1"
 )
 
@@ -129,7 +129,15 @@ func (e *Expression) evaluatePart(ctx context.Context, doc *helium.Document, p x
 		if strings.ContainsRune(p.body, '/') {
 			// Bare child sequence (/1/2/3) or name+child sequence (name/1/2).
 			// libxml2 supports these at top level without element() wrapper.
+			// evaluateElement validates the leading NCName and every index.
 			return evaluateElement(doc, p.body)
+		}
+		// A shorthand pointer must be a valid XML NCName per the XPointer
+		// framework. Reject malformed names (invalid NCName chars, invalid
+		// UTF-8) as syntax errors rather than silently resolving to no node,
+		// which would let XInclude unlink the include node.
+		if !xmlchar.IsValidNCName(p.body) {
+			return nil, fmt.Errorf("xpointer: invalid shorthand pointer %q (not an NCName)", p.body)
 		}
 		elem := doc.GetElementByID(p.body)
 		if elem == nil {
@@ -233,32 +241,6 @@ func parseParts(expr string) ([]xptrPart, error) {
 	return parts, nil
 }
 
-// isBareName reports whether s is a valid XML NCName: it starts with a letter
-// or '_', followed by NCName characters. It is used to validate the leading
-// shorthand/ID token of an element() body (e.g. the "r" in "r/1").
-func isBareName(s string) bool {
-	if s == "" {
-		return false
-	}
-	for i, r := range s {
-		if i == 0 {
-			if r == '_' || isLetter(r) {
-				continue
-			}
-			return false
-		}
-		if r == '_' || r == '-' || r == '.' || isLetter(r) || (r >= '0' && r <= '9') {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
-func isLetter(r rune) bool {
-	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r >= 0x80
-}
-
 // parseScheme parses the first XPointer scheme(body) from expr.
 // Returns the scheme, body, remaining string after the closing paren, and any error.
 // For bare names (no parenthesis), remaining is empty.
@@ -312,24 +294,21 @@ func evaluateElement(doc *helium.Document, body string) ([]helium.Node, error) {
 	// include node instead of surfacing the syntax error.
 	//
 	// A non-empty leading token must be a valid NCName (the shorthand ID); an
-	// empty leading token denotes an absolute "/..." child sequence. Every
-	// child-sequence segment after the first must be a 1-based integer index.
-	if parts[0] != "" && !isBareName(parts[0]) {
+	// empty leading token denotes an absolute "/..." child sequence. Only the
+	// very first segment may be empty (the leading "/" of an absolute sequence
+	// like "/1/2"). Every child-sequence segment after the first must be a
+	// non-empty 1-based integer index matching [1-9][0-9]* (no sign, no leading
+	// zero). An empty segment anywhere else is a trailing/doubled slash and is a
+	// syntax error.
+	if parts[0] != "" && !xmlchar.IsValidNCName(parts[0]) {
 		return nil, fmt.Errorf("xpointer: invalid element() id %q (not an NCName)", parts[0])
 	}
 	for _, part := range parts[1:] {
 		if part == "" {
-			continue
+			return nil, fmt.Errorf("xpointer: empty child-sequence segment in element() scheme (trailing or doubled %q)", "/")
 		}
-		childIdx, err := strconv.Atoi(part)
-		if err != nil {
-			return nil, fmt.Errorf("xpointer: invalid child index %q in element() scheme", part)
-		}
-		// Child-sequence indexes are 1-based per the XPointer element() scheme.
-		// An index < 1 is malformed; reject it rather than returning an empty
-		// node set (an empty result would silently unlink an XInclude node).
-		if childIdx < 1 {
-			return nil, fmt.Errorf("xpointer: child index %d out of range in element() scheme (must be >= 1)", childIdx)
+		if !isChildIndex(part) {
+			return nil, fmt.Errorf("xpointer: invalid child index %q in element() scheme (must match [1-9][0-9]*)", part)
 		}
 	}
 
@@ -345,10 +324,7 @@ func evaluateElement(doc *helium.Document, body string) ([]helium.Node, error) {
 	}
 
 	for _, part := range parts[1:] {
-		if part == "" {
-			continue
-		}
-		childIdx, _ := strconv.Atoi(part) // already validated above
+		childIdx := atoiChildIndex(part) // already validated above
 		cur = nthElementChild(cur, childIdx)
 		if cur == nil {
 			return nil, nil
@@ -359,6 +335,36 @@ func evaluateElement(doc *helium.Document, body string) ([]helium.Node, error) {
 		return nil, nil
 	}
 	return []helium.Node{cur}, nil
+}
+
+// isChildIndex reports whether s is a valid XPointer element() child-sequence
+// index: it must match [1-9][0-9]* exactly. That rejects the empty string, a
+// leading sign ("+1", "-1"), a leading zero ("01"), zero itself ("0"), and any
+// non-digit lexeme, all of which Atoi would otherwise silently accept or coerce.
+func isChildIndex(s string) bool {
+	if s == "" {
+		return false
+	}
+	if s[0] < '1' || s[0] > '9' {
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// atoiChildIndex converts a child-sequence index already validated by
+// isChildIndex into an int. The grammar guarantees only ASCII digits, so the
+// conversion cannot fail.
+func atoiChildIndex(s string) int {
+	n := 0
+	for i := 0; i < len(s); i++ {
+		n = n*10 + int(s[i]-'0')
+	}
+	return n
 }
 
 // nthElementChild returns the n-th element child (1-based) of the given node.

--- a/xpointer/xpointer.go
+++ b/xpointer/xpointer.go
@@ -200,6 +200,20 @@ func parseParts(expr string) ([]xptrPart, error) {
 			return nil, err
 		}
 
+		// A bare shorthand (barename) is only valid as the entire pointer on
+		// its own. Once scheme-based parsing has started, every remaining part
+		// must be a scheme(...) part. A trailing barename appended after a
+		// scheme part is malformed and must not be allowed to select an
+		// unintended node. (A lone trailing ")" left over from an unbalanced
+		// scheme body is not a barename and is tolerated as trailing garbage,
+		// matching libxml2.)
+		if scheme == "" && len(parts) > 0 {
+			if isBareName(body) {
+				return nil, fmt.Errorf("xpointer: bare shorthand %q is not allowed after scheme-based parts", body)
+			}
+			break
+		}
+
 		parts = append(parts, xptrPart{scheme: scheme, body: body})
 
 		// Bare name (no scheme) consumes everything
@@ -213,6 +227,33 @@ func parseParts(expr string) ([]xptrPart, error) {
 		return nil, fmt.Errorf("xpointer: empty expression")
 	}
 	return parts, nil
+}
+
+// isBareName reports whether s is a plausible XPointer shorthand barename
+// (an XML NCName: starts with a letter or '_', followed by NCName chars).
+// It is used to distinguish a real trailing shorthand from leftover garbage
+// such as an unbalanced ')'.
+func isBareName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if i == 0 {
+			if r == '_' || isLetter(r) {
+				continue
+			}
+			return false
+		}
+		if r == '_' || r == '-' || r == '.' || isLetter(r) || (r >= '0' && r <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func isLetter(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r >= 0x80
 }
 
 // parseScheme parses the first XPointer scheme(body) from expr.
@@ -285,6 +326,12 @@ func evaluateElement(doc *helium.Document, body string) ([]helium.Node, error) {
 		childIdx, err := strconv.Atoi(part)
 		if err != nil {
 			return nil, fmt.Errorf("xpointer: invalid child index %q in element() scheme", part)
+		}
+		// Child-sequence indexes are 1-based per the XPointer element() scheme.
+		// An index < 1 is malformed; reject it rather than returning an empty
+		// node set (an empty result would silently unlink an XInclude node).
+		if childIdx < 1 {
+			return nil, fmt.Errorf("xpointer: child index %d out of range in element() scheme (must be >= 1)", childIdx)
 		}
 		cur = nthElementChild(cur, childIdx)
 		if cur == nil {

--- a/xpointer/xpointer.go
+++ b/xpointer/xpointer.go
@@ -200,18 +200,22 @@ func parseParts(expr string) ([]xptrPart, error) {
 			return nil, err
 		}
 
-		// A bare shorthand (barename) is only valid as the entire pointer on
+		// A non-scheme trailing token is only valid as the entire pointer on
 		// its own. Once scheme-based parsing has started, every remaining part
-		// must be a scheme(...) part. A trailing barename appended after a
-		// scheme part is malformed and must not be allowed to select an
-		// unintended node. (A lone trailing ")" left over from an unbalanced
-		// scheme body is not a barename and is tolerated as trailing garbage,
-		// matching libxml2.)
+		// must be a scheme(...) part. Any trailing non-scheme text — a barename
+		// (e.g. "foo") OR a child-sequence (e.g. "/1" or "r/1") — appended after
+		// a scheme part is malformed and must not be silently ignored, since an
+		// ignored-but-malformed pointer would let XInclude unlink the include
+		// node instead of reporting the error.
+		//
+		// The single tolerated exception is a lone unbalanced ")" left over from
+		// a scheme body (e.g. "xpointer(/t1))"), which libxml2 accepts and the
+		// xinclude coalesce.xml golden test relies on.
 		if scheme == "" && len(parts) > 0 {
-			if isBareName(body) {
-				return nil, fmt.Errorf("xpointer: bare shorthand %q is not allowed after scheme-based parts", body)
+			if body == ")" {
+				break
 			}
-			break
+			return nil, fmt.Errorf("xpointer: trailing non-scheme text %q is not allowed after scheme-based parts", body)
 		}
 
 		parts = append(parts, xptrPart{scheme: scheme, body: body})
@@ -229,10 +233,9 @@ func parseParts(expr string) ([]xptrPart, error) {
 	return parts, nil
 }
 
-// isBareName reports whether s is a plausible XPointer shorthand barename
-// (an XML NCName: starts with a letter or '_', followed by NCName chars).
-// It is used to distinguish a real trailing shorthand from leftover garbage
-// such as an unbalanced ')'.
+// isBareName reports whether s is a valid XML NCName: it starts with a letter
+// or '_', followed by NCName characters. It is used to validate the leading
+// shorthand/ID token of an element() body (e.g. the "r" in "r/1").
 func isBareName(s string) bool {
 	if s == "" {
 		return false
@@ -303,23 +306,18 @@ func evaluateElement(doc *helium.Document, body string) ([]helium.Node, error) {
 
 	parts := strings.Split(body, "/")
 
-	var cur helium.Node = doc
-	startIdx := 0
-
-	if parts[0] == "" {
-		// Starts with "/" — absolute child sequence from document
-		startIdx = 1
-	} else {
-		// Starts with an NCName — look up element by ID first
-		elem := doc.GetElementByID(parts[0])
-		if elem == nil {
-			return nil, nil
-		}
-		cur = elem
-		startIdx = 1
+	// Validate the ENTIRE body syntactically BEFORE any document lookup, so that
+	// a malformed pointer is reported as an error regardless of whether the
+	// initial ID exists. A silent empty result would let XInclude unlink the
+	// include node instead of surfacing the syntax error.
+	//
+	// A non-empty leading token must be a valid NCName (the shorthand ID); an
+	// empty leading token denotes an absolute "/..." child sequence. Every
+	// child-sequence segment after the first must be a 1-based integer index.
+	if parts[0] != "" && !isBareName(parts[0]) {
+		return nil, fmt.Errorf("xpointer: invalid element() id %q (not an NCName)", parts[0])
 	}
-
-	for _, part := range parts[startIdx:] {
+	for _, part := range parts[1:] {
 		if part == "" {
 			continue
 		}
@@ -333,6 +331,24 @@ func evaluateElement(doc *helium.Document, body string) ([]helium.Node, error) {
 		if childIdx < 1 {
 			return nil, fmt.Errorf("xpointer: child index %d out of range in element() scheme (must be >= 1)", childIdx)
 		}
+	}
+
+	var cur helium.Node = doc
+
+	if parts[0] != "" {
+		// Starts with an NCName — look up element by ID.
+		elem := doc.GetElementByID(parts[0])
+		if elem == nil {
+			return nil, nil
+		}
+		cur = elem
+	}
+
+	for _, part := range parts[1:] {
+		if part == "" {
+			continue
+		}
+		childIdx, _ := strconv.Atoi(part) // already validated above
 		cur = nthElementChild(cur, childIdx)
 		if cur == nil {
 			return nil, nil

--- a/xpointer/xpointer.go
+++ b/xpointer/xpointer.go
@@ -361,7 +361,7 @@ func isChildIndex(s string) bool {
 // conversion cannot fail.
 func atoiChildIndex(s string) int {
 	n := 0
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		n = n*10 + int(s[i]-'0')
 	}
 	return n

--- a/xpointer/xpointer.go
+++ b/xpointer/xpointer.go
@@ -209,6 +209,18 @@ func parseParts(expr string) ([]xptrPart, error) {
 			return nil, err
 		}
 
+		// The XPointer framework defines SchemeName as a QName. A non-empty
+		// scheme name that is not a valid QName is a syntax error, NOT an
+		// unknown scheme: rejecting it here prevents a malformed scheme (e.g.
+		// "1bad(/x)") from being skipped via the unknown-scheme cascade and
+		// letting a later well-formed part succeed, which would bypass the
+		// trailing-text rejection below. A syntactically valid but unsupported
+		// scheme (e.g. "foo(...)") is still a valid QName and continues to
+		// cascade as an unknown scheme during evaluation.
+		if scheme != "" && !xmlchar.IsValidQName(scheme) {
+			return nil, fmt.Errorf("xpointer: invalid scheme name %q (not a QName)", scheme)
+		}
+
 		// A non-scheme trailing token is only valid as the entire pointer on
 		// its own. Once scheme-based parsing has started, every remaining part
 		// must be a scheme(...) part. Any trailing non-scheme text — a barename

--- a/xpointer/xpointer_test.go
+++ b/xpointer/xpointer_test.go
@@ -407,6 +407,94 @@ func TestElementBodyValidatedBeforeLookup(t *testing.T) {
 	}
 }
 
+func TestElementGrammarStrictness(t *testing.T) {
+	t.Parallel()
+
+	// Document with an NCName id "id" and nested structure for the valid cases.
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<?xml version="1.0"?>
+<root xml:id="id"><a><b>found</b></a></root>`))
+	require.NoError(t, err)
+
+	rejected := []struct {
+		name string
+		expr string
+	}{
+		// Empty child-sequence segments (trailing slash, doubled slash).
+		{"trailing slash absolute", "element(/)"},
+		{"doubled slash absolute", "element(/1//2)"},
+		{"trailing slash from id", "element(r/)"},
+		// Index lexeme grammar [1-9][0-9]*.
+		{"zero absolute", "element(/0)"},
+		{"bare zero token", "element(0)"},
+		{"plus-signed index", "element(+1)"},
+		{"leading-zero index", "element(01)"},
+		{"negative index", "element(/-1)"},
+		// Missing/out-of-range index whose ID does not exist.
+		{"missing id with zero index", "element(missing/0)"},
+		{"id with trailing slash", "element(id/)"},
+	}
+	for _, tt := range rejected {
+		t.Run("reject/"+tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			nodes, err := xpointer.Evaluate(t.Context(), doc, tt.expr)
+			require.Error(t, err, "expr %q must be rejected", tt.expr)
+			require.Nil(t, nodes, "expr %q", tt.expr)
+		})
+	}
+
+	valid := []struct {
+		name     string
+		expr     string
+		wantName string
+	}{
+		{"id plus sequence", "element(id/1/1)", "b"},
+		{"absolute sequence", "element(/1/1)", "a"},
+		{"absolute single", "element(/1)", "root"},
+		{"id alone", "element(id)", "root"},
+	}
+	for _, tt := range valid {
+		t.Run("accept/"+tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			nodes, err := xpointer.Evaluate(t.Context(), doc, tt.expr)
+			require.NoError(t, err, "expr %q must be accepted", tt.expr)
+			require.Len(t, nodes, 1, "expr %q", tt.expr)
+			require.Equal(t, tt.wantName, nodes[0].(*helium.Element).LocalName())
+		})
+	}
+}
+
+func TestShorthandNCNameStrictness(t *testing.T) {
+	t.Parallel()
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<?xml version="1.0"?>
+<root xml:id="good">found</root>`))
+	require.NoError(t, err)
+
+	t.Run("valid NCName resolves", func(t *testing.T) {
+		t.Parallel()
+
+		nodes, err := xpointer.Evaluate(t.Context(), doc, "good")
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+		require.Equal(t, "root", nodes[0].(*helium.Element).LocalName())
+	})
+
+	// A shorthand pointer that is not a valid NCName must be a syntax error,
+	// not a silent empty result. Includes a colon (NCNames are non-colonized),
+	// a leading digit, and invalid UTF-8.
+	for _, expr := range []string{"1bad", "a:b", "bad name", "\xff\xfe"} {
+		t.Run("reject/"+expr, func(t *testing.T) {
+			t.Parallel()
+
+			nodes, err := xpointer.Evaluate(t.Context(), doc, expr)
+			require.Error(t, err, "expr %q must be rejected", expr)
+			require.Nil(t, nodes, "expr %q", expr)
+		})
+	}
+}
+
 func TestMultiSchemeExpressionsTable(t *testing.T) {
 	t.Parallel()
 

--- a/xpointer/xpointer_test.go
+++ b/xpointer/xpointer_test.go
@@ -308,6 +308,57 @@ func TestBareNameChildSequence(t *testing.T) {
 	})
 }
 
+func TestElementChildIndexBounds(t *testing.T) {
+	t.Parallel()
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<?xml version="1.0"?>
+<root xml:id="r"><child>text</child></root>`))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		expr string
+	}{
+		{"zero index", "element(/0)"},
+		{"negative index", "element(/-1)"},
+		{"zero index mid-sequence", "element(/1/0)"},
+		{"zero index from id", "element(r/0)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// A child-sequence index < 1 is malformed: it must be an error,
+			// not a silent empty result (which would unlink an XInclude node).
+			nodes, err := xpointer.Evaluate(t.Context(), doc, tt.expr)
+			require.Error(t, err, "expr %q must be rejected", tt.expr)
+			require.Nil(t, nodes)
+		})
+	}
+}
+
+func TestShorthandAfterSchemeRejected(t *testing.T) {
+	t.Parallel()
+
+	// Parse with NewParser so xml:id registers in the ID table.
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<?xml version="1.0"?>
+<root><target xml:id="fallback">found</target></root>`))
+	require.NoError(t, err)
+
+	// A bare shorthand appended after a scheme-based part is invalid; it must
+	// not select the "fallback" element. The whole pointer must fail to parse.
+	nodes, err := xpointer.Evaluate(t.Context(), doc, "xpointer(//missing)fallback")
+	require.Error(t, err)
+	require.Nil(t, nodes)
+
+	// Sanity check: the same shorthand on its own still resolves the ID.
+	nodes, err = xpointer.Evaluate(t.Context(), doc, "fallback")
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	require.Equal(t, "target", nodes[0].(*helium.Element).LocalName())
+}
+
 func TestMultiSchemeExpressionsTable(t *testing.T) {
 	t.Parallel()
 

--- a/xpointer/xpointer_test.go
+++ b/xpointer/xpointer_test.go
@@ -419,6 +419,39 @@ func TestTrailingChildSequenceAfterSchemeRejected(t *testing.T) {
 	require.Nil(t, nodes)
 }
 
+func TestInvalidSchemeNameRejected(t *testing.T) {
+	t.Parallel()
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<?xml version="1.0"?>
+<root><target xml:id="x">found</target></root>`))
+	require.NoError(t, err)
+
+	// A scheme name is a QName per the XPointer framework. A malformed scheme
+	// name must be a syntax error, NOT an unknown-scheme cascade — otherwise a
+	// later well-formed part (element(/1)) could succeed and silently bypass
+	// the malformed leading part. libxml2 rejects these.
+	for _, expr := range []string{
+		"1bad(/x)",
+		"xpointer(//missing)1bad(/x)element(/1)",
+		"-bad(/x)",
+		"bad name(/x)",
+		":bad(/x)",
+	} {
+		nodes, err := xpointer.Evaluate(t.Context(), doc, expr)
+		require.Error(t, err, "expr %q must be rejected as a syntax error", expr)
+		require.Nil(t, nodes, "expr %q", expr)
+	}
+
+	// A syntactically valid but unsupported scheme name is a QName, so it must
+	// continue to cascade as an unknown scheme rather than abort parsing. Here
+	// the unknown "foo" scheme yields no nodes and the following element() part
+	// resolves the target.
+	nodes, err := xpointer.Evaluate(t.Context(), doc, "foo(/x)element(x)")
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	require.Equal(t, "target", nodes[0].(*helium.Element).LocalName())
+}
+
 func TestElementBodyValidatedBeforeLookup(t *testing.T) {
 	t.Parallel()
 

--- a/xpointer/xpointer_test.go
+++ b/xpointer/xpointer_test.go
@@ -338,6 +338,39 @@ func TestElementChildIndexBounds(t *testing.T) {
 	}
 }
 
+func TestElementChildIndexOverflow(t *testing.T) {
+	t.Parallel()
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<?xml version="1.0"?>
+<root xml:id="r"><child>text</child></root>`))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		expr string
+	}{
+		// 18446744073709551617 == math.MaxUint64+2. Naive base-10 accumulation
+		// into an int wraps this to 1 and would silently select the first child.
+		{"absolute overflow", "element(/18446744073709551617)"},
+		{"overflow then index", "element(/18446744073709551617/1)"},
+		{"index then overflow", "element(/1/18446744073709551617)"},
+		{"overflow from id", "element(r/99999999999999999999)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// An index that exceeds the int range must be reported as a syntax
+			// error, never wrapped to a small in-range value (which would select
+			// the wrong node) or coerced to a silent empty result.
+			nodes, err := xpointer.Evaluate(t.Context(), doc, tt.expr)
+			require.Error(t, err, "expr %q must be rejected as out of range", tt.expr)
+			require.Nil(t, nodes)
+		})
+	}
+}
+
 func TestShorthandAfterSchemeRejected(t *testing.T) {
 	t.Parallel()
 

--- a/xpointer/xpointer_test.go
+++ b/xpointer/xpointer_test.go
@@ -359,6 +359,54 @@ func TestShorthandAfterSchemeRejected(t *testing.T) {
 	require.Equal(t, "target", nodes[0].(*helium.Element).LocalName())
 }
 
+func TestTrailingChildSequenceAfterSchemeRejected(t *testing.T) {
+	t.Parallel()
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<?xml version="1.0"?>
+<root><target xml:id="fallback">found</target></root>`))
+	require.NoError(t, err)
+
+	// A trailing bare child-sequence appended after a scheme-based part is
+	// malformed: it must be rejected, not silently ignored. Silently ignoring
+	// it would let XInclude unlink the include node instead of reporting the
+	// malformed pointer.
+	for _, expr := range []string{
+		"xpointer(//missing)r/1",
+		"xpointer(//missing)/1",
+	} {
+		nodes, err := xpointer.Evaluate(t.Context(), doc, expr)
+		require.Error(t, err, "expr %q must be rejected", expr)
+		require.Nil(t, nodes, "expr %q", expr)
+	}
+
+	// The tolerated compatibility exception: a lone unbalanced ")" left over
+	// from a scheme body (libxml2 parity / xinclude coalesce.xml golden test).
+	nodes, err := xpointer.Evaluate(t.Context(), doc, "xpointer(//missing))")
+	require.NoError(t, err, "lone trailing ) must remain tolerated")
+	require.Nil(t, nodes)
+}
+
+func TestElementBodyValidatedBeforeLookup(t *testing.T) {
+	t.Parallel()
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<?xml version="1.0"?>
+<root xml:id="r"><child>text</child></root>`))
+	require.NoError(t, err)
+
+	// A malformed element() body must be reported as a syntax error regardless
+	// of whether the leading ID exists. element(0) has an invalid leading token
+	// (a bare "0" is neither an NCName nor an absolute child sequence), and
+	// element(missing/0) has an out-of-range index whose ID does not exist.
+	for _, expr := range []string{
+		"element(0)",
+		"element(missing/0)",
+	} {
+		nodes, err := xpointer.Evaluate(t.Context(), doc, expr)
+		require.Error(t, err, "expr %q must be rejected", expr)
+		require.Nil(t, nodes, "expr %q", expr)
+	}
+}
+
 func TestMultiSchemeExpressionsTable(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- element() child-sequence indexes < 1 now error instead of returning an empty node set (which silently unlinks an XInclude node)
- a bare shorthand appended after a scheme-based part is rejected; trailing unbalanced `)` stays tolerated to match libxml2