### PR TITLE
guard sink against nil handler and self-close

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -309,11 +309,12 @@ Drop-in replacement for encoding/xml backed by helium parser.
 
 Generic channel-based async event sink.
 
-- **New[T](ctx, Handler[T], ...Option) → *Sink[T]**
-- **Sink.Handle(ctx, T)** — async send (blocks if buffer full)
-- **Sink.Close()** — drain and stop
+- **New[T](ctx, Handler[T], ...Option) → *Sink[T]** — nil handler is replaced with a no-op (delivery never panics)
+- **Sink.Handle(ctx, T)** — async send (blocks if buffer full); re-entrant call from within a Handler is best-effort non-blocking
+- **Sink.Close()** — drain and stop; self-close from within a Handler returns immediately (no deadlock)
 - WithBufferSize(n) — default 256; negative values clamped to 0 (unbuffered)
 - Nil-safe: Handle() on nil *Sink is no-op
+- Re-entrancy-safe: a Handler may call Close or Handle on its own Sink without deadlock (worker-goroutine detection)
 - When T=error, satisfies helium.ErrorHandler
 - Files: `sink.go`
 - Imports: none

--- a/sink/doc.go
+++ b/sink/doc.go
@@ -13,7 +13,9 @@
 // making it usable as an async error collector during parsing and validation.
 //
 // The buffer size defaults to 256 and can be configured via [WithBufferSize].
-// Handle on a nil *Sink is a no-op.
+// Handle on a nil *Sink is a no-op, and a Sink built with a nil Handler
+// discards items rather than panicking. A Handler may safely call Close or
+// Handle on its own Sink; neither deadlocks.
 //
 // # Examples
 //

