### PR TITLE
split ]]> in stream CDATA WriteString

### DIFF
--- a/stream/stream.go
+++ b/stream/stream.go
@@ -396,7 +396,12 @@ func (w *Writer) writeCDATAEscaped(s string) {
 			// "]]>" detected: the preceding "]]" has already been
 			// written into this section, so flush up to here, close the
 			// section, and reopen a new one before emitting the '>'.
-			w.writeStr(s[start:i])
+			// Guard against an empty write when "]]>" straddles a call
+			// boundary (start == i), which would emit an avoidable empty
+			// write and could trip side-effecting io.StringWriter impls.
+			if start < i {
+				w.writeStr(s[start:i])
+			}
 			w.writeStr("]]><![CDATA[")
 			start = i
 			w.cdataBrackets = 0

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -68,20 +68,21 @@ type nsScope struct {
 //
 // (libxml2: xmlTextWriter)
 type Writer struct {
-	out         io.Writer
-	indent      string // indent string per level; empty = no indentation
-	quoteChar   byte   // attribute quote character ('"' or '\'')
-	singleByte  [1]byte
-	state       writerState
-	elemStack   []elementEntry
-	nsStack     []nsScope
-	stateStack  []writerState // for comment/PI/CDATA nesting
-	err         error         // sticky error
-	depth       int           // current element nesting depth (for indentation)
-	hasOutput   bool          // true after first output has been written
-	wroteNL     bool          // true after EndComment/EndPI wrote trailing \n (suppresses writeIndent's \n)
-	commentDash bool          // true if the current comment body ends with '-' (would form '--->' on close)
-	piQuestion  bool          // true if the current PI body ends with '?' (would form '?>' across writes)
+	out           io.Writer
+	indent        string // indent string per level; empty = no indentation
+	quoteChar     byte   // attribute quote character ('"' or '\'')
+	singleByte    [1]byte
+	state         writerState
+	elemStack     []elementEntry
+	nsStack       []nsScope
+	stateStack    []writerState // for comment/PI/CDATA nesting
+	err           error         // sticky error
+	depth         int           // current element nesting depth (for indentation)
+	hasOutput     bool          // true after first output has been written
+	wroteNL       bool          // true after EndComment/EndPI wrote trailing \n (suppresses writeIndent's \n)
+	commentDash   bool          // true if the current comment body ends with '-' (would form '--->' on close)
+	piQuestion    bool          // true if the current PI body ends with '?' (would form '?>' across writes)
+	cdataBrackets int           // count (0,1,2) of trailing ']' in the current CDATA body, to detect ']]>' across writes
 }
 
 // NewWriter creates a Writer that writes to w. Configure the Writer
@@ -379,6 +380,34 @@ func (w *Writer) writeTextEscaped(s string) {
 // writeAttrEscaped writes text content with XML escaping for attribute values.
 func (w *Writer) writeAttrEscaped(s string) {
 	w.writeEscaped(s, escapeAttr)
+}
+
+// writeCDATAEscaped writes content into the current CDATA section, splitting
+// any "]]>" terminator across two CDATA sections so the emitted bytes never
+// contain a raw "]]>" inside a single section. The "]]>" sequence is broken
+// after the "]]" by closing and reopening the section, yielding
+// "]]" + "]]><![CDATA[" + ">". The count of trailing ']' is tracked across
+// calls so a "]]>" split over multiple WriteString calls is also handled.
+func (w *Writer) writeCDATAEscaped(s string) {
+	start := 0
+	for i := range len(s) {
+		c := s[i]
+		if c == '>' && w.cdataBrackets >= 2 {
+			// "]]>" detected: the preceding "]]" has already been
+			// written into this section, so flush up to here, close the
+			// section, and reopen a new one before emitting the '>'.
+			w.writeStr(s[start:i])
+			w.writeStr("]]><![CDATA[")
+			start = i
+			w.cdataBrackets = 0
+		}
+		if c == ']' {
+			w.cdataBrackets++
+			continue
+		}
+		w.cdataBrackets = 0
+	}
+	w.writeStr(s[start:])
 }
 
 // --- Document lifecycle ---
@@ -772,7 +801,7 @@ func (w *Writer) WriteString(content string) error {
 		}
 		w.state = statePIText
 	case stateCDATA:
-		w.writeStr(content)
+		w.writeCDATAEscaped(content)
 	default:
 		return errors.New("stream: WriteString called in invalid state")
 	}
@@ -980,6 +1009,7 @@ func (w *Writer) StartCDATA() error {
 		w.elemStack[len(w.elemStack)-1].hasText = true
 	}
 	w.writeStr("<![CDATA[")
+	w.cdataBrackets = 0
 	w.stateStack = append(w.stateStack, w.state)
 	w.state = stateCDATA
 	return w.err

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -667,6 +667,47 @@ func TestCDATAWriteStringEscapesTerminator(t *testing.T) {
 		require.Equal(t, `<root><![CDATA[foo]]]]><![CDATA[>bar]]></root>`, out)
 		requireNoRawCDATATerminator(t, out)
 	})
+	t.Run("terminator straddling call boundary emits no empty write", func(t *testing.T) {
+		t.Parallel()
+		// "]]>" split as "]]" then ">" forces the split point to land at
+		// the very start of the second WriteString. The Writer must not
+		// flush an empty string before the CDATA split marker, which would
+		// trip a side-effecting io.StringWriter implementation.
+		sw := &noEmptyStringWriter{}
+		w := stream.NewWriter(sw)
+		require.NoError(t, w.StartElement("root"))
+		require.NoError(t, w.StartCDATA())
+		require.NoError(t, w.WriteString("]]"))
+		require.NoError(t, w.WriteString(">"))
+		require.NoError(t, w.EndCDATA())
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.Error())
+		require.Empty(t, sw.empties, "Writer emitted an empty WriteString")
+		out := sw.buf.String()
+		require.Equal(t, `<root><![CDATA[]]]]><![CDATA[>]]></root>`, out)
+		requireNoRawCDATATerminator(t, out)
+	})
+}
+
+// noEmptyStringWriter is an io.StringWriter that records any empty WriteString
+// call so tests can assert the Writer never emits an avoidable empty write.
+type noEmptyStringWriter struct {
+	buf     bytes.Buffer
+	empties int
+}
+
+func (w *noEmptyStringWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		w.empties++
+	}
+	return w.buf.Write(p)
+}
+
+func (w *noEmptyStringWriter) WriteString(s string) (int, error) {
+	if s == "" {
+		w.empties++
+	}
+	return w.buf.WriteString(s)
 }
 
 // requireNoRawCDATATerminator scans the emitted XML and asserts that no CDATA

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -638,6 +638,56 @@ func TestCDATAInvalidState(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestCDATAWriteStringEscapesTerminator(t *testing.T) {
+	t.Parallel()
+	t.Run("single write", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.NoError(t, w.StartCDATA())
+		require.NoError(t, w.WriteString("]]>"))
+		require.NoError(t, w.EndCDATA())
+		require.NoError(t, w.EndElement())
+		out := buf.String()
+		require.Equal(t, `<root><![CDATA[]]]]><![CDATA[>]]></root>`, out)
+		requireNoRawCDATATerminator(t, out)
+	})
+	t.Run("split across writes", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.NoError(t, w.StartCDATA())
+		require.NoError(t, w.WriteString("foo]]"))
+		require.NoError(t, w.WriteString(">bar"))
+		require.NoError(t, w.EndCDATA())
+		require.NoError(t, w.EndElement())
+		out := buf.String()
+		require.Equal(t, `<root><![CDATA[foo]]]]><![CDATA[>bar]]></root>`, out)
+		requireNoRawCDATATerminator(t, out)
+	})
+}
+
+// requireNoRawCDATATerminator scans the emitted XML and asserts that no CDATA
+// section contains a raw "]]>" before its own closing delimiter, which would
+// make the output malformed.
+func requireNoRawCDATATerminator(t *testing.T, s string) {
+	t.Helper()
+	const open = "<![CDATA["
+	for {
+		i := strings.Index(s, open)
+		if i < 0 {
+			break
+		}
+		body := s[i+len(open):]
+		end := strings.Index(body, "]]>")
+		require.GreaterOrEqual(t, end, 0, "unterminated CDATA section in %q", s)
+		require.NotContains(t, body[:end], "]]>", "raw ]]> inside CDATA section in %q", s)
+		s = body[end+3:]
+	}
+}
+
 func TestWriteRaw(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer


### PR DESCRIPTION
WriteString inside a StartCDATA/EndCDATA region wrote a raw ]]> into the section, producing malformed XML.
Now splits ]]> across two CDATA sections and tracks trailing ] across writes, matching the existing WriteCDATA behavior.