### PR TITLE
reject malformed char refs and foreign sax entities

### DIFF
--- a/parser_charref_test.go
+++ b/parser_charref_test.go
@@ -1,0 +1,93 @@
+package helium_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/enum"
+	"github.com/lestrrat-go/helium/sax"
+	"github.com/stretchr/testify/require"
+)
+
+// foreignEntity is a sax.Entity implementation that is NOT *helium.Entity.
+// A custom SAX handler returning such a value must produce an error rather
+// than panic from a forced type assertion.
+type foreignEntity struct {
+	name    string
+	content []byte
+}
+
+func (e *foreignEntity) Name() string                { return e.name }
+func (e *foreignEntity) SetOrig(string)              {}
+func (e *foreignEntity) EntityType() enum.EntityType { return enum.InternalGeneralEntity }
+func (e *foreignEntity) Content() []byte             { return e.content }
+func (e *foreignEntity) Checked() bool               { return true }
+func (e *foreignEntity) MarkChecked()                {}
+
+func TestGetEntityForeignTypeReturnsErrorNotPanic(t *testing.T) {
+	h := sax.New()
+	h.SetOnGetEntity(sax.GetEntityFunc(func(_ context.Context, name string) (sax.Entity, error) {
+		return &foreignEntity{name: name, content: []byte("hello")}, nil
+	}))
+
+	const input = `<!DOCTYPE root [<!ENTITY foo "ignored">]><root>&foo;</root>`
+
+	require.NotPanics(t, func() {
+		_, err := helium.NewParser().SAXHandler(h).Parse(t.Context(), []byte(input))
+		require.Error(t, err, "foreign sax.Entity type should yield an error")
+	})
+}
+
+func TestGetEntityHandlerNilErrorDoesNotPanic(t *testing.T) {
+	// A handler returning (nil, err) (e.g. "entity not found") must not panic.
+	// Per libxml2 semantics this falls through to undeclared-entity handling.
+	h := sax.New()
+	h.SetOnGetEntity(sax.GetEntityFunc(func(_ context.Context, name string) (sax.Entity, error) {
+		return nil, context.Canceled
+	}))
+
+	const input = `<!DOCTYPE root [<!ENTITY foo "ignored">]><root>&foo;</root>`
+
+	require.NotPanics(t, func() {
+		_, _ = helium.NewParser().SAXHandler(h).Parse(t.Context(), []byte(input))
+	})
+}
+
+func TestCharRefMissingSemicolonRejected(t *testing.T) {
+	for _, input := range []string{
+		`<root>&#65</root>`,
+		`<root>&#x41</root>`,
+	} {
+		_, err := helium.NewParser().Parse(t.Context(), []byte(input))
+		require.Error(t, err, "char ref without terminating ';' must be rejected: %s", input)
+	}
+}
+
+func TestCharRefMissingDigitsRejected(t *testing.T) {
+	for _, input := range []string{
+		`<root>&#;</root>`,
+		`<root>&#x;</root>`,
+	} {
+		_, err := helium.NewParser().Parse(t.Context(), []byte(input))
+		require.Error(t, err, "char ref without digits must be rejected: %s", input)
+	}
+}
+
+func TestCharRefValidAccepted(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{`<root>&#65;</root>`, "A"},
+		{`<root>&#x41;</root>`, "A"},
+	} {
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(tc.input))
+		require.NoError(t, err, "valid char ref must parse: %s", tc.input)
+		require.NotNil(t, doc)
+
+		root := doc.DocumentElement()
+		require.NotNil(t, root)
+		require.Equal(t, tc.want, string(root.Content()))
+	}
+}

