### PR TITLE
cap catalog file size on load

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -221,9 +221,13 @@ Schematron schema compilation and validation.
 
 OASIS XML Catalog resolution for public/system IDs and URIs.
 
-- **Load(ctx, path, ...LoadOption) → (*Catalog, error)**
+- **Load(ctx, path) → (*Catalog, error)** — convenience wrapper around `NewLoader().Load`
+- **NewLoader() → Loader** — fluent value-style loader; methods return updated copies
+- **Loader.ErrorHandler(h) → Loader** — deliver parse warnings to a handler
+- **Loader.MaxBytes(n) → Loader** — cap catalog file size; exceed → `ErrCatalogTooLarge` (default `MaxCatalogSize`, 10 MiB)
 - **Catalog.Resolve(ctx, pubID, sysID) → string** — resolve external identifier
 - **Catalog.ResolveURI(ctx, uri) → string** — resolve URI reference
+- Const `MaxCatalogSize`; sentinel `ErrCatalogTooLarge`
 - Catalog chaining via nextCatalog; URN urn:publicid: support
 - Files: `catalog.go`, `load.go`
 - Imports: helium, internal/catalog/, internal/lexicon/

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -2,10 +2,23 @@ package catalog
 
 import (
 	"context"
+	"errors"
 
 	helium "github.com/lestrrat-go/helium"
 	icatalog "github.com/lestrrat-go/helium/internal/catalog"
 )
+
+// MaxCatalogSize is the default maximum number of bytes read from a catalog
+// file. Catalog files are loaded from XML_CATALOG_FILES or the API, so an
+// unbounded read of a hostile or pathological source (e.g. /dev/zero) could
+// exhaust memory before parsing applies any limits. The file is read through a
+// strict byte cap and rejected with [ErrCatalogTooLarge] when it is exceeded.
+const MaxCatalogSize = 10 << 20 // 10 MiB
+
+// ErrCatalogTooLarge is returned when a catalog file exceeds the configured
+// byte cap (set via [Loader.MaxBytes]), or [MaxCatalogSize] when no cap is
+// configured. The cap is enforced against the actual number of bytes read.
+var ErrCatalogTooLarge = errors.New("catalog file exceeds maximum allowed size")
 
 // Catalog holds parsed catalog entries and provides resolution.
 // It wraps the internal catalog implementation and serves as the
