### PR TITLE
compare attr namespace by URI not pointer

### DIFF
--- a/attr_test.go
+++ b/attr_test.go
@@ -303,6 +303,45 @@ func TestGetAttributeNodeNS(t *testing.T) {
 	require.Nil(t, attr)
 }
 
+func TestSetAttributeNSDuplicate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("same namespace URI via different Namespace pointers is a duplicate", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		e := doc.CreateElement("root")
+
+		// Two distinct *Namespace values that share the same URI. Per XML
+		// rules an element may not carry two attributes with the same
+		// (namespace URI, local name), regardless of which namespace
+		// declaration (pointer) they reference.
+		ns1 := helium.NewNamespace("a", "http://example.com/ns")
+		ns2 := helium.NewNamespace("b", "http://example.com/ns")
+
+		_, err := e.SetAttributeNS("attr", "first", ns1)
+		require.NoError(t, err)
+
+		_, err = e.SetAttributeNS("attr", "second", ns2)
+		require.ErrorIs(t, err, helium.ErrDuplicateAttribute)
+	})
+
+	t.Run("genuinely different namespaces are not duplicates", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		e := doc.CreateElement("root")
+
+		ns1 := helium.NewNamespace("a", "http://example.com/ns1")
+		ns2 := helium.NewNamespace("b", "http://example.com/ns2")
+
+		_, err := e.SetAttributeNS("attr", "first", ns1)
+		require.NoError(t, err)
+
+		_, err = e.SetAttributeNS("attr", "second", ns2)
+		require.NoError(t, err)
+		require.Len(t, e.Attributes(), 2)
+	})
+}
+
 func TestRemoveAttribute(t *testing.T) {
 	t.Parallel()
 

--- a/attr_test.go
+++ b/attr_test.go
@@ -342,6 +342,48 @@ func TestSetAttributeNSDuplicate(t *testing.T) {
 	})
 }
 
+func TestSetLiteralAttributeNSDuplicate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("same namespace URI via different prefixes replaces in place", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		e := doc.CreateElement("root")
+
+		// Two distinct *Namespace values that share the same URI but differ
+		// in prefix. SetLiteralAttributeNS routes through addProperty, which
+		// must treat these as the SAME attribute (expanded name {urn:x}a)
+		// and replace in place rather than creating a second property that
+		// serializes to a different QName (p:a vs q:a) yet has an identical
+		// expanded name.
+		ns1 := helium.NewNamespace("p", "urn:x")
+		ns2 := helium.NewNamespace("q", "urn:x")
+
+		require.NoError(t, e.SetLiteralAttributeNS("a", "first", ns1))
+		require.NoError(t, e.SetLiteralAttributeNS("a", "second", ns2))
+
+		attrs := e.Attributes()
+		require.Len(t, attrs, 1)
+		require.Equal(t, "second", attrs[0].Value())
+		v, ok := e.GetAttributeNS("a", "urn:x")
+		require.True(t, ok)
+		require.Equal(t, "second", v)
+	})
+
+	t.Run("genuinely different namespaces coexist", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		e := doc.CreateElement("root")
+
+		ns1 := helium.NewNamespace("p", "urn:x")
+		ns2 := helium.NewNamespace("q", "urn:y")
+
+		require.NoError(t, e.SetLiteralAttributeNS("a", "first", ns1))
+		require.NoError(t, e.SetLiteralAttributeNS("a", "second", ns2))
+		require.Len(t, e.Attributes(), 2)
+	})
+}
+
 func TestRemoveAttribute(t *testing.T) {
 	t.Parallel()
 

--- a/element.go
+++ b/element.go
@@ -169,9 +169,18 @@ func (n *Element) SetAttributeNS(localname, value string, ns *Namespace) (*Eleme
 		return n, nil
 	}
 
+	var nsURI string
+	if ns != nil {
+		nsURI = ns.URI()
+	}
+
 	var last *Attribute
 	for ; p != nil; p = p.NextAttribute() {
-		if p.LocalName() == localname && p.ns == ns {
+		// Two attributes are duplicates when they share the same local
+		// name and namespace URI, per XML rules. Compare by URI value
+		// rather than *Namespace pointer identity so that distinct
+		// namespace declarations carrying the same URI still collide.
+		if p.LocalName() == localname && p.URI() == nsURI {
 			return nil, ErrDuplicateAttribute
 		}
 		last = p

--- a/element.go
+++ b/element.go
@@ -94,6 +94,25 @@ func (n *Element) SetBooleanAttribute(name string) error {
 	return nil
 }
 
+// attrMatches reports whether existing and the attribute identified by
+// (qname, nsURI, localName) are the same attribute for the purposes of
+// duplicate detection. Two attributes collide when EITHER their expanded
+// name (namespace URI + local name) matches OR their serialized QName
+// matches. The expanded-name test catches duplicates declared through
+// different namespace prefixes that resolve to the same URI (e.g. p:a and
+// q:a both bound to {urn:x}a); the QName test catches duplicates among
+// no-namespace attributes and any other identical serialization.
+//
+// This is the single attribute-identity check shared by every
+// attribute-creation entry point (addProperty, which backs SetAttribute
+// and SetLiteralAttribute(NS), and SetAttributeNS).
+func attrMatches(existing *Attribute, qname, nsURI, localName string) bool {
+	if existing.URI() == nsURI && existing.LocalName() == localName {
+		return true
+	}
+	return existing.Name() == qname
+}
+
 // addProperty inserts or replaces an attribute in the element's property list.
 func (n *Element) addProperty(attr *Attribute) {
 	p := n.properties
@@ -103,9 +122,13 @@ func (n *Element) addProperty(attr *Attribute) {
 		return
 	}
 
+	qname := attr.Name()
+	nsURI := attr.URI()
+	localName := attr.LocalName()
+
 	var last *Attribute
 	for ; p != nil; p = p.NextAttribute() {
-		if p.Name() == attr.Name() {
+		if attrMatches(p, qname, nsURI, localName) {
 			// Replace existing attribute in-place: splice new attr
 			// into the same position in the linked list.
 			pdn := p.baseDocNode()
@@ -169,18 +192,17 @@ func (n *Element) SetAttributeNS(localname, value string, ns *Namespace) (*Eleme
 		return n, nil
 	}
 
-	var nsURI string
-	if ns != nil {
-		nsURI = ns.URI()
-	}
+	// Use the same attribute-identity check as addProperty: an attribute is
+	// a duplicate when EITHER its expanded name (namespace URI + local name)
+	// OR its serialized QName matches an existing one. Comparing by URI
+	// value rather than *Namespace pointer identity means distinct namespace
+	// declarations carrying the same URI still collide.
+	qname := attr.Name()
+	nsURI := attr.URI()
 
 	var last *Attribute
 	for ; p != nil; p = p.NextAttribute() {
-		// Two attributes are duplicates when they share the same local
-		// name and namespace URI, per XML rules. Compare by URI value
-		// rather than *Namespace pointer identity so that distinct
-		// namespace declarations carrying the same URI still collide.
-		if p.LocalName() == localname && p.URI() == nsURI {
+		if attrMatches(p, qname, nsURI, localname) {
 			return nil, ErrDuplicateAttribute
 		}
 		last = p


### PR DESCRIPTION
- `Element.SetAttributeNS` detected duplicate attributes by `*Namespace` pointer identity, so two attributes sharing a namespace URI but declared via different namespace objects slipped past the duplicate check.
- Compare by namespace URI value + local name instead, matching XML duplicate-attribute rules; genuinely distinct namespaces still coexist.