### PR TITLE
bound xinclude reads and resolve file uris

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -6,10 +6,9 @@ Arrows show "imports" direction. Indented items are transitive.
 cmd/helium     → internal/cli/heliumcmd
 internal/cli/heliumcmd → helium, c14n, relaxng, schematron, xsd, xinclude, xpath1, xpath3, catalog, internal/cliutil
 shim           → helium, stream, enum, internal/encoding, internal/xmlchar
-xinclude       → helium, xpointer
+xinclude       → helium, xpointer, internal/encoding, internal/iofs, internal/lexicon
                   → xpath1 (via xpointer)
                   → internal/xmlchar (via xpointer)
-                  → internal/encoding
 xpath3         → helium, internal/xpath, internal/lexicon, internal/icu, internal/unparsedtext, internal/strcursor, internal/sequence, internal/xsdregex
 xslt3          → helium, xpath3, xsd, html, internal/lexicon, internal/sequence, internal/xpathstream, xslt3/internal/elements
 xsd            → helium, xpath1, internal/lexicon, internal/xsd/value, internal/xsdregex
@@ -52,7 +51,7 @@ c14n, xpath1, xpath3, html, catalog, relaxng, stream, xmlenc1
 xmldsig1 (root + c14n + internal/lexicon)
 
 ## Composition layer (depends on processing)
-xsd (root + xpath1 + internal/lexicon), xpointer (root + xpath1 + internal/xmlchar), schematron (root + xpath1), xinclude (root + xpointer), xslt3 (root + xpath3 + xsd + html + internal/elements), shim (root + stream)
+xsd (root + xpath1 + internal/lexicon), xpointer (root + xpath1 + internal/xmlchar), schematron (root + xpath1), xinclude (root + xpointer + internal/encoding + internal/iofs + internal/lexicon), xslt3 (root + xpath3 + xsd + html + internal/elements), shim (root + stream)
 
 ## Application layer
 internal/cli/heliumcmd (CLI implementation)

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -188,12 +188,14 @@ HTML 4.01 parser producing helium DOM or SAX events.
 XInclude 1.0 processing with recursive inclusion and fallback.
 
 - **NewProcessor() → Processor** — create fluent builder
-- Processor methods: `NoXIncludeMarkers()`, `NoBaseFixup()`, `Resolver(Resolver)`, `BaseURI(string)`, `WarningHandler(func)`
+- Processor methods: `NoXIncludeMarkers()`, `NoBaseFixup()`, `Resolver(Resolver)`, `BaseURI(string)`, `MaxIncludeSize(int)`, `ErrorHandler(helium.ErrorHandler)`
 - Terminal: **Process(ctx, *Document) → (int, error)**, **ProcessTree(ctx, Node) → (int, error)**
 - `Resolver` interface — custom resource loader; receives the href already resolved against the effective base (base arg is informational only — do NOT re-resolve, or the base directory is double-applied)
+- `MaxIncludeSize` — default per-include byte cap (10 MiB), used when `Processor.MaxIncludeSize` is unset or ≤ 0; over-cap reads fail with `ErrIncludeTooLarge`
+- Default `NewFSResolver` converts absolute `file:` hrefs to OS paths via `internal/iofs.FileURIToPath` (non-local hosts rejected)
 - Max depth 40, max URI 2000 chars, circular detection, doc/text caching
 - Files: `xinclude.go`
-- Imports: helium, xpointer/, internal/encoding/
+- Imports: helium, xpointer/, internal/encoding/, internal/iofs/, internal/lexicon/
 
 ## xpointer/
 

--- a/internal/iofs/iofs.go
+++ b/internal/iofs/iofs.go
@@ -3,9 +3,18 @@
 package iofs
 
 import (
+	"fmt"
 	"io/fs"
+	"net/url"
 	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 )
+
+// goosWindows is the runtime.GOOS value for Windows. Drive-letter handling in
+// "file:" URIs is gated on this so POSIX behavior is never altered.
+const goosWindows = "windows"
 
 // PermissiveRoot is an [fs.FS] backed by direct calls to [os.Open]. It
 // is the explicit opposite of [os.Root]: rather than sandboxing access
