### PR TITLE
Require dsig namespace for KeyInfo element match

### DIFF
--- a/xmldsig1/inclusive_namespaces_internal_test.go
+++ b/xmldsig1/inclusive_namespaces_internal_test.go
@@ -1,0 +1,74 @@
+package xmldsig1
+
+import (
+	"context"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// buildExcC14NReference constructs a ds:Reference whose single Transform is
+// Exclusive C14N carrying an InclusiveNamespaces child placed in namespace
+// incNS (declared under prefix incPx) with the given PrefixList. The Reference
+// (and its core children) live in the core XML-Signature namespace so that only
+// the InclusiveNamespaces namespace varies between cases.
+func buildExcC14NReference(t *testing.T, doc *helium.Document, incPx, incNS, prefixList string) *helium.Element {
+	t.Helper()
+
+	ref := doc.CreateElement("Reference")
+	require.NoError(t, ref.DeclareNamespace(nsPrefix, NamespaceDSig))
+	require.NoError(t, ref.SetActiveNamespace(nsPrefix, NamespaceDSig))
+
+	transforms := doc.CreateElement("Transforms")
+	require.NoError(t, transforms.SetActiveNamespace(nsPrefix, NamespaceDSig))
+	require.NoError(t, ref.AddChild(transforms))
+
+	transform := doc.CreateElement("Transform")
+	require.NoError(t, transform.SetActiveNamespace(nsPrefix, NamespaceDSig))
+	require.NoError(t, transform.SetLiteralAttribute("Algorithm", ExcC14N10))
+	require.NoError(t, transforms.AddChild(transform))
+
+	inc := doc.CreateElement("InclusiveNamespaces")
+	require.NoError(t, inc.DeclareNamespace(incPx, incNS))
+	require.NoError(t, inc.SetActiveNamespace(incPx, incNS))
+	require.NoError(t, inc.SetLiteralAttribute("PrefixList", prefixList))
+	require.NoError(t, transform.AddChild(inc))
+
+	return ref
+}
+
+// TestInclusiveNamespacesForeignNamespaceIgnored guards against namespace
+// confusion in the Exclusive C14N InclusiveNamespaces element. That element
+// lives only in the exc-c14n namespace; matching on local name alone would let
+// a foreign-namespace <evil:InclusiveNamespaces> inject a PrefixList and alter
+// which namespaces are canonicalized. A foreign-namespace look-alike must
+// therefore contribute no prefixes.
+func TestInclusiveNamespacesForeignNamespaceIgnored(t *testing.T) {
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(`<root/>`))
+	require.NoError(t, err)
+
+	ref := buildExcC14NReference(t, doc, "evil", "urn:example:evil", "a b c")
+
+	parsed, err := parseReferenceElement(ref)
+	require.NoError(t, err)
+	require.Len(t, parsed.transforms, 1)
+	require.Empty(t, parsed.transforms[0].prefixes,
+		"a foreign-namespace InclusiveNamespaces must contribute no prefixes")
+}
+
+// TestInclusiveNamespacesExcC14NParsed is the positive control: an
+// InclusiveNamespaces in the exc-c14n namespace must still contribute its
+// PrefixList.
+func TestInclusiveNamespacesExcC14NParsed(t *testing.T) {
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(`<root/>`))
+	require.NoError(t, err)
+
+	ref := buildExcC14NReference(t, doc, "ec", ExcC14N10, "a b c")
+
+	parsed, err := parseReferenceElement(ref)
+	require.NoError(t, err)
+	require.Len(t, parsed.transforms, 1)
+	require.Equal(t, []string{"a", "b", "c"}, parsed.transforms[0].prefixes,
+		"a correctly exc-c14n-namespaced InclusiveNamespaces must contribute its prefixes")
+}

