### PR TITLE
validate stream xmldecl, dtd, and char output

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -21,7 +21,7 @@ xmldsig1       → helium, c14n, internal/lexicon
 xmlenc1        → helium
 html           → helium, sax, push
 catalog        → helium, internal/catalog, internal/lexicon
-stream         → internal/encoding
+stream         → internal/encoding, internal/xmlchar
 sax            → helium, enum
 helium (root)  → sax, enum, internal/encoding, internal/bitset, internal/parser, push, internal/stack
 sink           → (none)

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -237,7 +237,7 @@ Streaming XML writer (no DOM needed).
 - Methods: StartDocument/EndDocument, StartElement/EndElement, WriteAttribute, WriteString (escaped), WriteRaw (unescaped), WriteComment, WritePI, WriteCDATA, StartDTD/EndDTD, WriteDTDElement/Entity/Attlist/Notation, Flush
 - State machine: tracks open elements, namespace scopes, self-close optimization
 - Files: `stream.go` (single ~1100 line file)
-- Imports: internal/encoding/
+- Imports: internal/encoding/, internal/xmlchar/
 
 ## sax/
 
@@ -429,11 +429,16 @@ Parser option bitset type and constants. Bit positions match libxml2's XML_PARSE
 
 ## internal/xmlchar/
 
-XML 1.0 NCName character classification. Single source of truth for NCNameStartChar, NCNameChar, and IsValidNCName.
+XML 1.0 character classification and name validation. Single source of truth for the NCName/QName/Name productions, plus XML Char range, encoding-name, and PI-target validation shared across packages.
 
+- **IsChar(rune) → bool** — XML 1.0 Char production (legal document character)
 - **IsNCNameStartChar(rune) → bool** — XML 1.0 NCName start character production
 - **IsNCNameChar(rune) → bool** — XML 1.0 NCName continuation character production
 - **IsValidNCName(string) → bool** — validates a complete NCName string
+- **IsValidQName(string) → bool** — validates a complete QName (NCName, optionally prefixed)
+- **IsValidName(string) → bool** — validates a complete XML Name (NCName allowing colons)
+- **IsValidEncName(string) → bool** — validates an XML declaration encoding name
+- **IsValidPITarget(string) → bool** — validates a processing-instruction target
 - Files: `xmlchar.go`
 - Imports: none
 

--- a/internal/xmlchar/xmlchar.go
+++ b/internal/xmlchar/xmlchar.go
@@ -83,6 +83,38 @@ func IsValidQName(s string) bool {
 	return IsValidNCName(s)
 }
 
+// IsValidEncName reports whether s is a valid XML EncName (XML 1.0 §4.3.3):
+//
+//	EncName ::= [A-Za-z] ([A-Za-z0-9._] | '-')*
+//
+// This mirrors the parser's encoding-name production (see
+// parserCtx.parseEncodingName) and is intentionally ASCII-only: it ensures an
+// untrusted encoding string emitted into the XML declaration cannot inject
+// markup or be an otherwise-malformed EncName (e.g. "utf 8").
+func IsValidEncName(s string) bool {
+	if s == "" {
+		return false
+	}
+	if !isEncNameStart(s[0]) {
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		if !isEncNameChar(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isEncNameStart(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isEncNameChar(c byte) bool {
+	return isEncNameStart(c) || (c >= '0' && c <= '9') ||
+		c == '.' || c == '_' || c == '-'
+}
+
 // IsValidNCName checks whether s is a valid XML NCName (non-colonized name).
 func IsValidNCName(s string) bool {
 	if s == "" {

--- a/internal/xmlchar/xmlchar.go
+++ b/internal/xmlchar/xmlchar.go
@@ -115,6 +115,41 @@ func isEncNameChar(c byte) bool {
 		c == '.' || c == '_' || c == '-'
 }
 
+// IsValidName checks whether s is a valid XML Name (XML 1.0 §2.3):
+//
+//	Name          ::= NameStartChar (NameChar)*
+//	NameStartChar ::= ":" | NCNameStartChar
+//	NameChar      ::= NameStartChar | "-" | "." | [0-9] | #xB7 | ...
+//
+// Unlike NCName/QName, a Name may contain colons anywhere (including leading,
+// trailing, or repeated), so the Name production is strictly broader than
+// QName. This matches the XML DTD productions for element, attlist, notation,
+// and doctype names, which helium's parser reads as the Name production.
+func IsValidName(s string) bool {
+	if s == "" {
+		return false
+	}
+	// Decode explicitly (not range) so invalid UTF-8 — which range reports as
+	// RuneError indistinguishable from a real U+FFFD — is rejected by width.
+	first := true
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			return false
+		}
+		if first {
+			if r != ':' && !IsNCNameStartChar(r) {
+				return false
+			}
+			first = false
+		} else if r != ':' && !IsNCNameChar(r) {
+			return false
+		}
+		i += size
+	}
+	return true
+}
+
 // IsValidNCName checks whether s is a valid XML NCName (non-colonized name).
 func IsValidNCName(s string) bool {
 	if s == "" {

--- a/internal/xmlchar/xmlchar_test.go
+++ b/internal/xmlchar/xmlchar_test.go
@@ -208,6 +208,45 @@ func TestIsNCNameChar(t *testing.T) {
 	}
 }
 
+func TestIsValidName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"foo", true},
+		{"_bar", true},
+		{"café", true},
+		{"a123", true},
+		{"a:b", true},   // single colon (QName-shaped) is a valid Name
+		{"a:b:c", true}, // multiple colons: valid Name but NOT a valid QName
+		{":foo", true},  // leading colon: valid Name, invalid QName/NCName
+		{"foo:", true},  // trailing colon: valid Name, invalid QName/NCName
+		{":", true},     // a bare colon is a valid NameStartChar
+		{"a-b.c", true},
+		{"", false},                   // empty
+		{"1abc", false},               // must start with NameStartChar
+		{"-abc", false},               // '-' is not a NameStartChar
+		{".abc", false},               // '.' is not a NameStartChar
+		{"a b", false},                // space is not a NameChar
+		{"a<b", false},                // '<' must be rejected (injection guard)
+		{string([]byte{0xff}), false}, // invalid UTF-8
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, xmlchar.IsValidName(tt.input))
+		})
+	}
+}
+
+func TestIsValidNameWidthAware(t *testing.T) {
+	t.Parallel()
+	require.True(t, xmlchar.IsValidName("a�b"), "valid U+FFFD must be accepted")
+	require.True(t, xmlchar.IsValidName("�"), "U+FFFD is a valid NameStartChar")
+	require.False(t, xmlchar.IsValidName(string([]byte{0xff})), "invalid UTF-8 must be rejected")
+}
+
 func TestIsValidNCNameWidthAware(t *testing.T) {
 	t.Parallel()
 	require.True(t, xmlchar.IsValidNCName("a�b"), "valid U+FFFD must be accepted")

--- a/internal/xmlchar/xmlchar_test.go
+++ b/internal/xmlchar/xmlchar_test.go
@@ -39,6 +39,36 @@ func TestIsValidNCName(t *testing.T) {
 	}
 }
 