@@ -37,6 +50,7 @@ func (c *Catalog) ResolveURI(ctx context.Context, uri string) string {
 // loaderConfig holds configuration for a Loader.
 type loaderConfig struct {
 	errorHandler helium.ErrorHandler
+	maxBytes     int
 }
 
 // Loader loads OASIS XML Catalog files. It is a value-style wrapper:
@@ -64,5 +78,16 @@ func (l Loader) clone() Loader {
 func (l Loader) ErrorHandler(h helium.ErrorHandler) Loader {
 	l = l.clone()
 	l.cfg.errorHandler = h
+	return l
+}
+
+// MaxBytes returns a copy of the Loader that caps the number of bytes read
+// from a catalog file at n. The cap guards against hostile or pathological
+// sources (e.g. /dev/zero) that could otherwise exhaust memory. When a catalog
+// file exceeds the cap, Load fails with [ErrCatalogTooLarge]. A value less than
+// or equal to zero (the default) means [MaxCatalogSize] (10 MiB) is used.
+func (l Loader) MaxBytes(n int) Loader {
+	l = l.clone()
+	l.cfg.maxBytes = n
 	return l
 }

--- a/catalog/fuzz_test.go
+++ b/catalog/fuzz_test.go
@@ -25,7 +25,7 @@ func FuzzLoad(f *testing.F) {
 			return
 		}
 
-		cat, err := loadFromBytes(t.Context(), data, "file:///fuzz/catalog.xml", helium.NilErrorHandler{})
+		cat, err := loadFromBytes(t.Context(), data, "file:///fuzz/catalog.xml", helium.NilErrorHandler{}, 0)
 		if err != nil {
 			return
 		}

--- a/catalog/load.go
+++ b/catalog/load.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -98,7 +99,8 @@ func loadInternal(ctx context.Context, filename string, eh helium.ErrorHandler, 
 // cap is maxBytes, or [MaxCatalogSize] when maxBytes is less than or equal to
 // zero. LimitReader allows one extra byte so a file exactly at the cap is
 // accepted while anything larger is detected and rejected with
-// [ErrCatalogTooLarge].
+// [ErrCatalogTooLarge]. The extra byte is suppressed when the cap is already
+// math.MaxInt64 so it cannot overflow into a zero-byte read.
 func readCatalogFile(absPath string, maxBytes int) ([]byte, error) {
 	limit := int64(maxBytes)
 	if limit <= 0 {
@@ -111,7 +113,17 @@ func readCatalogFile(absPath string, maxBytes int) ([]byte, error) {
 	}
 	defer f.Close()
 
-	data, err := io.ReadAll(io.LimitReader(f, limit+1))
+	// Read one byte past the cap so a file that is exactly at the cap is
+	// accepted while anything larger is detected, but guard against overflow:
+	// limit+1 wraps to a negative value for limit==math.MaxInt on 64-bit
+	// platforms, which would make io.LimitReader read zero bytes and silently
+	// reject a valid catalog.
+	readLimit := limit
+	if readLimit < math.MaxInt64 {
+		readLimit++
+	}
+
+	data, err := io.ReadAll(io.LimitReader(f, readLimit))
 	if err != nil {
 		return nil, fmt.Errorf("catalog: failed to read %q: %w", absPath, err)
 	}

--- a/catalog/load.go
+++ b/catalog/load.go
@@ -22,10 +22,11 @@ const goosWindows = "windows"
 // internalLoader implements icatalog.Loader using helium's parser.
 type internalLoader struct {
 	errorHandler helium.ErrorHandler
+	maxBytes     int
 }
 
 func (l internalLoader) Load(ctx context.Context, filename string) (*icatalog.Catalog, error) {
-	return loadInternal(ctx, filename, l.errorHandler)
+	return loadInternal(ctx, filename, l.errorHandler, l.maxBytes)
 }
 
 // Load parses an OASIS XML Catalog file and returns a Catalog.
@@ -52,7 +53,7 @@ func (l Loader) Load(ctx context.Context, filename string) (*Catalog, error) { /
 		eh = helium.NilErrorHandler{}
 	}
 
-	ic, err := loadInternal(ctx, filename, eh)
+	ic, err := loadInternal(ctx, filename, eh, cfg.maxBytes)
 	if err != nil {
 		closeHandler(eh)
 		return nil, err
@@ -62,7 +63,7 @@ func (l Loader) Load(ctx context.Context, filename string) (*Catalog, error) { /
 	return &Catalog{cat: ic}, nil
 }
 
-func loadInternal(ctx context.Context, filename string, eh helium.ErrorHandler) (*icatalog.Catalog, error) {
+func loadInternal(ctx context.Context, filename string, eh helium.ErrorHandler, maxBytes int) (*icatalog.Catalog, error) {
 	path, isFileURI, err := catalogFilePath(filename)
 	if err != nil {
 		return nil, err
@@ -73,9 +74,9 @@ func loadInternal(ctx context.Context, filename string, eh helium.ErrorHandler) 
 		return nil, fmt.Errorf("catalog: failed to resolve path %q: %w", filename, err)
 	}
 
-	data, err := os.ReadFile(absPath)
+	data, err := readCatalogFile(absPath, maxBytes)
 	if err != nil {
-		return nil, fmt.Errorf("catalog: failed to read %q: %w", absPath, err)
+		return nil, err
 	}
 
 	// Read from the local filesystem path, but resolve relative URIs in the
@@ -89,7 +90,36 @@ func loadInternal(ctx context.Context, filename string, eh helium.ErrorHandler) 
 		baseURI = localPathToFileURI(absPath)
 	}
 
-	return loadFromBytes(ctx, data, baseURI, eh)
+	return loadFromBytes(ctx, data, baseURI, eh, maxBytes)
+}
+
+// readCatalogFile reads a catalog file at absPath through a bounded reader so an
+// unbounded or pathological source (e.g. /dev/zero) cannot exhaust memory. The
+// cap is maxBytes, or [MaxCatalogSize] when maxBytes is less than or equal to
+// zero. LimitReader allows one extra byte so a file exactly at the cap is
+// accepted while anything larger is detected and rejected with
+// [ErrCatalogTooLarge].
+func readCatalogFile(absPath string, maxBytes int) ([]byte, error) {
+	limit := int64(maxBytes)
+	if limit <= 0 {
+		limit = MaxCatalogSize
+	}
+
+	f, err := os.Open(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("catalog: failed to read %q: %w", absPath, err)
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(io.LimitReader(f, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("catalog: failed to read %q: %w", absPath, err)
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("catalog: %q exceeds maximum size of %d bytes: %w", absPath, limit, ErrCatalogTooLarge)
+	}
+
+	return data, nil
 }
 
 // catalogFilePath converts a catalog reference into a local filesystem path.
@@ -193,7 +223,7 @@ func hasDriveLetterPrefix(s string) bool {
 		(s[2] == '\\' || s[2] == '/')
 }
 
-func loadFromBytes(ctx context.Context, data []byte, baseURI string, eh helium.ErrorHandler) (*icatalog.Catalog, error) {
+func loadFromBytes(ctx context.Context, data []byte, baseURI string, eh helium.ErrorHandler, maxBytes int) (*icatalog.Catalog, error) {
 	p := helium.NewParser()
 	doc, err := p.Parse(ctx, data)
 	if err != nil {
@@ -213,7 +243,7 @@ func loadFromBytes(ctx context.Context, data []byte, baseURI string, eh helium.E
 	cat := &icatalog.Catalog{
 		Prefer:  icatalog.PreferPublic, // default per OASIS spec
 		BaseURI: baseURI,
-		Loader:  internalLoader{errorHandler: eh},
+		Loader:  internalLoader{errorHandler: eh, maxBytes: maxBytes},
 	}
 
 	if v := getAttr(root, lexicon.AttrPrefer); v != "" {

--- a/catalog/load_cap_test.go
+++ b/catalog/load_cap_test.go
@@ -1,6 +1,7 @@
 package catalog_test
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,5 +71,19 @@ func TestLoadMaxBytes(t *testing.T) {
 		require.NoError(t, err)
 		got := cat.Resolve(t.Context(), "", "http://example.com/test.dtd")
 		require.NotEqual(t, "", got)
+	})
+
+	t.Run("MaxInt cap does not overflow into a zero read", func(t *testing.T) {
+		t.Parallel()
+		// MaxBytes(math.MaxInt) once made the over-cap probe (limit+1) overflow
+		// to a negative value on 64-bit platforms, so io.LimitReader read zero
+		// bytes and a valid catalog failed to parse. A huge cap must load a
+		// normal catalog successfully.
+		path := writeCatalog(t, minimalCatalogXML)
+
+		cat, err := catalog.NewLoader().MaxBytes(math.MaxInt).Load(t.Context(), path)
+		require.NoError(t, err)
+		got := cat.Resolve(t.Context(), "", "http://example.com/test.dtd")
+		require.NotEqual(t, "", got, "expected the system entry to resolve")
 	})
 }

--- a/catalog/load_cap_test.go
+++ b/catalog/load_cap_test.go
@@ -1,7 +1,6 @@
 package catalog_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,7 +35,7 @@ func TestLoadMaxBytes(t *testing.T) {
 		padded := minimalCatalogXML + strings.Repeat(" ", 4096)
 		path := writeCatalog(t, padded)
 
-		_, err := catalog.NewLoader().MaxBytes(64).Load(context.Background(), path)
+		_, err := catalog.NewLoader().MaxBytes(64).Load(t.Context(), path)
 		require.Error(t, err)
 		require.ErrorIs(t, err, catalog.ErrCatalogTooLarge)
 	})
@@ -45,9 +44,9 @@ func TestLoadMaxBytes(t *testing.T) {
 		t.Parallel()
 		path := writeCatalog(t, minimalCatalogXML)
 
-		cat, err := catalog.NewLoader().MaxBytes(64<<10).Load(context.Background(), path)
+		cat, err := catalog.NewLoader().MaxBytes(64<<10).Load(t.Context(), path)
 		require.NoError(t, err)
-		got := cat.Resolve(context.Background(), "", "http://example.com/test.dtd")
+		got := cat.Resolve(t.Context(), "", "http://example.com/test.dtd")
 		require.NotEqual(t, "", got, "expected the system entry to resolve")
 	})
 
@@ -55,9 +54,9 @@ func TestLoadMaxBytes(t *testing.T) {
 		t.Parallel()
 		path := writeCatalog(t, minimalCatalogXML)
 
-		cat, err := catalog.Load(context.Background(), path)
+		cat, err := catalog.Load(t.Context(), path)
 		require.NoError(t, err)
-		got := cat.Resolve(context.Background(), "", "http://example.com/test.dtd")
+		got := cat.Resolve(t.Context(), "", "http://example.com/test.dtd")
 		require.NotEqual(t, "", got)
 	})
 
@@ -67,9 +66,9 @@ func TestLoadMaxBytes(t *testing.T) {
 		info, err := os.Stat(path)
 		require.NoError(t, err)
 
-		cat, err := catalog.NewLoader().MaxBytes(int(info.Size())).Load(context.Background(), path)
+		cat, err := catalog.NewLoader().MaxBytes(int(info.Size())).Load(t.Context(), path)
 		require.NoError(t, err)
-		got := cat.Resolve(context.Background(), "", "http://example.com/test.dtd")
+		got := cat.Resolve(t.Context(), "", "http://example.com/test.dtd")
 		require.NotEqual(t, "", got)
 	})
 }

--- a/catalog/load_cap_test.go
+++ b/catalog/load_cap_test.go
@@ -1,0 +1,75 @@
+package catalog_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium/catalog"
+	"github.com/stretchr/testify/require"
+)
+
+const minimalCatalogXML = `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <system systemId="http://example.com/test.dtd" uri="test.dtd"/>
+</catalog>`
+
+// writeCatalog writes content to a catalog file in a fresh temp dir and returns
+// its path.
+func writeCatalog(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "catalog.xml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestLoadMaxBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("over cap fails with ErrCatalogTooLarge", func(t *testing.T) {
+		t.Parallel()
+		// Pad the catalog past a small cap with trailing whitespace, which keeps
+		// the XML well-formed so the failure is the size cap, not a parse error.
+		padded := minimalCatalogXML + strings.Repeat(" ", 4096)
+		path := writeCatalog(t, padded)
+
+		_, err := catalog.NewLoader().MaxBytes(64).Load(context.Background(), path)
+		require.Error(t, err)
+		require.ErrorIs(t, err, catalog.ErrCatalogTooLarge)
+	})
+
+	t.Run("under cap still loads", func(t *testing.T) {
+		t.Parallel()
+		path := writeCatalog(t, minimalCatalogXML)
+
+		cat, err := catalog.NewLoader().MaxBytes(64<<10).Load(context.Background(), path)
+		require.NoError(t, err)
+		got := cat.Resolve(context.Background(), "", "http://example.com/test.dtd")
+		require.NotEqual(t, "", got, "expected the system entry to resolve")
+	})
+
+	t.Run("default cap loads a normal catalog", func(t *testing.T) {
+		t.Parallel()
+		path := writeCatalog(t, minimalCatalogXML)
+
+		cat, err := catalog.Load(context.Background(), path)
+		require.NoError(t, err)
+		got := cat.Resolve(context.Background(), "", "http://example.com/test.dtd")
+		require.NotEqual(t, "", got)
+	})
+
+	t.Run("at cap loads", func(t *testing.T) {
+		t.Parallel()
+		path := writeCatalog(t, minimalCatalogXML)
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+
+		cat, err := catalog.NewLoader().MaxBytes(int(info.Size())).Load(context.Background(), path)
+		require.NoError(t, err)
+		got := cat.Resolve(context.Background(), "", "http://example.com/test.dtd")
+		require.NotEqual(t, "", got)
+	})
+}


### PR DESCRIPTION
- Read catalog files through a bounded `io.LimitReader` capped at `MaxCatalogSize` (10 MiB) so a huge catalog from `XML_CATALOG_FILES`/API cannot exhaust memory; over-cap fails with new sentinel `ErrCatalogTooLarge`
- New public API: const `MaxCatalogSize`, error `ErrCatalogTooLarge`, fluent option `Loader.MaxBytes(n)`