@@ -30,4 +39,52 @@ type PermissiveRoot struct{}
 // Open implements [fs.FS].
 func (PermissiveRoot) Open(name string) (fs.File, error) {
 	return os.Open(name) //nolint:gosec,wrapcheck // intentional passthrough; see type doc
+}
+
+// FileURIToPath converts a "file:" URI into a local filesystem path. It mirrors
+// the conversion performed in package catalog (added in PR #602) so that other
+// loaders — notably the XInclude processor — resolve "file:" hrefs identically.
+//
+// For "file:///abs/path" the host is empty and Path holds the (already
+// percent-decoded) absolute path. A "file://host/path" with a non-localhost
+// host is not addressable on the local filesystem and is rejected. URI hosts are
+// case-insensitive, so an empty host and "localhost" in any case both denote the
+// local machine. An opaque "file:" URI such as "file:next.xml" (u.Opaque set,
+// empty u.Path) and a "file://localhost" URI with no path are rejected rather
+// than letting an empty path read the process working directory.
+func FileURIToPath(ref string) (string, error) {
+	u, err := url.Parse(ref)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse file URI %q: %w", ref, err)
+	}
+
+	if u.Scheme != "file" {
+		return "", fmt.Errorf("not a file URI: %q", ref)
+	}
+
+	if u.Host != "" && !strings.EqualFold(u.Host, "localhost") {
+		return "", fmt.Errorf("non-local file URI host %q in %q", u.Host, ref)
+	}
+
+	if u.Opaque != "" || u.Path == "" {
+		return "", fmt.Errorf("invalid file URI %q: no local path", ref)
+	}
+
+	return fileURIPathFor(runtime.GOOS, u.Path), nil
+}
+
+// fileURIPathFor is the OS-parameterized conversion of a "file:" URI path
+// component into a local filesystem path. The drive-letter slash strip only
+// applies on Windows; on POSIX "/C:/tmp/x" is a valid absolute path and is left
+// untouched. goos is threaded explicitly so the conversion is deterministically
+// testable on a non-Windows CI host.
+func fileURIPathFor(goos, p string) string {
+	if goos == goosWindows && len(p) >= 3 && p[0] == '/' && isASCIILetter(p[1]) && p[2] == ':' {
+		p = p[1:]
+	}
+	return filepath.FromSlash(p)
+}
+
+func isASCIILetter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 }

--- a/internal/iofs/iofs_test.go
+++ b/internal/iofs/iofs_test.go
@@ -1,0 +1,51 @@
+package iofs_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/internal/iofs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileURIToPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("absolute file URI", func(t *testing.T) {
+		t.Parallel()
+		p, err := iofs.FileURIToPath("file:///tmp/inc.xml")
+		require.NoError(t, err)
+		require.Equal(t, "/tmp/inc.xml", p)
+	})
+
+	t.Run("localhost host", func(t *testing.T) {
+		t.Parallel()
+		p, err := iofs.FileURIToPath("file://localhost/tmp/inc.xml")
+		require.NoError(t, err)
+		require.Equal(t, "/tmp/inc.xml", p)
+	})
+
+	t.Run("percent-decoded path", func(t *testing.T) {
+		t.Parallel()
+		p, err := iofs.FileURIToPath("file:///tmp/a%20b.xml")
+		require.NoError(t, err)
+		require.Equal(t, "/tmp/a b.xml", p)
+	})
+
+	t.Run("non-local host rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := iofs.FileURIToPath("file://remote/tmp/inc.xml")
+		require.Error(t, err)
+	})
+
+	t.Run("opaque file URI rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := iofs.FileURIToPath("file:next.xml")
+		require.Error(t, err)
+	})
+
+	t.Run("non-file scheme rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := iofs.FileURIToPath("http://example.com/inc.xml")
+		require.Error(t, err)
+	})
+}

