### PR TITLE
harden xslt3gen asset paths and param qnames

### DIFF
--- a/tools/xslt3gen/main.go
+++ b/tools/xslt3gen/main.go
@@ -305,11 +305,16 @@ func main() {
 			continue
 		}
 
-		tsFile := filepath.Join(sourceDir, tsRef.File)
+		// The test-set href itself is catalog-derived; verify it stays inside
+		// sourceDir before opening it.
+		tsRel, ok := catalogRelPath(sourceDir, ".", tsRef.File)
+		if !ok {
+			continue
+		}
+		tsFile := filepath.Join(sourceDir, tsRel)
 		ts := parseTestSet(tsFile)
-		tsDir := filepath.Dir(tsRef.File)           // e.g. "tests/insn/apply-templates"
-		tsDirAbs := filepath.Join(sourceDir, tsDir) // absolute path for reading files
-		addCatalogReferencedFiles(assetFiles, tsDir, ts)
+		tsDir := filepath.Dir(tsRel) // e.g. "tests/insn/apply-templates"
+		addCatalogReferencedFiles(assetFiles, sourceDir, tsDir, ts)
 
 		// Some test sets reference non-XML files (JSON, text, etc.) at runtime
 		// via unparsed-text(). Copy the entire directory tree for these.
@@ -326,51 +331,37 @@ func main() {
 			localEnvs[ts.Environments[i].Name] = &ts.Environments[i]
 			// Track environment-level stylesheet and source assets
 			for _, ss := range ts.Environments[i].Stylesheets {
-				if ss.File != "" {
-					relPath := filepath.Join(tsDir, ss.File)
-					assetFiles[relPath] = struct{}{}
-					absPath := filepath.Join(sourceDir, relPath)
-					for _, dep := range collectTransitiveDeps(sourceDir, absPath) {
-						relDep, err := filepath.Rel(sourceDir, dep)
-						if err == nil {
-							assetFiles[relDep] = struct{}{}
-						}
-					}
+				relPath, ok := catalogRelPath(sourceDir, tsDir, ss.File)
+				if !ok {
+					continue
 				}
+				assetFiles[relPath] = struct{}{}
+				addTransitiveDeps(assetFiles, sourceDir, relPath)
 			}
 			// Track environment-level package assets
 			for _, pkg := range ts.Environments[i].Packages {
-				if pkg.File != "" {
-					relPath := filepath.Join(tsDir, pkg.File)
-					assetFiles[relPath] = struct{}{}
-					absPath := filepath.Join(sourceDir, relPath)
-					for _, dep := range collectTransitiveDeps(sourceDir, absPath) {
-						relDep, err := filepath.Rel(sourceDir, dep)
-						if err == nil {
-							assetFiles[relDep] = struct{}{}
-						}
-					}
+				relPath, ok := catalogRelPath(sourceDir, tsDir, pkg.File)
+				if !ok {
+					continue
 				}
+				assetFiles[relPath] = struct{}{}
+				addTransitiveDeps(assetFiles, sourceDir, relPath)
 			}
 			for _, src := range ts.Environments[i].Sources {
-				if src.File != "" {
-					relPath := filepath.Join(tsDir, src.File)
+				if relPath, ok := catalogRelPath(sourceDir, tsDir, src.File); ok {
 					assetFiles[relPath] = struct{}{}
 				}
 			}
 			for _, sch := range ts.Environments[i].Schemas {
-				if sch.File != "" {
-					relPath := filepath.Join(tsDir, sch.File)
+				if relPath, ok := catalogRelPath(sourceDir, tsDir, sch.File); ok {
 					assetFiles[relPath] = struct{}{}
 				}
 			}
 			for _, col := range ts.Environments[i].Collections {
 				for _, src := range col.Sources {
-					if src.File == "" {
-						continue
+					if relPath, ok := catalogRelPath(sourceDir, tsDir, src.File); ok {
+						assetFiles[relPath] = struct{}{}
 					}
-					relPath := filepath.Join(tsDir, src.File)
-					assetFiles[relPath] = struct{}{}
 				}
 			}
 		}
@@ -411,7 +402,10 @@ func main() {
 
 			// Find primary and secondary stylesheets
 			for _, ss := range tc.Test.Stylesheets {
-				relPath := filepath.Join(tsDir, ss.File)
+				relPath, ok := catalogRelPath(sourceDir, tsDir, ss.File)
+				if !ok {
+					continue
+				}
 				if ss.Role == "secondary" {
 					gt.SecondaryStylesheets = append(gt.SecondaryStylesheets, relPath)
 				} else {
@@ -422,7 +416,10 @@ func main() {
 			// Process packages before the single-stylesheet fallback so
 			// that a principal package takes priority.
 			for _, pkg := range tc.Test.Packages {
-				relPath := filepath.Join(tsDir, pkg.File)
+				relPath, ok := catalogRelPath(sourceDir, tsDir, pkg.File)
+				if !ok {
+					continue
+				}
 				if pkg.Role == "principal" {
 					if gt.StylesheetPath == "" {
 						gt.StylesheetPath = relPath
@@ -435,18 +432,14 @@ func main() {
 					})
 				}
 				assetFiles[relPath] = struct{}{}
-				absPath := filepath.Join(sourceDir, relPath)
-				for _, dep := range collectTransitiveDeps(sourceDir, absPath) {
-					relDep, err := filepath.Rel(sourceDir, dep)
-					if err == nil {
-						assetFiles[relDep] = struct{}{}
-					}
-				}
+				addTransitiveDeps(assetFiles, sourceDir, relPath)
 			}
 
 			// If only one stylesheet and no explicit role, it's the primary
 			if gt.StylesheetPath == "" && len(tc.Test.Stylesheets) == 1 {
-				gt.StylesheetPath = filepath.Join(tsDir, tc.Test.Stylesheets[0].File)
+				if relPath, ok := catalogRelPath(sourceDir, tsDir, tc.Test.Stylesheets[0].File); ok {
+					gt.StylesheetPath = relPath
+				}
 			}
 
 			// Fall back to environment-level stylesheet/packages if test has none
@@ -464,7 +457,10 @@ func main() {
 						}
 					}
 					for _, ss := range env.Stylesheets {
-						relPath := filepath.Join(tsDir, ss.File)
+						relPath, ok := catalogRelPath(sourceDir, tsDir, ss.File)
+						if !ok {
+							continue
+						}
 						if ss.Role == "secondary" {
 							gt.SecondaryStylesheets = append(gt.SecondaryStylesheets, relPath)
 						} else {
@@ -474,11 +470,16 @@ func main() {
 					// Only promote a lone environment stylesheet to primary
 					// when the source document does not define the stylesheet.
 					if gt.StylesheetPath == "" && len(env.Stylesheets) == 1 && !sourceDefinesStylesheet {
-						gt.StylesheetPath = filepath.Join(tsDir, env.Stylesheets[0].File)
+						if relPath, ok := catalogRelPath(sourceDir, tsDir, env.Stylesheets[0].File); ok {
+							gt.StylesheetPath = relPath
+						}
 					}
 					// Environment-level packages as principal fallback
 					for _, pkg := range env.Packages {
-						relPath := filepath.Join(tsDir, pkg.File)
+						relPath, ok := catalogRelPath(sourceDir, tsDir, pkg.File)
+						if !ok {
+							continue
+						}
 						if pkg.Role == "principal" && gt.StylesheetPath == "" {
 							gt.StylesheetPath = relPath
 						}
@@ -491,22 +492,20 @@ func main() {
 				env := resolveEnvironment(tc.Environment, localEnvs)
 				if env != nil {
 					for _, pkg := range env.Packages {
-						if pkg.Role == "secondary" || pkg.Role == "" {
-							relPath := filepath.Join(tsDir, pkg.File)
-							gt.PackageDeps = append(gt.PackageDeps, packageDep{
-								URI:            pkg.URI,
-								PackageVersion: pkg.PackageVersion,
-								FilePath:       relPath,
-							})
-							assetFiles[relPath] = struct{}{}
-							absPath := filepath.Join(sourceDir, relPath)
-							for _, dep := range collectTransitiveDeps(sourceDir, absPath) {
-								relDep, err := filepath.Rel(sourceDir, dep)
-								if err == nil {
-									assetFiles[relDep] = struct{}{}
-								}
-							}
+						if pkg.Role != "secondary" && pkg.Role != "" {
+							continue
 						}
+						relPath, ok := catalogRelPath(sourceDir, tsDir, pkg.File)
+						if !ok {
+							continue
+						}
+						gt.PackageDeps = append(gt.PackageDeps, packageDep{
+							URI:            pkg.URI,
+							PackageVersion: pkg.PackageVersion,
+							FilePath:       relPath,
+						})
+						assetFiles[relPath] = struct{}{}
+						addTransitiveDeps(assetFiles, sourceDir, relPath)
 					}
 				}
 			}
@@ -585,16 +584,16 @@ func main() {
 			env := resolveEnvironment(tc.Environment, localEnvs)
 			if env != nil {
 				for _, src := range env.Sources {
-					if src.File != "" {
-						relPath := filepath.Join(tsDir, src.File)
+					srcRel, srcOK := catalogRelPath(sourceDir, tsDir, src.File)
+					if srcOK {
 						// Always copy source files as assets (for document()/fn:doc() etc.)
-						assetFiles[relPath] = struct{}{}
+						assetFiles[srcRel] = struct{}{}
 					}
 					if src.Role != "." {
 						continue
 					}
-					if src.File != "" {
-						gt.SourceDocPath = filepath.Join(tsDir, src.File)
+					if srcOK {
+						gt.SourceDocPath = srcRel
 					} else if src.Content != nil {
 						gt.SourceContent = decodeXMLText(string(src.Content.Inner))
 					} else if xmlContent := extractParseXMLContent(src.Select); xmlContent != "" {
@@ -615,12 +614,18 @@ func main() {
 				for _, col := range env.Collections {
 					def := collectionDef{URI: col.URI}
 					for _, src := range col.Sources {
-						if src.File == "" {
+						// Containment is checked on the file portion only; any
+						// "#fragment" suffix is preserved in the doc path since
+						// fn:collection consumers rely on it.
+						relPath, ok := catalogRelPath(sourceDir, tsDir, src.File)
+						if !ok {
 							continue
 						}
-						relPath := filepath.Join(tsDir, src.File)
+						assetFiles[relPath] = struct{}{}
+						if _, frag, hasFrag := strings.Cut(src.File, "#"); hasFrag {
+							relPath += "#" + frag
+						}
 						def.DocPaths = append(def.DocPaths, relPath)
-						assetFiles[normalizeAssetPath(relPath)] = struct{}{}
 					}
 					gt.Collections = append(gt.Collections, def)
 				}
@@ -628,10 +633,10 @@ func main() {
 				// Use the first schema with role="source-reference" or no role
 				// (not "stylesheet-import" which is for xsl:import-schema).
 				for _, sch := range env.Schemas {
-					if sch.File == "" {
+					relPath, ok := catalogRelPath(sourceDir, tsDir, sch.File)
+					if !ok {
 						continue
 					}
-					relPath := filepath.Join(tsDir, sch.File)
 					assetFiles[relPath] = struct{}{}
 					if sch.Role == "stylesheet-import" {
 						gt.ImportSchemaPaths = append(gt.ImportSchemaPaths, relPath)
@@ -646,7 +651,7 @@ func main() {
 			}
 
 			// Parse assertions
-			gt.Assertions = parseResultAssertions(tc, tsDirAbs)
+			gt.Assertions = parseResultAssertions(tc, sourceDir, tsDir)
 			classifyError(&gt)
 			classifyUnsupportedAssertions(&gt)
 			isSchemaAware := hasFeatureDep(ts.Dependencies, "schema_aware") ||
@@ -668,27 +673,16 @@ func main() {
 				}
 			}
 
-			// Track stylesheet assets
+			// Track stylesheet assets. gt.StylesheetPath and the secondary
+			// stylesheets are already contained (validated at assignment via
+			// catalogRelPath), so transitive scanning stays within sourceDir.
 			if gt.StylesheetPath != "" {
 				assetFiles[gt.StylesheetPath] = struct{}{}
-				// Scan transitive xsl:import/xsl:include deps
-				absPath := filepath.Join(sourceDir, gt.StylesheetPath)
-				for _, dep := range collectTransitiveDeps(sourceDir, absPath) {
-					relDep, err := filepath.Rel(sourceDir, dep)
-					if err == nil {
-						assetFiles[relDep] = struct{}{}
-					}
-				}
+				addTransitiveDeps(assetFiles, sourceDir, gt.StylesheetPath)
 			}
 			for _, ss := range gt.SecondaryStylesheets {
 				assetFiles[ss] = struct{}{}
-				absPath := filepath.Join(sourceDir, ss)
-				for _, dep := range collectTransitiveDeps(sourceDir, absPath) {
-					relDep, err := filepath.Rel(sourceDir, dep)
-					if err == nil {
-						assetFiles[relDep] = struct{}{}
-					}
-				}
+				addTransitiveDeps(assetFiles, sourceDir, ss)
 			}
 
 			if isExcludedTestCase(gt.CaseName) {
@@ -799,32 +793,30 @@ func parseTestSet(path string) *xslTestSetFile {
 	return &ts
 }
 
-func addCatalogReferencedFiles(assetFiles map[string]struct{}, tsDir string, ts *xslTestSetFile) {
+func addCatalogReferencedFiles(assetFiles map[string]struct{}, sourceDir, tsDir string, ts *xslTestSetFile) {
 	for _, env := range ts.Environments {
-		addCatalogFileRefs(assetFiles, tsDir, env.Stylesheets, env.Packages)
+		addCatalogFileRefs(assetFiles, sourceDir, tsDir, env.Stylesheets, env.Packages)
 	}
 
 	for _, tc := range ts.TestCases {
 		if tc.Environment != nil {
-			addCatalogFileRefs(assetFiles, tsDir, tc.Environment.Stylesheets, tc.Environment.Packages)
+			addCatalogFileRefs(assetFiles, sourceDir, tsDir, tc.Environment.Stylesheets, tc.Environment.Packages)
 		}
-		addCatalogFileRefs(assetFiles, tsDir, tc.Test.Stylesheets, tc.Test.Packages)
+		addCatalogFileRefs(assetFiles, sourceDir, tsDir, tc.Test.Stylesheets, tc.Test.Packages)
 	}
 }
 
-func addCatalogFileRefs(assetFiles map[string]struct{}, tsDir string, stylesheets []xslStylesheet, packages []xslPackage) {
+func addCatalogFileRefs(assetFiles map[string]struct{}, sourceDir, tsDir string, stylesheets []xslStylesheet, packages []xslPackage) {
 	for _, ss := range stylesheets {
-		if ss.File == "" {
-			continue
+		if rel, ok := catalogRelPath(sourceDir, tsDir, ss.File); ok {
+			assetFiles[rel] = struct{}{}
 		}
-		assetFiles[normalizeAssetPath(filepath.Join(tsDir, ss.File))] = struct{}{}
 	}
 
 	for _, pkg := range packages {
-		if pkg.File == "" {
-			continue
+		if rel, ok := catalogRelPath(sourceDir, tsDir, pkg.File); ok {
+			assetFiles[rel] = struct{}{}
 		}
-		assetFiles[normalizeAssetPath(filepath.Join(tsDir, pkg.File))] = struct{}{}
 	}
 }
 
@@ -1061,6 +1053,20 @@ func collectTransitiveDeps(sourceDir, xslPath string) []string {
 	return result
 }
 
+// addTransitiveDeps scans the contained, sourceDir-relative stylesheet/package
+// at relPath for transitive xsl:import/xsl:include (and schema) dependencies and
+// records each discovered in-tree dependency in assetFiles. relPath MUST already
+// have passed catalogRelPath containment.
+func addTransitiveDeps(assetFiles map[string]struct{}, sourceDir, relPath string) {
+	absPath := filepath.Join(sourceDir, relPath)
+	for _, dep := range collectTransitiveDeps(sourceDir, absPath) {
+		relDep, err := filepath.Rel(sourceDir, dep)
+		if err == nil {
+			assetFiles[relDep] = struct{}{}
+		}
+	}
+}
+
 // resolveDep resolves a discovered dependency reference (relative to dir) and
 // verifies it stays within the containment root. It returns the cleaned
 // absolute path, or ok=false (with a logged warning) when the reference is
@@ -1233,24 +1239,36 @@ const (
 	w3cAssertSkipCall = "w3cAssertSkip()"
 )
 
-func parseResultAssertions(tc xslTestCase, tsDir string) []assertion {
+func parseResultAssertions(tc xslTestCase, sourceDir, tsDir string) []assertion {
 	resultXML := "<result xmlns=\"" + xslTestNS + "\">" + string(tc.Result.Inner) + "</result>"
-	return parseAssertionXML(resultXML, tsDir)
+	return parseAssertionXML(resultXML, sourceDir, tsDir)
 }
 
-func parseAssertionXML(s string, tsDir string) []assertion {
+func parseAssertionXML(s string, sourceDir, tsDir string) []assertion {
 	var result xmlResultWrapper
 	if err := xml.Unmarshal([]byte(s), &result); err != nil {
 		return nil
 	}
 	var out []assertion
 	for _, child := range result.Children {
-		out = append(out, convertAssertion(child, tsDir))
+		out = append(out, convertAssertion(child, sourceDir, tsDir))
 	}
 	return out
 }
 
-func convertAssertion(xa xmlAssertion, tsDir string) assertion {
+// readContainedAssertionFile reads an assert-xml / assert-serialization "file"
+// reference at gen time after verifying it stays inside sourceDir. An escaping
+// or absolute reference yields an error string rather than reading outside the
+// test tree.
+func readContainedAssertionFile(sourceDir, tsDir, file string) ([]byte, error) {
+	rel, ok := catalogRelPath(sourceDir, tsDir, file)
+	if !ok {
+		return nil, fmt.Errorf("unsafe assertion file path %q", file)
+	}
+	return os.ReadFile(filepath.Join(sourceDir, rel))
+}
+
+func convertAssertion(xa xmlAssertion, sourceDir, tsDir string) assertion {
 	a := assertion{
 		Type: xa.XMLName.Local,
 	}
@@ -1259,8 +1277,7 @@ func convertAssertion(xa xmlAssertion, tsDir string) assertion {
 	case "assert-xml":
 		if xa.File != "" {
 			// Read the .out file content at gen time and embed it
-			outPath := filepath.Join(tsDir, xa.File)
-			data, err := os.ReadFile(outPath)
+			data, err := readContainedAssertionFile(sourceDir, tsDir, xa.File)
 			if err != nil {
 				a.Value = fmt.Sprintf("ERROR: cannot read %s: %v", xa.File, err)
 			} else {
@@ -1275,22 +1292,21 @@ func convertAssertion(xa xmlAssertion, tsDir string) assertion {
 		a.Value = decodeXMLText(string(xa.Inner))
 	case "all-of", "any-of":
 		for _, child := range xa.Children {
-			a.Children = append(a.Children, convertAssertion(child, tsDir))
+			a.Children = append(a.Children, convertAssertion(child, sourceDir, tsDir))
 		}
 	case "assert-message":
 		for _, child := range xa.Children {
-			a.Children = append(a.Children, convertAssertion(child, tsDir))
+			a.Children = append(a.Children, convertAssertion(child, sourceDir, tsDir))
 		}
 	case "assert-result-document":
 		a.URI = xa.URI
 		for _, child := range xa.Children {
-			a.Children = append(a.Children, convertAssertion(child, tsDir))
+			a.Children = append(a.Children, convertAssertion(child, sourceDir, tsDir))
 		}
 	case "assert-serialization":
 		a.Method = xa.Method
 		if xa.File != "" {
-			outPath := filepath.Join(tsDir, xa.File)
-			data, err := os.ReadFile(outPath)
+			data, err := readContainedAssertionFile(sourceDir, tsDir, xa.File)
 			if err != nil {
 				a.Value = fmt.Sprintf("ERROR: cannot read %s: %v", xa.File, err)
 			} else if !utf8.Valid(data) {
@@ -1313,7 +1329,7 @@ func convertAssertion(xa xmlAssertion, tsDir string) assertion {
 		a.Value = decodeXMLText(string(xa.Inner))
 	case "not":
 		for _, child := range xa.Children {
-			a.Children = append(a.Children, convertAssertion(child, tsDir))
+			a.Children = append(a.Children, convertAssertion(child, sourceDir, tsDir))
 		}
 	case "assert-posture-and-sweep":
 		a.Value = "skip: streaming not supported"
@@ -2143,6 +2159,38 @@ func addAssetTree(assetFiles map[string]struct{}, rootDir, relDir string) error 
 func normalizeAssetPath(path string) string {
 	base, _, _ := strings.Cut(path, "#")
 	return base
+}
+
+// catalogRelPath turns a catalog-derived file reference (a test-set-relative
+// "file" / "href" attribute under tsDir) into a sourceDir-relative path,
+// rejecting any reference that is absolute or escapes sourceDir via ".."
+// segments. It returns the cleaned, slash-normalized relative path and ok=true
+// on success; on rejection it logs a warning and returns ok=false.
+//
+// This is the single choke point every catalog-derived on-disk path must pass
+// through BEFORE it is scanned, stored on a generatedTest, or opened — so an
+// escaping reference can never reach os.Open/os.ReadFile or be written into a
+// generated test.
+func catalogRelPath(sourceDir, tsDir, file string) (string, bool) {
+	if file == "" {
+		return "", false
+	}
+	if filepath.IsAbs(file) || filepath.IsAbs(normalizeAssetPath(file)) {
+		log.Printf("xslt3gen: skipping absolute catalog path %q (under %q)", file, tsDir)
+		return "", false
+	}
+	rel := normalizeAssetPath(filepath.Join(tsDir, file))
+	full, err := containedPath(sourceDir, rel)
+	if err != nil {
+		log.Printf("xslt3gen: skipping unsafe catalog path %q (under %q): %v", file, tsDir, err)
+		return "", false
+	}
+	cleaned, err := filepath.Rel(sourceDir, full)
+	if err != nil {
+		log.Printf("xslt3gen: skipping unsafe catalog path %q (under %q): %v", file, tsDir, err)
+		return "", false
+	}
+	return cleaned, true
 }
 
 // containedPath joins root and relPath, rejecting any relPath that is absolute

--- a/tools/xslt3gen/main.go
+++ b/tools/xslt3gen/main.go
@@ -330,7 +330,7 @@ func main() {
 					relPath := filepath.Join(tsDir, ss.File)
 					assetFiles[relPath] = struct{}{}
 					absPath := filepath.Join(sourceDir, relPath)
-					for _, dep := range collectTransitiveDeps(absPath) {
+					for _, dep := range collectTransitiveDeps(sourceDir, absPath) {
 						relDep, err := filepath.Rel(sourceDir, dep)
 						if err == nil {
 							assetFiles[relDep] = struct{}{}
@@ -344,7 +344,7 @@ func main() {
 					relPath := filepath.Join(tsDir, pkg.File)
 					assetFiles[relPath] = struct{}{}
 					absPath := filepath.Join(sourceDir, relPath)
-					for _, dep := range collectTransitiveDeps(absPath) {
+					for _, dep := range collectTransitiveDeps(sourceDir, absPath) {
 						relDep, err := filepath.Rel(sourceDir, dep)
 						if err == nil {
 							assetFiles[relDep] = struct{}{}
@@ -436,7 +436,7 @@ func main() {
 				}
 				assetFiles[relPath] = struct{}{}
 				absPath := filepath.Join(sourceDir, relPath)
-				for _, dep := range collectTransitiveDeps(absPath) {
+				for _, dep := range collectTransitiveDeps(sourceDir, absPath) {
 					relDep, err := filepath.Rel(sourceDir, dep)
 					if err == nil {
 						assetFiles[relDep] = struct{}{}
@@ -500,7 +500,7 @@ func main() {
 							})
 							assetFiles[relPath] = struct{}{}
 							absPath := filepath.Join(sourceDir, relPath)
-							for _, dep := range collectTransitiveDeps(absPath) {
+							for _, dep := range collectTransitiveDeps(sourceDir, absPath) {
 								relDep, err := filepath.Rel(sourceDir, dep)
 								if err == nil {
 									assetFiles[relDep] = struct{}{}
@@ -673,7 +673,7 @@ func main() {
 				assetFiles[gt.StylesheetPath] = struct{}{}
 				// Scan transitive xsl:import/xsl:include deps
 				absPath := filepath.Join(sourceDir, gt.StylesheetPath)
-				for _, dep := range collectTransitiveDeps(absPath) {
+				for _, dep := range collectTransitiveDeps(sourceDir, absPath) {
 					relDep, err := filepath.Rel(sourceDir, dep)
 					if err == nil {
 						assetFiles[relDep] = struct{}{}
@@ -683,7 +683,7 @@ func main() {
 			for _, ss := range gt.SecondaryStylesheets {
 				assetFiles[ss] = struct{}{}
 				absPath := filepath.Join(sourceDir, ss)
-				for _, dep := range collectTransitiveDeps(absPath) {
+				for _, dep := range collectTransitiveDeps(sourceDir, absPath) {
 					relDep, err := filepath.Rel(sourceDir, dep)
 					if err == nil {
 						assetFiles[relDep] = struct{}{}
@@ -1054,14 +1054,37 @@ func resolveQNameWithAttrs(name string, attrs []xml.Attr) string {
 // Stylesheet dependency scanning
 // ──────────────────────────────────────────────────────────────────────
 
-func collectTransitiveDeps(xslPath string) []string {
+func collectTransitiveDeps(sourceDir, xslPath string) []string {
 	visited := make(map[string]struct{})
 	var result []string
-	collectDepsRecursive(xslPath, visited, &result)
+	collectDepsRecursive(sourceDir, xslPath, visited, &result)
 	return result
 }
 
-func collectDepsRecursive(xslPath string, visited map[string]struct{}, result *[]string) {
+// resolveDep resolves a discovered dependency reference (relative to dir) and
+// verifies it stays within the containment root. It returns the cleaned
+// absolute path, or ok=false (with a logged warning) when the reference is
+// absolute or escapes the root.
+func resolveDep(root, dir, ref string) (string, bool) {
+	if filepath.IsAbs(ref) {
+		log.Printf("xslt3gen: skipping absolute dependency %q", ref)
+		return "", false
+	}
+	depAbs := filepath.Join(dir, ref)
+	rel, err := filepath.Rel(root, depAbs)
+	if err != nil {
+		log.Printf("xslt3gen: skipping dependency %q: %v", ref, err)
+		return "", false
+	}
+	contained, err := containedPath(root, rel)
+	if err != nil {
+		log.Printf("xslt3gen: skipping dependency %q: %v", ref, err)
+		return "", false
+	}
+	return contained, true
+}
+
+func collectDepsRecursive(sourceDir, xslPath string, visited map[string]struct{}, result *[]string) {
 	absPath, err := filepath.Abs(xslPath)
 	if err != nil {
 		return
@@ -1097,9 +1120,12 @@ func collectDepsRecursive(xslPath string, visited map[string]struct{}, result *[
 		if isXSLT && (se.Name.Local == "import" || se.Name.Local == "include") {
 			for _, attr := range se.Attr {
 				if attr.Name.Local == "href" {
-					depPath := filepath.Join(dir, attr.Value)
+					depPath, ok := resolveDep(sourceDir, dir, attr.Value)
+					if !ok {
+						continue
+					}
 					*result = append(*result, depPath)
-					collectDepsRecursive(depPath, visited, result)
+					collectDepsRecursive(sourceDir, depPath, visited, result)
 				}
 			}
 			continue
@@ -1108,9 +1134,12 @@ func collectDepsRecursive(xslPath string, visited map[string]struct{}, result *[
 		if isXSLT && se.Name.Local == "import-schema" {
 			for _, attr := range se.Attr {
 				if attr.Name.Local == "schema-location" && attr.Value != "" {
-					depPath := filepath.Join(dir, attr.Value)
+					depPath, ok := resolveDep(sourceDir, dir, attr.Value)
+					if !ok {
+						continue
+					}
 					*result = append(*result, depPath)
-					collectSchemaDeps(depPath, visited, result)
+					collectSchemaDeps(sourceDir, depPath, visited, result)
 				}
 			}
 			continue
@@ -1119,9 +1148,12 @@ func collectDepsRecursive(xslPath string, visited map[string]struct{}, result *[
 		if isXSD && (se.Name.Local == "include" || se.Name.Local == "import") {
 			for _, attr := range se.Attr {
 				if attr.Name.Local == "schemaLocation" && attr.Value != "" {
-					depPath := filepath.Join(dir, attr.Value)
+					depPath, ok := resolveDep(sourceDir, dir, attr.Value)
+					if !ok {
+						continue
+					}
 					*result = append(*result, depPath)
-					collectSchemaDeps(depPath, visited, result)
+					collectSchemaDeps(sourceDir, depPath, visited, result)
 				}
 			}
 			continue
@@ -1130,7 +1162,10 @@ func collectDepsRecursive(xslPath string, visited map[string]struct{}, result *[
 		if isXSLT && se.Name.Local == "source-document" {
 			for _, attr := range se.Attr {
 				if attr.Name.Local == "href" && attr.Value != "" && !strings.Contains(attr.Value, "{") {
-					depPath := filepath.Join(dir, normalizeAssetPath(attr.Value))
+					depPath, ok := resolveDep(sourceDir, dir, normalizeAssetPath(attr.Value))
+					if !ok {
+						continue
+					}
 					*result = append(*result, depPath)
 				}
 			}
@@ -1144,7 +1179,7 @@ func collectDepsRecursive(xslPath string, visited map[string]struct{}, result *[
 
 // collectSchemaDeps scans an XSD file for xs:include/xs:import with
 // schemaLocation attributes and collects them as transitive dependencies.
-func collectSchemaDeps(xsdPath string, visited map[string]struct{}, result *[]string) {
+func collectSchemaDeps(sourceDir, xsdPath string, visited map[string]struct{}, result *[]string) {
 	absPath, err := filepath.Abs(xsdPath)
 	if err != nil {
 		return
@@ -1178,9 +1213,12 @@ func collectSchemaDeps(xsdPath string, visited map[string]struct{}, result *[]st
 		}
 		for _, attr := range se.Attr {
 			if attr.Name.Local == "schemaLocation" && attr.Value != "" {
-				depPath := filepath.Join(dir, attr.Value)
+				depPath, ok := resolveDep(sourceDir, dir, attr.Value)
+				if !ok {
+					continue
+				}
 				*result = append(*result, depPath)
-				collectSchemaDeps(depPath, visited, result)
+				collectSchemaDeps(sourceDir, depPath, visited, result)
 			}
 		}
 	}

--- a/tools/xslt3gen/main.go
+++ b/tools/xslt3gen/main.go
@@ -529,7 +529,7 @@ func main() {
 						if gt.InitialTemplateParams == nil {
 							gt.InitialTemplateParams = make(map[string]string)
 						}
-						gt.InitialTemplateParams[p.Name] = p.Select
+						gt.InitialTemplateParams[resolvedName] = p.Select
 					}
 				}
 			}
@@ -570,12 +570,13 @@ func main() {
 			if len(tc.Test.Params) > 0 {
 				gt.Params = make(map[string]string)
 				for _, p := range tc.Test.Params {
-					gt.Params[p.Name] = p.Select
+					name := resolveQNameWithAttrs(p.Name, p.Attrs)
+					gt.Params[name] = p.Select
 					if p.As != "" {
 						if gt.ParamTypes == nil {
 							gt.ParamTypes = make(map[string]string)
 						}
-						gt.ParamTypes[p.Name] = p.As
+						gt.ParamTypes[name] = p.As
 					}
 				}
 			}
@@ -702,8 +703,19 @@ func main() {
 	copied := 0
 	for relPath := range assetFiles {
 		normalizedRelPath := normalizeAssetPath(relPath)
-		srcFull := filepath.Join(sourceDir, resolvedAssetSourcePath(normalizedRelPath))
-		dstFull := filepath.Join(assetsDir, normalizedRelPath)
+		// Reject paths that escape the destination asset tree (absolute or
+		// ".."-escaping). A catalog referencing "../../xslt3/pwn.go" or an
+		// absolute path must not let the generator write outside assetsDir.
+		dstFull, err := containedPath(assetsDir, normalizedRelPath)
+		if err != nil {
+			log.Printf("warning: skipping unsafe asset path %q: %v", relPath, err)
+			continue
+		}
+		srcFull, err := containedPath(sourceDir, resolvedAssetSourcePath(normalizedRelPath))
+		if err != nil {
+			log.Printf("warning: skipping unsafe asset path %q: %v", relPath, err)
+			continue
+		}
 		if err := copyFile(srcFull, dstFull); err != nil {
 			log.Printf("warning: copying %s: %v", relPath, err)
 			continue
@@ -2093,6 +2105,26 @@ func addAssetTree(assetFiles map[string]struct{}, rootDir, relDir string) error 
 func normalizeAssetPath(path string) string {
 	base, _, _ := strings.Cut(path, "#")
 	return base
+}
+
+// containedPath joins root and relPath, rejecting any relPath that is absolute
+// or escapes root via ".." segments. It returns the cleaned absolute path on
+// success. This prevents a malicious or malformed catalog asset reference (e.g.
+// "../../xslt3/pwn.go" or "/etc/passwd") from causing the generator to read or
+// write outside the intended testdata tree.
+func containedPath(root, relPath string) (string, error) {
+	if filepath.IsAbs(relPath) {
+		return "", fmt.Errorf("absolute path not allowed: %q", relPath)
+	}
+	cleaned := filepath.Clean(filepath.Join(root, relPath))
+	rel, err := filepath.Rel(root, cleaned)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes root %q: %q", root, relPath)
+	}
+	return cleaned, nil
 }
 
 func boolAttrTrue(v string) bool {

--- a/tools/xslt3gen/main_test.go
+++ b/tools/xslt3gen/main_test.go
@@ -100,6 +100,107 @@ func TestResolveDepRejectsEscape(t *testing.T) {
 	})
 }
 
+func TestCatalogRelPath(t *testing.T) {
+	sourceDir := filepath.Join("/tmp", "source")
+
+	t.Run("in-tree file resolves to slash-normalized rel path", func(t *testing.T) {
+		got, ok := catalogRelPath(sourceDir, "tests/insn", "foo.xsl")
+		require.True(t, ok)
+		require.Equal(t, filepath.Join("tests", "insn", "foo.xsl"), got)
+	})
+
+	t.Run("empty file rejected", func(t *testing.T) {
+		_, ok := catalogRelPath(sourceDir, "tests/insn", "")
+		require.False(t, ok)
+	})
+
+	t.Run("dot-dot escape rejected", func(t *testing.T) {
+		_, ok := catalogRelPath(sourceDir, "tests/insn", "../../../xslt3/pwn.go")
+		require.False(t, ok)
+	})
+
+	t.Run("absolute file rejected", func(t *testing.T) {
+		_, ok := catalogRelPath(sourceDir, "tests/insn", "/etc/passwd")
+		require.False(t, ok)
+	})
+
+	t.Run("escaping tsDir rejected", func(t *testing.T) {
+		_, ok := catalogRelPath(sourceDir, "../../etc", "passwd")
+		require.False(t, ok)
+	})
+
+	t.Run("fragment stripped before containment", func(t *testing.T) {
+		got, ok := catalogRelPath(sourceDir, "tests/insn", "foo.xml#frag")
+		require.True(t, ok)
+		require.Equal(t, filepath.Join("tests", "insn", "foo.xml"), got)
+	})
+
+	t.Run("interior dot-dot staying inside is allowed", func(t *testing.T) {
+		got, ok := catalogRelPath(sourceDir, "tests/insn", "../shared/common.xsl")
+		require.True(t, ok)
+		require.Equal(t, filepath.Join("tests", "shared", "common.xsl"), got)
+	})
+}
+
+// TestAddTransitiveDepsContainment verifies that the dependency-collection entry
+// point used while populating the asset set never records a dependency that
+// escapes sourceDir, even when the entry stylesheet imports an outside file.
+func TestAddTransitiveDepsContainment(t *testing.T) {
+	sourceDir := t.TempDir()
+	outside := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(sourceDir, "tests", "insn"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(sourceDir, "tests", "shared"), 0o755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "tests", "shared", "common.xsl"),
+		[]byte(`<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"/>`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "evil.xsl"),
+		[]byte(`<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"/>`), 0o644))
+
+	entrySrc := `<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:include href="../shared/common.xsl"/>
+  <xsl:import href="../../` + filepath.Base(outside) + `/evil.xsl"/>
+</xsl:stylesheet>`
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "tests", "insn", "main.xsl"),
+		[]byte(entrySrc), 0o644))
+
+	assetFiles := make(map[string]struct{})
+	// main.xsl is the contained entry path (as produced by catalogRelPath).
+	addTransitiveDeps(assetFiles, sourceDir, filepath.Join("tests", "insn", "main.xsl"))
+
+	require.Contains(t, assetFiles, filepath.Join("tests", "shared", "common.xsl"))
+	for rel := range assetFiles {
+		require.False(t, filepath.IsAbs(rel) || rel == ".." ||
+			(len(rel) >= 3 && rel[:3] == ".."+string(filepath.Separator)),
+			"asset %q escapes sourceDir", rel)
+	}
+}
+
+// TestReadContainedAssertionFile verifies the assert-xml/assert-serialization
+// "file" read site rejects escaping references before reading.
+func TestReadContainedAssertionFile(t *testing.T) {
+	sourceDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(sourceDir, "tests", "insn"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "tests", "insn", "expected.out"),
+		[]byte("hello"), 0o644))
+
+	t.Run("in-tree file read", func(t *testing.T) {
+		data, err := readContainedAssertionFile(sourceDir, "tests/insn", "expected.out")
+		require.NoError(t, err)
+		require.Equal(t, "hello", string(data))
+	})
+
+	t.Run("escaping file rejected without read", func(t *testing.T) {
+		_, err := readContainedAssertionFile(sourceDir, "tests/insn", "../../../etc/passwd")
+		require.Error(t, err)
+	})
+
+	t.Run("absolute file rejected", func(t *testing.T) {
+		_, err := readContainedAssertionFile(sourceDir, "tests/insn", "/etc/passwd")
+		require.Error(t, err)
+	})
+}
+
 func TestResolveQNameWithAttrs(t *testing.T) {
 	t.Run("prefixed name resolves to Clark notation", func(t *testing.T) {
 		attrs := []xml.Attr{

--- a/tools/xslt3gen/main_test.go
+++ b/tools/xslt3gen/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/xml"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainedPath(t *testing.T) {
+	root := filepath.Join("/tmp", "assets")
+
+	t.Run("normal relative path", func(t *testing.T) {
+		got, err := containedPath(root, "tests/insn/foo.xsl")
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(root, "tests", "insn", "foo.xsl"), got)
+	})
+
+	t.Run("absolute path rejected", func(t *testing.T) {
+		_, err := containedPath(root, "/etc/passwd")
+		require.Error(t, err)
+	})
+
+	t.Run("dot-dot escape rejected", func(t *testing.T) {
+		_, err := containedPath(root, "../../xslt3/pwn.go")
+		require.Error(t, err)
+	})
+
+	t.Run("interior dot-dot that stays inside is allowed", func(t *testing.T) {
+		got, err := containedPath(root, "tests/insn/../foo.xsl")
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(root, "tests", "foo.xsl"), got)
+	})
+
+	t.Run("interior dot-dot that escapes is rejected", func(t *testing.T) {
+		_, err := containedPath(root, "tests/../../foo.xsl")
+		require.Error(t, err)
+	})
+}
+
+func TestResolveQNameWithAttrs(t *testing.T) {
+	t.Run("prefixed name resolves to Clark notation", func(t *testing.T) {
+		attrs := []xml.Attr{
+			{Name: xml.Name{Space: "xmlns", Local: "p"}, Value: "urn:p"},
+		}
+		got := resolveQNameWithAttrs("p:x", attrs)
+		require.Equal(t, "{urn:p}x", got)
+	})
+
+	t.Run("unprefixed name kept as-is", func(t *testing.T) {
+		got := resolveQNameWithAttrs("x", nil)
+		require.Equal(t, "x", got)
+	})
+
+	t.Run("unbound prefix kept as-is", func(t *testing.T) {
+		got := resolveQNameWithAttrs("p:x", nil)
+		require.Equal(t, "p:x", got)
+	})
+}

--- a/tools/xslt3gen/main_test.go
+++ b/tools/xslt3gen/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/xml"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -36,6 +37,66 @@ func TestContainedPath(t *testing.T) {
 	t.Run("interior dot-dot that escapes is rejected", func(t *testing.T) {
 		_, err := containedPath(root, "tests/../../foo.xsl")
 		require.Error(t, err)
+	})
+}
+
+func TestCollectTransitiveDepsContainment(t *testing.T) {
+	// root/ is the containment boundary. tests/ holds the entry stylesheet,
+	// shared/ holds an in-tree dependency, and an out-of-tree file sits
+	// outside root entirely.
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "tests"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "shared"), 0o755))
+
+	insideDep := filepath.Join(root, "shared", "common.xsl")
+	require.NoError(t, os.WriteFile(insideDep,
+		[]byte(`<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"/>`), 0o644))
+
+	outsideDep := filepath.Join(outside, "evil.xsl")
+	require.NoError(t, os.WriteFile(outsideDep,
+		[]byte(`<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"/>`), 0o644))
+
+	entry := filepath.Join(root, "tests", "main.xsl")
+	entrySrc := `<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:include href="../shared/common.xsl"/>
+  <xsl:import href="../../` + filepath.Base(outside) + `/evil.xsl"/>
+  <xsl:import href="` + outsideDep + `"/>
+</xsl:stylesheet>`
+	require.NoError(t, os.WriteFile(entry, []byte(entrySrc), 0o644))
+
+	deps := collectTransitiveDeps(root, entry)
+
+	require.Contains(t, deps, insideDep, "in-tree dependency must be discovered")
+	for _, d := range deps {
+		require.NotEqual(t, outsideDep, d, "absolute escaping dependency must be rejected")
+		rel, err := filepath.Rel(root, d)
+		require.NoError(t, err)
+		require.False(t, rel == ".." || filepath.IsAbs(rel) ||
+			len(rel) >= 2 && rel[:2] == "..",
+			"dependency %q escapes root", d)
+	}
+}
+
+func TestResolveDepRejectsEscape(t *testing.T) {
+	root := filepath.Join("/tmp", "assets")
+	dir := filepath.Join(root, "tests", "insn")
+
+	t.Run("in-tree relative reference is resolved", func(t *testing.T) {
+		got, ok := resolveDep(root, dir, "../shared/common.xsl")
+		require.True(t, ok)
+		require.Equal(t, filepath.Join(root, "tests", "shared", "common.xsl"), got)
+	})
+
+	t.Run("dot-dot escape rejected", func(t *testing.T) {
+		_, ok := resolveDep(root, dir, "../../../etc/passwd")
+		require.False(t, ok)
+	})
+
+	t.Run("absolute reference rejected", func(t *testing.T) {
+		_, ok := resolveDep(root, dir, "/etc/passwd")
+		require.False(t, ok)
 	})
 }
 


### PR DESCRIPTION
- reject absolute and `..`-escaping catalog asset paths before read/write (containedPath)
- use resolved `{uri}local` qname keys for all param maps (initial-template non-tunnel, global params, ParamTypes), matching tunnel/initial-mode
- regenerated against pinned w3c suite: no generated-output diff (only prefixed param in catalog is `my:b` with tunnel=yes; no current asset path escapes root) — both fixes are latent-bug hardening