### PR TITLE
resolve through all XML_CATALOG_FILES entries

### DIFF
--- a/internal/cli/heliumcmd/lint.go
+++ b/internal/cli/heliumcmd/lint.go
@@ -108,7 +108,7 @@ func (c *command) runContext(ctx context.Context, args []string) int {
 		return ExitErr
 	}
 
-	var cat *catalog.Catalog
+	var cat helium.CatalogResolver
 	if cfg.catalogs && !cfg.noCatalogs {
 		cat = c.loadCatalogFromEnv(ctx)
 	}
@@ -357,24 +357,47 @@ func (c *command) parseArgs(args []string) (*config, []string) {
 	return cfg, files
 }
 
-func (c *command) loadCatalogFromEnv(ctx context.Context) *catalog.Catalog {
+// catalogChain resolves through an ordered list of catalogs, returning the
+// first non-empty match. XML_CATALOG_FILES is a whitespace-separated list, so
+// every listed catalog must participate in resolution, in listed order.
+type catalogChain []*catalog.Catalog
+
+func (cc catalogChain) Resolve(ctx context.Context, pubID, sysID string) string {
+	for _, cat := range cc {
+		if uri := cat.Resolve(ctx, pubID, sysID); uri != "" {
+			return uri
+		}
+	}
+	return ""
+}
+
+func (cc catalogChain) ResolveURI(ctx context.Context, uri string) string {
+	for _, cat := range cc {
+		if resolved := cat.ResolveURI(ctx, uri); resolved != "" {
+			return resolved
+		}
+	}
+	return ""
+}
+
+func (c *command) loadCatalogFromEnv(ctx context.Context) helium.CatalogResolver {
 	envFiles := os.Getenv("XML_CATALOG_FILES")
 	if envFiles == "" {
 		return nil
 	}
-	for f := range strings.SplitSeq(envFiles, " ") {
-		f = strings.TrimSpace(f)
-		if f == "" {
-			continue
-		}
+	var chain catalogChain
+	for f := range strings.FieldsSeq(envFiles) {
 		cat, err := catalog.Load(ctx, f)
 		if err != nil {
 			_, _ = fmt.Fprintf(c.stderr, "%s: failed to load catalog %s: %s\n", c.prog, f, err)
 			continue
 		}
-		return cat
+		chain = append(chain, cat)
 	}
-	return nil
+	if len(chain) == 0 {
+		return nil
+	}
+	return chain
 }
 
 func (c *command) compileSchema(ctx context.Context, cfg *config) (*xsd.Schema, error) {
@@ -385,7 +408,7 @@ func (c *command) compileSchema(ctx context.Context, cfg *config) (*xsd.Schema, 
 	return schema, nil
 }
 
-func (c *command) processInput(ctx context.Context, cfg *config, input namedInput, cat *catalog.Catalog, schema *xsd.Schema, out io.Writer) int {
+func (c *command) processInput(ctx context.Context, cfg *config, input namedInput, cat helium.CatalogResolver, schema *xsd.Schema, out io.Writer) int {
 	var buf []byte
 	var err error
 	if input.stdin {

--- a/internal/cli/heliumcmd/lint_test.go
+++ b/internal/cli/heliumcmd/lint_test.go
@@ -607,6 +607,39 @@ func TestCatalogLoading(t *testing.T) {
 	require.Equal(t, heliumcmd.ExitOK, code)
 }
 
+// TestCatalogChainSecondFile exercises XML_CATALOG_FILES holding multiple
+// space-separated catalogs where only the second one carries the mapping.
+// Resolution must consult every listed catalog in order, not just the first.
+func TestCatalogChainSecondFile(t *testing.T) {
+	dir := t.TempDir()
+
+	dtdContent := `<!ATTLIST doc status CDATA "active">`
+	writeFile(t, dir, "test.dtd", dtdContent)
+
+	emptyCat := `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+</catalog>`
+	emptyFile := writeFile(t, dir, "empty.xml", emptyCat)
+
+	usefulCat := `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <system systemId="http://example.com/test.dtd" uri="` + filepath.Join(dir, "test.dtd") + `"/>
+</catalog>`
+	usefulFile := writeFile(t, dir, "useful.xml", usefulCat)
+
+	xmlContent := `<?xml version="1.0"?>
+<!DOCTYPE doc SYSTEM "http://example.com/test.dtd">
+<doc>hello</doc>`
+	xmlFile := writeFile(t, dir, "test.xml", xmlContent)
+
+	t.Setenv("XML_CATALOG_FILES", emptyFile+" "+usefulFile)
+
+	out, _, code := executeLintFile(t, xmlFile, "--catalogs", "--loaddtd", "--dtdattr")
+	require.Equal(t, heliumcmd.ExitOK, code)
+	// The ATTLIST default from the resolved DTD must materialize.
+	require.Contains(t, out, `status="active"`)
+}
+
 func TestFormatNestedElements(t *testing.T) {
 	out, _, code := executeLintStdin(t, `<a><b><c><d/></c></b></a>`, "--format")
 	require.Equal(t, 0, code)


### PR DESCRIPTION
- CLI catalog loader consulted only the first successfully loaded catalog in XML_CATALOG_FILES; remaining entries were ignored
- load every whitespace-separated entry and resolve through them in listed order (first match wins) via a CatalogResolver chain