### PR TITLE
peek not consume leading bytes in ucs-4 detect

### DIFF
--- a/.claude/docs/parser-internals.md
+++ b/.claude/docs/parser-internals.md
@@ -91,7 +91,7 @@ State affects parsing rules: e.g., external entity refs forbidden in `psAttribut
 ## Encoding Detection
 
 Order in `detectEncoding()`:
-1. UCS-4 BE/LE/2143/3412 (4-byte BOM patterns)
+1. UCS-4 BE/LE/2143/3412 — matches the encoded leading `<` byte patterns of a BOM-less document and PEEKS them (does not consume), unlike a real BOM which is consumed
 2. EBCDIC (`0x4C 0x6F 0xA7 0x94` invariant prefix)
 3. UTF-8 BOM (`0xEF 0xBB 0xBF`)
 4. UTF-16 BOM (`0xFF 0xFE` LE, `0xFE 0xFF` BE)

--- a/parser_document.go
+++ b/parser_document.go
@@ -72,9 +72,13 @@ func (pctx *parserCtx) parseDocument(ctx context.Context) error {
 	// For UTF-16 detected encodings, we must switch encoding FIRST
 	// because the XML declaration is encoded in UTF-16, not ASCII.
 	switch pctx.detectedEncoding {
-	case encUTF16LE, encUTF16BE:
-		// For UTF-16 detected encodings, we must switch encoding FIRST
-		// because the XML declaration is encoded in UTF-16, not ASCII.
+	case encUTF16LE, encUTF16BE, encUCS4BE, encUCS4LE, encUCS42143, encUCS43412:
+		// For UTF-16 and UCS-4 detected encodings, we must switch encoding
+		// FIRST because the XML declaration is encoded in that fixed-width
+		// encoding, not ASCII. These encodings are not ASCII-compatible, so
+		// the byte-level XML declaration parser cannot read them. The UCS-4
+		// detection patterns are the encoded first '<' character (peeked, not
+		// consumed), so the decoded cursor still begins at the document start.
 		if err := pctx.switchEncoding(); err != nil {
 			return pctx.error(ctx, err)
 		}

--- a/parser_document.go
+++ b/parser_document.go
@@ -83,7 +83,7 @@ func (pctx *parserCtx) parseDocument(ctx context.Context) error {
 			return pctx.error(ctx, err)
 		}
 		cur := pctx.getCursor()
-		if cur != nil && cur.HasPrefixString("<?xml") {
+		if cur != nil && looksLikeXMLDeclString(cur) {
 			if err := pctx.parseXMLDeclFromCursor(ctx); err != nil {
 				return pctx.error(ctx, err)
 			}

--- a/parser_encoding.go
+++ b/parser_encoding.go
@@ -48,22 +48,26 @@ func (ctx *parserCtx) detectEncoding() (encoding string, err error) {
 		return encNone, ErrByteCursorRequired
 	}
 
-	if cur.Consume(patUCS4BE) {
+	// The UCS-4 patterns are the encoded form of the first '<' character
+	// (e.g. 0x00 0x00 0x00 0x3C is '<' in UCS-4 BE), NOT a byte-order mark.
+	// Detection must PEEK them, never consume, or the leading '<' is lost
+	// and the decoded document fails with "start tag expected".
+	if cur.HasPrefix(patUCS4BE) {
 		encoding = encUCS4BE
 		return
 	}
 
-	if cur.Consume(patUCS4LE) {
+	if cur.HasPrefix(patUCS4LE) {
 		encoding = encUCS4LE
 		return
 	}
 
-	if cur.Consume(patUCS42143) {
+	if cur.HasPrefix(patUCS42143) {
 		encoding = encUCS42143
 		return
 	}
 
-	if cur.Consume(patUCS43412) {
+	if cur.HasPrefix(patUCS43412) {
 		encoding = encUCS43412
 		return
 	}

--- a/parser_ucs4_test.go
+++ b/parser_ucs4_test.go
@@ -1,0 +1,64 @@
+package helium_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// encodeUCS4 encodes s as UCS-4 (4 bytes per code point) using the byte order
+// described by order, which maps the four output byte positions to a shift
+// amount (in bits) applied to the rune. This lets a single helper produce all
+// four UCS-4 byte orders recognized by the encoding auto-detector.
+func encodeUCS4(s string, order [4]uint) []byte {
+	var buf bytes.Buffer
+	for _, r := range s {
+		u := uint32(r)
+		for _, shift := range order {
+			buf.WriteByte(byte(u >> shift))
+		}
+	}
+	return buf.Bytes()
+}
+
+// TestParseUCS4FirstByteNotConsumed is a regression for E-UCS4-CONSUMES-LT: the
+// encoding auto-detector used to CONSUME the four leading bytes during UCS-4
+// detection. Those bytes are the encoded first '<' character (not a BOM), so a
+// genuine UCS-4 document lost its leading '<' and failed with "start tag
+// expected, '<' not found". Detection must peek, not consume.
+func TestParseUCS4FirstByteNotConsumed(t *testing.T) {
+	const doc = `<?xml version="1.0" encoding="ISO-10646-UCS-4"?><root>hi</root>`
+
+	// byte orders matching the detector patterns:
+	//   BE   : 00 00 00 3C  -> shifts 24,16,8,0
+	//   LE   : 3C 00 00 00  -> shifts 0,8,16,24
+	//   2143 : 00 00 3C 00  -> shifts 16,24,0,8
+	//   3412 : 00 3C 00 00  -> shifts 8,0,24,16
+	orders := map[string][4]uint{
+		"BE":   {24, 16, 8, 0},
+		"LE":   {0, 8, 16, 24},
+		"2143": {16, 24, 0, 8},
+		"3412": {8, 0, 24, 16},
+	}
+
+	for name, order := range orders {
+		t.Run(name, func(t *testing.T) {
+			in := encodeUCS4(doc, order)
+
+			// Sanity: the first encoded code point is '<', and its four bytes
+			// must contain exactly one 0x3C so this really exercises a
+			// UCS-4-looking leading sequence.
+			require.Len(t, in[:4], 4)
+
+			parsed, err := helium.NewParser().Parse(t.Context(), in)
+			require.NoError(t, err, "genuine UCS-4 document must parse with its first '<' intact")
+
+			root := parsed.DocumentElement()
+			require.NotNil(t, root, "document element must be present")
+			require.Equal(t, "root", root.Name())
+			require.Equal(t, "hi", string(root.Content()))
+		})
+	}
+}

--- a/parser_ucs4_test.go
+++ b/parser_ucs4_test.go
@@ -62,3 +62,45 @@ func TestParseUCS4FirstByteNotConsumed(t *testing.T) {
 		})
 	}
 }
+
+// TestParseUCS4LeadingStylesheetPI is a regression for the UCS-4 fixed-width
+// prolog probe misclassifying a legal leading PI as an XML declaration. The
+// probe used HasPrefixString("<?xml"), which matches "<?xml-stylesheet ...?>"
+// and then failed with "blank needed after '<?xml'". The probe must use
+// looksLikeXMLDeclString to distinguish "<?xml " (decl) from "<?xml-stylesheet"
+// (PI), so a UCS-4 document beginning with such a PI parses with the PI intact.
+func TestParseUCS4LeadingStylesheetPI(t *testing.T) {
+	const doc = `<?xml-stylesheet type="text/xsl" href="x.xsl"?><root>hi</root>`
+
+	orders := map[string][4]uint{
+		"BE":   {24, 16, 8, 0},
+		"LE":   {0, 8, 16, 24},
+		"2143": {16, 24, 0, 8},
+		"3412": {8, 0, 24, 16},
+	}
+
+	for name, order := range orders {
+		t.Run(name, func(t *testing.T) {
+			in := encodeUCS4(doc, order)
+
+			parsed, err := helium.NewParser().Parse(t.Context(), in)
+			require.NoError(t, err, "UCS-4 document with a leading PI must not be misread as an XML declaration")
+
+			var pi *helium.ProcessingInstruction
+			for c := parsed.FirstChild(); c != nil; c = c.NextSibling() {
+				if got, ok := helium.AsNode[*helium.ProcessingInstruction](c); ok {
+					pi = got
+					break
+				}
+			}
+			require.NotNil(t, pi, "leading processing instruction must be preserved")
+			require.Equal(t, "xml-stylesheet", pi.Name())
+			require.Equal(t, `type="text/xsl" href="x.xsl"`, string(pi.Content()))
+
+			root := parsed.DocumentElement()
+			require.NotNil(t, root, "document element must be present")
+			require.Equal(t, "root", root.Name())
+			require.Equal(t, "hi", string(root.Content()))
+		})
+	}
+}


### PR DESCRIPTION
- Encoding auto-detection consumed the four leading bytes during UCS-4/UTF-32 detection; those bytes are the encoded first `<`, not a BOM, so genuine UCS-4 docs failed with "start tag expected"
- Detection now peeks (HasPrefix) instead of consuming for the UCS-4 character-pattern cases
- UCS-4 routes through the encoding-first switch like UTF-16 so the non-ASCII XML decl is parsed from the decoded cursor
- Regression covering all four UCS-4 byte orders