### PR TITLE
honor context cancellation in xml parse loops

### DIFF
--- a/.claude/docs/parser-internals.md
+++ b/.claude/docs/parser-internals.md
@@ -205,7 +205,7 @@ Both XML and HTML push parsers use the `push` package (`push.Parser[T]`), which 
 
 **XML PushParser** (`parser.go` + `push/`): `p.NewPushParser(ctx)` → `pp.Push(chunk)` → `doc, err := pp.Close()`
 
-Parser runs in a background goroutine reading from the stream via `ParseReader`. Tokens are processed incrementally as data is pushed — the stream's `Read` blocks until bytes are available, so the parser advances as each chunk arrives.
+Parser runs in a background goroutine reading from the stream via `ParseReader`. Tokens are processed incrementally as data is pushed — the stream's `Read` blocks until bytes are available, so the parser advances as each chunk arrives. The stream wait is context-aware: cancelling the context passed to `New`/`NewPushParser` unblocks a waiting `Read`, which returns the context error so the background parse aborts even while waiting for more pushed data (see Context Cancellation below).
 
 **HTML PushParser** (`html/html.go` + `push/`): `p.NewPushParser(ctx)` → `pp.Push(chunk)` → `doc, err := pp.Close()`
 
@@ -276,6 +276,29 @@ parse context is cancelled or its deadline is exceeded, the parser aborts:
 - The cancellation is observed both in the normal content loop and inside the
   recovery / `skipToRecoverPoint()` skip path, so an in-progress recovery scan
   also aborts promptly.
+
+### Cancellation boundary (between reads vs. blocked Read)
+
+Cancellation is checked BETWEEN read operations and parse steps — before each
+cursor refill and between content-loop iterations. The parser does not (and
+cannot generically) interrupt a read already in progress:
+
+- **`Parse([]byte, ...)`**: reads from an in-memory byte slice, so there is no
+  blocking read. Cancellation is always observed promptly.
+- **`ParseReader(io.Reader, ...)`**: cancellation is observed as soon as the
+  parser regains control between reads. A reader already blocked inside its own
+  `Read` cannot be unblocked generically — Go provides no way to cancel a Read in
+  progress. Such a read is only interruptible if the reader itself honors the
+  context or a deadline (e.g. sets a read deadline when `ctx.Done()` fires, or
+  returns an error from `Read` on cancellation). To make a slow/never-returning
+  reader cancellable, wrap it so its `Read` observes `ctx`, or read the bytes
+  yourself and call `Parse`.
+- **Push parser** (`push` package): the parser-owned stream wait IS a sync.Cond,
+  not an arbitrary `io.Reader.Read`, so it is unblocked on cancellation. A watcher
+  goroutine broadcasts on the cond when `ctx.Done()` fires; `stream.Read` then
+  returns the context error instead of blocking for more pushed data. The watcher
+  exits when the stream is closed so it does not outlive a parse on a context that
+  is never cancelled.
 
 ## Early Termination
 

--- a/.claude/docs/parser-internals.md
+++ b/.claude/docs/parser-internals.md
@@ -250,16 +250,38 @@ After parsing start tag:
 
 ## Recovery Mode (RecoverOnError)
 
-On error in `parseContent()`:
+On a recoverable parse error in `parseContent()`:
 1. Save error in `recoverErr`
 2. Set `disableSAX=true`
 3. `skipToRecoverPoint()` → advance to next `<`
 4. Continue parsing
 5. Return partial document + saved error
 
+Recovery applies only to genuine parse errors (malformed content). It does NOT
+apply to context cancellation — see Context Cancellation below.
+
+## Context Cancellation (parse abort)
+
+Context cancellation is distinct from recovery and from `StopParser`. When the
+parse context is cancelled or its deadline is exceeded, the parser aborts:
+
+- `context.Canceled` / `context.DeadlineExceeded` BYPASS recovery entirely, even
+  when `RecoverOnError(true)` is set — a cancelled parse is not a recoverable
+  parse error.
+- Parse returns a **nil document** and the **context error** (matchable with
+  `errors.Is(err, context.Canceled)` / `context.DeadlineExceeded`). It never
+  returns a partial tree.
+- The SAX `Error` handler is NOT invoked: a clean cancellation must not look like
+  a malformed document to the handler.
+- The cancellation is observed both in the normal content loop and inside the
+  recovery / `skipToRecoverPoint()` skip path, so an in-progress recovery scan
+  also aborts promptly.
+
 ## Early Termination
 
-`StopParser(ctx)` → set `stopped=true`, `instate=psEOF`. Returns parsed document so far, nil error.
+`StopParser(ctx)` → set `stopped=true`, `instate=psEOF`. Returns the parsed
+document so far and a nil error (partial document, as opposed to context
+cancellation which returns a nil document and the context error).
 
 ## Key Parser Fluent Method Effects
 

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,7 @@
 package helium
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -48,6 +49,17 @@ var (
 	errParserStopped       = errors.New("parser stopped")
 	errNoCursor            = errors.New("parser has no input")
 )
+
+// isParseAbort reports whether err signals that parsing must stop immediately
+// rather than be treated as a recoverable parse error. This covers the
+// internal stop sentinel (helium.StopParser) and context cancellation /
+// deadline expiry. Such errors must never enter recovery, be rewrapped as a
+// parse error, or fire SAX error handlers as if the document were malformed.
+func isParseAbort(err error) bool {
+	return errors.Is(err, errParserStopped) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded)
+}
 
 // DTDDupTokenError is returned when a DTD attribute enumeration contains
 // a duplicate token value.

