### PR TITLE
fix opaque file uri and file-base uri resolution

### DIFF
--- a/catalog/load.go
+++ b/catalog/load.go
@@ -134,6 +134,14 @@ func catalogFilePath(ref string) (string, bool, error) {
 		return "", false, fmt.Errorf("catalog: non-local file URI host %q in %q", u.Host, ref)
 	}
 
+	// An opaque file: URI such as "file:next.xml" has u.Opaque set and an empty
+	// u.Path, and a "file://localhost" URI has no path at all. Neither denotes a
+	// local filesystem path, so reject them rather than letting an empty path
+	// fall through and read the process working directory.
+	if u.Opaque != "" || u.Path == "" {
+		return "", false, fmt.Errorf("catalog: invalid file URI %q: no local path", ref)
+	}
+
 	return fileURIPath(u.Path), true, nil
 }
 

--- a/catalog/load_internal_test.go
+++ b/catalog/load_internal_test.go
@@ -125,6 +125,31 @@ func TestCatalogFilePathRemoteHostRejected(t *testing.T) {
 	require.Error(t, err)
 }
 
+// catalogFilePath must reject an opaque file: URI such as "file:next.xml"
+// (url.URL.Opaque is set, Path is empty). Such a reference has no local path,
+// so it must error rather than silently fall through to reading the process
+// working directory.
+func TestCatalogFilePathOpaqueRejected(t *testing.T) {
+	tests := []string{
+		"file:next.xml",
+		"file:sub/next.xml",
+	}
+
+	for _, ref := range tests {
+		t.Run(ref, func(t *testing.T) {
+			_, _, err := catalogFilePath(ref)
+			require.Error(t, err)
+		})
+	}
+}
+
+// catalogFilePath must reject a file: URI whose path component is empty, such
+// as "file://localhost" with no path. There is no local path to read.
+func TestCatalogFilePathEmptyPathRejected(t *testing.T) {
+	_, _, err := catalogFilePath("file://localhost")
+	require.Error(t, err)
+}
+
 // catalogFilePath must keep a POSIX "file:///C:/..." path absolute. The
 // drive-letter slash strip is Windows-only; on POSIX "/C:/tmp/..." is a valid
 // absolute path, so this asserts deterministically on the Linux CI host.

--- a/internal/catalog/uri.go
+++ b/internal/catalog/uri.go
@@ -6,9 +6,13 @@ import (
 	"strings"
 )
 
