### PR TITLE
return defensive copy from leaf Content()

### DIFF
--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -95,7 +95,9 @@ NamespaceDeclNode(18) XIncludeStartNode(19) XIncludeEndNode(20) NamespaceNode(21
 `Document.GetElementByID(id)` — O(1) via `ids map[string]*Element` (populated during parse). Falls back to O(n) tree walk if map empty.
 
 ### Content() Default
-`docnode.Content()` walks children and concatenates. Overridden by Text, CDATA, Comment, PI, EntityRef (which return their own content directly).
+`docnode.Content()` walks children and concatenates (returns a fresh buffer). Overridden by Text, CDATA, Comment, PI, EntityRef.
+
+The text-bearing leaves (Text, Comment, CDATASection) store content in an internal mutable `content []byte`. Their exported `Content()` returns a **defensive copy** (`bytes.Clone`) so a caller mutating the result cannot corrupt the DOM. Internal read-only hot paths (serializers in `writer.go`/`writer_xhtml.go`) use the package-level `rawContent(Node)` helper — backed by an unexported `rawContent()` method on each of those three leaf types — to get the raw slice without the copy. The `rawContentNode` interface gates the no-copy path; for any other node `rawContent` falls back to `Content()`. PI/EntityRef/Entity/NamespaceNodeWrapper already returned string-derived copies and are unaffected.
 
 ### Predefined Entities
 5 singletons: `EntityLT`, `EntityGT`, `EntityAmpersand`, `EntityApostrophe`, `EntityQuote`. Type `InternalPredefinedEntity`. Cannot be redeclared.

--- a/node.go
+++ b/node.go
@@ -190,6 +190,25 @@ func (n docnode) Content() []byte {
 	return b.Bytes()
 }
 
+// rawContentNode is implemented by leaf nodes (Text, Comment, CDATASection)
+// that store their textual content in an internal mutable byte slice. It
+// exposes that slice directly (without the defensive copy the exported
+// Content() makes) for internal read-only hot paths such as serialization.
+type rawContentNode interface {
+	rawContent() []byte
+}
+
+// rawContent returns the internal content byte slice of n WITHOUT copying when
+// n is a leaf node that aliases its content (Text, Comment, CDATASection).
+// Callers MUST treat the result as read-only; mutating it corrupts the DOM.
+// For any other node it falls back to the (already copy-safe) Content().
+func rawContent(n Node) []byte {
+	if rc, ok := n.(rawContentNode); ok {
+		return rc.rawContent()
+	}
+	return n.Content()
+}
+
 func appendText(n MutableNode, b []byte) error {
 	// Fast path: if last child is already a text node, append directly
 	// without allocating a new Text node.

--- a/node_content_alias_test.go
+++ b/node_content_alias_test.go
@@ -56,3 +56,40 @@ func TestContentDefensiveCopy(t *testing.T) {
 		})
 	}
 }
+
+// TestContentInputCopyOnStore verifies that the leaf constructors copy the
+// caller's input slice on store. Mutating the original input slice AFTER the
+// Create* call must NOT change the node's content (the DOM must not alias the
+// caller's buffer).
+func TestContentInputCopyOnStore(t *testing.T) {
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneExplicitNo)
+
+	const original = "hello world"
+
+	makers := map[string]func(buf []byte) helium.Node{
+		"Text": func(buf []byte) helium.Node {
+			return doc.CreateText(buf)
+		},
+		"Comment": func(buf []byte) helium.Node {
+			return doc.CreateComment(buf)
+		},
+		"CDATASection": func(buf []byte) helium.Node {
+			return doc.CreateCDATASection(buf)
+		},
+	}
+
+	for name, make := range makers {
+		t.Run(name, func(t *testing.T) {
+			buf := []byte(original)
+			n := make(buf)
+			require.Equal(t, original, string(n.Content()), "initial content")
+
+			// Mutate the caller's input slice AFTER constructing the node.
+			for i := range buf {
+				buf[i] = 'X'
+			}
+
+			require.Equal(t, original, string(n.Content()), "content after input-slice mutation")
+		})
+	}
+}

