### PR TITLE
guard CreateAttribute nil doc and empty char ref

### DIFF
--- a/document.go
+++ b/document.go
@@ -760,7 +760,16 @@ func (d *Document) stringToNodeList(value string) (ret Node, err error) {
 			}
 
 			val := entbuf.String()
-			ent, ok := d.GetEntity(val)
+
+			// Predefined entities (amp, lt, gt, apos, quot) are not
+			// document-dependent, so resolve them up front. This ensures
+			// they inline correctly even when the document (and thus its
+			// internal/external subset) is nil.
+			ent, err2 := resolvePredefinedEntity(val)
+			ok := err2 == nil
+			if !ok {
+				ent, ok = d.GetEntity(val)
+			}
 
 			// Predefined entities are inlined; all others (resolved or not)
 			// become entity reference nodes. This matches libxml2's

--- a/document.go
+++ b/document.go
@@ -587,6 +587,9 @@ func (d *Document) GetEntity(name string) (ent *Entity, found bool) {
 			}
 		}()
 	}
+	if d == nil {
+		return nil, false
+	}
 	if ints := d.intSubset; ints != nil {
 		if pdebug.Enabled {
 			pdebug.Printf("Looking into internal subset...")
@@ -859,18 +862,24 @@ func (d *Document) CreateCharRef(name string) (*EntityRef, error) {
 		return nil, errors.New("empty name")
 	}
 
-	n := newEntityRef()
-	n.doc = d
+	var decoded string
 	if name[0] != '&' {
-		n.name = name
+		decoded = name
 	} else {
 		// the name should be everything but '&' and ';'
 		if name[len(name)-1] == ';' {
-			n.name = name[1 : len(name)-1]
+			decoded = name[1 : len(name)-1]
 		} else {
-			n.name = name[1:]
+			decoded = name[1:]
 		}
 	}
+	if decoded == "" {
+		return nil, fmt.Errorf("char ref %q has an empty name", name)
+	}
+
+	n := newEntityRef()
+	n.doc = d
+	n.name = decoded
 	return n, nil
 }
 

--- a/document_test.go
+++ b/document_test.go
@@ -153,6 +153,9 @@ func TestCreateAttributeNilDocWithEntityValue(t *testing.T) {
 	require.NoError(t, err, "CreateAttribute on a nil document must not panic")
 	require.NotNil(t, attr)
 	require.Equal(t, "name", attr.Name())
+	// Predefined entities are not document-dependent, so they must resolve
+	// to their literal characters even when the document is nil.
+	require.Equal(t, "a&b", attr.Value(), "predefined entity must resolve on a nil document")
 }
 
 func TestCreateCharRefRejectsEmptyName(t *testing.T) {

--- a/document_test.go
+++ b/document_test.go
@@ -143,3 +143,29 @@ func TestCreatePIOwnerDocument(t *testing.T) {
 	pi := doc.CreatePI("p", "data")
 	require.Same(t, doc, pi.OwnerDocument(), "PI owner document should be the creating document")
 }
+
+func TestCreateAttributeNilDocWithEntityValue(t *testing.T) {
+	t.Parallel()
+	var doc *helium.Document
+	// A value containing an entity reference forces the entity-resolution
+	// path, which historically dereferenced the nil document and panicked.
+	attr, err := doc.CreateAttribute("name", "a&amp;b", nil)
+	require.NoError(t, err, "CreateAttribute on a nil document must not panic")
+	require.NotNil(t, attr)
+	require.Equal(t, "name", attr.Name())
+}
+
+func TestCreateCharRefRejectsEmptyName(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "", helium.StandaloneImplicitNo)
+	// "&" decodes to an empty name; this must be rejected rather than
+	// producing a degenerate entity-ref node with an empty name.
+	ref, err := doc.CreateCharRef("&")
+	require.Error(t, err, "CreateCharRef with empty decoded name must return an error")
+	require.Nil(t, ref)
+
+	// "&;" likewise decodes to an empty name.
+	ref, err = doc.CreateCharRef("&;")
+	require.Error(t, err)
+	require.Nil(t, ref)
+}


### PR DESCRIPTION
- `Document.GetEntity` now returns not-found for a nil receiver, so `CreateAttribute` no longer panics when called on a nil document with an entity-bearing value.
- `CreateCharRef` rejects input that decodes to an empty name (e.g. `&`, `&;`) instead of creating a degenerate empty-name entity-ref node.