-// ResolveURI resolves value against base. If value is already absolute
-// (has a scheme) or base is empty, value is returned as-is.
-// For file paths, filepath.Join is used.
+// ResolveURI resolves value against base. If value already has a scheme, or
+// base is empty, value is returned as-is. When base carries a URI scheme (e.g.
+// "file:///..."), the reference is resolved in URI space via
+// (*url.URL).ResolveReference, which handles path-absolute ("/abs/x"),
+// relative ("x"), and absolute-URI references correctly. When base is a
+// non-URI local path, OS-path semantics apply: an absolute value is returned
+// unchanged and a relative value is joined against the base directory.
 func ResolveURI(base, value string) string {
 	if value == "" {
 		return ""
@@ -18,27 +22,32 @@ func ResolveURI(base, value string) string {
 		return value
 	}
 
-	if filepath.IsAbs(value) {
-		return value
-	}
-
 	if base == "" {
 		return value
 	}
 
-	if !HasScheme(base) {
-		return filepath.Join(filepath.Dir(base), value)
+	// When base has a URI scheme, resolve in URI space. A path-absolute
+	// reference such as "/abs/asset.xml" must stay in the base's URI space
+	// ("file:///abs/asset.xml"), not collapse to a bare local path.
+	if HasScheme(base) {
+		baseURL, err := url.Parse(base)
+		if err != nil {
+			return value
+		}
+		ref, err := url.Parse(value)
+		if err != nil {
+			return value
+		}
+		return baseURL.ResolveReference(ref).String()
 	}
 
-	baseURL, err := url.Parse(base)
-	if err != nil {
+	// Non-URI local-path base: apply OS-path semantics. An absolute value is
+	// returned unchanged; a relative one is joined against the base directory.
+	if filepath.IsAbs(value) {
 		return value
 	}
-	ref, err := url.Parse(value)
-	if err != nil {
-		return value
-	}
-	return baseURL.ResolveReference(ref).String()
+
+	return filepath.Join(filepath.Dir(base), value)
 }
 
 // HasScheme checks if s looks like a URI with a scheme (e.g., "http://...").

--- a/internal/catalog/uri_test.go
+++ b/internal/catalog/uri_test.go
@@ -12,6 +12,8 @@ import (
 // scheme. A path-absolute reference such as "/abs/asset.xml" against a
 // "file:///..." base must stay in "file:" URI space ("file:///abs/asset.xml"),
 // not collapse to the bare local path "/abs/asset.xml".
+const fileCatalogURI = "file:///tmp/catalog.xml"
+
 func TestResolveURI(t *testing.T) {
 	t.Parallel()
 
@@ -23,13 +25,13 @@ func TestResolveURI(t *testing.T) {
 	}{
 		{
 			name:   "empty value",
-			base:   "file:///tmp/catalog.xml",
+			base:   fileCatalogURI,
 			value:  "",
 			expect: "",
 		},
 		{
 			name:   "value already has scheme",
-			base:   "file:///tmp/catalog.xml",
+			base:   fileCatalogURI,
 			value:  "http://example.com/x.xsd",
 			expect: "http://example.com/x.xsd",
 		},
@@ -37,19 +39,19 @@ func TestResolveURI(t *testing.T) {
 			// Regression: a path-absolute reference against a file: base must
 			// resolve in URI space, keeping the file: scheme.
 			name:   "path-absolute ref against file base",
-			base:   "file:///tmp/catalog.xml",
+			base:   fileCatalogURI,
 			value:  "/abs/asset.xml",
 			expect: "file:///abs/asset.xml",
 		},
 		{
 			name:   "relative ref against file base",
-			base:   "file:///tmp/catalog.xml",
+			base:   fileCatalogURI,
 			value:  "asset.xml",
 			expect: "file:///tmp/asset.xml",
 		},
 		{
 			name:   "absolute-uri ref against file base",
-			base:   "file:///tmp/catalog.xml",
+			base:   fileCatalogURI,
 			value:  "http://example.com/asset.xml",
 			expect: "http://example.com/asset.xml",
 		},

--- a/internal/catalog/uri_test.go
+++ b/internal/catalog/uri_test.go
@@ -1,0 +1,85 @@
+package catalog_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/lestrrat-go/helium/internal/catalog"
+	"github.com/stretchr/testify/require"
+)
+
+// ResolveURI must resolve references in URI space when the base carries a URI
+// scheme. A path-absolute reference such as "/abs/asset.xml" against a
+// "file:///..." base must stay in "file:" URI space ("file:///abs/asset.xml"),
+// not collapse to the bare local path "/abs/asset.xml".
+func TestResolveURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		base   string
+		value  string
+		expect string
+	}{
+		{
+			name:   "empty value",
+			base:   "file:///tmp/catalog.xml",
+			value:  "",
+			expect: "",
+		},
+		{
+			name:   "value already has scheme",
+			base:   "file:///tmp/catalog.xml",
+			value:  "http://example.com/x.xsd",
+			expect: "http://example.com/x.xsd",
+		},
+		{
+			// Regression: a path-absolute reference against a file: base must
+			// resolve in URI space, keeping the file: scheme.
+			name:   "path-absolute ref against file base",
+			base:   "file:///tmp/catalog.xml",
+			value:  "/abs/asset.xml",
+			expect: "file:///abs/asset.xml",
+		},
+		{
+			name:   "relative ref against file base",
+			base:   "file:///tmp/catalog.xml",
+			value:  "asset.xml",
+			expect: "file:///tmp/asset.xml",
+		},
+		{
+			name:   "absolute-uri ref against file base",
+			base:   "file:///tmp/catalog.xml",
+			value:  "http://example.com/asset.xml",
+			expect: "http://example.com/asset.xml",
+		},
+		{
+			// Non-URI local-path base keeps the original OS-path behavior: a
+			// path-absolute reference is returned unchanged.
+			name:   "path-absolute ref against local-path base",
+			base:   filepath.FromSlash("/tmp/catalog.xml"),
+			value:  filepath.FromSlash("/abs/asset.xml"),
+			expect: filepath.FromSlash("/abs/asset.xml"),
+		},
+		{
+			// Non-URI local-path base: a relative reference joins against the
+			// base directory as an OS path.
+			name:   "relative ref against local-path base",
+			base:   filepath.FromSlash("/tmp/catalog.xml"),
+			value:  "asset.xml",
+			expect: filepath.FromSlash("/tmp/asset.xml"),
+		},
+		{
+			name:   "empty base relative value",
+			base:   "",
+			value:  "asset.xml",
+			expect: "asset.xml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expect, catalog.ResolveURI(tc.base, tc.value))
+		})
+	}
+}


### PR DESCRIPTION
- reject opaque/empty-path file: URIs (e.g. `file:next.xml`) in catalogFilePath instead of reading the process cwd
- resolve catalog references in URI space when the base has a scheme, so a path-absolute `uri="/abs/asset.xml"` against a file: base yields `file:///abs/asset.xml`; non-URI local-path bases keep OS-path semantics