--- a/xmldsig1/keyinfo.go
+++ b/xmldsig1/keyinfo.go
@@ -193,6 +193,15 @@ func parseKeyInfo(keyInfoElem *helium.Element) (*KeyInfoData, error) {
 		if !ok {
 			continue
 		}
+		// Core KeyInfo children (X509Data, KeyValue) live only in the core
+		// XML-Signature namespace. Matching on local name alone would let a
+		// foreign-namespace look-alike (e.g. <evil:X509Data>) supply an
+		// attacker-chosen verification key, so require the core namespace. The
+		// 1.1 xmldsig11# namespace is for new 1.1 elements and must not satisfy
+		// this check.
+		if !isDSigCoreNS(elem) {
+			continue
+		}
 		switch localName(elem) {
 		case "X509Data":
 			if err := parseX509Data(elem, data); err != nil {
@@ -211,6 +220,11 @@ func parseX509Data(elem *helium.Element, data *KeyInfoData) error {
 	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
 		certElem, ok := helium.AsNode[*helium.Element](child)
 		if !ok {
+			continue
+		}
+		// X509Certificate is a core XML-Signature element; a foreign-namespace
+		// look-alike must not supply a verification certificate.
+		if !isDSigCoreNS(certElem) {
 			continue
 		}
 		if localName(certElem) != "X509Certificate" {
@@ -237,8 +251,19 @@ func parseKeyValue(elem *helium.Element, data *KeyInfoData) error {
 		}
 		switch localName(kvElem) {
 		case "RSAKeyValue":
+			// RSAKeyValue is a core XML-Signature element; reject
+			// foreign-namespace look-alikes.
+			if !isDSigCoreNS(kvElem) {
+				continue
+			}
 			return parseRSAKeyValue(kvElem, data)
 		case "ECKeyValue":
+			// ECKeyValue is an XML-Signature 1.1 element, so it lives in the
+			// xmldsig11# namespace rather than the core namespace. Require that
+			// exact namespace and reject foreign-namespace look-alikes.
+			if !isDSig11NS(kvElem) {
+				continue
+			}
 			return parseECKeyValue(kvElem, data)
 		}
 	}
@@ -250,6 +275,11 @@ func parseRSAKeyValue(elem *helium.Element, data *KeyInfoData) error {
 	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
 		e, ok := helium.AsNode[*helium.Element](child)
 		if !ok {
+			continue
+		}
+		// Modulus and Exponent are core XML-Signature elements; reject
+		// foreign-namespace look-alikes before consuming their base64 content.
+		if !isDSigCoreNS(e) {
 			continue
 		}
 		decoded, err := decodeBase64(textContent(e))
@@ -277,6 +307,11 @@ func parseECKeyValue(elem *helium.Element, data *KeyInfoData) error {
 	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
 		e, ok := helium.AsNode[*helium.Element](child)
 		if !ok {
+			continue
+		}
+		// NamedCurve and PublicKey are XML-Signature 1.1 elements; require the
+		// xmldsig11# namespace and reject foreign-namespace look-alikes.
+		if !isDSig11NS(e) {
 			continue
 		}
 		switch localName(e) {

--- a/xmldsig1/keyinfo_namespace_internal_test.go
+++ b/xmldsig1/keyinfo_namespace_internal_test.go
@@ -1,0 +1,123 @@
+package xmldsig1
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"math/big"
+	"testing"
+	"time"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// newKeyInfoCertElem builds a <KeyInfo><X509Data><X509Certificate>... subtree
+// whose elements are placed in the namespace ns (declared under prefix px). The
+// returned element is the KeyInfo root, ready to hand to parseKeyInfo.
+func newKeyInfoCertElem(t *testing.T, doc *helium.Document, px, ns string, certDER []byte) *helium.Element {
+	t.Helper()
+
+	keyInfo := doc.CreateElement("KeyInfo")
+	require.NoError(t, keyInfo.DeclareNamespace(px, ns))
+	require.NoError(t, keyInfo.SetActiveNamespace(px, ns))
+
+	x509Data := doc.CreateElement("X509Data")
+	require.NoError(t, x509Data.SetActiveNamespace(px, ns))
+	require.NoError(t, keyInfo.AddChild(x509Data))
+
+	certElem := doc.CreateElement("X509Certificate")
+	require.NoError(t, certElem.SetActiveNamespace(px, ns))
+	require.NoError(t, certElem.AddChild(
+		doc.CreateText([]byte(base64.StdEncoding.EncodeToString(certDER)))))
+	require.NoError(t, x509Data.AddChild(certElem))
+
+	return keyInfo
+}
+
+// selfSignedCertDER returns a throwaway self-signed certificate's DER bytes.
+func selfSignedCertDER(t *testing.T) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	return der
+}
+
+// TestKeyInfoForeignNamespaceX509Ignored guards against namespace confusion in
+// KeyInfo parsing. The parser fed key material (certificates, key values) into
+// key resolution; matching those elements on local name alone would let a
+// foreign-namespace <evil:X509Data>/<evil:X509Certificate> masquerade as the
+// core ds:X509Data and supply an attacker-chosen verification certificate. A
+// foreign-namespace KeyInfo subtree must therefore yield no parsed key material.
+func TestKeyInfoForeignNamespaceX509Ignored(t *testing.T) {
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(`<root/>`))
+	require.NoError(t, err)
+	certDER := selfSignedCertDER(t)
+
+	const evilNS = "urn:example:evil"
+	keyInfo := newKeyInfoCertElem(t, doc, "evil", evilNS, certDER)
+	require.Equal(t, evilNS, elementNamespaceURI(keyInfo))
+
+	data, err := parseKeyInfo(keyInfo)
+	require.NoError(t, err)
+	require.Empty(t, data.X509Certificates,
+		"a foreign-namespace X509Data look-alike must not supply a certificate")
+}
+
+// TestKeyInfoCoreNamespaceX509Parsed is the positive control: a correctly
+// ds-namespaced KeyInfo/X509Data/X509Certificate subtree must still parse.
+func TestKeyInfoCoreNamespaceX509Parsed(t *testing.T) {
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(`<root/>`))
+	require.NoError(t, err)
+	certDER := selfSignedCertDER(t)
+
+	keyInfo := newKeyInfoCertElem(t, doc, nsPrefix, NamespaceDSig, certDER)
+	require.Equal(t, NamespaceDSig, elementNamespaceURI(keyInfo))
+
+	data, err := parseKeyInfo(keyInfo)
+	require.NoError(t, err)
+	require.Len(t, data.X509Certificates, 1,
+		"a correctly ds-namespaced X509Certificate must still parse")
+}
+
+// TestKeyInfoForeignNamespaceRSAKeyValueIgnored ensures the same guard covers
+// the RSAKeyValue path: a foreign-namespace KeyValue/RSAKeyValue look-alike
+// must not supply key material.
+func TestKeyInfoForeignNamespaceRSAKeyValueIgnored(t *testing.T) {
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(`<root/>`))
+	require.NoError(t, err)
+
+	const evilNS = "urn:example:evil"
+	keyInfo := doc.CreateElement("KeyInfo")
+	require.NoError(t, keyInfo.DeclareNamespace("evil", evilNS))
+	require.NoError(t, keyInfo.SetActiveNamespace("evil", evilNS))
+
+	keyValue := doc.CreateElement("KeyValue")
+	require.NoError(t, keyValue.SetActiveNamespace("evil", evilNS))
+	require.NoError(t, keyInfo.AddChild(keyValue))
+
+	rsaKV := doc.CreateElement("RSAKeyValue")
+	require.NoError(t, rsaKV.SetActiveNamespace("evil", evilNS))
+	require.NoError(t, keyValue.AddChild(rsaKV))
+
+	mod := doc.CreateElement("Modulus")
+	require.NoError(t, mod.SetActiveNamespace("evil", evilNS))
+	require.NoError(t, mod.AddChild(doc.CreateText([]byte(base64.StdEncoding.EncodeToString([]byte{1, 2, 3})))))
+	require.NoError(t, rsaKV.AddChild(mod))
+
+	data, err := parseKeyInfo(keyInfo)
+	require.NoError(t, err)
+	require.Nil(t, data.RSAKeyValue,
+		"a foreign-namespace RSAKeyValue look-alike must not supply key material")
+}

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -360,6 +360,16 @@ func parseReferenceElement(elem *helium.Element) (parsedReference, error) {
 					if !ok {
 						continue
 					}
+					// InclusiveNamespaces is an Exclusive XML Canonicalization
+					// element and lives ONLY in the exc-c14n namespace
+					// (http://www.w3.org/2001/10/xml-exc-c14n#), not the core
+					// XML-Signature namespace. Matching on local name alone would
+					// let a foreign-namespace look-alike inject a PrefixList and
+					// alter which namespaces are canonicalized, so require the
+					// exact exc-c14n namespace.
+					if !isExcC14NNS(incElem) {
+						continue
+					}
 					if localName(incElem) == "InclusiveNamespaces" {
 						pl, _ := incElem.GetAttribute("PrefixList")
 						if pl != "" {

--- a/xmldsig1/xmldsig1.go
+++ b/xmldsig1/xmldsig1.go
@@ -194,6 +194,24 @@ func isDSigCoreNS(e *helium.Element) bool {
 	return elementNamespaceURI(e) == NamespaceDSig
 }
 
+// isDSig11NS reports whether e is in the XML-Signature 1.1 namespace
+// (http://www.w3.org/2009/xmldsig11#). The 1.1-specific elements (ECKeyValue,
+// NamedCurve, PublicKey, DEREncodedKeyValue, ...) live ONLY in this namespace;
+// they are not part of the core xmldsig# namespace. As with the core check,
+// matching such elements on local name alone would let a foreign-namespace
+// look-alike supply attacker-chosen key material, so the exact namespace is
+// required.
+func isDSig11NS(e *helium.Element) bool {
+	return elementNamespaceURI(e) == NamespaceDSig11
+}
+
+// isExcC14NNS reports whether e is in the Exclusive XML Canonicalization
+// namespace (http://www.w3.org/2001/10/xml-exc-c14n#). The InclusiveNamespaces
+// element lives only here, not in the core XML-Signature namespace.
+func isExcC14NNS(e *helium.Element) bool {
+	return elementNamespaceURI(e) == ExcC14N10
+}
+
 func elementNamespaceURI(e *helium.Element) string {
 	name := e.Name()
 	for i := range len(name) {


### PR DESCRIPTION
Finding D-SIG-002: the xmldsig1 parser matched several KeyInfo/transform child
elements by local name only, ignoring namespace, so a foreign-namespace
look-alike could masquerade as a core dsig element. Core SignedInfo/Reference/
Transform matching was already namespace-checked; this extends the same guard to
the remaining matches:

- KeyInfo children X509Data, KeyValue, X509Certificate, RSAKeyValue, Modulus,
  Exponent now require the core xmldsig# namespace.
- ECKeyValue/NamedCurve/PublicKey now require the xmldsig11# namespace.
- Transform's InclusiveNamespaces now requires the exc-c14n namespace.

Only element-matching namespace checks change; digest/signature algorithm
acceptance defaults are untouched. Regressions assert a same-local-name element
in a foreign namespace is ignored while a correctly-namespaced one still parses.
