### PR TITLE
require namespace match for xmlenc elements

### DIFF
--- a/xmlenc1/export_test.go
+++ b/xmlenc1/export_test.go
@@ -28,6 +28,13 @@ func HardenedParserForTest() helium.Parser {
 	return newHardenedInnerParser()
 }
 
+// ParseEncryptedDataForTest is a test-only re-export of the package
+// internal EncryptedData parser so tests can assert namespace-aware
+// element matching directly against a parsed DOM.
+func ParseEncryptedDataForTest(elem *helium.Element) (*EncryptedData, error) {
+	return parseEncryptedData(elem)
+}
+
 // AESKeyWrapForTest wraps key material under a KEK using RFC 3394 AES Key
 // Wrap. It exists so security tests can assemble an EncryptedKey whose
 // wrapped session-key length does not match the declared block algorithm,

--- a/xmlenc1/parse.go
+++ b/xmlenc1/parse.go
@@ -3,6 +3,7 @@ package xmlenc1
 import (
 	"encoding/base64"
 	"fmt"
+	"slices"
 	"strings"
 
 	helium "github.com/lestrrat-go/helium"
@@ -10,6 +11,10 @@ import (
 
 // parseEncryptedData parses an EncryptedData element.
 func parseEncryptedData(elem *helium.Element) (*EncryptedData, error) {
+	if elem == nil || !isXMLEncElem(elem, "EncryptedData") {
+		return nil, fmt.Errorf("%w: expected xenc:EncryptedData", ErrMalformedEncrypted)
+	}
+
 	ed := &EncryptedData{}
 	ed.ID, _ = elem.GetAttribute("Id")
 	ed.Type, _ = elem.GetAttribute("Type")
@@ -66,6 +71,10 @@ func parseKeyInfoForEncryption(elem *helium.Element, ed *EncryptedData) error {
 
 // parseEncryptedKey parses an EncryptedKey element.
 func parseEncryptedKey(elem *helium.Element) (*EncryptedKey, error) {
+	if elem == nil || !isXMLEncElem(elem, "EncryptedKey") {
+		return nil, fmt.Errorf("%w: expected xenc:EncryptedKey", ErrMalformedEncrypted)
+	}
+
 	ek := &EncryptedKey{}
 	ek.ID, _ = elem.GetAttribute("Id")
 	ek.Recipient, _ = elem.GetAttribute("Recipient")
@@ -164,13 +173,7 @@ func isElemNS(e *helium.Element, local string, nsURIs ...string) bool {
 	if localName(e) != local {
 		return false
 	}
-	uri := e.URI()
-	for _, want := range nsURIs {
-		if uri == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(nsURIs, e.URI())
 }
 
 // isXMLEncElem reports whether e is an XML Encryption element

--- a/xmlenc1/parse.go
+++ b/xmlenc1/parse.go
@@ -19,18 +19,18 @@ func parseEncryptedData(elem *helium.Element) (*EncryptedData, error) {
 		if !ok {
 			continue
 		}
-		switch localName(e) {
-		case "EncryptionMethod":
+		switch {
+		case isXMLEncElem(e, "EncryptionMethod"):
 			em, err := parseEncryptionMethod(e)
 			if err != nil {
 				return nil, err
 			}
 			ed.EncryptionMethod = em
-		case "KeyInfo":
+		case isDSigElem(e, "KeyInfo"):
 			if err := parseKeyInfoForEncryption(e, ed); err != nil {
 				return nil, err
 			}
-		case "CipherData":
+		case isXMLEncElem(e, "CipherData"):
 			cv, err := parseCipherData(e)
 			if err != nil {
 				return nil, err
@@ -52,7 +52,7 @@ func parseKeyInfoForEncryption(elem *helium.Element, ed *EncryptedData) error {
 		if !ok {
 			continue
 		}
-		if localName(e) == "EncryptedKey" {
+		if isXMLEncElem(e, "EncryptedKey") {
 			ek, err := parseEncryptedKey(e)
 			if err != nil {
 				return err
@@ -75,20 +75,20 @@ func parseEncryptedKey(elem *helium.Element) (*EncryptedKey, error) {
 		if !ok {
 			continue
 		}
-		switch localName(e) {
-		case "EncryptionMethod":
+		switch {
+		case isXMLEncElem(e, "EncryptionMethod"):
 			em, err := parseEncryptionMethod(e)
 			if err != nil {
 				return nil, err
 			}
 			ek.EncryptionMethod = em
-		case "CipherData":
+		case isXMLEncElem(e, "CipherData"):
 			cv, err := parseCipherData(e)
 			if err != nil {
 				return nil, err
 			}
 			ek.CipherValue = cv
-		case "CarriedKeyName":
+		case isXMLEncElem(e, "CarriedKeyName"):
 			ek.CarriedKeyName = textContent(e)
 		}
 	}
@@ -109,12 +109,12 @@ func parseEncryptionMethod(elem *helium.Element) (*EncryptionMethod, error) {
 		if !ok {
 			continue
 		}
-		switch localName(e) {
-		case "DigestMethod":
+		switch {
+		case isDSigElem(e, "DigestMethod"):
 			em.DigestMethod, _ = e.GetAttribute("Algorithm")
-		case "MGF":
+		case isMGFElem(e):
 			em.MGFAlgorithm, _ = e.GetAttribute("Algorithm")
-		case "OAEPparams":
+		case isXMLEncElem(e, "OAEPparams"):
 			decoded, err := decodeBase64(textContent(e))
 			if err != nil {
 				return nil, fmt.Errorf("%w: invalid OAEPparams: %v", ErrMalformedEncrypted, err)
@@ -132,7 +132,7 @@ func parseCipherData(elem *helium.Element) ([]byte, error) {
 		if !ok {
 			continue
 		}
-		if localName(e) == "CipherValue" {
+		if isXMLEncElem(e, "CipherValue") {
 			decoded, err := decodeBase64(textContent(e))
 			if err != nil {
 				return nil, fmt.Errorf("%w: invalid CipherValue: %v", ErrMalformedEncrypted, err)
@@ -152,6 +152,45 @@ func localName(e *helium.Element) string {
 		}
 	}
 	return name
+}
+
+// isElemNS reports whether e has the given local name and one of the
+// supplied namespace URIs. XML Encryption/Signature elements are
+// namespace-qualified, so matching by local name alone would wrongly
+// treat a foreign-namespaced element (e.g. someone else's
+// "CipherValue") as an XMLEnc element. Every element match in this
+// package must therefore require the correct namespace URI.
+func isElemNS(e *helium.Element, local string, nsURIs ...string) bool {
+	if localName(e) != local {
+		return false
+	}
+	uri := e.URI()
+	for _, want := range nsURIs {
+		if uri == want {
+			return true
+		}
+	}
+	return false
+}
+
+// isXMLEncElem reports whether e is an XML Encryption element
+// (namespace http://www.w3.org/2001/04/xmlenc#) with the given local name.
+func isXMLEncElem(e *helium.Element, local string) bool {
+	return isElemNS(e, local, NamespaceXMLEnc)
+}
+
+// isDSigElem reports whether e is an XML Digital Signature element
+// (namespace http://www.w3.org/2000/09/xmldsig#) with the given local name.
+// KeyInfo and DigestMethod are defined in the dsig namespace.
+func isDSigElem(e *helium.Element, local string) bool {
+	return isElemNS(e, local, NamespaceDSig)
+}
+
+// isMGFElem reports whether e is an MGF element. The element is defined
+// in the XML Encryption 1.1 namespace, but accept the base xmlenc
+// namespace too for robustness against producers that misqualify it.
+func isMGFElem(e *helium.Element) bool {
+	return isElemNS(e, "MGF", NamespaceXMLEnc11, NamespaceXMLEnc)
 }
 
 // decodeBase64 decodes base64 text after stripping all XML whitespace

--- a/xmlenc1/xmlenc1_test.go
+++ b/xmlenc1/xmlenc1_test.go
@@ -719,6 +719,20 @@ func TestParseElementMatchingRequiresNamespace(t *testing.T) {
 		require.Equal(t, []byte("hello"), ed.CipherValue)
 	})
 
+	t.Run("foreign root with valid xenc children is rejected", func(t *testing.T) {
+		// The entry element itself is foreign-namespaced even though all
+		// of its children are correctly xenc-qualified. The parser must
+		// reject the entry element rather than trusting the children.
+		xml := `<foo:EncryptedData xmlns:foo="` + foreignNS + `" xmlns:xenc="` + xencNS + `">` +
+			`<xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>` +
+			`<xenc:CipherData><xenc:CipherValue>aGVsbG8=</xenc:CipherValue></xenc:CipherData>` +
+			`</foo:EncryptedData>`
+		doc := mustParseXML(t, xml)
+
+		_, err := xmlenc1.ParseEncryptedDataForTest(doc.DocumentElement())
+		require.Error(t, err, "foreign-namespaced EncryptedData root must not be accepted")
+	})
+
 	t.Run("foreign CipherValue inside correct CipherData is not matched", func(t *testing.T) {
 		// The CipherData is correctly namespaced but its CipherValue
 		// child is foreign. The foreign CipherValue must be ignored,

--- a/xmlenc1/xmlenc1_test.go
+++ b/xmlenc1/xmlenc1_test.go
@@ -677,3 +677,58 @@ func TestEncryptElementRootInPlace(t *testing.T) {
 	require.NoError(t, err)
 	require.NotContains(t, xml, "hidden")
 }
+
+// TestParseElementMatchingRequiresNamespace verifies that XMLEnc child
+// elements are matched by both local name AND namespace URI. A foreign
+// namespace that happens to reuse the same local names (EncryptedData,
+// CipherData, CipherValue, EncryptionMethod, KeyInfo) must NOT be
+// treated as the XMLEnc element.
+func TestParseElementMatchingRequiresNamespace(t *testing.T) {
+	const xencNS = "http://www.w3.org/2001/04/xmlenc#"
+	const dsigNS = "http://www.w3.org/2000/09/xmldsig#"
+	const foreignNS = "urn:example:not-xmlenc"
+
+	t.Run("foreign namespace is not matched", func(t *testing.T) {
+		// Every child reuses the XMLEnc local names but lives in a
+		// foreign namespace. None should be picked up, so CipherData
+		// resolution fails (missing CipherData/CipherValue).
+		xml := `<EncryptedData xmlns="` + foreignNS + `">` +
+			`<EncryptionMethod Algorithm="x"/>` +
+			`<KeyInfo/>` +
+			`<CipherData><CipherValue>aGVsbG8=</CipherValue></CipherData>` +
+			`</EncryptedData>`
+		doc := mustParseXML(t, xml)
+
+		_, err := xmlenc1.ParseEncryptedDataForTest(doc.DocumentElement())
+		require.Error(t, err, "foreign-namespaced CipherData must not be matched")
+	})
+
+	t.Run("correct namespace is matched", func(t *testing.T) {
+		// Same structure but correctly namespace-qualified: xenc for
+		// the XMLEnc elements, ds for KeyInfo. CipherValue must resolve.
+		xml := `<xenc:EncryptedData xmlns:xenc="` + xencNS + `" xmlns:ds="` + dsigNS + `">` +
+			`<xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>` +
+			`<ds:KeyInfo/>` +
+			`<xenc:CipherData><xenc:CipherValue>aGVsbG8=</xenc:CipherValue></xenc:CipherData>` +
+			`</xenc:EncryptedData>`
+		doc := mustParseXML(t, xml)
+
+		ed, err := xmlenc1.ParseEncryptedDataForTest(doc.DocumentElement())
+		require.NoError(t, err)
+		require.NotNil(t, ed.EncryptionMethod)
+		require.Equal(t, []byte("hello"), ed.CipherValue)
+	})
+
+	t.Run("foreign CipherValue inside correct CipherData is not matched", func(t *testing.T) {
+		// The CipherData is correctly namespaced but its CipherValue
+		// child is foreign. The foreign CipherValue must be ignored,
+		// leaving CipherData without a usable value.
+		xml := `<xenc:EncryptedData xmlns:xenc="` + xencNS + `" xmlns:foo="` + foreignNS + `">` +
+			`<xenc:CipherData><foo:CipherValue>aGVsbG8=</foo:CipherValue></xenc:CipherData>` +
+			`</xenc:EncryptedData>`
+		doc := mustParseXML(t, xml)
+
+		_, err := xmlenc1.ParseEncryptedDataForTest(doc.DocumentElement())
+		require.Error(t, err, "foreign-namespaced CipherValue must not be matched")
+	})
+}


### PR DESCRIPTION
- Match XMLEnc/dsig child elements by local name AND namespace URI, not local name alone
- Foreign-namespaced elements reusing names like CipherValue/EncryptedData are no longer treated as XMLEnc elements
- No cipher/algorithm default changes; element-matching only