--- a/node_content_alias_test.go
+++ b/node_content_alias_test.go
@@ -1,0 +1,58 @@
+package helium_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestContentDefensiveCopy verifies that the exported Content() on the leaf
+// node types (Text, Comment, CDATASection) returns a defensive copy of the
+// node's internal bytes. Mutating the returned slice must NOT corrupt the DOM,
+// and a subsequent read must still return the original content.
+func TestContentDefensiveCopy(t *testing.T) {
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneExplicitNo)
+
+	const original = "hello world"
+
+	makers := map[string]func() helium.Node{
+		"Text": func() helium.Node {
+			n := doc.CreateText([]byte(original))
+			return n
+		},
+		"Comment": func() helium.Node {
+			n := doc.CreateComment([]byte(original))
+			return n
+		},
+		"CDATASection": func() helium.Node {
+			n := doc.CreateCDATASection([]byte(original))
+			return n
+		},
+	}
+
+	for name, make := range makers {
+		t.Run(name, func(t *testing.T) {
+			n := make()
+			require.Equal(t, original, string(n.Content()), "initial content")
+
+			// Mutating the returned slice must not affect the node.
+			got := n.Content()
+			require.Len(t, got, len(original))
+			for i := range got {
+				got[i] = 'X'
+			}
+
+			// Re-read must return the untouched original.
+			require.Equal(t, original, string(n.Content()), "content after caller mutation")
+
+			// Two separate Content() calls must not alias each other either.
+			a := n.Content()
+			b := n.Content()
+			if len(a) > 0 {
+				a[0] = 'Z'
+				require.NotEqual(t, a[0], b[0], "second Content() call must not alias the first")
+			}
+		})
+	}
+}