+func TestIsValidEncName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"UTF-8", true},
+		{"utf-8", true},
+		{"ISO-8859-1", true},
+		{"Shift_JIS", true},
+		{"a", true},
+		{"a1._-", true},
+		{"", false},
+		{"utf 8", false},
+		{"1utf8", false},
+		{".utf8", false},
+		{"-utf8", false},
+		{"_utf8", false},
+		{"utf+8", false},
+		{"utf8\"?><x/>", false},
+		{"カタカナ", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, xmlchar.IsValidEncName(tt.input))
+		})
+	}
+}
+
 func TestIsValidQName(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -693,6 +693,13 @@ func (w *Writer) StartElementNS(prefix, localName, namespaceURI string) error {
 	if err := validateNSParts("element", prefix, localName); err != nil {
 		return err
 	}
+	// Validate the namespace URI before StartElement emits anything or
+	// declareNS records a declaration, so an untrusted URI cannot inject
+	// markup as an xmlns attribute value and a rejected call leaves the
+	// writer unmutated.
+	if err := validateXMLChars("namespace URI", namespaceURI); err != nil {
+		return err
+	}
 	qname := qualifiedName(prefix, localName)
 	if err := w.StartElement(qname); err != nil {
 		return err
@@ -875,6 +882,13 @@ func (w *Writer) StartAttributeNS(prefix, localName, namespaceURI string) error 
 	// Validate parts before declareNS mutates the namespace scope, so an
 	// invalid prefix/local name never leaks a declaration or markup.
 	if err := validateNSParts("attribute", prefix, localName); err != nil {
+		return err
+	}
+	// Validate the namespace URI before declareNS records a declaration or
+	// StartAttribute emits anything, so an untrusted URI cannot inject markup
+	// as an xmlns attribute value and a rejected call leaves the writer
+	// unmutated.
+	if err := validateXMLChars("namespace URI", namespaceURI); err != nil {
 		return err
 	}
 	if namespaceURI != "" && prefix != "" {
@@ -1394,7 +1408,14 @@ func (w *Writer) EndDTD() error {
 	return w.err
 }
 
-// WriteDTD writes a complete DOCTYPE declaration.
+// WriteDTD writes a complete DOCTYPE declaration. The name, pubid, and sysid
+// arguments are validated, but subset is written verbatim into the internal
+// subset ("[" ... "]") without any escaping or validation, like [Writer.WriteRaw].
+// Callers must ensure subset is well-formed DTD content; passing untrusted
+// input may produce malformed output or introduce XML injection
+// vulnerabilities. To build an internal subset safely, use the
+// WriteDTDElement, WriteDTDAttlist, WriteDTDEntity, and WriteDTDNotation
+// methods between StartDTD and EndDTD instead.
 func (w *Writer) WriteDTD(name, pubid, sysid, subset string) error {
 	if err := w.StartDTD(name, pubid, sysid); err != nil {
 		return err

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"slices"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/lestrrat-go/helium/internal/encoding"
 	"github.com/lestrrat-go/helium/internal/xmlchar"
@@ -401,6 +402,9 @@ func isPubidChar(r rune) bool {
 // validatePubid reports whether s consists solely of PubidChars, so it cannot
 // inject markup or be unrepresentable when emitted as a DTD public identifier.
 func validatePubid(s string) bool {
+	if !utf8.ValidString(s) {
+		return false
+	}
 	for _, r := range s {
 		if !isPubidChar(r) {
 			return false
@@ -415,6 +419,9 @@ func validatePubid(s string) bool {
 // contain markup-significant '<' or '>'.
 func validateSystemID(s string) bool {
 	if strings.Contains(s, "'") && strings.Contains(s, `"`) {
+		return false
+	}
+	if !utf8.ValidString(s) {
 		return false
 	}
 	for _, r := range s {
@@ -432,6 +439,9 @@ func validateSystemID(s string) bool {
 // kind shapes the error message. It is used to reject control characters
 // (e.g. NUL) from text, attribute, comment, PI, and CDATA output.
 func validateXMLChars(kind, s string) error {
+	if !utf8.ValidString(s) {
+		return fmt.Errorf("stream: invalid UTF-8 byte sequence in %s content", kind)
+	}
 	for _, r := range s {
 		if !xmlchar.IsChar(r) {
 			return fmt.Errorf("stream: invalid XML character %#U in %s content", r, kind)

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -414,9 +414,12 @@ func validatePubid(s string) bool {
 }
 
 // validateSystemID reports whether s is representable as a quoted DTD system
-// identifier. A system literal must contain only valid XML chars and must not
-// contain both quote characters (which would make it unquotable), and must not
-// contain markup-significant '<' or '>'.
+// identifier. Per the XML SystemLiteral grammar a system literal may contain
+// any valid XML char except the delimiting quote, so the only constraints are
+// that s be valid XML chars and not contain both quote characters (which would
+// make it unquotable). '<' and '>' are permitted: they are harmless inside the
+// quoted literal, and dtdQuoteFor prevents the value from breaking out of its
+// quotes.
 func validateSystemID(s string) bool {
 	if strings.Contains(s, "'") && strings.Contains(s, `"`) {
 		return false
@@ -426,9 +429,6 @@ func validateSystemID(s string) bool {
 	}
 	for _, r := range s {
 		if !xmlchar.IsChar(r) {
-			return false
-		}
-		if r == '<' || r == '>' {
 			return false
 		}
 	}

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -905,6 +905,14 @@ func (w *Writer) StartAttributeNS(prefix, localName, namespaceURI string) error 
 	if err := validateXMLChars("namespace URI", namespaceURI); err != nil {
 		return err
 	}
+	// Verify the writer is in the correct state before declareNS records a
+	// declaration, so a call made after the start tag is closed is rejected
+	// without leaking a namespace declaration into the scope (which would make
+	// a later child element skip emitting its xmlns:prefix binding). This
+	// mirrors the state check StartAttribute performs below.
+	if w.state != stateName {
+		return errors.New("stream: StartAttribute called outside element opening tag")
+	}
 	if namespaceURI != "" && prefix != "" {
 		w.declareNS(prefix, namespaceURI)
 	}

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -450,6 +450,25 @@ func validateXMLChars(kind, s string) error {
 	return nil
 }
 
+// validateDTDFragment validates a DTD declaration body fragment (an element
+// contentspec or an attlist body) that is written verbatim into the internal
+// subset. Beyond rejecting non-XML characters, it forbids the markup-delimiter
+// characters '<' and '>', which can never legitimately appear in an element
+// contentspec or an attlist body. Allowing them would let an untrusted fragment
+// terminate the current declaration and inject a new one (e.g. a content of
+// "ANY><!ENTITY e \"pwn\"" smuggling an extra <!ENTITY declaration).
+func validateDTDFragment(kind, s string) error {
+	if err := validateXMLChars(kind, s); err != nil {
+		return err
+	}
+	for _, r := range s {
+		if r == '<' || r == '>' {
+			return fmt.Errorf("stream: %s content must not contain %q", kind, string(r))
+		}
+	}
+	return nil
+}
+
 // qualifiedName returns prefix:localName or just localName if prefix is empty.
 func qualifiedName(prefix, localName string) string {
 	if prefix == "" {
@@ -750,6 +769,14 @@ func (w *Writer) FullEndElement() error {
 
 // WriteElement is a convenience for StartElement + WriteString + EndElement.
 func (w *Writer) WriteElement(name, content string) error {
+	if w.err != nil {
+		return w.err
+	}
+	// Pre-validate content before StartElement emits the opening tag, so a
+	// rejected write leaves the writer unmutated.
+	if err := validateXMLChars("text", content); err != nil {
+		return err
+	}
 	if err := w.StartElement(name); err != nil {
 		return err
 	}
@@ -761,6 +788,14 @@ func (w *Writer) WriteElement(name, content string) error {
 
 // WriteElementNS is a convenience for StartElementNS + WriteString + EndElement.
 func (w *Writer) WriteElementNS(prefix, localName, namespaceURI, content string) error {
+	if w.err != nil {
+		return w.err
+	}
+	// Pre-validate content before StartElementNS declares the namespace or
+	// emits markup, so a rejected write leaves the writer unmutated.
+	if err := validateXMLChars("text", content); err != nil {
+		return err
+	}
 	if err := w.StartElementNS(prefix, localName, namespaceURI); err != nil {
 		return err
 	}
@@ -836,6 +871,14 @@ func (w *Writer) EndAttribute() error {
 
 // WriteAttribute is a convenience for StartAttribute + WriteString + EndAttribute.
 func (w *Writer) WriteAttribute(name, value string) error {
+	if w.err != nil {
+		return w.err
+	}
+	// Pre-validate the value before StartAttribute emits ` name="`, so a
+	// rejected write leaves the writer unmutated.
+	if err := validateXMLChars("attribute", value); err != nil {
+		return err
+	}
 	if err := w.StartAttribute(name); err != nil {
 		return err
 	}
@@ -847,6 +890,14 @@ func (w *Writer) WriteAttribute(name, value string) error {
 
 // WriteAttributeNS is a convenience for StartAttributeNS + WriteString + EndAttribute.
 func (w *Writer) WriteAttributeNS(prefix, localName, namespaceURI, value string) error {
+	if w.err != nil {
+		return w.err
+	}
+	// Pre-validate the value before StartAttributeNS declares the namespace or
+	// emits markup, so a rejected write leaves the writer unmutated.
+	if err := validateXMLChars("attribute", value); err != nil {
+		return err
+	}
 	if err := w.StartAttributeNS(prefix, localName, namespaceURI); err != nil {
 		return err
 	}
@@ -1012,6 +1063,11 @@ func (w *Writer) WriteComment(content string) error {
 	if w.err != nil {
 		return w.err
 	}
+	// Pre-validate content before StartComment emits "<!--", so a rejected
+	// write leaves the writer unmutated.
+	if err := validateXMLChars("comment", content); err != nil {
+		return err
+	}
 	if strings.Contains(content, "--") {
 		return errors.New("stream: comment content must not contain '--'")
 	}
@@ -1093,6 +1149,11 @@ func (w *Writer) WritePI(target, content string) error {
 	if w.err != nil {
 		return w.err
 	}
+	// Pre-validate content before StartPI emits "<?target", so a rejected
+	// write leaves the writer unmutated.
+	if err := validateXMLChars("processing instruction", content); err != nil {
+		return err
+	}
 	if strings.Contains(content, "?>") {
 		return errors.New("stream: processing instruction content must not contain '?>'")
 	}
@@ -1156,6 +1217,14 @@ func (w *Writer) EndCDATA() error {
 // If content contains "]]>", it is split into multiple CDATA sections
 // per the XML serialization spec (e.g., "]]>" becomes "]]]]><![CDATA[>").
 func (w *Writer) WriteCDATA(content string) error {
+	if w.err != nil {
+		return w.err
+	}
+	// Pre-validate content before StartCDATA emits "<![CDATA[", so a rejected
+	// write leaves the writer unmutated.
+	if err := validateXMLChars("CDATA", content); err != nil {
+		return err
+	}
 	for {
 		idx := strings.Index(content, "]]>")
 		if idx < 0 {
@@ -1316,7 +1385,7 @@ func (w *Writer) WriteDTDElement(name, content string) error {
 	if !xmlchar.IsValidQName(name) {
 		return fmt.Errorf("stream: invalid DTD element name %q", name)
 	}
-	if err := validateXMLChars("DTD element", content); err != nil {
+	if err := validateDTDFragment("DTD element", content); err != nil {
 		return err
 	}
 	w.ensureDTDInternalSubset()
@@ -1339,7 +1408,7 @@ func (w *Writer) WriteDTDAttlist(name, content string) error {
 	if !xmlchar.IsValidQName(name) {
 		return fmt.Errorf("stream: invalid DTD attlist name %q", name)
 	}
-	if err := validateXMLChars("DTD attlist", content); err != nil {
+	if err := validateDTDFragment("DTD attlist", content); err != nil {
 		return err
 	}
 	w.ensureDTDInternalSubset()

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -1332,7 +1332,7 @@ func (w *Writer) StartDTD(name, pubid, sysid string) error {
 	}
 	// Validate name and external identifiers before writing, so an untrusted
 	// value cannot inject markup into (or produce an unquotable) DOCTYPE.
-	if !xmlchar.IsValidQName(name) {
+	if !xmlchar.IsValidName(name) {
 		return fmt.Errorf("stream: invalid DTD name %q", name)
 	}
 	if pubid != "" && !validatePubid(pubid) {
@@ -1450,7 +1450,7 @@ func (w *Writer) WriteDTDElement(name, content string) error {
 	if w.state != stateDTD && w.state != stateDTDText {
 		return errors.New("stream: WriteDTDElement called outside DTD")
 	}
-	if !xmlchar.IsValidQName(name) {
+	if !xmlchar.IsValidName(name) {
 		return fmt.Errorf("stream: invalid DTD element name %q", name)
 	}
 	if err := validateDTDFragment("DTD element", content); err != nil {
@@ -1473,7 +1473,7 @@ func (w *Writer) WriteDTDAttlist(name, content string) error {
 	if w.state != stateDTD && w.state != stateDTDText {
 		return errors.New("stream: WriteDTDAttlist called outside DTD")
 	}
-	if !xmlchar.IsValidQName(name) {
+	if !xmlchar.IsValidName(name) {
 		return fmt.Errorf("stream: invalid DTD attlist name %q", name)
 	}
 	if err := validateDTDAttlistFragment("DTD attlist", content); err != nil {
@@ -1540,7 +1540,7 @@ func (w *Writer) WriteDTDExternalEntity(pe bool, name, pubid, sysid, ndata strin
 	if sysid != "" && !validateSystemID(sysid) {
 		return fmt.Errorf("stream: invalid DTD system identifier %q", sysid)
 	}
-	if ndata != "" && !xmlchar.IsValidQName(ndata) {
+	if ndata != "" && !xmlchar.IsValidName(ndata) {
 		return fmt.Errorf("stream: invalid DTD notation name %q", ndata)
 	}
 	w.ensureDTDInternalSubset()
@@ -1583,7 +1583,7 @@ func (w *Writer) WriteDTDNotation(name, pubid, sysid string) error {
 	if w.state != stateDTD && w.state != stateDTDText {
 		return errors.New("stream: WriteDTDNotation called outside DTD")
 	}
-	if !xmlchar.IsValidQName(name) {
+	if !xmlchar.IsValidName(name) {
 		return fmt.Errorf("stream: invalid DTD notation name %q", name)
 	}
 	if pubid != "" && !validatePubid(pubid) {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -577,14 +577,24 @@ func (w *Writer) StartDocument(version, enc, standalone string) error {
 	if standalone != "" && standalone != "yes" && standalone != "no" {
 		return fmt.Errorf("stream: invalid standalone value %q (want \"yes\", \"no\", or empty)", standalone)
 	}
+	// Validate the encoding name BEFORE writing any output: first against the XML
+	// EncName production (so a syntactically malformed value like "utf 8" cannot
+	// be emitted raw into the declaration), then for actual support. encoding.Load
+	// is lenient (it normalizes/accepts non-EncName spellings), so the syntactic
+	// check must come first.
+	if enc != "" {
+		if !xmlchar.IsValidEncName(enc) {
+			return fmt.Errorf("stream: invalid encoding name %q", enc)
+		}
+		if encoding.Load(enc) == nil {
+			return fmt.Errorf("stream: unsupported encoding %q", enc)
+		}
+	}
 	w.writeStr("<?xml version=")
 	w.writeByte(w.quoteChar)
 	w.writeStr(version)
 	w.writeByte(w.quoteChar)
 	if enc != "" {
-		if encoding.Load(enc) == nil {
-			return fmt.Errorf("stream: unsupported encoding %q", enc)
-		}
 		w.writeStr(" encoding=")
 		w.writeByte(w.quoteChar)
 		w.writeStr(enc)
@@ -1483,7 +1493,10 @@ func (w *Writer) WriteDTDEntity(pe bool, name, content string) error {
 	if w.state != stateDTD && w.state != stateDTDText {
 		return errors.New("stream: WriteDTDEntity called outside DTD")
 	}
-	if !xmlchar.IsValidQName(name) {
+	// An entity name is an XML Name, but helium's parser forbids colons in entity
+	// names, so validate as an NCName to match parser behavior (a "p:e" written
+	// here would be unparseable).
+	if !xmlchar.IsValidNCName(name) {
 		return fmt.Errorf("stream: invalid DTD entity name %q", name)
 	}
 	if err := validateXMLChars("DTD entity", content); err != nil {
@@ -1511,7 +1524,10 @@ func (w *Writer) WriteDTDExternalEntity(pe bool, name, pubid, sysid, ndata strin
 	if w.state != stateDTD && w.state != stateDTDText {
 		return errors.New("stream: WriteDTDExternalEntity called outside DTD")
 	}
-	if !xmlchar.IsValidQName(name) {
+	// An entity name is an XML Name, but helium's parser forbids colons in entity
+	// names, so validate as an NCName to match parser behavior (a "p:e" written
+	// here would be unparseable).
+	if !xmlchar.IsValidNCName(name) {
 		return fmt.Errorf("stream: invalid DTD entity name %q", name)
 	}
 	if pubid != "" && !validatePubid(pubid) {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -362,6 +362,84 @@ func validateNSParts(kind, prefix, localName string) error {
 	return nil
 }
 
+// isValidXMLVersion reports whether v is a valid XML declaration VersionNum.
+// VersionNum ::= '1.' [0-9]+ (XML 1.0 §2.8). Restricting to this grammar
+// prevents an untrusted version string from injecting markup into the XML
+// declaration (e.g. `1.0"?><x/>`).
+func isValidXMLVersion(v string) bool {
+	rest, ok := strings.CutPrefix(v, "1.")
+	if !ok {
+		return false
+	}
+	if rest == "" {
+		return false
+	}
+	for i := range len(rest) {
+		if rest[i] < '0' || rest[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// isPubidChar reports whether r is a valid XML PubidChar (XML 1.0 §2.3):
+//
+//	PubidChar ::= #x20 | #xD | #xA | [a-zA-Z0-9] | [-'()+,./:=?;!*#@$_%]
+func isPubidChar(r rune) bool {
+	switch {
+	case r == 0x20 || r == 0xD || r == 0xA:
+		return true
+	case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		return true
+	case strings.ContainsRune("-'()+,./:=?;!*#@$_%", r):
+		return true
+	default:
+		return false
+	}
+}
+
+// validatePubid reports whether s consists solely of PubidChars, so it cannot
+// inject markup or be unrepresentable when emitted as a DTD public identifier.
+func validatePubid(s string) bool {
+	for _, r := range s {
+		if !isPubidChar(r) {
+			return false
+		}
+	}
+	return true
+}
+
+// validateSystemID reports whether s is representable as a quoted DTD system
+// identifier. A system literal must contain only valid XML chars and must not
+// contain both quote characters (which would make it unquotable), and must not
+// contain markup-significant '<' or '>'.
+func validateSystemID(s string) bool {
+	if strings.Contains(s, "'") && strings.Contains(s, `"`) {
+		return false
+	}
+	for _, r := range s {
+		if !xmlchar.IsChar(r) {
+			return false
+		}
+		if r == '<' || r == '>' {
+			return false
+		}
+	}
+	return true
+}
+
+// validateXMLChars reports whether s contains only valid XML 1.0 Chars.
+// kind shapes the error message. It is used to reject control characters
+// (e.g. NUL) from text, attribute, comment, PI, and CDATA output.
+func validateXMLChars(kind, s string) error {
+	for _, r := range s {
+		if !xmlchar.IsChar(r) {
+			return fmt.Errorf("stream: invalid XML character %#U in %s content", r, kind)
+		}
+	}
+	return nil
+}
+
 // qualifiedName returns prefix:localName or just localName if prefix is empty.
 func qualifiedName(prefix, localName string) string {
 	if prefix == "" {
@@ -428,6 +506,14 @@ func (w *Writer) StartDocument(version, enc, standalone string) error {
 	}
 	if version == "" {
 		version = "1.0"
+	}
+	// Validate version and standalone before writing, so an untrusted value
+	// cannot inject markup into (or otherwise corrupt) the XML declaration.
+	if !isValidXMLVersion(version) {
+		return fmt.Errorf("stream: invalid XML version %q", version)
+	}
+	if standalone != "" && standalone != "yes" && standalone != "no" {
+		return fmt.Errorf("stream: invalid standalone value %q (want \"yes\", \"no\", or empty)", standalone)
 	}
 	w.writeStr("<?xml version=")
 	w.writeByte(w.quoteChar)
@@ -770,19 +856,31 @@ func (w *Writer) WriteString(content string) error {
 	}
 	switch w.state {
 	case stateName:
+		if err := validateXMLChars("text", content); err != nil {
+			return err
+		}
 		w.closeTagIfOpen()
 		if len(w.elemStack) > 0 {
 			w.elemStack[len(w.elemStack)-1].hasText = true
 		}
 		w.writeTextEscaped(content)
 	case stateNone, stateText, stateDocument:
+		if err := validateXMLChars("text", content); err != nil {
+			return err
+		}
 		if len(w.elemStack) > 0 {
 			w.elemStack[len(w.elemStack)-1].hasText = true
 		}
 		w.writeTextEscaped(content)
 	case stateAttribute:
+		if err := validateXMLChars("attribute", content); err != nil {
+			return err
+		}
 		w.writeAttrEscaped(content)
 	case stateComment:
+		if err := validateXMLChars("comment", content); err != nil {
+			return err
+		}
 		if w.commentDash && strings.HasPrefix(content, "-") {
 			return errors.New("stream: comment content must not contain '--'")
 		}
@@ -794,6 +892,9 @@ func (w *Writer) WriteString(content string) error {
 			w.commentDash = strings.HasSuffix(content, "-")
 		}
 	case statePI, statePIText:
+		if err := validateXMLChars("processing instruction", content); err != nil {
+			return err
+		}
 		if w.piQuestion && strings.HasPrefix(content, ">") {
 			return errors.New("stream: processing instruction content must not contain '?>'")
 		}
@@ -806,6 +907,9 @@ func (w *Writer) WriteString(content string) error {
 		}
 		w.state = statePIText
 	case stateCDATA:
+		if err := validateXMLChars("CDATA", content); err != nil {
+			return err
+		}
 		w.writeCDATAEscaped(content)
 	default:
 		return errors.New("stream: WriteString called in invalid state")
@@ -1086,6 +1190,17 @@ func (w *Writer) StartDTD(name, pubid, sysid string) error {
 	if pubid != "" && sysid == "" {
 		return errors.New("stream: StartDTD requires sysid when pubid is provided")
 	}
+	// Validate name and external identifiers before writing, so an untrusted
+	// value cannot inject markup into (or produce an unquotable) DOCTYPE.
+	if !xmlchar.IsValidQName(name) {
+		return fmt.Errorf("stream: invalid DTD name %q", name)
+	}
+	if pubid != "" && !validatePubid(pubid) {
+		return fmt.Errorf("stream: invalid DTD public identifier %q", pubid)
+	}
+	if sysid != "" && !validateSystemID(sysid) {
+		return fmt.Errorf("stream: invalid DTD system identifier %q", sysid)
+	}
 	if w.indent != "" {
 		w.writeStr("\n")
 	}
@@ -1188,6 +1303,12 @@ func (w *Writer) WriteDTDElement(name, content string) error {
 	if w.state != stateDTD && w.state != stateDTDText {
 		return errors.New("stream: WriteDTDElement called outside DTD")
 	}
+	if !xmlchar.IsValidQName(name) {
+		return fmt.Errorf("stream: invalid DTD element name %q", name)
+	}
+	if err := validateXMLChars("DTD element", content); err != nil {
+		return err
+	}
 	w.ensureDTDInternalSubset()
 	w.writeStr("<!ELEMENT ")
 	w.writeStr(name)
@@ -1204,6 +1325,12 @@ func (w *Writer) WriteDTDAttlist(name, content string) error {
 	}
 	if w.state != stateDTD && w.state != stateDTDText {
 		return errors.New("stream: WriteDTDAttlist called outside DTD")
+	}
+	if !xmlchar.IsValidQName(name) {
+		return fmt.Errorf("stream: invalid DTD attlist name %q", name)
+	}
+	if err := validateXMLChars("DTD attlist", content); err != nil {
+		return err
 	}
 	w.ensureDTDInternalSubset()
 	w.writeStr("<!ATTLIST ")
@@ -1222,6 +1349,12 @@ func (w *Writer) WriteDTDEntity(pe bool, name, content string) error {
 	}
 	if w.state != stateDTD && w.state != stateDTDText {
 		return errors.New("stream: WriteDTDEntity called outside DTD")
+	}
+	if !xmlchar.IsValidQName(name) {
+		return fmt.Errorf("stream: invalid DTD entity name %q", name)
+	}
+	if err := validateXMLChars("DTD entity", content); err != nil {
+		return err
 	}
 	w.ensureDTDInternalSubset()
 	w.writeStr("<!ENTITY ")
@@ -1245,6 +1378,18 @@ func (w *Writer) WriteDTDExternalEntity(pe bool, name, pubid, sysid, ndata strin
 	if w.state != stateDTD && w.state != stateDTDText {
 		return errors.New("stream: WriteDTDExternalEntity called outside DTD")
 	}
+	if !xmlchar.IsValidQName(name) {
+		return fmt.Errorf("stream: invalid DTD entity name %q", name)
+	}
+	if pubid != "" && !validatePubid(pubid) {
+		return fmt.Errorf("stream: invalid DTD public identifier %q", pubid)
+	}
+	if sysid != "" && !validateSystemID(sysid) {
+		return fmt.Errorf("stream: invalid DTD system identifier %q", sysid)
+	}
+	if ndata != "" && !xmlchar.IsValidQName(ndata) {
+		return fmt.Errorf("stream: invalid DTD notation name %q", ndata)
+	}
 	w.ensureDTDInternalSubset()
 	w.writeStr("<!ENTITY ")
 	if pe {
@@ -1253,18 +1398,21 @@ func (w *Writer) WriteDTDExternalEntity(pe bool, name, pubid, sysid, ndata strin
 	w.writeStr(name)
 	if pubid != "" {
 		w.writeStr(" PUBLIC ")
-		w.writeByte(w.quoteChar)
+		pubQ := dtdQuoteFor(pubid, w.quoteChar)
+		w.writeByte(pubQ)
 		w.writeStr(pubid)
-		w.writeByte(w.quoteChar)
+		w.writeByte(pubQ)
 		w.writeByte(' ')
-		w.writeByte(w.quoteChar)
+		sysQ := dtdQuoteFor(sysid, w.quoteChar)
+		w.writeByte(sysQ)
 		w.writeStr(sysid)
-		w.writeByte(w.quoteChar)
+		w.writeByte(sysQ)
 	} else if sysid != "" {
 		w.writeStr(" SYSTEM ")
-		w.writeByte(w.quoteChar)
+		sysQ := dtdQuoteFor(sysid, w.quoteChar)
+		w.writeByte(sysQ)
 		w.writeStr(sysid)
-		w.writeByte(w.quoteChar)
+		w.writeByte(sysQ)
 	}
 	if ndata != "" {
 		w.writeStr(" NDATA ")
@@ -1282,25 +1430,37 @@ func (w *Writer) WriteDTDNotation(name, pubid, sysid string) error {
 	if w.state != stateDTD && w.state != stateDTDText {
 		return errors.New("stream: WriteDTDNotation called outside DTD")
 	}
+	if !xmlchar.IsValidQName(name) {
+		return fmt.Errorf("stream: invalid DTD notation name %q", name)
+	}
+	if pubid != "" && !validatePubid(pubid) {
+		return fmt.Errorf("stream: invalid DTD public identifier %q", pubid)
+	}
+	if sysid != "" && !validateSystemID(sysid) {
+		return fmt.Errorf("stream: invalid DTD system identifier %q", sysid)
+	}
 	w.ensureDTDInternalSubset()
 	w.writeStr("<!NOTATION ")
 	w.writeStr(name)
 	if pubid != "" {
 		w.writeStr(" PUBLIC ")
-		w.writeByte(w.quoteChar)
+		pubQ := dtdQuoteFor(pubid, w.quoteChar)
+		w.writeByte(pubQ)
 		w.writeStr(pubid)
-		w.writeByte(w.quoteChar)
+		w.writeByte(pubQ)
 		if sysid != "" {
 			w.writeByte(' ')
-			w.writeByte(w.quoteChar)
+			sysQ := dtdQuoteFor(sysid, w.quoteChar)
+			w.writeByte(sysQ)
 			w.writeStr(sysid)
-			w.writeByte(w.quoteChar)
+			w.writeByte(sysQ)
 		}
 	} else if sysid != "" {
 		w.writeStr(" SYSTEM ")
-		w.writeByte(w.quoteChar)
+		sysQ := dtdQuoteFor(sysid, w.quoteChar)
+		w.writeByte(sysQ)
 		w.writeStr(sysid)
-		w.writeByte(w.quoteChar)
+		w.writeByte(sysQ)
 	}
 	w.writeByte('>')
 	return w.err

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -450,13 +450,13 @@ func validateXMLChars(kind, s string) error {
 	return nil
 }
 
-// validateDTDFragment validates a DTD declaration body fragment (an element
-// contentspec or an attlist body) that is written verbatim into the internal
-// subset. Beyond rejecting non-XML characters, it forbids the markup-delimiter
-// characters '<' and '>', which can never legitimately appear in an element
-// contentspec or an attlist body. Allowing them would let an untrusted fragment
-// terminate the current declaration and inject a new one (e.g. a content of
-// "ANY><!ENTITY e \"pwn\"" smuggling an extra <!ENTITY declaration).
+// validateDTDFragment validates an element contentspec written verbatim into
+// the internal subset. Beyond rejecting non-XML characters, it forbids the
+// markup-delimiter characters '<' and '>', which can never legitimately appear
+// in an element contentspec (a contentspec has no quoted literals). Allowing
+// them would let an untrusted fragment terminate the current declaration and
+// inject a new one (e.g. a content of "ANY><!ENTITY e \"pwn\"" smuggling an
+// extra <!ENTITY declaration).
 func validateDTDFragment(kind, s string) error {
 	if err := validateXMLChars(kind, s); err != nil {
 		return err
@@ -465,6 +465,39 @@ func validateDTDFragment(kind, s string) error {
 		if r == '<' || r == '>' {
 			return fmt.Errorf("stream: %s content must not contain %q", kind, string(r))
 		}
+	}
+	return nil
+}
+
+// validateDTDAttlistFragment validates an attlist body written verbatim into
+// the internal subset. Like validateDTDFragment it rejects non-XML characters
+// and any '<'. Unlike a contentspec, an attlist body legitimately contains
+// quoted attribute default values (e.g. a CDATA "a>b"), so a '>' inside a
+// single- or double-quoted literal is permitted; a '>' outside any quote is
+// rejected because it would terminate the <!ATTLIST and allow injection of a
+// following declaration. An unterminated literal is treated as outside-quote
+// for the trailing content, so a dangling '>' is still caught.
+func validateDTDAttlistFragment(kind, s string) error {
+	if err := validateXMLChars(kind, s); err != nil {
+		return err
+	}
+	var quote rune // 0 when outside a literal, else the active quote char
+	for _, r := range s {
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			}
+		case r == '\'' || r == '"':
+			quote = r
+		case r == '<':
+			return fmt.Errorf("stream: %s content must not contain %q", kind, string(r))
+		case r == '>':
+			return fmt.Errorf("stream: %s content must not contain %q outside a quoted literal", kind, string(r))
+		}
+	}
+	if quote != 0 {
+		return fmt.Errorf("stream: %s content has an unterminated %q literal", kind, string(quote))
 	}
 	return nil
 }
@@ -1408,7 +1441,7 @@ func (w *Writer) WriteDTDAttlist(name, content string) error {
 	if !xmlchar.IsValidQName(name) {
 		return fmt.Errorf("stream: invalid DTD attlist name %q", name)
 	}
-	if err := validateDTDFragment("DTD attlist", content); err != nil {
+	if err := validateDTDAttlistFragment("DTD attlist", content); err != nil {
 		return err
 	}
 	w.ensureDTDInternalSubset()

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -483,6 +483,12 @@ func validateDTDAttlistFragment(kind, s string) error {
 	}
 	var quote rune // 0 when outside a literal, else the active quote char
 	for _, r := range s {
+		// '<' is never legal in an attlist body: raw '<' is forbidden even
+		// inside an AttValue literal per the XML grammar, so reject it
+		// regardless of quote state.
+		if r == '<' {
+			return fmt.Errorf("stream: %s content must not contain %q", kind, string(r))
+		}
 		switch {
 		case quote != 0:
 			if r == quote {
@@ -490,8 +496,6 @@ func validateDTDAttlistFragment(kind, s string) error {
 			}
 		case r == '\'' || r == '"':
 			quote = r
-		case r == '<':
-			return fmt.Errorf("stream: %s content must not contain %q", kind, string(r))
 		case r == '>':
 			return fmt.Errorf("stream: %s content must not contain %q outside a quoted literal", kind, string(r))
 		}

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -279,6 +279,43 @@ func TestStartAttributeNSRejectsInvalidParts(t *testing.T) {
 	require.Error(t, w.StartAttributeNS("p", "bad local", "urn:x"))
 }
 
+func TestNamespaceURIRejectsInvalidChars(t *testing.T) {
+	t.Parallel()
+	badUTF8 := string([]byte{0xff})
+	t.Run("element NS NUL rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.Error(t, w.StartElementNS("", "a", "x\x00"))
+		require.Empty(t, buf.String())
+	})
+	t.Run("element NS invalid UTF-8 rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.Error(t, w.StartElementNS("p", "a", "urn:"+badUTF8))
+		require.Empty(t, buf.String())
+	})
+	t.Run("attribute NS NUL rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		buf.Reset()
+		require.Error(t, w.StartAttributeNS("p", "a", "x\x00"))
+		require.Empty(t, buf.String())
+	})
+	t.Run("attribute NS invalid UTF-8 rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		buf.Reset()
+		require.Error(t, w.StartAttributeNS("p", "a", "urn:"+badUTF8))
+		require.Empty(t, buf.String())
+	})
+}
+
 func TestAttributeEscaping(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -1641,6 +1641,36 @@ func TestDTDFragmentInjectionRejected(t *testing.T) {
 		require.Error(t, w.WriteDTDAttlist("root", `id CDATA #IMPLIED><!ENTITY e "pwn"`))
 		require.NotContains(t, buf.String(), "ENTITY")
 	})
+	t.Run("attlist unquoted greater-than injection rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("root", "", ""))
+		require.Error(t, w.WriteDTDAttlist("root", `x CDATA "v"> <!ENTITY e "pwn"`))
+		require.NotContains(t, buf.String(), "ENTITY")
+	})
+	t.Run("attlist quoted greater-than accepted", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("root", "", ""))
+		require.NoError(t, w.WriteDTDAttlist("root", `a CDATA "a>b"`))
+		require.NoError(t, w.EndDTD())
+		require.Contains(t, buf.String(), `<!ATTLIST root a CDATA "a>b">`)
+	})
+	t.Run("attlist unterminated literal trailing greater-than rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("root", "", ""))
+		// The opening quote is never closed; malformed (unterminated)
+		// quoting is rejected, so the trailing '>' cannot smuggle markup.
+		require.Error(t, w.WriteDTDAttlist("root", `a CDATA "unterminated literal >`))
+		require.NotContains(t, buf.String(), "ATTLIST")
+	})
 	t.Run("valid contentspec and attlist still accepted", func(t *testing.T) {
 		t.Parallel()
 		var buf bytes.Buffer

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -1612,3 +1612,95 @@ func TestInvalidUTF8Rejection(t *testing.T) {
 		require.Error(t, w.StartDTD("root", "", "sys"+bad))
 	})
 }
+
+func TestDTDFragmentInjectionRejected(t *testing.T) {
+	t.Parallel()
+	t.Run("element contentspec injection rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("root", "", ""))
+		require.Error(t, w.WriteDTDElement("root", `ANY><!ENTITY e "pwn"`))
+		require.NotContains(t, buf.String(), "ENTITY")
+	})
+	t.Run("element contentspec less-than rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("root", "", ""))
+		require.Error(t, w.WriteDTDElement("root", `<!ELEMENT x ANY`))
+	})
+	t.Run("attlist body injection rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("root", "", ""))
+		require.Error(t, w.WriteDTDAttlist("root", `id CDATA #IMPLIED><!ENTITY e "pwn"`))
+		require.NotContains(t, buf.String(), "ENTITY")
+	})
+	t.Run("valid contentspec and attlist still accepted", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("root", "", ""))
+		require.NoError(t, w.WriteDTDElement("root", "(a|b)*"))
+		require.NoError(t, w.WriteDTDElement("a", "(#PCDATA)"))
+		require.NoError(t, w.WriteDTDElement("b", "EMPTY"))
+		require.NoError(t, w.WriteDTDAttlist("a", `id ID #REQUIRED kind CDATA #IMPLIED`))
+		require.NoError(t, w.EndDTD())
+	})
+}
+
+func TestOneShotHelpersPreValidateBeforeMutation(t *testing.T) {
+	t.Parallel()
+	bad := "x\x00"
+	t.Run("WriteComment", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		buf.Reset()
+		require.Error(t, w.WriteComment(bad))
+		require.Empty(t, buf.String())
+	})
+	t.Run("WritePI", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		buf.Reset()
+		require.Error(t, w.WritePI("target", bad))
+		require.Empty(t, buf.String())
+	})
+	t.Run("WriteCDATA", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		buf.Reset()
+		require.Error(t, w.WriteCDATA(bad))
+		require.Empty(t, buf.String())
+	})
+	t.Run("WriteAttribute", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		buf.Reset()
+		require.Error(t, w.WriteAttribute("attr", bad))
+		require.Empty(t, buf.String())
+	})
+	t.Run("WriteElement", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		buf.Reset()
+		require.Error(t, w.WriteElement("child", bad))
+		require.Empty(t, buf.String())
+	})
+}

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -1459,3 +1459,137 @@ func (fb *flushableBuffer) Flush() error {
 	fb.flushed = true
 	return nil
 }
+
+func TestStartDocumentVersionStandaloneValidation(t *testing.T) {
+	t.Parallel()
+	t.Run("version injection rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		err := w.StartDocument(`1.0"?><x/>`, "", "")
+		require.Error(t, err)
+		require.Empty(t, buf.String())
+	})
+	t.Run("non-1.x version rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.Error(t, w.StartDocument("2.0", "", ""))
+	})
+	t.Run("valid 1.1 accepted", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("1.1", "", ""))
+	})
+	t.Run("invalid standalone rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		err := w.StartDocument("1.0", "", `yes"?><x/>`)
+		require.Error(t, err)
+		require.Empty(t, buf.String())
+	})
+	t.Run("standalone yes/no accepted", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("1.0", "", "yes"))
+		require.Contains(t, buf.String(), `standalone="yes"`)
+	})
+}
+
+func TestDTDIdentifierValidation(t *testing.T) {
+	t.Parallel()
+	t.Run("name injection rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.Error(t, w.StartDTD(`x><!ENTITY e "pwn">`, "", ""))
+	})
+	t.Run("sysid with both quotes rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.Error(t, w.StartDTD("root", "", `a'b"c`))
+	})
+	t.Run("sysid markup rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.Error(t, w.StartDTD("root", "", `x"><x/>`))
+	})
+	t.Run("pubid invalid char rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.Error(t, w.StartDTD("root", "pub<id", "sys"))
+	})
+	t.Run("notation identifiers validated", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("root", "", "sys"))
+		require.Error(t, w.WriteDTDNotation("n", "", `x"><x/>`))
+	})
+	t.Run("valid dtd accepted", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("root", "-//W3C//DTD//EN", "http://example.com/x.dtd"))
+		require.NoError(t, w.EndDTD())
+	})
+}
+
+func TestInvalidXMLCharRejection(t *testing.T) {
+	t.Parallel()
+	t.Run("text NUL rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("a"))
+		require.Error(t, w.WriteString("x\x00y"))
+	})
+	t.Run("attribute NUL rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("a"))
+		require.Error(t, w.WriteAttribute("k", "v\x00"))
+	})
+	t.Run("comment control char rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("a"))
+		require.Error(t, w.WriteComment("c\x01"))
+	})
+	t.Run("PI control char rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("a"))
+		require.Error(t, w.WritePI("tgt", "d\x00"))
+	})
+	t.Run("CDATA NUL rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("a"))
+		require.Error(t, w.WriteCDATA("c\x00d"))
+	})
+	t.Run("valid chars accepted", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("a"))
+		require.NoError(t, w.WriteString("hello\tworld\n"))
+		require.NoError(t, w.EndElement())
+	})
+}

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -1860,3 +1860,44 @@ func TestWriteDTDEntityAcceptsNCName(t *testing.T) {
 	require.NoError(t, w.WriteDTDEntity(false, "ent", "v"))
 	require.NoError(t, w.WriteDTDExternalEntity(false, "logo", "", "logo.gif", "gif"))
 }
+
+// DTD element/attlist/notation/doctype/NDATA names follow the XML Name
+// production, which is broader than QName: a Name may contain multiple colons
+// (or leading/trailing colons). Such names must be accepted, while genuinely
+// malformed names (injection, empty) must still be rejected.
+func TestDTDNamesUseXMLNameProduction(t *testing.T) {
+	t.Parallel()
+	t.Run("multi-colon names accepted", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		// "a:b:c" is a valid Name but NOT a valid QName.
+		require.NoError(t, w.StartDTD("a:b:c", "", ""))
+		require.NoError(t, w.WriteDTDElement("a:b:c", "(#PCDATA)"))
+		require.NoError(t, w.WriteDTDAttlist("a:b:c", "x CDATA #IMPLIED"))
+		require.NoError(t, w.WriteDTDNotation("n:o:t", "", "sys"))
+		require.NoError(t, w.WriteDTDExternalEntity(false, "img", "", "img.gif", "g:i:f"))
+		require.NoError(t, w.EndDTD())
+		out := buf.String()
+		require.Contains(t, out, "<!DOCTYPE a:b:c")
+		require.Contains(t, out, "<!ELEMENT a:b:c")
+		require.Contains(t, out, "<!ATTLIST a:b:c")
+		require.Contains(t, out, "<!NOTATION n:o:t")
+		require.Contains(t, out, "NDATA g:i:f")
+	})
+	t.Run("invalid names still rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("root", "", ""))
+		require.Error(t, w.WriteDTDElement("a b", "(#PCDATA)"), "space not a NameChar")
+		require.Error(t, w.WriteDTDElement(`x><!ENTITY e "pwn">`, "(#PCDATA)"), "injection")
+		require.Error(t, w.WriteDTDElement("", "(#PCDATA)"), "empty")
+		require.Error(t, w.WriteDTDElement("1bad", "(#PCDATA)"), "bad start char")
+		require.Error(t, w.WriteDTDAttlist("a b", "x CDATA #IMPLIED"), "space not a NameChar")
+		require.Error(t, w.WriteDTDNotation("n>x", "", "sys"), "injection")
+		require.Error(t, w.WriteDTDExternalEntity(false, "img", "", "img.gif", "g h"), "bad NDATA")
+	})
+}

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -1697,6 +1697,16 @@ func TestDTDFragmentInjectionRejected(t *testing.T) {
 		require.NoError(t, w.EndDTD())
 		require.Contains(t, buf.String(), `<!ATTLIST root a CDATA "a>b">`)
 	})
+	t.Run("attlist quoted less-than rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("root", "", ""))
+		// '<' is forbidden in an AttValue even inside a quoted literal.
+		require.Error(t, w.WriteDTDAttlist("root", `a CDATA "<"`))
+		require.NotContains(t, buf.String(), "ATTLIST")
+	})
 	t.Run("attlist unterminated literal trailing greater-than rejected", func(t *testing.T) {
 		t.Parallel()
 		var buf bytes.Buffer

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -1771,3 +1771,73 @@ func TestOneShotHelpersPreValidateBeforeMutation(t *testing.T) {
 		require.Empty(t, buf.String())
 	})
 }
+
+func TestStartDocumentRejectsMalformedEncName(t *testing.T) {
+	t.Parallel()
+	// A value that is not a valid XML EncName (contains a space) must be rejected
+	// before any output is written, even though the lenient encoding.Load would
+	// otherwise normalize and accept it.
+	for _, bad := range []string{"utf 8", "1utf8", "utf8\"?><x/>", "utf+8"} {
+		t.Run(bad, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			w := stream.NewWriter(&buf)
+			err := w.StartDocument("1.0", bad, "")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid encoding name")
+			require.Empty(t, buf.String(), "writer must be unmutated on rejection")
+		})
+	}
+}
+
+func TestStartDocumentUnsupportedEncNameLeavesWriterUnmutated(t *testing.T) {
+	t.Parallel()
+	// A syntactically valid but unsupported EncName must be rejected before the
+	// XML-declaration prefix is written.
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	err := w.StartDocument("1.0", "BOGUS-999", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported encoding")
+	require.Empty(t, buf.String(), "writer must be unmutated on rejection")
+}
+
+func TestWriteDTDEntityRejectsColonizedName(t *testing.T) {
+	t.Parallel()
+	// Entity names are NCNames in helium's parser (colons are forbidden), so a
+	// "p:e" name must be rejected without mutating the writer.
+	t.Run("internal", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("root", "", ""))
+		buf.Reset()
+		err := w.WriteDTDEntity(false, "p:e", "v")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid DTD entity name")
+		require.Empty(t, buf.String(), "writer must be unmutated on rejection")
+	})
+	t.Run("external", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("root", "", ""))
+		buf.Reset()
+		err := w.WriteDTDExternalEntity(false, "p:e", "", "ext.dtd", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid DTD entity name")
+		require.Empty(t, buf.String(), "writer must be unmutated on rejection")
+	})
+}
+
+func TestWriteDTDEntityAcceptsNCName(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartDocument("", "", ""))
+	require.NoError(t, w.StartDTD("root", "", ""))
+	require.NoError(t, w.WriteDTDEntity(false, "ent", "v"))
+	require.NoError(t, w.WriteDTDExternalEntity(false, "logo", "", "logo.gif", "gif"))
+}

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -1552,12 +1552,21 @@ func TestDTDIdentifierValidation(t *testing.T) {
 		require.NoError(t, w.StartDocument("", "", ""))
 		require.Error(t, w.StartDTD("root", "", `a'b"c`))
 	})
-	t.Run("sysid markup rejected", func(t *testing.T) {
+	t.Run("sysid with angle brackets accepted", func(t *testing.T) {
 		t.Parallel()
-		var buf bytes.Buffer
-		w := stream.NewWriter(&buf)
-		require.NoError(t, w.StartDocument("", "", ""))
-		require.Error(t, w.StartDTD("root", "", `x"><x/>`))
+		// A SystemLiteral may contain any XML char except the delimiting
+		// quote, so '<' and '>' are valid and must round-trip.
+		for _, sysid := range []string{"a>b", "a<b"} {
+			var buf bytes.Buffer
+			w := stream.NewWriter(&buf)
+			require.NoError(t, w.StartDocument("", "", ""))
+			require.NoError(t, w.StartDTD("root", "", sysid))
+			require.NoError(t, w.EndDTD())
+			require.NoError(t, w.StartElement("root"))
+			require.NoError(t, w.EndElement())
+			require.NoError(t, w.EndDocument())
+			require.Contains(t, buf.String(), `SYSTEM "`+sysid+`"`)
+		}
 	})
 	t.Run("pubid invalid char rejected", func(t *testing.T) {
 		t.Parallel()
@@ -1572,7 +1581,7 @@ func TestDTDIdentifierValidation(t *testing.T) {
 		w := stream.NewWriter(&buf)
 		require.NoError(t, w.StartDocument("", "", ""))
 		require.NoError(t, w.StartDTD("root", "", "sys"))
-		require.Error(t, w.WriteDTDNotation("n", "", `x"><x/>`))
+		require.Error(t, w.WriteDTDNotation("n", "", `a'b"c`))
 	})
 	t.Run("valid dtd accepted", func(t *testing.T) {
 		t.Parallel()

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -1593,3 +1593,22 @@ func TestInvalidXMLCharRejection(t *testing.T) {
 		require.NoError(t, w.EndElement())
 	})
 }
+
+func TestInvalidUTF8Rejection(t *testing.T) {
+	t.Parallel()
+	bad := string([]byte{0xff})
+	t.Run("text content rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("a"))
+		require.Error(t, w.WriteString(bad))
+	})
+	t.Run("system id rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.Error(t, w.StartDTD("root", "", "sys"+bad))
+	})
+}

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -815,6 +815,23 @@ func TestNamespaceNotRedeclared(t *testing.T) {
 	require.Equal(t, `<ns:root xmlns:ns="http://example.com"><ns:child/></ns:root>`, buf.String())
 }
 
+func TestStartAttributeNSAfterTagCloseLeavesNamespaceUnmutated(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("root"))
+	// Write text to close the start tag so the writer is no longer in
+	// stateName. A StartAttributeNS call now must be rejected.
+	require.NoError(t, w.WriteString("x"))
+	require.Error(t, w.StartAttributeNS("ns", "attr", "http://example.com"))
+	// The rejected call must not have recorded the ns:->uri declaration, so a
+	// child element with the same prefix still emits its xmlns:ns binding.
+	require.NoError(t, w.StartElementNS("ns", "child", "http://example.com"))
+	require.NoError(t, w.EndElement())
+	require.NoError(t, w.EndElement())
+	require.Equal(t, `<root>x<ns:child xmlns:ns="http://example.com"/></root>`, buf.String())
+}
+
 func TestNamespaceRedeclaredDifferentURI(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer


### PR DESCRIPTION
- StartDocument validates XML version (`1.x`) and standalone (`yes`/`no`/empty), rejecting markup injection into the XML declaration.
- StartDTD and the DTD entity/notation/element/attlist writers validate names (QName), PublicIDs (PubidChar), and SystemIDs (no markup, not both quotes); external entity/notation now select a safe quote like StartDTD.
- WriteString rejects invalid XML 1.0 chars (e.g. NUL) in text, attribute, comment, PI, and CDATA content via internal/xmlchar.IsChar.
- Behavior change: these methods now return errors for inputs that previously emitted malformed/injected output (no signature changes).