--- a/parser_entity_ref.go
+++ b/parser_entity_ref.go
@@ -543,6 +543,7 @@ func (ctx *parserCtx) parseCharRef() (r rune, err error) {
 		return
 	}
 	if cur.ConsumeString("&#x") {
+		var digits int
 		for c := cur.Peek(); !cur.Done() && c != ';'; c = cur.Peek() {
 			if c >= '0' && c <= '9' {
 				val = val*16 + int32(c-'0')
@@ -554,6 +555,7 @@ func (ctx *parserCtx) parseCharRef() (r rune, err error) {
 				err = errors.New("invalid hex CharRef")
 				return
 			}
+			digits++
 			// Stop accumulating once the value is out of range so an
 			// oversized reference cannot wrap int32 into a valid-looking rune.
 			if val > unicode.MaxRune {
@@ -564,12 +566,19 @@ func (ctx *parserCtx) parseCharRef() (r rune, err error) {
 				return utf8.RuneError, err
 			}
 		}
-		if cur.Peek() == ';' {
-			if err := cur.Advance(1); err != nil {
-				return utf8.RuneError, err
-			}
+		if digits == 0 {
+			err = errors.New("invalid hex CharRef: missing digits")
+			return
+		}
+		if cur.Peek() != ';' {
+			err = ErrSemicolonRequired
+			return
+		}
+		if err := cur.Advance(1); err != nil {
+			return utf8.RuneError, err
 		}
 	} else if cur.ConsumeString("&#") {
+		var digits int
 		for !cur.Done() && cur.Peek() != ';' {
 			c := cur.Peek()
 			if c >= '0' && c <= '9' {
@@ -578,6 +587,7 @@ func (ctx *parserCtx) parseCharRef() (r rune, err error) {
 				err = errors.New("invalid decimal CharRef")
 				return
 			}
+			digits++
 			// Stop accumulating once the value is out of range so an
 			// oversized reference cannot wrap int32 into a valid-looking rune.
 			if val > unicode.MaxRune {
@@ -588,10 +598,16 @@ func (ctx *parserCtx) parseCharRef() (r rune, err error) {
 				return utf8.RuneError, err
 			}
 		}
-		if cur.Peek() == ';' {
-			if err := cur.Advance(1); err != nil {
-				return utf8.RuneError, err
-			}
+		if digits == 0 {
+			err = errors.New("invalid decimal CharRef: missing digits")
+			return
+		}
+		if cur.Peek() != ';' {
+			err = ErrSemicolonRequired
+			return
+		}
+		if err := cur.Advance(1); err != nil {
+			return utf8.RuneError, err
 		}
 	} else {
 		err = errors.New("invalid char ref")
@@ -649,10 +665,18 @@ func (pctx *parserCtx) parseEntityRef(ctx context.Context) (ent *Entity, err err
 	err = nil
 
 	if s := pctx.sax; s != nil {
-		var loadedEnt sax.Entity
-		loadedEnt, _ = s.GetEntity(ctx, name)
+		// A non-nil error here is advisory (e.g. "entity not found"): we fall
+		// through to the undeclared-entity handling below, matching libxml2's
+		// getEntity-returns-NULL behavior. Only a non-nil returned entity is
+		// consumed, and it must be a *Entity. A foreign sax.Entity
+		// implementation yields a clear error rather than a forced-cast panic.
+		loadedEnt, _ := s.GetEntity(ctx, name)
 		if loadedEnt != nil {
-			ent = loadedEnt.(*Entity) //nolint:forcetypeassert
+			typed, ok := loadedEnt.(*Entity)
+			if !ok {
+				return nil, pctx.error(ctx, fmt.Errorf("SAX GetEntity returned unsupported entity type %T for entity '%s'", loadedEnt, name))
+			}
+			ent = typed
 			return
 		}
 


### PR DESCRIPTION
- `parseCharRef` now requires terminating `;` and at least one digit (decimal and hex); previously `&#65` without `;` parsed as `A`.
- guard SAX `GetEntity` result against foreign `sax.Entity` types with a clear error instead of a forced-cast panic.
- behavior change toward correctness: inputs (e.g. external-parsed-entity content `&#65`) that previously parsed now error.
