### PR TITLE
revert nil-Document guard in GetEntity

### DIFF
--- a/document.go
+++ b/document.go
@@ -587,9 +587,6 @@ func (d *Document) GetEntity(name string) (ent *Entity, found bool) {
 			}
 		}()
 	}
-	if d == nil {
-		return nil, false
-	}
 	if ints := d.intSubset; ints != nil {
 		if pdebug.Enabled {
 			pdebug.Printf("Looking into internal subset...")

--- a/document_test.go
+++ b/document_test.go
@@ -144,20 +144,6 @@ func TestCreatePIOwnerDocument(t *testing.T) {
 	require.Same(t, doc, pi.OwnerDocument(), "PI owner document should be the creating document")
 }
 
-func TestCreateAttributeNilDocWithEntityValue(t *testing.T) {
-	t.Parallel()
-	var doc *helium.Document
-	// A value containing an entity reference forces the entity-resolution
-	// path, which historically dereferenced the nil document and panicked.
-	attr, err := doc.CreateAttribute("name", "a&amp;b", nil)
-	require.NoError(t, err, "CreateAttribute on a nil document must not panic")
-	require.NotNil(t, attr)
-	require.Equal(t, "name", attr.Name())
-	// Predefined entities are not document-dependent, so they must resolve
-	// to their literal characters even when the document is nil.
-	require.Equal(t, "a&b", attr.Value(), "predefined entity must resolve on a nil document")
-}
-
 func TestCreateCharRefRejectsEmptyName(t *testing.T) {
 	t.Parallel()
 	doc := helium.NewDocument("1.0", "", helium.StandaloneImplicitNo)


### PR DESCRIPTION
Removes the `if d == nil` guard added to `Document.GetEntity` in #641. Calling a `*Document` method on a nil receiver is caller misuse, not a real defect; the guard added defensive surface for it. Keeps the two genuinely-independent parts of #641: `CreateCharRef` empty-name validation (input validation) and the predefined-entity resolution in `stringToNodeList` (doc-independent entity resolution, helps DTD-less docs generally). Removes the nil-doc caller-misuse test; the empty-charref test remains.