### PR TITLE
fix windows isatty success-vs-error logic

### DIFF
--- a/internal/cliutil/tty_windows.go
+++ b/internal/cliutil/tty_windows.go
@@ -29,8 +29,8 @@ func setStdHandle(stdhandle int32, handle syscall.Handle) error {
 // IsTty checks if the given fd is a tty
 func IsTty(fd uintptr) bool {
 	var st uint32
-	r1, _, err := procGetConsoleMode.Call(fd, uintptr(unsafe.Pointer(&st)))
-	return r1 != 0 && err != nil
+	r1, _, _ := procGetConsoleMode.Call(fd, uintptr(unsafe.Pointer(&st)))
+	return r1 != 0
 }
 
 var stdin = os.Stdin


### PR DESCRIPTION
IsTty in internal/cliutil/tty_windows.go returned r1 != 0 && err != nil, ANDing a successful GetConsoleMode call (r1 != 0) with err != nil. Since GetConsoleMode signals success via r1 != 0 (with err being ERROR_SUCCESS), the old condition could never reliably detect a real console. Corrected to return r1 != 0.