--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -1388,6 +1388,18 @@ type normalizingFS struct {
 
 // Open implements [fs.FS].
 func (n normalizingFS) Open(name string) (fs.File, error) {
+	// An included document parsed with BaseURI("file:///...") resolves its own
+	// external DTDs/entities against that base, yielding "file:" URIs (e.g.
+	// "file:///dir/decl.dtd") rather than plain paths. Convert those to a local
+	// path here, mirroring fsResolver.Resolve, so nested external-DTD/entity
+	// resolution succeeds uniformly. Non-local-host file URIs are rejected.
+	if isFileURI(name) {
+		p, err := iofs.FileURIToPath(name)
+		if err != nil {
+			return nil, fmt.Errorf("xinclude: %w", err)
+		}
+		return n.fsys.Open(filepath.ToSlash(p)) //nolint:wrapcheck // passthrough; underlying FS errors propagate verbatim
+	}
 	return n.fsys.Open(path.Clean(filepath.ToSlash(name))) //nolint:wrapcheck // passthrough; underlying FS errors propagate verbatim
 }
 

--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -2,9 +2,11 @@ package xinclude
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"net/url"
 	"path"
 	"path/filepath"
@@ -24,6 +26,19 @@ const (
 	maxURILength = 2000
 )
 
+// MaxIncludeSize is the default maximum number of bytes read from a single
+// included resource (XML or text) when no cap is configured via
+// [Processor.MaxIncludeSize]. It guards against a hostile or pathological
+// Resolver (e.g. one returning an endless or multi-gigabyte reader) exhausting
+// memory: the bytes of every included resource are read fully and cached.
+const MaxIncludeSize = 10 << 20 // 10 MiB
+
+// ErrIncludeTooLarge is returned when an included resource exceeds the
+// configured maximum size (see [Processor.MaxIncludeSize], default
+// [MaxIncludeSize]). The cap is enforced against the actual number of bytes
+// read, not any reported size.
+var ErrIncludeTooLarge = errors.New("xi:include: included resource exceeds maximum allowed size")
+
 // Resolver loads content from a URI.
 //
 // The processor resolves each xi:include href against the include's
@@ -40,11 +55,12 @@ type Resolver interface {
 
 // processorCfg holds the configuration for a Processor.
 type processorCfg struct {
-	noMarkers    bool
-	noBaseFixup  bool
-	resolver     Resolver
-	baseURI      string
-	errorHandler helium.ErrorHandler
+	noMarkers      bool
+	noBaseFixup    bool
+	resolver       Resolver
+	baseURI        string
+	errorHandler   helium.ErrorHandler
+	maxIncludeSize int
 }
 
 // Processor configures XInclude processing. It is a value-style wrapper:
@@ -147,6 +163,19 @@ func (p Processor) BaseURI(uri string) Processor {
 	return p
 }
 
+// MaxIncludeSize sets the maximum number of bytes read from a single included
+// resource (XML or text). The cap is enforced against the actual number of
+// bytes read, guarding against a hostile or pathological Resolver (e.g. an
+// endless or multi-gigabyte reader) exhausting memory before the bytes are
+// cached. A value less than or equal to zero (the default) means
+// [MaxIncludeSize] (10 MiB) is used. Exceeding the cap fails the include with
+// [ErrIncludeTooLarge].
+func (p Processor) MaxIncludeSize(n int) Processor {
+	p = p.clone()
+	p.cfg.maxIncludeSize = n
+	return p
+}
+
 // ErrorHandler sets a handler for non-fatal warnings such as
 // entity definition mismatches during XInclude entity merging.
 // Errors delivered to the handler have ErrorLevelWarning.
@@ -167,16 +196,17 @@ type txtCacheEntry struct {
 }
 
 type processor struct {
-	noMarkers    bool
-	noBaseFixup  bool
-	resolver     Resolver
-	baseURI      string
-	expanding    map[string]bool          // circular inclusion detection (set during recursive expansion)
-	docCache     map[string]docCacheEntry // cached raw bytes for XML documents
-	txtCache     map[string]txtCacheEntry // cached text inclusions
-	errorHandler helium.ErrorHandler
-	depth        int
-	count        int
+	noMarkers      bool
+	noBaseFixup    bool
+	resolver       Resolver
+	baseURI        string
+	expanding      map[string]bool          // circular inclusion detection (set during recursive expansion)
+	docCache       map[string]docCacheEntry // cached raw bytes for XML documents
+	txtCache       map[string]txtCacheEntry // cached text inclusions
+	errorHandler   helium.ErrorHandler
+	maxIncludeSize int
+	depth          int
+	count          int
 }
 
 // Process performs XInclude processing on the document.
@@ -204,14 +234,15 @@ func (proc Processor) ProcessTree(ctx context.Context, node helium.Node) (int, e
 		cfg = &processorCfg{}
 	}
 	p := &processor{
-		noMarkers:    cfg.noMarkers,
-		noBaseFixup:  cfg.noBaseFixup,
-		resolver:     cfg.resolver,
-		baseURI:      cfg.baseURI,
-		errorHandler: cfg.errorHandler,
-		expanding:    make(map[string]bool),
-		docCache:     make(map[string]docCacheEntry),
-		txtCache:     make(map[string]txtCacheEntry),
+		noMarkers:      cfg.noMarkers,
+		noBaseFixup:    cfg.noBaseFixup,
+		resolver:       cfg.resolver,
+		baseURI:        cfg.baseURI,
+		errorHandler:   cfg.errorHandler,
+		maxIncludeSize: cfg.maxIncludeSize,
+		expanding:      make(map[string]bool),
+		docCache:       make(map[string]docCacheEntry),
+		txtCache:       make(map[string]txtCacheEntry),
 	}
 	if p.resolver == nil {
 		p.resolver = NewFSResolver(nil)
@@ -618,7 +649,7 @@ func (p *processor) loadXMLDoc(ctx context.Context, uri string, base string, sub
 	}
 	defer func() { _ = rc.Close() }()
 
-	data, err := io.ReadAll(rc)
+	data, err := p.readCapped(rc)
 	if err != nil {
 		wrapErr := fmt.Errorf("xi:include: error reading %q: %w", uri, err)
 		p.docCache[cacheKey] = docCacheEntry{err: wrapErr}
@@ -645,6 +676,35 @@ func (p *processor) loadXMLDoc(ctx context.Context, uri string, base string, sub
 // base directory (e.g. open dir/dir/inc.xml instead of dir/inc.xml).
 func (p *processor) resolve(uri, base string) (io.ReadCloser, error) {
 	return p.resolver.Resolve(uri, base) //nolint:wrapcheck // callers wrap with the URI for context
+}
+
+// readCapped reads all bytes from r but no more than the configured include-size
+// cap, returning [ErrIncludeTooLarge] when the resource exceeds it. The cap is
+// enforced against the bytes actually read so a Resolver that returns an
+// endless or oversized reader cannot exhaust memory.
+func (p *processor) readCapped(r io.Reader) ([]byte, error) {
+	limit := p.maxIncludeSize
+	if limit <= 0 {
+		limit = MaxIncludeSize
+	}
+	limit64 := int64(limit)
+
+	// Read one byte past the cap so a resource exactly at the limit succeeds
+	// while anything larger is detected, guarding against overflow when
+	// limit==math.MaxInt on 64-bit platforms (int64(limit)+1 would wrap).
+	readLimit := limit64
+	if readLimit < math.MaxInt64 {
+		readLimit++
+	}
+
+	data, err := io.ReadAll(io.LimitReader(r, readLimit))
+	if int64(len(data)) > limit64 {
+		return nil, ErrIncludeTooLarge
+	}
+	if err != nil {
+		return nil, err //nolint:wrapcheck // caller wraps with the URI for context
+	}
+	return data, nil
 }
 
 func (p *processor) parseXMLData(ctx context.Context, data []byte, uri string, substituteEntities bool) (*helium.Document, error) {
@@ -735,7 +795,7 @@ func (p *processor) loadText(uri string, base string) ([]byte, error) {
 	}
 	defer func() { _ = rc.Close() }()
 
-	data, err := io.ReadAll(rc)
+	data, err := p.readCapped(rc)
 	if err != nil {
 		wrapErr := fmt.Errorf("xi:include: error reading %q: %w", uri, err)
 		p.txtCache[uri] = txtCacheEntry{err: wrapErr}
@@ -1278,6 +1338,17 @@ func (p *processor) computeFixupBases(inc *helium.Element, sourceURI string) (st
 	return relSource, effectiveBaseURI(inc, relTarget)
 }
 
+// isFileURI reports whether href is an absolute "file:" URI (e.g.
+// "file:///tmp/inc.xml"). Such hrefs must be converted to a local path before
+// being handed to an [fs.FS]; plain OS paths and other schemes are not.
+func isFileURI(href string) bool {
+	u, err := url.Parse(href)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == lexicon.SchemeFile
+}
+
 // fsResolver resolves URIs by reading from an [fs.FS]. The default FS
 // is [iofs.PermissiveRoot] which opens any OS path verbatim; callers
 // handling untrusted input should construct one with a stricter fs.FS
@@ -1334,6 +1405,19 @@ func (r *fsResolver) Resolve(href, _ string) (io.ReadCloser, error) {
 	// directly — base is intentionally ignored. Joining base here would
 	// double-apply the base directory (e.g. dir/dir/inc.xml).
 	//
+	// An absolute "file:" href (e.g. from <xi:include href="file:///tmp/x"/>)
+	// is a URI, not a path; handing it to fs.FS verbatim would clean it to
+	// "file:/tmp/x" and fail. Convert it to a local filesystem path first,
+	// matching the catalog loader (PR #602). Non-local-host file URIs are
+	// rejected by the helper.
+	if isFileURI(href) {
+		p, err := iofs.FileURIToPath(href)
+		if err != nil {
+			return nil, fmt.Errorf("xi:include: %w", err)
+		}
+		return r.fsys.Open(filepath.ToSlash(p)) //nolint:wrapcheck // resolver errors propagate to caller verbatim
+	}
+
 	// Upstream resolution (resolveURI) may emit OS-specific separators via
 	// filepath.Join on Windows, so normalize to slashes for fs.FS, which
 	// requires slash-separated names.

--- a/xinclude/xinclude_test.go
+++ b/xinclude/xinclude_test.go
@@ -1,9 +1,11 @@
 package xinclude_test
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1576,4 +1578,118 @@ func TestZeroValueProcessorFluent(t *testing.T) {
 	count, err := proc.NoXIncludeMarkers().Process(t.Context(), doc)
 	require.NoError(t, err)
 	require.Equal(t, 0, count)
+}
+
+// endlessResolver returns a reader that never reaches EOF, simulating a hostile
+// or pathological resolver whose response would exhaust memory if read fully.
+type endlessResolver struct{}
+
+func (endlessResolver) Resolve(string, string) (io.ReadCloser, error) {
+	return io.NopCloser(repeatingReader{b: 'x'}), nil
+}
+
+type repeatingReader struct{ b byte }
+
+func (r repeatingReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = r.b
+	}
+	return len(p), nil
+}
+
+func TestXIncludeMaxIncludeSize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("text include over cap fails with ErrIncludeTooLarge", func(t *testing.T) {
+		t.Parallel()
+		doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
+			<xi:include href="huge.txt" parse="text"/>
+		</root>`)
+
+		_, err := xinclude.NewProcessor().
+			Resolver(endlessResolver{}).
+			MaxIncludeSize(1024).
+			Process(t.Context(), doc)
+		require.Error(t, err)
+		require.ErrorIs(t, err, xinclude.ErrIncludeTooLarge)
+	})
+
+	t.Run("xml include over cap fails with ErrIncludeTooLarge", func(t *testing.T) {
+		t.Parallel()
+		doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
+			<xi:include href="huge.xml"/>
+		</root>`)
+
+		_, err := xinclude.NewProcessor().
+			Resolver(endlessResolver{}).
+			MaxIncludeSize(1024).
+			Process(t.Context(), doc)
+		require.Error(t, err)
+		require.ErrorIs(t, err, xinclude.ErrIncludeTooLarge)
+	})
+
+	t.Run("include at or under cap succeeds", func(t *testing.T) {
+		t.Parallel()
+		doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
+			<xi:include href="small.txt" parse="text"/>
+		</root>`)
+
+		res := &stringResolver{files: map[string]string{"small.txt": "hello"}}
+		count, err := xinclude.NewProcessor().
+			Resolver(res).
+			MaxIncludeSize(1024).
+			NoXIncludeMarkers().NoBaseFixup().
+			Process(t.Context(), doc)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+	})
+}
+
+func TestXIncludeFileURIHref(t *testing.T) {
+	t.Parallel()
+
+	// Write a real include target and reference it via an absolute file:// URI.
+	// The default permissive resolver must convert the URI to an OS path rather
+	// than handing "file:/..." to os.Open verbatim.
+	dir := t.TempDir()
+	target := filepath.Join(dir, "inc.xml")
+	require.NoError(t, os.WriteFile(target, []byte(`<loaded>FromFileURI</loaded>`), 0o600))
+
+	fileURI := (&url.URL{Scheme: "file", Path: filepath.ToSlash(target)}).String()
+
+	doc := parseXML(t, fmt.Sprintf(`<root xmlns:xi="http://www.w3.org/2001/XInclude">
+		<xi:include href="%s"/>
+	</root>`, fileURI))
+
+	count, err := xinclude.NewProcessor().
+		NoXIncludeMarkers().NoBaseFixup().
+		Process(t.Context(), doc)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	root := docElement(doc)
+	require.NotNil(t, root)
+	var found bool
+	for c := root.FirstChild(); c != nil; c = c.NextSibling() {
+		if c.Type() == helium.ElementNode && c.(*helium.Element).LocalName() == "loaded" {
+			found = true
+			require.Equal(t, "FromFileURI", string(c.Content()))
+		}
+	}
+	require.True(t, found, "loaded element from file URI not found")
+}
+
+func TestXIncludeFileURINonLocalHost(t *testing.T) {
+	t.Parallel()
+
+	doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
+		<xi:include href="file://remotehost/tmp/inc.xml"/>
+	</root>`)
+
+	_, err := xinclude.NewProcessor().
+		NoXIncludeMarkers().NoBaseFixup().
+		Process(t.Context(), doc)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, fs.ErrNotExist) || strings.Contains(err.Error(), "non-local file URI host"),
+		"expected non-local host rejection, got: %v", err)
 }

--- a/xinclude/xinclude_test.go
+++ b/xinclude/xinclude_test.go
@@ -1,7 +1,6 @@
 package xinclude_test
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -1690,6 +1689,6 @@ func TestXIncludeFileURINonLocalHost(t *testing.T) {
 		NoXIncludeMarkers().NoBaseFixup().
 		Process(t.Context(), doc)
 	require.Error(t, err)
-	require.True(t, errors.Is(err, fs.ErrNotExist) || strings.Contains(err.Error(), "non-local file URI host"),
-		"expected non-local host rejection, got: %v", err)
+	require.ErrorContains(t, err, "non-local file URI host",
+		"expected explicit non-local host rejection, got: %v", err)
 }

--- a/xinclude/xinclude_test.go
+++ b/xinclude/xinclude_test.go
@@ -1678,6 +1678,49 @@ func TestXIncludeFileURIHref(t *testing.T) {
 	require.True(t, found, "loaded element from file URI not found")
 }
 
+func TestXIncludeFileURINestedExternalDTD(t *testing.T) {
+	t.Parallel()
+
+	// Regression: a file:// XInclude whose included document references an
+	// external DTD that defines a general entity. The included doc is parsed
+	// with BaseURI("file:///.../inc.xml"), so the DTD SYSTEM ref resolves to a
+	// "file:" URI handed to the inner parser's FS (normalizingFS). That FS must
+	// convert the file: URI to a local path too, or the nested external DTD is
+	// never found and its entity is silently missed. The entity-merge step then
+	// surfaces the entity into the target's internal subset, proving the nested
+	// DTD was actually located and parsed.
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "inc.dtd"),
+		[]byte(`<!ENTITY greet "hello from nested dtd">`), 0o600))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "inc.xml"),
+		[]byte(`<?xml version="1.0"?>`+
+			`<!DOCTYPE chapter SYSTEM "inc.dtd">`+
+			`<chapter>text</chapter>`), 0o600))
+
+	fileURI := (&url.URL{Scheme: "file", Path: filepath.ToSlash(filepath.Join(dir, "inc.xml"))}).String()
+
+	doc := parseXML(t, fmt.Sprintf(`<root xmlns:xi="http://www.w3.org/2001/XInclude">
+		<xi:include href="%s"/>
+	</root>`, fileURI))
+
+	count, err := xinclude.NewProcessor().
+		NoXIncludeMarkers().NoBaseFixup().
+		Process(t.Context(), doc)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	// The entity defined in the included document's EXTERNAL DTD must have been
+	// merged into the target's internal subset. This only happens if the nested
+	// "file:" DTD reference was converted to a local path and successfully read.
+	intSub := doc.IntSubset()
+	require.NotNil(t, intSub, "target should have a merged internal subset")
+	greet, ok := intSub.LookupEntity("greet")
+	require.True(t, ok, "entity from nested external DTD must be merged, proving the file: DTD URI was resolved")
+	require.Equal(t, "hello from nested dtd", string(greet.Content()))
+}
+
 func TestXIncludeFileURINonLocalHost(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- Cap each included resource (XML and text) with `io.LimitReader`; default `MaxIncludeSize` (10 MiB), configurable via `Processor.MaxIncludeSize(int)`. Over-cap reads fail with `ErrIncludeTooLarge`, blocking a memory DoS from a hostile/endless Resolver.
- Default FS resolver now converts absolute `file:` hrefs (e.g. `file:///tmp/inc.xml`) to OS paths via new `internal/iofs.FileURIToPath`, mirroring catalog PR #602; non-local-host file URIs rejected.
- API additions: `Processor.MaxIncludeSize(int)`, const `MaxIncludeSize`, `ErrIncludeTooLarge`.