--- a/node_leaf.go
+++ b/node_leaf.go
@@ -15,8 +15,7 @@ type CDATASection struct {
 func newCDATASection(b []byte) *CDATASection {
 	c := CDATASection{}
 	c.etype = CDATASectionNode
-	c.content = make([]byte, len(b))
-	copy(c.content, b)
+	c.content = bytes.Clone(b)
 	c.name = "(CDATA)"
 	return &c
 }
@@ -62,7 +61,7 @@ type Comment struct {
 func newComment(b []byte) *Comment {
 	t := Comment{}
 	t.etype = CommentNode
-	t.content = b
+	t.content = bytes.Clone(b)
 	return &t
 }
 

--- a/node_leaf.go
+++ b/node_leaf.go
@@ -1,6 +1,10 @@
 package helium
 
-import "github.com/lestrrat-go/pdebug"
+import (
+	"bytes"
+
+	"github.com/lestrrat-go/pdebug"
+)
 
 // CDATASection represents a CDATA section node in the DOM tree
 // (libxml2: xmlNode with type XML_CDATA_SECTION_NODE).
@@ -30,7 +34,15 @@ func (n *CDATASection) AddSibling(cur Node) error {
 	return addSibling(n, cur)
 }
 
+// Content returns a defensive copy of the CDATA section's content. Mutating the
+// returned slice does NOT affect the node; re-reading returns the original bytes.
 func (n CDATASection) Content() []byte {
+	return bytes.Clone(n.content)
+}
+
+// rawContent returns the internal content slice without copying for read-only
+// internal hot paths. See the package-level rawContent for the contract.
+func (n CDATASection) rawContent() []byte {
 	return n.content
 }
 
@@ -84,7 +96,15 @@ func (n *Comment) AddSibling(cur Node) error {
 	return addSibling(n, cur)
 }
 
+// Content returns a defensive copy of the comment's content. Mutating the
+// returned slice does NOT affect the node; re-reading returns the original bytes.
 func (n Comment) Content() []byte {
+	return bytes.Clone(n.content)
+}
+
+// rawContent returns the internal content slice without copying for read-only
+// internal hot paths. See the package-level rawContent for the contract.
+func (n Comment) rawContent() []byte {
 	return n.content
 }
 
@@ -242,7 +262,15 @@ func (n *Text) AddSibling(cur Node) error {
 	return addSibling(n, cur)
 }
 
+// Content returns a defensive copy of the text node's content. Mutating the
+// returned slice does NOT affect the node; re-reading returns the original bytes.
 func (n Text) Content() []byte {
+	return bytes.Clone(n.content)
+}
+
+// rawContent returns the internal content slice without copying for read-only
+// internal hot paths. See the package-level rawContent for the contract.
+func (n Text) rawContent() []byte {
 	return n.content
 }
 

--- a/writer.go
+++ b/writer.go
@@ -401,7 +401,10 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 		// Validate the byte slice directly: a string() copy here would double the
 		// peak memory for a large (attacker-controlled) comment before the same
 		// bytes are written below.
-		content := n.Content()
+		// rawContent avoids the defensive copy Content() makes: this path is
+		// read-only and a copy here would double the peak memory for a large
+		// (attacker-controlled) comment before the same bytes are written below.
+		content := rawContent(n)
 		if bytes.Contains(content, []byte("--")) || (len(content) > 0 && content[len(content)-1] == '-') {
 			// check() keeps the first sticky error, so an earlier I/O failure is
 			// not clobbered by this validation error.
@@ -409,7 +412,7 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 			return d.err
 		}
 		d.writeString(out, "<!--")
-		d.writeBytes(out, n.Content())
+		d.writeBytes(out, content)
 		d.writeString(out, "-->")
 		return d.err
 	case ProcessingInstructionNode:
@@ -446,7 +449,8 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 		d.writeString(out, ";")
 		return d.err
 	case TextNode:
-		c := n.Content()
+		// Read-only serialization: use the internal slice without a copy.
+		c := rawContent(n)
 		if n.Name() == xmlTextNoEnc {
 			// xmlTextNoEnc is a libxml2 marker (set on the node's name, not
 			// its content) indicating the text should be emitted without
@@ -464,7 +468,8 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 	case CDATASectionNode:
 		// Mirrors xmlsave.c XML_CDATA_SECTION_NODE handling.
 		// Splits content on "]]>" sequences so the output is well-formed.
-		c := n.Content()
+		// Read-only serialization: use the internal slice without a copy.
+		c := rawContent(n)
 		if len(c) == 0 {
 			d.writeString(out, "<![CDATA[]]>")
 		} else {

--- a/writer.go
+++ b/writer.go
@@ -575,7 +575,7 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 			for achld := range Children(attr) {
 				count++
 				if achld.Type() == TextNode {
-					if err := escapeAttrValue(out, achld.Content(), d.escapeNonASCII); err != nil {
+					if err := escapeAttrValue(out, rawContent(achld), d.escapeNonASCII); err != nil {
 						return err
 					}
 				} else {

--- a/writer_xhtml.go
+++ b/writer_xhtml.go
@@ -224,7 +224,8 @@ func (d *writeSession) dumpXHTMLAttrList(out io.Writer, e *Element) error {
 		} else {
 			for achld := range Children(attr) {
 				if achld.Type() == TextNode {
-					d.check(escapeAttrValue(out, achld.Content(), d.escapeNonASCII))
+					// Read-only escape pass: use the internal slice without a copy.
+					d.check(escapeAttrValue(out, rawContent(achld), d.escapeNonASCII))
 				} else {
 					d.check(d.writeNode(out, achld))
 				}


### PR DESCRIPTION
- `Text`/`Comment`/`CDATASection` `Content()` now return a `bytes.Clone` copy so callers can't mutate node state through the result (or vice-versa)
- internal read-only serializer hot paths use new unexported `rawContent(Node)` helper to skip the copy
- regression: mutating the slice from `Content()` leaves node content unchanged