--- a/sink/sink.go
+++ b/sink/sink.go
@@ -2,6 +2,7 @@ package sink
 
 import (
 	"context"
+	"reflect"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -64,7 +65,7 @@ type Sink[T any] struct {
 // A nil handler is replaced with a no-op handler that discards items, so the
 // returned Sink is always safe to deliver to and never panics on delivery.
 func New[T any](ctx context.Context, handler Handler[T], options ...Option) *Sink[T] {
-	if handler == nil {
+	if isNilHandler(handler) {
 		handler = HandlerFunc[T](func(context.Context, T) {})
 	}
 	cfg := config{bufSize: 256}
@@ -82,6 +83,24 @@ func New[T any](ctx context.Context, handler Handler[T], options ...Option) *Sin
 	}
 	go s.start(ctx)
 	return s
+}
+
+// isNilHandler reports whether handler is nil — either a nil interface value or
+// a non-nil interface wrapping a nil-able dynamic value (e.g. a nil
+// HandlerFunc[T], or a nil pointer that implements Handler). Both forms would
+// panic at delivery time, so they are treated as "no handler" and substituted
+// with a no-op.
+func isNilHandler[T any](handler Handler[T]) bool {
+	if handler == nil {
+		return true
+	}
+	rv := reflect.ValueOf(handler)
+	switch rv.Kind() {
+	case reflect.Func, reflect.Pointer, reflect.Map, reflect.Slice, reflect.Chan, reflect.Interface:
+		return rv.IsNil()
+	default:
+		return false
+	}
 }
 
 // Handle sends data to the sink for async processing. If the buffer is full,

--- a/sink/sink.go
+++ b/sink/sink.go
@@ -2,7 +2,9 @@ package sink
 
 import (
 	"context"
+	"runtime"
 	"sync"
+	"sync/atomic"
 )
 
 // Handler processes items delivered to a Sink's background goroutine.
@@ -34,7 +36,9 @@ func WithBufferSize(n int) Option {
 // Sink is a generic, channel-based event sink. Items are sent via Handle()
 // and processed asynchronously by a Handler in a background goroutine.
 //
-// A nil *Sink is safe to use — Handle() is a no-op on a nil receiver.
+// A nil *Sink is safe to use — Handle() is a no-op on a nil receiver. A Sink
+// created with a nil Handler is also safe — items are discarded rather than
+// delivered, so delivery never panics.
 //
 // When T is error, *Sink[error] satisfies the helium.ErrorHandler interface.
 type Sink[T any] struct {
@@ -46,12 +50,23 @@ type Sink[T any] struct {
 	mu      sync.RWMutex
 	closed  bool
 	senders sync.WaitGroup
+	// workerID holds the goroutine id of the background worker. It is set
+	// once when the worker starts and read by Close to detect a re-entrant
+	// Close issued from within a Handler (which would otherwise deadlock on
+	// done). A value of 0 means "not yet set".
+	workerID atomic.Uint64
 }
 
 // New creates a Sink that delivers items to handler in a background
 // goroutine. The goroutine exits when Close() is called or ctx is cancelled.
 // In both cases, buffered items are drained before the goroutine exits.
+//
+// A nil handler is replaced with a no-op handler that discards items, so the
+// returned Sink is always safe to deliver to and never panics on delivery.
 func New[T any](ctx context.Context, handler Handler[T], options ...Option) *Sink[T] {
+	if handler == nil {
+		handler = HandlerFunc[T](func(context.Context, T) {})
+	}
 	cfg := config{bufSize: 256}
 	for _, o := range options {
 		o(&cfg)
@@ -72,6 +87,12 @@ func New[T any](ctx context.Context, handler Handler[T], options ...Option) *Sin
 // Handle sends data to the sink for async processing. If the buffer is full,
 // Handle blocks until space is available, ctx is cancelled, or the sink closes.
 // Safe to call on a nil receiver (no-op).
+//
+// Handle may be called re-entrantly from within a Handler. In that case it does
+// a non-blocking best-effort send (dropping the item if the buffer is full or
+// the sink is closing) rather than blocking: the calling goroutine is the
+// worker itself, so blocking on its own buffer would deadlock and would also
+// stall a concurrent Close that waits on in-flight senders.
 func (s *Sink[T]) Handle(ctx context.Context, data T) {
 	if s == nil {
 		return
@@ -81,11 +102,29 @@ func (s *Sink[T]) Handle(ctx context.Context, data T) {
 		s.mu.RUnlock()
 		return
 	}
+	// Register as an in-flight sender before releasing the lock. This blocks
+	// shutdown from closing ch until the send below completes, which both
+	// prevents a send-on-closed-channel panic and avoids a data race between
+	// the send and close(ch).
 	s.senders.Add(1)
 	ch := s.ch
 	closing := s.closing
 	s.mu.RUnlock()
 	defer s.senders.Done()
+
+	// A re-entrant send from the worker goroutine must never block: the worker
+	// is the only goroutine that drains ch, so blocking on a full buffer would
+	// deadlock it (and stall any concurrent Close waiting on this sender). Fall
+	// back to a non-blocking best-effort send, dropping the item if the buffer
+	// is full or the sink is closing.
+	if id := s.workerID.Load(); id != 0 && id == goroutineID() {
+		select {
+		case <-closing:
+		case ch <- data:
+		default:
+		}
+		return
+	}
 
 	select {
 	case <-closing:
@@ -96,11 +135,23 @@ func (s *Sink[T]) Handle(ctx context.Context, data T) {
 
 // Close stops the sink and waits for all buffered items to be processed.
 // Safe to call on a nil receiver (no-op). Safe to call multiple times.
+//
+// Close is safe to call from within a Handler (a "self-close"). In that case
+// it initiates shutdown and returns immediately instead of waiting on the
+// worker goroutine — waiting would deadlock, because the worker is the very
+// goroutine executing the Handler that called Close. The worker drains any
+// remaining buffered items and exits once the active Handler returns.
 func (s *Sink[T]) Close() error {
 	if s == nil {
 		return nil
 	}
 	s.shutdown()
+	// Detect a re-entrant Close issued from the worker goroutine itself.
+	// Blocking on done in that case is a guaranteed deadlock, so skip the
+	// wait and let the worker unwind naturally.
+	if id := s.workerID.Load(); id != 0 && id == goroutineID() {
+		return nil
+	}
 	<-s.done
 	return nil
 }
@@ -117,6 +168,7 @@ func (s *Sink[T]) shutdown() {
 }
 
 func (s *Sink[T]) start(ctx context.Context) {
+	s.workerID.Store(goroutineID())
 	defer close(s.done)
 	for {
 		select {
@@ -134,4 +186,34 @@ func (s *Sink[T]) start(ctx context.Context) {
 			return
 		}
 	}
+}
+
+// goroutineID returns the id of the calling goroutine. It is used solely to
+// detect a re-entrant Close issued from the worker goroutine, where blocking
+// on done would deadlock. It is best-effort: if the runtime stack header
+// cannot be parsed, it returns 0, which simply disables the optimization and
+// preserves the (correct, blocking) behavior for all other callers.
+func goroutineID() uint64 {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	// The stack header looks like: "goroutine 123 [running]:\n..."
+	const prefix = "goroutine "
+	b := buf[:n]
+	if len(b) < len(prefix) {
+		return 0
+	}
+	b = b[len(prefix):]
+	var id uint64
+	var saw bool
+	for _, c := range b {
+		if c < '0' || c > '9' {
+			break
+		}
+		id = id*10 + uint64(c-'0')
+		saw = true
+	}
+	if !saw {
+		return 0
+	}
+	return id
 }

--- a/sink/sink_test.go
+++ b/sink/sink_test.go
@@ -275,6 +275,66 @@ func TestSinkReentrantHandleDoesNotDeadlock(t *testing.T) {
 	require.NotEmpty(t, handled)
 }
 
+func TestSinkTypedNilHandlerFuncDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// A typed-nil HandlerFunc[T] is a non-nil Handler interface wrapping a nil
+	// function value. It must be detected and replaced with the no-op handler
+	// rather than slipping through to panic in HandlerFunc.Handle.
+	var h sink.HandlerFunc[string]
+	require.Nil(t, h)
+
+	var s *sink.Sink[string]
+	require.NotPanics(t, func() {
+		s = sink.New[string](ctx, h)
+	})
+
+	require.NotPanics(t, func() {
+		s.Handle(ctx, "first")
+		s.Handle(ctx, "second")
+	})
+
+	require.NoError(t, s.Close())
+}
+
+// nilableHandler is a pointer-receiver Handler whose Handle dereferences the
+// receiver, so a typed-nil *nilableHandler would panic if ever invoked.
+type nilableHandler struct{ called bool }
+
+func (n *nilableHandler) Handle(_ context.Context, _ string) {
+	n.called = true
+}
+
+func TestSinkTypedNilInterfaceHandlerDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// A typed-nil pointer that implements Handler is a non-nil interface
+	// wrapping a nil pointer. It must be treated as "no handler" so delivery
+	// drains to the no-op instead of panicking on the nil dereference.
+	var impl *nilableHandler
+	var h sink.Handler[string] = impl
+
+	s := sink.New[string](ctx, h, sink.WithBufferSize(2))
+	require.NotPanics(t, func() {
+		for i := range 6 {
+			s.Handle(ctx, string(rune('a'+i)))
+		}
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- s.Close() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close on a typed-nil-handler sink deadlocked")
+	}
+}
+
 func TestSinkErrorSatisfiesErrorHandler(t *testing.T) {
 	t.Parallel()
 

--- a/sink/sink_test.go
+++ b/sink/sink_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/lestrrat-go/helium/sink"
 	"github.com/stretchr/testify/require"
@@ -166,6 +167,112 @@ func TestSinkCancelledContext(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	require.Contains(t, got, "before-cancel")
+}
+
+func TestSinkNilHandlerDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	var s *sink.Sink[string]
+	require.NotPanics(t, func() {
+		s = sink.New[string](ctx, nil)
+	})
+
+	// Delivering an item must not panic even though no real handler was given.
+	require.NotPanics(t, func() {
+		s.Handle(ctx, "first")
+		s.Handle(ctx, "second")
+	})
+
+	require.NoError(t, s.Close())
+}
+
+func TestSinkNilHandlerDeliveryDrainsWithoutPanic(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	s := sink.New[int](ctx, nil, sink.WithBufferSize(4))
+	for i := range 8 {
+		s.Handle(ctx, i)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Close() }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close on a nil-handler sink deadlocked")
+	}
+}
+
+func TestSinkSelfCloseDoesNotDeadlock(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	var s *sink.Sink[string]
+	closeErr := make(chan error, 1)
+
+	s = sink.New[string](ctx, sink.HandlerFunc[string](func(_ context.Context, _ string) {
+		// A handler that closes its own sink from within Handle must not
+		// deadlock: Close is expected to return promptly.
+		closeErr <- s.Close()
+	}))
+
+	s.Handle(ctx, "trigger")
+
+	select {
+	case err := <-closeErr:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("self-close from within Handler deadlocked")
+	}
+
+	// A subsequent external Close must also return promptly and not deadlock.
+	extClose := make(chan error, 1)
+	go func() { extClose <- s.Close() }()
+	select {
+	case err := <-extClose:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("external Close after self-close deadlocked")
+	}
+}
+
+func TestSinkReentrantHandleDoesNotDeadlock(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	var s *sink.Sink[int]
+	handled := make(chan int, 16)
+
+	s = sink.New[int](ctx, sink.HandlerFunc[int](func(c context.Context, v int) {
+		handled <- v
+		// Re-emit a derived item from within Handle. This must not block the
+		// worker goroutine on its own (possibly full) buffer.
+		if v < 3 {
+			s.Handle(c, v+1)
+		}
+	}), sink.WithBufferSize(1))
+
+	s.Handle(ctx, 0)
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- s.Close() }()
+
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("re-entrant Handle from within Handler deadlocked")
+	}
+
+	require.NotEmpty(t, handled)
 }
 
 func TestSinkErrorSatisfiesErrorHandler(t *testing.T) {


### PR DESCRIPTION
- `sink.New` replaces a nil Handler with a no-op so delivery never panics (no signature change: still returns `*Sink[T]`, no error)
- self-close: a Handler calling `Close` on its own Sink returns immediately instead of deadlocking (worker-goroutine detection)
- re-entrant `Handle` from within a Handler is a non-blocking best-effort send; fixes a related send-on-closed-channel race
