### PR TITLE
test foreign sax entity in attribute value

### DIFF
--- a/parser_charref_test.go
+++ b/parser_charref_test.go
@@ -55,17 +55,24 @@ func TestGetEntityHandlerNilErrorDoesNotPanic(t *testing.T) {
 }
 
 func TestGetEntityForeignTypeInAttrValueDoesNotPanic(t *testing.T) {
-	// The attribute-value entity-resolution path (parseStringEntityRef ->
-	// entityCheck) also receives the sax.Entity returned by a custom handler.
-	// A foreign (non-*helium.Entity) value must be handled gracefully via the
-	// comma-ok assertion in entityCheck rather than triggering a forced-cast
-	// panic.
+	// Exercise the nested string-decoding path (parseStringEntityRef ->
+	// entityCheck) rather than the direct attribute parseEntityRef path.
+	//
+	// `foo` is declared in the internal subset as "&bar;" and resolves to a
+	// real *helium.Entity (the handler returns nil for it). Decoding "&foo;"
+	// recurses into its content, calling parseStringEntityRef("&bar;"), which
+	// returns a FOREIGN (non-*helium.Entity) sax.Entity for `bar`. That foreign
+	// value then reaches entityCheck, which must handle it gracefully via its
+	// comma-ok assertion rather than triggering a forced-cast panic.
 	h := sax.New()
 	h.SetOnGetEntity(sax.GetEntityFunc(func(_ context.Context, name string) (sax.Entity, error) {
-		return &foreignEntity{name: name, content: []byte("hello")}, nil
+		if name == "bar" {
+			return &foreignEntity{name: name, content: []byte("hello")}, nil
+		}
+		return nil, nil //nolint:nilnil
 	}))
 
-	const input = `<!DOCTYPE root [<!ENTITY foo "ignored">]><root attr="&foo;"/>`
+	const input = `<!DOCTYPE root [<!ENTITY foo "&bar;">]><root attr="&foo;"/>`
 
 	require.NotPanics(t, func() {
 		_, _ = helium.NewParser().SAXHandler(h).Parse(t.Context(), []byte(input))

--- a/parser_charref_test.go
+++ b/parser_charref_test.go
@@ -54,6 +54,24 @@ func TestGetEntityHandlerNilErrorDoesNotPanic(t *testing.T) {
 	})
 }
 
+func TestGetEntityForeignTypeInAttrValueDoesNotPanic(t *testing.T) {
+	// The attribute-value entity-resolution path (parseStringEntityRef ->
+	// entityCheck) also receives the sax.Entity returned by a custom handler.
+	// A foreign (non-*helium.Entity) value must be handled gracefully via the
+	// comma-ok assertion in entityCheck rather than triggering a forced-cast
+	// panic.
+	h := sax.New()
+	h.SetOnGetEntity(sax.GetEntityFunc(func(_ context.Context, name string) (sax.Entity, error) {
+		return &foreignEntity{name: name, content: []byte("hello")}, nil
+	}))
+
+	const input = `<!DOCTYPE root [<!ENTITY foo "ignored">]><root attr="&foo;"/>`
+
+	require.NotPanics(t, func() {
+		_, _ = helium.NewParser().SAXHandler(h).Parse(t.Context(), []byte(input))
+	})
+}
+
 func TestCharRefMissingSemicolonRejected(t *testing.T) {
 	for _, input := range []string{
 		`<root>&#65</root>`,


### PR DESCRIPTION
- E-SAX-ENTITY-TYPEASSERT already fixed on main (#611): GetEntity result uses comma-ok cast + error check, no forced-cast panic
- Add regression covering a foreign sax.Entity referenced inside an attribute value (parseStringEntityRef -> entityCheck path)