--- a/html/parser.go
+++ b/html/parser.go
@@ -475,6 +475,14 @@ func (p *parser) parse(ctx context.Context) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		// A non-EOF read error from the underlying reader (e.g. the push
+		// parser's stream returning the context error when its blocking wait
+		// is cancelled) is recorded by the cursor and otherwise masked by
+		// Done(). Surface it so a cancelled or failed read aborts the parse
+		// rather than silently accepting truncated input.
+		if err := p.cur.Err(); err != nil {
+			return err
+		}
 		if p.cur.Peek() == '<' {
 			if p.cur.PeekAt(1) == '/' {
 				p.parseEndTag()
@@ -500,6 +508,13 @@ func (p *parser) parse(ctx context.Context) error {
 		} else {
 			p.parseCharacters()
 		}
+	}
+
+	// A clean Done() may mask a non-EOF read error that arrived together with
+	// the final bytes (e.g. a cancelled push-stream wait). Surface it before
+	// reporting success.
+	if err := p.cur.Err(); err != nil {
+		return err
 	}
 
 	p.htmlAutoCloseOnEnd()

--- a/parser.go
+++ b/parser.go
@@ -733,6 +733,8 @@ found:
 	innerCtx = sax.WithDocumentLocator(innerCtx, newctx)
 	innerCtx = context.WithValue(innerCtx, stopFuncKey{}, newctx.stop)
 	if err := newctx.parseContent(innerCtx); err != nil {
+		// errParserStopped is a benign stop (helium.StopParser); any other
+		// error, including context cancellation, propagates with a nil result.
 		if !errors.Is(err, errParserStopped) {
 			return nil, err
 		}

--- a/parser.go
+++ b/parser.go
@@ -540,6 +540,11 @@ func (p Parser) Parse(ctx context.Context, b []byte) (*Document, error) { //noli
 		if errors.Is(err, errParserStopped) {
 			return pctx.doc, nil
 		}
+		// A cancelled or timed-out parse is not a recoverable parse error:
+		// return the context error with a nil document, never a partial tree.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
 		if p.cfg.options.IsSet(parseRecover) {
 			// ParseRecover: return the partial document along with the error
 			return pctx.doc, err
@@ -592,6 +597,11 @@ func (p Parser) ParseReader(ctx context.Context, r io.Reader) (*Document, error)
 	if err := pctx.parseDocument(ctx); err != nil {
 		if errors.Is(err, errParserStopped) {
 			return pctx.doc, nil
+		}
+		// A cancelled or timed-out parse is not a recoverable parse error:
+		// return the context error with a nil document, never a partial tree.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
 		}
 		if p.cfg.options.IsSet(parseRecover) {
 			return pctx.doc, err

--- a/parser.go
+++ b/parser.go
@@ -514,6 +514,13 @@ func (p Parser) closeHandler() {
 // returned error is [ErrDTDValidationFailed] and the document is still
 // returned. Individual validation errors are delivered to the [ErrorHandler]
 // configured via [Parser.ErrorHandler].
+//
+// Cancellation: if ctx is cancelled or its deadline is exceeded, Parse aborts
+// and returns the context error (matched by [errors.Is] against
+// [context.Canceled] / [context.DeadlineExceeded]) with a nil Document — never
+// a partial tree. Because Parse reads from an in-memory byte slice there is no
+// blocking read, so cancellation is always observed promptly: the parser checks
+// the context between parse steps and between cursor refills.
 func (p Parser) Parse(ctx context.Context, b []byte) (*Document, error) { //nolint:contextcheck
 	if ctx == nil {
 		ctx = context.Background()
@@ -573,6 +580,21 @@ func (p Parser) Parse(ctx context.Context, b []byte) (*Document, error) { //noli
 // This is identical to [Parse] but reads from a stream instead of a byte slice.
 // EBCDIC encoding detection is not supported when parsing from a reader.
 // See [Parse] for DTD validation error handling.
+//
+// Cancellation: context cancellation and deadlines are observed BETWEEN read
+// operations and parse steps. The parser checks ctx before each cursor refill
+// (read from r) and between parse steps, so a cancelled or timed-out context is
+// honored as soon as the parser regains control, returning the context error
+// (matched by [errors.Is] against [context.Canceled] /
+// [context.DeadlineExceeded]) with a nil Document.
+//
+// A reader already blocked inside its own Read call cannot be interrupted
+// generically: Go provides no way to unblock a Read in progress. Such a read is
+// only interruptible if r itself honors the context or a deadline — for example
+// a reader that sets a read deadline when ctx.Done() fires, or that returns from
+// Read with an error on cancellation. If r can block indefinitely (e.g. a slow
+// or never-returning network reader), wrap it so its Read observes ctx, or pass
+// the already-read bytes to [Parse] instead.
 func (p Parser) ParseReader(ctx context.Context, r io.Reader) (*Document, error) { //nolint:contextcheck
 	if ctx == nil {
 		ctx = context.Background()

--- a/parser_content.go
+++ b/parser_content.go
@@ -80,9 +80,15 @@ func (pctx *parserCtx) parseMisc(ctx context.Context) error {
 	}
 
 	cur := pctx.getCursor()
-	for !cur.Done() && pctx.instate != psEOF {
+	for {
+		// Check the context BEFORE cur.Done(), which may refill the cursor
+		// from an io.Reader and block; this lets a cancelled context be
+		// observed between reads rather than after a blocking refill.
 		if err := ctx.Err(); err != nil {
 			return err
+		}
+		if cur.Done() || pctx.instate == psEOF {
+			break
 		}
 		if cur.HasPrefixString("<?") {
 			if err := pctx.parsePI(ctx); err != nil {

--- a/parser_content.go
+++ b/parser_content.go
@@ -81,6 +81,9 @@ func (pctx *parserCtx) parseMisc(ctx context.Context) error {
 
 	cur := pctx.getCursor()
 	for !cur.Done() && pctx.instate != psEOF {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if cur.HasPrefixString("<?") {
 			if err := pctx.parsePI(ctx); err != nil {
 				return pctx.error(ctx, err)

--- a/parser_ctx_cancel_test.go
+++ b/parser_ctx_cancel_test.go
@@ -2,7 +2,9 @@ package helium_test
 
 import (
 	"context"
+	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -52,5 +54,69 @@ func TestParseContextCancelledDuringParse(t *testing.T) {
 		require.ErrorIs(t, err, context.Canceled, "Parse must return the context error")
 	case <-time.After(10 * time.Second):
 		t.Fatal("Parse did not return promptly after context cancellation")
+	}
+}
+
+// errRecordingSAX embeds the default tree builder and records every SAX Error
+// callback so the test can assert that context cancellation does NOT surface as
+// a parse error to the SAX handler.
+type errRecordingSAX struct {
+	*helium.TreeBuilder
+	mu     sync.Mutex
+	errors []error
+}
+
+func (s *errRecordingSAX) Error(ctx context.Context, err error) error {
+	s.mu.Lock()
+	s.errors = append(s.errors, err)
+	s.mu.Unlock()
+	return s.TreeBuilder.Error(ctx, err)
+}
+
+func (s *errRecordingSAX) recorded() []error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]error(nil), s.errors...)
+}
+
+// TestParseContextCancelDoesNotFireSAXError verifies that when a context is
+// cancelled mid-parse, Parse returns the context error and the SAX Error
+// handler is NOT invoked as if the document were malformed.
+func TestParseContextCancelDoesNotFireSAXError(t *testing.T) {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0"?><root>`)
+	for range 200000 {
+		b.WriteString(`<a>x</a>`)
+	}
+	b.WriteString(`</root>`)
+	input := []byte(b.String())
+
+	handler := &errRecordingSAX{TreeBuilder: helium.NewTreeBuilder()}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(2 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := helium.NewParser().SAXHandler(handler).Parse(ctx, input)
+		done <- err
+	}()
+
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Parse did not return promptly after context cancellation")
+	}
+
+	require.ErrorIs(t, err, context.Canceled, "Parse must return the context error")
+
+	for _, e := range handler.recorded() {
+		require.False(t,
+			errors.Is(e, context.Canceled) || errors.Is(e, context.DeadlineExceeded),
+			"SAX Error handler must not be invoked for context cancellation, got: %v", e)
 	}
 }

--- a/parser_ctx_cancel_test.go
+++ b/parser_ctx_cancel_test.go
@@ -149,3 +149,52 @@ func TestParseContextCancelWithRecoverOnError(t *testing.T) {
 		t.Fatal("Parse did not return promptly after context cancellation")
 	}
 }
+
+// malformedRecoverableDoc builds a large document that becomes malformed right
+// after the root start tag: the content is a huge run of plain text with no
+// closing tag. With RecoverOnError the parser fails on the unterminated content
+// and then sits in its skip-to-recover-point loop scanning the long tail. This
+// keeps recovery active long enough for a concurrently-cancelled context to be
+// observed inside the recovery/skip path.
+func malformedRecoverableDoc() []byte {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0"?><root>`)
+	// A stray '<' with no following name forces a parse error; the long run of
+	// text after it must be skipped during recovery (skipToRecoverPoint), which
+	// is where the cancellation needs to be observed.
+	b.WriteString(`<`)
+	b.WriteString(strings.Repeat("x", 10_000_000))
+	return []byte(b.String())
+}
+
+// TestParseContextCancelDuringRecovery verifies that cancellation observed
+// while the parser is in its recovery / skip-to-recover-point path returns
+// promptly with the context error and a nil document, and never blocks. The
+// input is malformed so recovery is active and RecoverOnError is enabled so the
+// parser would otherwise keep scanning the long tail to the end of input.
+func TestParseContextCancelDuringRecovery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct {
+		doc *helium.Document
+		err error
+	}, 1)
+	go func() {
+		doc, err := helium.NewParser().RecoverOnError(true).Parse(ctx, malformedRecoverableDoc())
+		done <- struct {
+			doc *helium.Document
+			err error
+		}{doc, err}
+	}()
+
+	// Give the parser a moment to enter the recovery/skip loop, then cancel.
+	time.AfterFunc(20*time.Millisecond, cancel)
+
+	select {
+	case res := <-done:
+		require.ErrorIs(t, res.err, context.Canceled, "Parse must return the context error when cancelled during recovery")
+		require.Nil(t, res.doc, "cancelled parse must not return a partial document")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Parse did not return promptly after cancellation during recovery")
+	}
+}

--- a/parser_ctx_cancel_test.go
+++ b/parser_ctx_cancel_test.go
@@ -120,3 +120,32 @@ func TestParseContextCancelDoesNotFireSAXError(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled, "Parse must return the context error")
 	require.Empty(t, handler.recorded(), "SAX Error handler must not be invoked on a clean cancellation")
 }
+
+// TestParseContextCancelWithRecoverOnError verifies that a mid-parse
+// cancellation is not treated as a recoverable parse error: even with
+// RecoverOnError(true) enabled, Parse must return the context error AND a nil
+// document, never a partial tree.
+func TestParseContextCancelWithRecoverOnError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	handler := &cancellingSAX{TreeBuilder: helium.NewTreeBuilder(), cancel: cancel, cancelAt: 100}
+
+	done := make(chan struct {
+		doc *helium.Document
+		err error
+	}, 1)
+	go func() {
+		doc, err := helium.NewParser().RecoverOnError(true).SAXHandler(handler).Parse(ctx, largeDoc())
+		done <- struct {
+			doc *helium.Document
+			err error
+		}{doc, err}
+	}()
+
+	select {
+	case res := <-done:
+		require.ErrorIs(t, res.err, context.Canceled, "Parse must return the context error even with RecoverOnError")
+		require.Nil(t, res.doc, "cancelled parse must not return a partial document")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Parse did not return promptly after context cancellation")
+	}
+}

--- a/parser_ctx_cancel_test.go
+++ b/parser_ctx_cancel_test.go
@@ -28,7 +28,7 @@ func TestParseContextCancelledDuringParse(t *testing.T) {
 	// iterates enough times to observe the cancellation.
 	var b strings.Builder
 	b.WriteString(`<?xml version="1.0"?><root>`)
-	for i := 0; i < 200000; i++ {
+	for range 200000 {
 		b.WriteString(`<a>x</a>`)
 	}
 	b.WriteString(`</root>`)

--- a/parser_ctx_cancel_test.go
+++ b/parser_ctx_cancel_test.go
@@ -1,0 +1,56 @@
+package helium_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseContextCancelledUpFront verifies that a context cancelled before
+// Parse runs aborts immediately with the context error instead of doing work.
+func TestParseContextCancelledUpFront(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := helium.NewParser().Parse(ctx, []byte(`<?xml version="1.0"?><root><a/></root>`))
+	require.ErrorIs(t, err, context.Canceled, "Parse must return the context error")
+}
+
+// TestParseContextCancelledDuringParse verifies that cancelling the context
+// while Parse is running on a large, deeply repetitive input aborts promptly
+// with the context error rather than running to completion.
+func TestParseContextCancelledDuringParse(t *testing.T) {
+	// Build a large document with many sibling elements so the content loop
+	// iterates enough times to observe the cancellation.
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0"?><root>`)
+	for i := 0; i < 200000; i++ {
+		b.WriteString(`<a>x</a>`)
+	}
+	b.WriteString(`</root>`)
+	input := []byte(b.String())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel shortly after parsing begins.
+	go func() {
+		time.Sleep(2 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := helium.NewParser().Parse(ctx, input)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled, "Parse must return the context error")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Parse did not return promptly after context cancellation")
+	}
+}

--- a/parser_ctx_cancel_test.go
+++ b/parser_ctx_cancel_test.go
@@ -67,7 +67,7 @@ func (s *cancellingSAX) recorded() []error {
 // TestParseContextCancelledUpFront verifies that a context cancelled before
 // Parse runs aborts immediately with the context error instead of doing work.
 func TestParseContextCancelledUpFront(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	_, err := helium.NewParser().Parse(ctx, []byte(`<?xml version="1.0"?><root><a/></root>`))
@@ -79,7 +79,7 @@ func TestParseContextCancelledUpFront(t *testing.T) {
 // running to completion. Cancellation is triggered deterministically from a SAX
 // handler after a known number of elements have been parsed.
 func TestParseContextCancelledDuringParse(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	handler := &cancellingSAX{TreeBuilder: helium.NewTreeBuilder(), cancel: cancel, cancelAt: 100}
 
 	done := make(chan error, 1)
@@ -101,7 +101,7 @@ func TestParseContextCancelledDuringParse(t *testing.T) {
 // handler is NOT invoked at all: a clean cancellation must not look like a
 // malformed document to the handler.
 func TestParseContextCancelDoesNotFireSAXError(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	handler := &cancellingSAX{TreeBuilder: helium.NewTreeBuilder(), cancel: cancel, cancelAt: 100}
 
 	done := make(chan error, 1)
@@ -126,7 +126,7 @@ func TestParseContextCancelDoesNotFireSAXError(t *testing.T) {
 // RecoverOnError(true) enabled, Parse must return the context error AND a nil
 // document, never a partial tree.
 func TestParseContextCancelWithRecoverOnError(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	handler := &cancellingSAX{TreeBuilder: helium.NewTreeBuilder(), cancel: cancel, cancelAt: 100}
 
 	done := make(chan struct {
@@ -173,7 +173,7 @@ func malformedRecoverableDoc() []byte {
 // input is malformed so recovery is active and RecoverOnError is enabled so the
 // parser would otherwise keep scanning the long tail to the end of input.
 func TestParseContextCancelDuringRecovery(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	done := make(chan struct {
 		doc *helium.Document

--- a/parser_ctx_cancel_test.go
+++ b/parser_ctx_cancel_test.go
@@ -2,15 +2,67 @@ package helium_test
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/sax"
 	"github.com/stretchr/testify/require"
 )
+
+// largeDoc builds a document with many sibling elements so the content loop
+// iterates enough times to observe a mid-parse cancellation.
+func largeDoc() []byte {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0"?><root>`)
+	for range 200000 {
+		b.WriteString(`<a>x</a>`)
+	}
+	b.WriteString(`</root>`)
+	return []byte(b.String())
+}
+
+// cancellingSAX embeds the default tree builder and cancels the parse context
+// after a fixed number of StartElementNS callbacks. This makes cancellation
+// deterministic: the parser is guaranteed to have entered the content loop and
+// processed a known number of elements before the context is cancelled, so the
+// next loop iteration observes the cancellation regardless of machine speed. It
+// also records every SAX Error callback so a test can assert that a clean
+// cancellation surfaces no error to the SAX handler.
+type cancellingSAX struct {
+	*helium.TreeBuilder
+	cancel   context.CancelFunc
+	cancelAt int
+	mu       sync.Mutex
+	starts   int
+	errors   []error
+}
+
+func (s *cancellingSAX) StartElementNS(ctx context.Context, localname, prefix, uri string, namespaces []sax.Namespace, attrs []sax.Attribute) error {
+	s.mu.Lock()
+	s.starts++
+	fire := s.cancel != nil && s.starts == s.cancelAt
+	s.mu.Unlock()
+	if fire {
+		s.cancel()
+	}
+	return s.TreeBuilder.StartElementNS(ctx, localname, prefix, uri, namespaces, attrs)
+}
+
+func (s *cancellingSAX) Error(ctx context.Context, err error) error {
+	s.mu.Lock()
+	s.errors = append(s.errors, err)
+	s.mu.Unlock()
+	return s.TreeBuilder.Error(ctx, err)
+}
+
+func (s *cancellingSAX) recorded() []error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]error(nil), s.errors...)
+}
 
 // TestParseContextCancelledUpFront verifies that a context cancelled before
 // Parse runs aborts immediately with the context error instead of doing work.
@@ -23,29 +75,16 @@ func TestParseContextCancelledUpFront(t *testing.T) {
 }
 
 // TestParseContextCancelledDuringParse verifies that cancelling the context
-// while Parse is running on a large, deeply repetitive input aborts promptly
-// with the context error rather than running to completion.
+// while Parse is running aborts promptly with the context error rather than
+// running to completion. Cancellation is triggered deterministically from a SAX
+// handler after a known number of elements have been parsed.
 func TestParseContextCancelledDuringParse(t *testing.T) {
-	// Build a large document with many sibling elements so the content loop
-	// iterates enough times to observe the cancellation.
-	var b strings.Builder
-	b.WriteString(`<?xml version="1.0"?><root>`)
-	for range 200000 {
-		b.WriteString(`<a>x</a>`)
-	}
-	b.WriteString(`</root>`)
-	input := []byte(b.String())
-
 	ctx, cancel := context.WithCancel(context.Background())
-	// Cancel shortly after parsing begins.
-	go func() {
-		time.Sleep(2 * time.Millisecond)
-		cancel()
-	}()
+	handler := &cancellingSAX{TreeBuilder: helium.NewTreeBuilder(), cancel: cancel, cancelAt: 100}
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := helium.NewParser().Parse(ctx, input)
+		_, err := helium.NewParser().SAXHandler(handler).Parse(ctx, largeDoc())
 		done <- err
 	}()
 
@@ -57,51 +96,17 @@ func TestParseContextCancelledDuringParse(t *testing.T) {
 	}
 }
 
-// errRecordingSAX embeds the default tree builder and records every SAX Error
-// callback so the test can assert that context cancellation does NOT surface as
-// a parse error to the SAX handler.
-type errRecordingSAX struct {
-	*helium.TreeBuilder
-	mu     sync.Mutex
-	errors []error
-}
-
-func (s *errRecordingSAX) Error(ctx context.Context, err error) error {
-	s.mu.Lock()
-	s.errors = append(s.errors, err)
-	s.mu.Unlock()
-	return s.TreeBuilder.Error(ctx, err)
-}
-
-func (s *errRecordingSAX) recorded() []error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return append([]error(nil), s.errors...)
-}
-
 // TestParseContextCancelDoesNotFireSAXError verifies that when a context is
 // cancelled mid-parse, Parse returns the context error and the SAX Error
-// handler is NOT invoked as if the document were malformed.
+// handler is NOT invoked at all: a clean cancellation must not look like a
+// malformed document to the handler.
 func TestParseContextCancelDoesNotFireSAXError(t *testing.T) {
-	var b strings.Builder
-	b.WriteString(`<?xml version="1.0"?><root>`)
-	for range 200000 {
-		b.WriteString(`<a>x</a>`)
-	}
-	b.WriteString(`</root>`)
-	input := []byte(b.String())
-
-	handler := &errRecordingSAX{TreeBuilder: helium.NewTreeBuilder()}
-
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		time.Sleep(2 * time.Millisecond)
-		cancel()
-	}()
+	handler := &cancellingSAX{TreeBuilder: helium.NewTreeBuilder(), cancel: cancel, cancelAt: 100}
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := helium.NewParser().SAXHandler(handler).Parse(ctx, input)
+		_, err := helium.NewParser().SAXHandler(handler).Parse(ctx, largeDoc())
 		done <- err
 	}()
 
@@ -113,10 +118,5 @@ func TestParseContextCancelDoesNotFireSAXError(t *testing.T) {
 	}
 
 	require.ErrorIs(t, err, context.Canceled, "Parse must return the context error")
-
-	for _, e := range handler.recorded() {
-		require.False(t,
-			errors.Is(e, context.Canceled) || errors.Is(e, context.DeadlineExceeded),
-			"SAX Error handler must not be invoked for context cancellation, got: %v", e)
-	}
+	require.Empty(t, handler.recorded(), "SAX Error handler must not be invoked on a clean cancellation")
 }

--- a/parser_document.go
+++ b/parser_document.go
@@ -246,9 +246,15 @@ func (pctx *parserCtx) parseContent(ctx context.Context) error {
 
 	doRecover := pctx.options.IsSet(parseRecover)
 
-	for !cur.Done() && !pctx.stopped {
+	for {
+		// Check the context BEFORE cur.Done(), which may refill the cursor
+		// from an io.Reader and block; this lets a cancelled context be
+		// observed between reads rather than after a blocking refill.
 		if err := ctx.Err(); err != nil {
 			return err
+		}
+		if cur.Done() || pctx.stopped {
+			break
 		}
 		if cur.Peek() == '<' && cur.PeekAt(1) == '/' {
 			break

--- a/parser_document.go
+++ b/parser_document.go
@@ -55,6 +55,17 @@ func (pctx *parserCtx) parseDocument(ctx context.Context) error {
 
 	// nothing left? eek
 	if bcur.Done() {
+		// An apparently empty document may instead be a cancelled read: the
+		// push parser's stream returns the context error from its blocking
+		// wait, which the byte cursor records and Done() then masks. Surface
+		// cancellation (and any other sticky read error) instead of the
+		// misleading "empty document".
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := bcur.Err(); err != nil {
+			return pctx.error(ctx, err)
+		}
 		return pctx.error(ctx, errors.New("empty document"))
 	}
 
@@ -189,6 +200,15 @@ func (pctx *parserCtx) parseDocument(ctx context.Context) error {
 	pctx.skipBlanks(ctx)
 
 	if cur.Peek() != '<' {
+		// A cancelled or failed read can leave the cursor at an apparent end
+		// of input; report the underlying cause rather than a misleading
+		// "start tag expected".
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := pctx.cursorDecodeErr(); err != nil {
+			return pctx.error(ctx, err)
+		}
 		return pctx.error(ctx, ErrEmptyDocument)
 	}
 

--- a/parser_document.go
+++ b/parser_document.go
@@ -24,6 +24,12 @@ func (pctx *parserCtx) parseDocument(ctx context.Context) error {
 	ctx = sax.WithDocumentLocator(ctx, pctx)
 	ctx = context.WithValue(ctx, stopFuncKey{}, pctx.stop)
 
+	// Honor a context that is already cancelled before any parsing work
+	// (or blocking reads) begins.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	if s := pctx.sax; s != nil {
 		switch err := s.SetDocumentLocator(ctx, pctx); err {
 		case nil, sax.ErrHandlerUnspecified:
@@ -241,6 +247,9 @@ func (pctx *parserCtx) parseContent(ctx context.Context) error {
 	doRecover := pctx.options.IsSet(parseRecover)
 
 	for !cur.Done() && !pctx.stopped {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if cur.Peek() == '<' && cur.PeekAt(1) == '/' {
 			break
 		}

--- a/parser_document.go
+++ b/parser_document.go
@@ -288,7 +288,7 @@ func (pctx *parserCtx) parseContent(ctx context.Context) error {
 			err = pctx.parseReference(ctx)
 		default:
 			if err := pctx.parseCharData(ctx, false); err != nil {
-				if !doRecover || errors.Is(err, errParserStopped) {
+				if !doRecover || isParseAbort(err) {
 					return err
 				}
 				if pctx.recoverErr == nil {
@@ -296,13 +296,15 @@ func (pctx *parserCtx) parseContent(ctx context.Context) error {
 				}
 				pctx.disableSAX = true
 				pctx.wellFormed = false
-				pctx.skipToRecoverPoint()
+				if err := pctx.skipToRecoverPoint(ctx); err != nil {
+					return err
+				}
 			}
 			continue
 		}
 
 		if err != nil {
-			if !doRecover || errors.Is(err, errParserStopped) {
+			if !doRecover || isParseAbort(err) {
 				return pctx.error(ctx, err)
 			}
 			if pctx.recoverErr == nil {
@@ -312,7 +314,9 @@ func (pctx *parserCtx) parseContent(ctx context.Context) error {
 			pctx.wellFormed = false
 
 			prevLine, prevCol := cur.LineNumber(), cur.Column()
-			pctx.skipToRecoverPoint()
+			if err := pctx.skipToRecoverPoint(ctx); err != nil {
+				return err
+			}
 			if !cur.Done() && cur.LineNumber() == prevLine && cur.Column() == prevCol {
 				_ = cur.Advance(1)
 			}
@@ -333,14 +337,25 @@ func (pctx *parserCtx) parseContent(ctx context.Context) error {
 
 // skipToRecoverPoint advances the cursor past unrecoverable content to the
 // next '<' character or EOF, for re-synchronization in parseRecover mode.
-func (ctx *parserCtx) skipToRecoverPoint() {
-	cur := ctx.getCursor()
+// It returns the context error if the context is cancelled so that recovery
+// cannot run (or block on a cursor refill) after cancellation.
+func (pctx *parserCtx) skipToRecoverPoint(ctx context.Context) error {
+	cur := pctx.getCursor()
 	if cur == nil {
-		return
+		return nil
 	}
-	for !cur.Done() {
+	for {
+		// Check the context BEFORE cur.Done(), which may refill the cursor
+		// from an io.Reader and block; this lets a cancelled context abort
+		// recovery rather than spin or block.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if cur.Done() {
+			return nil
+		}
 		if cur.Peek() == '<' {
-			return
+			return nil
 		}
 		_ = cur.Advance(1)
 	}

--- a/parser_dtd_subset.go
+++ b/parser_dtd_subset.go
@@ -92,6 +92,9 @@ func (pctx *parserCtx) parseInternalSubset(ctx context.Context) error {
 		if pctx.stopped {
 			return errParserStopped
 		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		cur = pctx.getCursor()
 		if cur == nil || cur.Done() || cur.Peek() == ']' {
 			break

--- a/parser_push_test.go
+++ b/parser_push_test.go
@@ -2,9 +2,11 @@ package helium_test
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/stretchr/testify/require"
@@ -215,6 +217,35 @@ func TestPushParser(t *testing.T) {
 		got, err := pp.Close()
 		require.NoError(t, err)
 		require.Equal(t, dumpDoc(t, want), dumpDoc(t, got))
+	})
+
+	t.Run("context cancel while waiting for data", func(t *testing.T) {
+		t.Parallel()
+
+		// Push a partial document and never push the rest. The background
+		// parser will block in the stream's Read waiting for more data. The
+		// stream wait is context-aware, so cancelling must unblock it and let
+		// Close return promptly with the context error.
+		ctx, cancel := context.WithCancel(t.Context())
+
+		p := helium.NewParser()
+		pp := p.NewPushParser(ctx)
+		require.NoError(t, pp.Push([]byte(`<?xml version="1.0"?><root>`)))
+
+		cancel()
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := pp.Close()
+			done <- err
+		}()
+
+		select {
+		case err := <-done:
+			require.ErrorIs(t, err, context.Canceled, "Close must return the context error")
+		case <-time.After(10 * time.Second):
+			t.Fatal("push parser did not abort promptly after context cancellation")
+		}
 	})
 
 	t.Run("real file", func(t *testing.T) {

--- a/parserctx.go
+++ b/parserctx.go
@@ -529,6 +529,12 @@ func (pctx *parserCtx) errorAtLevel(ctx context.Context, err error, level ErrorL
 	if errors.Is(err, errParserStopped) {
 		return errParserStopped
 	}
+	// Context cancellation/deadline is not a genuine parse failure; pass it
+	// through unchanged so callers see the context error and SAX error
+	// handlers are not fired as if the document was malformed.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
 	// If it's wrapped, just return as is
 	if _, ok := err.(ErrParseError); ok {
 		return err

--- a/parserctx.go
+++ b/parserctx.go
@@ -525,14 +525,14 @@ func (pctx *parserCtx) namespaceError(ctx context.Context, err error) error {
 }
 
 func (pctx *parserCtx) errorAtLevel(ctx context.Context, err error, level ErrorLevel) error {
-	// errParserStopped is not a real error; pass through unwrapped.
-	if errors.Is(err, errParserStopped) {
-		return errParserStopped
-	}
-	// Context cancellation/deadline is not a genuine parse failure; pass it
-	// through unchanged so callers see the context error and SAX error
-	// handlers are not fired as if the document was malformed.
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	// Parse-abort errors (the stop sentinel, context cancellation, deadline
+	// expiry) are not genuine parse failures: pass them through unchanged so
+	// callers see them directly and SAX error handlers are not fired as if the
+	// document were malformed.
+	if isParseAbort(err) {
+		if errors.Is(err, errParserStopped) {
+			return errParserStopped
+		}
 		return err
 	}
 	// If it's wrapped, just return as is

--- a/parserctx.go
+++ b/parserctx.go
@@ -387,11 +387,14 @@ func (ctx *parserCtx) getCursor() strcursor.Cursor {
 // EOF via Done(), so callers must consult this explicitly to reject malformed
 // encoded input.
 func (ctx *parserCtx) cursorDecodeErr() error {
-	u8, ok := ctx.getCursor().(*strcursor.UTF8Cursor)
-	if !ok {
+	switch cur := ctx.getCursor().(type) {
+	case *strcursor.UTF8Cursor:
+		return cur.Err()
+	case *strcursor.ByteCursor:
+		return cur.Err()
+	default:
 		return nil
 	}
-	return u8.Err()
 }
 
 func (ctx *parserCtx) popInput() any { //nolint:unparam // return value used for type generality

--- a/push/push.go
+++ b/push/push.go
@@ -15,28 +15,68 @@ import (
 )
 
 // stream is a thread-safe concurrent buffer. Write appends data and
-// signals waiting readers; Read blocks until enough bytes are available
-// or the stream is closed.
+// signals waiting readers; Read blocks until enough bytes are available,
+// the stream is closed, or the supplied context is cancelled.
+//
+// A blocked Read is a parser-owned wait (sync.Cond), not an arbitrary
+// io.Reader.Read, so it can be unblocked on context cancellation: a watcher
+// goroutine broadcasts on the cond when ctx.Done() fires, and Read returns the
+// context error after waking.
 type stream struct {
 	mu     sync.Mutex
 	cond   *sync.Cond
 	buf    bytes.Buffer
 	closed bool
 	wrErr  error
+	// ctx is stored intentionally: the stream's blocking Read is a
+	// parser-owned wait (sync.Cond), and storing the context lets that wait
+	// observe cancellation and return the context error. This is the
+	// controllable-wait exception to the usual "do not store a context" rule.
+	ctx      context.Context //nolint:containedctx
+	stopOnce sync.Once
+	stop     chan struct{}
 }
 
-func newStream() *stream {
-	s := &stream{}
+func newStream(ctx context.Context) *stream {
+	if ctx == nil {
+		ctx = context.Background() //nolint:contextcheck // background fallback only when caller passes a nil context
+	}
+	s := &stream{ctx: ctx, stop: make(chan struct{})}
 	s.cond = sync.NewCond(&s.mu)
+	// Wake any blocked Read when the context is cancelled so the parser
+	// can observe the cancellation between reads. The watcher exits when the
+	// stream is closed so it does not outlive the parse on a context that is
+	// never cancelled.
+	if ctx.Done() != nil {
+		go func() {
+			select {
+			case <-ctx.Done():
+				s.cond.Broadcast()
+			case <-s.stop:
+			}
+		}()
+	}
 	return s
+}
+
+// stopWatcher terminates the context watcher goroutine. Safe to call multiple
+// times and from any close path.
+func (s *stream) stopWatcher() {
+	s.stopOnce.Do(func() { close(s.stop) })
 }
 
 func (s *stream) Read(p []byte) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for s.buf.Len() < len(p) && !s.closed {
+	for s.buf.Len() < len(p) && !s.closed && s.ctx.Err() == nil {
 		s.cond.Wait()
+	}
+
+	// Honor context cancellation before delivering buffered bytes so a
+	// cancelled parse aborts promptly rather than draining the buffer.
+	if err := s.ctx.Err(); err != nil {
+		return 0, err
 	}
 
 	if s.buf.Len() == 0 && s.closed {
@@ -62,22 +102,23 @@ func (s *stream) Write(p []byte) (int, error) {
 	return n, err
 }
 
-func (s *stream) close() error {
+func (s *stream) close() {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	s.closed = true
 	s.cond.Broadcast()
-	return nil
+	s.mu.Unlock()
+
+	s.stopWatcher()
 }
 
 func (s *stream) closeWithWriteError(err error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	s.wrErr = err
 	s.closed = true
 	s.cond.Broadcast()
+	s.mu.Unlock()
+
+	s.stopWatcher()
 }
 
 // Source is the interface satisfied by any parser that can parse from
@@ -105,8 +146,12 @@ type result[T any] struct {
 // New creates a Parser and starts a background goroutine that feeds
 // pushed data to the given [ReaderParser]. The goroutine recovers from
 // panics and delivers the result when [Parser.Close] is called.
+//
+// If ctx is cancelled, the internal stream's blocking Read is unblocked and
+// returns the context error, so the background parse aborts promptly even while
+// it is waiting for more pushed data.
 func New[T any](ctx context.Context, p Source[T]) *Parser[T] {
-	s := newStream()
+	s := newStream(ctx)
 	pp := &Parser[T]{
 		s:    s,
 		done: make(chan result[T], 1),
@@ -144,10 +189,7 @@ func (pp *Parser[T]) Write(p []byte) (int, error) {
 // return the same result.
 func (pp *Parser[T]) Close() (T, error) {
 	pp.closeOnce.Do(func() {
-		if err := pp.s.close(); err != nil {
-			pp.res = result[T]{err: err}
-			return
-		}
+		pp.s.close()
 		pp.res = <-pp.done
 	})
 	return pp.res.val, pp.res.err

--- a/push/push.go
+++ b/push/push.go
@@ -51,7 +51,12 @@ func newStream(ctx context.Context) *stream {
 		go func() {
 			select {
 			case <-ctx.Done():
+				// Hold the lock around Broadcast so a Read that has just
+				// observed ctx.Err()==nil but not yet called cond.Wait()
+				// cannot miss this wakeup (lost-wakeup race).
+				s.mu.Lock()
 				s.cond.Broadcast()
+				s.mu.Unlock()
 			case <-s.stop:
 			}
 		}()


### PR DESCRIPTION
- check `ctx.Err()` at the top of `parseDocument` and in the document content, misc, and internal-subset parse loops so a cancelled context aborts promptly with the context error
- previously the loops only checked the internal `pctx.stopped` flag, so a cancelled context could not abort CPU work on hostile input
- add external tests covering both up-front cancellation and cancellation mid-parse