### PR TITLE
fix xsd regex anchor literals and timeout race

### DIFF
--- a/internal/xsdregex/regex.go
+++ b/internal/xsdregex/regex.go
@@ -65,7 +65,14 @@ func (e *regexError) Error() string { return e.Message }
 // through and relies on Go's (different) interpretation. It also does NOT reject
 // Perl-specific constructs or validate back-references — call RejectPerlSpecific
 // and Validate separately for those checks.
-func translateXPathRegex(pattern string, dotAll, ignoreCase bool) (string, error) {
+// xsdPattern selects between the two regex flavors that share this translator:
+//
+//   - true  → XSD xs:pattern facet. The pattern is implicitly anchored to the
+//     whole value and '^'/'$' are ordinary literal characters, not anchors.
+//   - false → XPath/XQuery fn:matches/tokenize/replace. The pattern is NOT
+//     implicitly anchored and '^'/'$' keep their RE2 anchor meaning (start/end,
+//     multiline with the 'm' flag).
+func translateXPathRegex(pattern string, dotAll, ignoreCase, xsdPattern bool) (string, error) {
 	isDotAll := dotAll
 	var b strings.Builder
 	runes := []rune(pattern)
@@ -175,12 +182,14 @@ func translateXPathRegex(pattern string, dotAll, ignoreCase bool) (string, error
 			continue
 		}
 
-		// '^' and '$' are RE2 anchors but ordinary literal characters in the
-		// XSD/XPath regex grammar (the only XSD metacharacters are
+		// In the XSD xs:pattern grammar '^' and '$' are ordinary literal
+		// characters, not anchors (the only XSD metacharacters are
 		// . \ ? * + { } ( ) [ ] |, and the whole pattern is already implicitly
 		// anchored when Compile wraps it in \A(?:...)\z). Escape them so RE2
-		// treats them as literals rather than zero-width anchors.
-		if r == '^' || r == '$' {
+		// treats them as literals. In XPath/XQuery regex (fn:matches/tokenize/
+		// replace) '^' and '$' are anchors (start/end, multiline with 'm'); leave
+		// them untouched so the engine keeps that meaning.
+		if xsdPattern && (r == '^' || r == '$') {
 			b.WriteRune('\\')
 			b.WriteRune(r)
 			i++
@@ -1183,9 +1192,12 @@ func rejectPerlSpecific(pattern string) error {
 	return nil
 }
 
-// Translate converts an XPath/XML Schema regex pattern into a Go RE2 pattern.
+// Translate converts an XPath/XQuery regex pattern (fn:matches/tokenize/replace)
+// into a Go RE2 pattern. In this flavor '^' and '$' are anchors and the pattern
+// is not implicitly anchored; use Compile for XSD xs:pattern facets, where
+// '^'/'$' are literals and the whole value must match.
 func Translate(pattern string, dotAll, ignoreCase bool) (string, error) {
-	return translateXPathRegex(pattern, dotAll, ignoreCase)
+	return translateXPathRegex(pattern, dotAll, ignoreCase, false)
 }
 
 // Regexp is a compiled XML Schema pattern-facet regular expression. It matches
@@ -1231,7 +1243,10 @@ func Compile(pattern string) (*Regexp, error) {
 		return nil, err
 	}
 
-	translated, err := translateXPathRegex(pattern, false, false)
+	// Compile handles XSD xs:pattern facets: '^'/'$' are literal characters and
+	// the pattern is implicitly anchored to the whole value (the \A(?:...)\z
+	// wrap below). Pass xsdPattern=true so the translator escapes '^'/'$'.
+	translated, err := translateXPathRegex(pattern, false, false, true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/xsdregex/regex.go
+++ b/internal/xsdregex/regex.go
@@ -6,19 +6,39 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/dlclark/regexp2"
 )
 
-// DefaultMatchTimeout bounds how long the regexp2 backtracking engine spends on
-// a single pattern-facet match before giving up. Patterns that use constructs
-// RE2 cannot handle (character-class subtraction, large quantifiers) compile to
-// regexp2, which is vulnerable to catastrophic backtracking on adversarial
-// inputs; this is a defense-in-depth ceiling for those matches. RE2-compiled
-// patterns are linear-time and unaffected. Set to 0 to disable; mutating it
-// affects only subsequently-compiled patterns.
-var DefaultMatchTimeout = 5 * time.Second
+// defaultMatchTimeoutNanos holds the current default match timeout, in
+// nanoseconds, as an atomic so concurrent compilation (which reads it) and
+// SetDefaultMatchTimeout (which writes it) cannot race. See DefaultMatchTimeout.
+var defaultMatchTimeoutNanos atomic.Int64
+
+func init() {
+	defaultMatchTimeoutNanos.Store(int64(5 * time.Second))
+}
+
+// DefaultMatchTimeout returns the bound on how long the regexp2 backtracking
+// engine spends on a single pattern-facet match before giving up. Patterns that
+// use constructs RE2 cannot handle (character-class subtraction, large
+// quantifiers) compile to regexp2, which is vulnerable to catastrophic
+// backtracking on adversarial inputs; this is a defense-in-depth ceiling for
+// those matches. RE2-compiled patterns are linear-time and unaffected. A value
+// of 0 disables the timeout.
+func DefaultMatchTimeout() time.Duration {
+	return time.Duration(defaultMatchTimeoutNanos.Load())
+}
+
+// SetDefaultMatchTimeout sets the default match timeout returned by
+// DefaultMatchTimeout. Setting it to 0 disables the timeout. The change affects
+// only subsequently-compiled patterns. It is safe to call concurrently with
+// regex compilation.
+func SetDefaultMatchTimeout(d time.Duration) {
+	defaultMatchTimeoutNanos.Store(int64(d))
+}
 
 // errCodeFORX0002 mirrors the XPath FORX0002 ("invalid regular expression")
 // error code. This package is layering-neutral (no xpath3 dependency); callers
@@ -151,6 +171,18 @@ func translateXPathRegex(pattern string, dotAll, ignoreCase bool) (string, error
 			} else {
 				b.WriteString(`[^\n\r]`)
 			}
+			i++
+			continue
+		}
+
+		// '^' and '$' are RE2 anchors but ordinary literal characters in the
+		// XSD/XPath regex grammar (the only XSD metacharacters are
+		// . \ ? * + { } ( ) [ ] |, and the whole pattern is already implicitly
+		// anchored when Compile wraps it in \A(?:...)\z). Escape them so RE2
+		// treats them as literals rather than zero-width anchors.
+		if r == '^' || r == '$' {
+			b.WriteRune('\\')
+			b.WriteRune(r)
 			i++
 			continue
 		}
@@ -1168,7 +1200,7 @@ type Regexp struct {
 func (r *Regexp) MatchString(s string) bool {
 	if r.backtrack != nil {
 		// regexp2 is a backtracking engine; the only error it returns is a
-		// match-timeout (see DefaultMatchTimeout). A timed-out match cannot be
+		// match-timeout (see DefaultMatchTimeout()). A timed-out match cannot be
 		// proven to satisfy the pattern, so report it as a non-match rather than
 		// letting a catastrophic-backtracking input hang the caller.
 		ok, _ := r.backtrack.MatchString(s)
@@ -1214,7 +1246,7 @@ func Compile(pattern string) (*Regexp, error) {
 		}
 		// Bound backtracking so an adversarial pattern/value cannot hang the
 		// process (catastrophic backtracking). 0 disables the timeout.
-		if t := DefaultMatchTimeout; t > 0 {
+		if t := DefaultMatchTimeout(); t > 0 {
 			re.MatchTimeout = t
 		}
 		return &Regexp{backtrack: re}, nil

--- a/internal/xsdregex/regex_test.go
+++ b/internal/xsdregex/regex_test.go
@@ -1,0 +1,107 @@
+package xsdregex_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/helium/internal/xsdregex"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCaretDollarAreLiterals(t *testing.T) {
+	// In the XSD/XPath regex grammar '^' and '$' are literal characters, not
+	// anchors, and the pattern is implicitly anchored to the whole value. So
+	// "^a$" must match only the literal string "^a$" and nothing else.
+	re, err := xsdregex.Compile("^a$")
+	require.NoError(t, err, "compiling ^a$")
+
+	require.True(t, re.MatchString("^a$"), `pattern "^a$" should match literal "^a$"`)
+	require.False(t, re.MatchString("a"), `pattern "^a$" should not match "a"`)
+	require.False(t, re.MatchString("^a"), `pattern "^a$" should not match "^a"`)
+	require.False(t, re.MatchString("a$"), `pattern "^a$" should not match "a$"`)
+	require.False(t, re.MatchString(""), `pattern "^a$" should not match empty`)
+}
+
+func TestLiteralAnchorChars(t *testing.T) {
+	t.Run("bare caret", func(t *testing.T) {
+		re, err := xsdregex.Compile("^")
+		require.NoError(t, err)
+		require.True(t, re.MatchString("^"))
+		require.False(t, re.MatchString(""))
+	})
+	t.Run("bare dollar", func(t *testing.T) {
+		re, err := xsdregex.Compile("$")
+		require.NoError(t, err)
+		require.True(t, re.MatchString("$"))
+		require.False(t, re.MatchString(""))
+	})
+	t.Run("dollar amount", func(t *testing.T) {
+		re, err := xsdregex.Compile(`\$[0-9]+`)
+		require.NoError(t, err)
+		require.True(t, re.MatchString("$100"))
+		require.False(t, re.MatchString("100"))
+	})
+}
+
+func TestXSDMetacharsStillWork(t *testing.T) {
+	// A pattern using genuine XSD regex metacharacters must keep working after
+	// the ^/$ literal fix.
+	re, err := xsdregex.Compile(`(ab)+|c*\d{2,3}`)
+	require.NoError(t, err, "compiling pattern with XSD metachars")
+
+	require.True(t, re.MatchString("ababab"), "(ab)+ branch")
+	require.True(t, re.MatchString("12"), `\d{2,3} branch (2 digits)`)
+	require.True(t, re.MatchString("ccc123"), `c*\d{2,3} branch`)
+	require.False(t, re.MatchString("1"), "single digit should fail {2,3}")
+	require.False(t, re.MatchString("abx"), "trailing junk should fail (implicit anchoring)")
+}
+
+func TestNegatedCharClassUnaffected(t *testing.T) {
+	// '^' as the first char of a character class is negation, not a literal,
+	// and must keep that meaning.
+	re, err := xsdregex.Compile(`[^a]`)
+	require.NoError(t, err)
+	require.True(t, re.MatchString("b"))
+	require.False(t, re.MatchString("a"))
+}
+
+func TestDefaultMatchTimeoutAccessors(t *testing.T) {
+	orig := xsdregex.DefaultMatchTimeout()
+	t.Cleanup(func() { xsdregex.SetDefaultMatchTimeout(orig) })
+
+	require.Equal(t, 5*time.Second, orig, "default timeout should be 5s")
+
+	xsdregex.SetDefaultMatchTimeout(2 * time.Second)
+	require.Equal(t, 2*time.Second, xsdregex.DefaultMatchTimeout())
+
+	xsdregex.SetDefaultMatchTimeout(0)
+	require.Equal(t, time.Duration(0), xsdregex.DefaultMatchTimeout(), "0 should disable")
+}
+
+func TestDefaultMatchTimeoutNoRace(t *testing.T) {
+	// Concurrent SetDefaultMatchTimeout and Compile must not race (run with
+	// -race). Compile reads the default timeout when routing a pattern to the
+	// regexp2 backtracking engine (character-class subtraction here).
+	orig := xsdregex.DefaultMatchTimeout()
+	t.Cleanup(func() { xsdregex.SetDefaultMatchTimeout(orig) })
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				xsdregex.SetDefaultMatchTimeout(time.Duration(j) * time.Millisecond)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_, err := xsdregex.Compile(`[a-z-[aeiou]]+`)
+				require.NoError(t, err)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/xsdregex/regex_test.go
+++ b/internal/xsdregex/regex_test.go
@@ -60,10 +60,12 @@ func TestLiteralAnchorChars(t *testing.T) {
 		require.False(t, re.MatchString(""))
 	})
 	t.Run("dollar amount", func(t *testing.T) {
-		re, err := xsdregex.Compile(`\$[0-9]+`)
+		// In XSD regex a bare '$' is a literal character, not an end anchor.
+		// This proves '$' is matched literally and is NOT treated as an anchor.
+		re, err := xsdregex.Compile(`$[0-9]+`)
 		require.NoError(t, err)
-		require.True(t, re.MatchString("$100"))
-		require.False(t, re.MatchString("100"))
+		require.True(t, re.MatchString("$123"), "bare $ is a literal, so $123 matches")
+		require.False(t, re.MatchString("123"), "$ is not an anchor, so 123 alone does not match")
 	})
 }
 

--- a/internal/xsdregex/regex_test.go
+++ b/internal/xsdregex/regex_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestCaretDollarAreLiterals(t *testing.T) {
-	// In the XSD/XPath regex grammar '^' and '$' are literal characters, not
-	// anchors, and the pattern is implicitly anchored to the whole value. So
-	// "^a$" must match only the literal string "^a$" and nothing else.
+	// In the XSD xs:pattern grammar (Compile) '^' and '$' are literal
+	// characters, not anchors, and the pattern is implicitly anchored to the
+	// whole value. So "^a$" must match only the literal string "^a$".
 	re, err := xsdregex.Compile("^a$")
 	require.NoError(t, err, "compiling ^a$")
 
@@ -21,6 +21,29 @@ func TestCaretDollarAreLiterals(t *testing.T) {
 	require.False(t, re.MatchString("^a"), `pattern "^a$" should not match "^a"`)
 	require.False(t, re.MatchString("a$"), `pattern "^a$" should not match "a$"`)
 	require.False(t, re.MatchString(""), `pattern "^a$" should not match empty`)
+}
+
+// TestCaretDollarModeDistinction pins the two opposite regex flavors that share
+// this translator. Compile is the XSD xs:pattern facet, where '^'/'$' are
+// literal characters; Translate is the XPath/XQuery flavor (fn:matches/
+// tokenize/replace), where '^'/'$' must stay RE2 anchors.
+func TestCaretDollarModeDistinction(t *testing.T) {
+	t.Run("xsd pattern escapes anchors as literals", func(t *testing.T) {
+		out, err := xsdregex.Translate("^a$", false, false)
+		require.NoError(t, err)
+		// In the XPath flavor '^'/'$' are anchors, so Translate must NOT escape
+		// them; the output is left as-is for RE2 to treat as zero-width anchors.
+		require.Equal(t, "^a$", out, "XPath Translate keeps ^/$ as anchors")
+	})
+
+	t.Run("xsd compile treats anchors as literals", func(t *testing.T) {
+		// Compile (xs:pattern) must treat the same pattern as the literal
+		// three-character string, anchored to the whole value.
+		re, err := xsdregex.Compile("^a$")
+		require.NoError(t, err)
+		require.True(t, re.MatchString("^a$"), "xs:pattern ^a$ matches literal ^a$")
+		require.False(t, re.MatchString("a"), "xs:pattern ^a$ does not match bare a")
+	})
 }
 
 func TestLiteralAnchorChars(t *testing.T) {
@@ -87,17 +110,17 @@ func TestDefaultMatchTimeoutNoRace(t *testing.T) {
 	t.Cleanup(func() { xsdregex.SetDefaultMatchTimeout(orig) })
 
 	var wg sync.WaitGroup
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			for j := 0; j < 100; j++ {
+			for j := range 100 {
 				xsdregex.SetDefaultMatchTimeout(time.Duration(j) * time.Millisecond)
 			}
 		}()
 		go func() {
 			defer wg.Done()
-			for j := 0; j < 100; j++ {
+			for range 100 {
 				_, err := xsdregex.Compile(`[a-z-[aeiou]]+`)
 				require.NoError(t, err)
 			}


### PR DESCRIPTION
- xsdregex: escape `^`/`$` so they translate to literals, not RE2 anchors (XSD regex is implicitly anchored; `Compile("^a$")` now matches only `^a$`)
- xsdregex: replace mutable `DefaultMatchTimeout` var with atomic `DefaultMatchTimeout()`/`SetDefaultMatchTimeout()` accessors to fix the compile-time data race (public API change)
