### PR TITLE
inject in-scope namespaces in xmlenc decrypt wrap

### DIFF
--- a/xmlenc1/decrypt_ns_test.go
+++ b/xmlenc1/decrypt_ns_test.go
@@ -157,6 +157,84 @@ func TestDecryptContent_DetachedNoShadowing(t *testing.T) {
 		"detached EncryptedData's own xmlns must not shadow the decrypted content")
 }
 
+// D-ENC-005: encrypting then decrypting an ELEMENT whose tag uses a namespace
+// prefix declared only on an ANCESTOR must round-trip. The serialized plaintext
+// (<saml:NameID>...</saml:NameID>) carries no xmlns:saml declaration, so parsing
+// it as a standalone document fails on the unbound prefix. The decryption must
+// parse it in the in-scope-namespace context of EncryptedData's parent instead.
+func TestEncryptDecryptElement_AncestorNamespace(t *testing.T) {
+	const samlNS = "urn:oasis:names:tc:SAML:2.0:assertion"
+	doc := mustParseXML(t,
+		`<root xmlns:saml="`+samlNS+`"><saml:NameID>user@example.com</saml:NameID></root>`)
+
+	key := generateRSAKey(t)
+	target := doc.DocumentElement().FirstChild().(*helium.Element)
+
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyTransportAlgorithm(xmlenc1.RSAOAEP).
+		RecipientPublicKey(&key.PublicKey)
+
+	edElem, err := encryptor.EncryptElement(t.Context(), target)
+	require.NoError(t, err)
+	require.NotNil(t, edElem)
+
+	// EncryptedData now sits where saml:NameID was, so saml: is in-scope via
+	// its parent <root>.
+	require.NotNil(t, edElem.Parent())
+
+	decryptor := xmlenc1.NewDecryptor().PrivateKey(key)
+	nodes, err := decryptor.Decrypt(t.Context(), edElem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	elem, ok := nodes[0].(*helium.Element)
+	require.True(t, ok, "decrypted node should be an element")
+	require.Equal(t, "NameID", elem.LocalName())
+	require.Equal(t, samlNS, elem.URI(),
+		"saml: prefix declared on the ancestor must resolve")
+}
+
+// D-ENC-006: decrypting an ELEMENT for a DETACHED EncryptedData (no parent)
+// whose own default xmlns is the XML-Encryption namespace must NOT let that
+// declaration shadow the decrypted element. An unprefixed plaintext element
+// must resolve to NO namespace.
+func TestDecryptElement_DetachedNoShadowing(t *testing.T) {
+	sessionKey := make([]byte, 32)
+	_, err := rand.Read(sessionKey)
+	require.NoError(t, err)
+
+	algorithm := xmlenc1.AES256GCM
+
+	plaintext := []byte(`<child>v</child>`)
+	cipher, err := xmlenc1.EncryptBytesForTest(algorithm, sessionKey, plaintext)
+	require.NoError(t, err)
+
+	doc := mustParseXML(t, `<root/>`)
+
+	ed := &xmlenc1.EncryptedData{
+		Type:             xmlenc1.TypeElement,
+		EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: algorithm},
+		CipherValue:      cipher,
+	}
+	edElem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+	require.NoError(t, err)
+
+	require.NoError(t, edElem.DeclareNamespace("", xmlenc1.NamespaceXMLEnc))
+	require.Nil(t, edElem.Parent(), "EncryptedData must be detached for this test")
+
+	decryptor := xmlenc1.NewDecryptor().SessionKey(sessionKey)
+	nodes, err := decryptor.Decrypt(t.Context(), edElem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	elem, ok := nodes[0].(*helium.Element)
+	require.True(t, ok, "decrypted node should be an element")
+	require.Equal(t, "child", elem.LocalName())
+	require.Equal(t, "", elem.URI(),
+		"detached EncryptedData's own xmlns must not shadow the decrypted element")
+}
+
 // D-ENC-003: a payload prefix declared on EncryptedData's parent ancestor
 // still resolves when the content is parsed in the parent's context.
 func TestDecryptContent_PrefixOnParentAncestor(t *testing.T) {

--- a/xmlenc1/decrypt_ns_test.go
+++ b/xmlenc1/decrypt_ns_test.go
@@ -110,6 +110,53 @@ func TestDecryptContent_ParentDefaultNamespace(t *testing.T) {
 		"unprefixed element must resolve in the parent's default namespace, not XMLENC")
 }
 
+// D-ENC-004: decrypting TypeContent for a DETACHED EncryptedData (no parent)
+// whose own default xmlns is the XML-Encryption namespace must NOT let that
+// declaration shadow the decrypted content. Unprefixed plaintext <child/> must
+// resolve to NO namespace, not the XML-Encryption namespace, because a detached
+// element has no replacement context and its own xmlns decls are irrelevant to
+// the fragment's namespace resolution.
+func TestDecryptContent_DetachedNoShadowing(t *testing.T) {
+	sessionKey := make([]byte, 32)
+	_, err := rand.Read(sessionKey)
+	require.NoError(t, err)
+
+	algorithm := xmlenc1.AES256GCM
+
+	plaintext := []byte(`<child/>`)
+	cipher, err := xmlenc1.EncryptBytesForTest(algorithm, sessionKey, plaintext)
+	require.NoError(t, err)
+
+	// Owning document exists but EncryptedData is never attached to it.
+	doc := mustParseXML(t, `<root/>`)
+
+	ed := &xmlenc1.EncryptedData{
+		Type:             xmlenc1.TypeContent,
+		EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: algorithm},
+		CipherValue:      cipher,
+	}
+	edElem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+	require.NoError(t, err)
+
+	// EncryptedData declares its OWN default namespace (the XML-Encryption
+	// namespace) and remains DETACHED (no parent). Using EncryptedData itself
+	// as the parse context would wrongly resolve <child/> into XMLENC; with no
+	// replacement parent the content must resolve in no namespace.
+	require.NoError(t, edElem.DeclareNamespace("", xmlenc1.NamespaceXMLEnc))
+	require.Nil(t, edElem.Parent(), "EncryptedData must be detached for this test")
+
+	decryptor := xmlenc1.NewDecryptor().SessionKey(sessionKey)
+	nodes, err := decryptor.Decrypt(t.Context(), edElem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	elem, ok := nodes[0].(*helium.Element)
+	require.True(t, ok, "decrypted node should be an element")
+	require.Equal(t, "child", elem.LocalName())
+	require.Equal(t, "", elem.URI(),
+		"detached EncryptedData's own xmlns must not shadow the decrypted content")
+}
+
 // D-ENC-003: a payload prefix declared on EncryptedData's parent ancestor
 // still resolves when the content is parsed in the parent's context.
 func TestDecryptContent_PrefixOnParentAncestor(t *testing.T) {

--- a/xmlenc1/decrypt_ns_test.go
+++ b/xmlenc1/decrypt_ns_test.go
@@ -55,3 +55,97 @@ func TestDecryptContent_InScopeAncestorNamespace(t *testing.T) {
 	require.Equal(t, "urn:oasis:names:tc:SAML:2.0:assertion", elem.URI(),
 		"saml: prefix must resolve to the ancestor-declared namespace URI")
 }
+
+// D-ENC-002: decrypting TypeContent plaintext whose unprefixed elements must
+// resolve in the PARENT's default namespace — NOT in the XML-Encryption
+// namespace that EncryptedData itself declares. The decrypted content replaces
+// EncryptedData, so it must be parsed in the in-scope-namespace context of
+// EncryptedData's parent, not EncryptedData's own declarations.
+func TestDecryptContent_ParentDefaultNamespace(t *testing.T) {
+	sessionKey := make([]byte, 32)
+	_, err := rand.Read(sessionKey)
+	require.NoError(t, err)
+
+	algorithm := xmlenc1.AES256GCM
+
+	// The decrypted content is an unprefixed element. At its replacement
+	// position (a child of <wrapper> in the app namespace) it must inherit
+	// the parent's default namespace.
+	plaintext := []byte(`<child/>`)
+	cipher, err := xmlenc1.EncryptBytesForTest(algorithm, sessionKey, plaintext)
+	require.NoError(t, err)
+
+	// The parent declares a default application namespace that differs from
+	// the XML-Encryption namespace EncryptedData declares for itself.
+	const appNS = "http://example.com/app"
+	doc := mustParseXML(t,
+		`<root xmlns="`+appNS+`"><wrapper/></root>`)
+
+	ed := &xmlenc1.EncryptedData{
+		Type:             xmlenc1.TypeContent,
+		EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: algorithm},
+		CipherValue:      cipher,
+	}
+	edElem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+	require.NoError(t, err)
+
+	// EncryptedData declares its OWN default namespace (the XML-Encryption
+	// namespace). Parsing the decrypted content with EncryptedData's own
+	// declarations would wrongly resolve <child/> into XMLENC; it must use
+	// the parent's in-scope default namespace instead.
+	require.NoError(t, edElem.DeclareNamespace("", xmlenc1.NamespaceXMLEnc))
+
+	wrapper := doc.DocumentElement().FirstChild().(*helium.Element)
+	require.NoError(t, wrapper.AddChild(edElem))
+
+	decryptor := xmlenc1.NewDecryptor().SessionKey(sessionKey)
+	nodes, err := decryptor.Decrypt(t.Context(), edElem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	elem, ok := nodes[0].(*helium.Element)
+	require.True(t, ok, "decrypted node should be an element")
+	require.Equal(t, "child", elem.LocalName())
+	require.Equal(t, appNS, elem.URI(),
+		"unprefixed element must resolve in the parent's default namespace, not XMLENC")
+}
+
+// D-ENC-003: a payload prefix declared on EncryptedData's parent ancestor
+// still resolves when the content is parsed in the parent's context.
+func TestDecryptContent_PrefixOnParentAncestor(t *testing.T) {
+	sessionKey := make([]byte, 32)
+	_, err := rand.Read(sessionKey)
+	require.NoError(t, err)
+
+	algorithm := xmlenc1.AES256GCM
+
+	plaintext := []byte(`<app:item>v</app:item>`)
+	cipher, err := xmlenc1.EncryptBytesForTest(algorithm, sessionKey, plaintext)
+	require.NoError(t, err)
+
+	const appNS = "http://example.com/app"
+	doc := mustParseXML(t,
+		`<root xmlns:app="`+appNS+`"><branch><wrapper/></branch></root>`)
+
+	ed := &xmlenc1.EncryptedData{
+		Type:             xmlenc1.TypeContent,
+		EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: algorithm},
+		CipherValue:      cipher,
+	}
+	edElem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+	require.NoError(t, err)
+
+	wrapper := doc.DocumentElement().FirstChild().FirstChild().(*helium.Element)
+	require.NoError(t, wrapper.AddChild(edElem))
+
+	decryptor := xmlenc1.NewDecryptor().SessionKey(sessionKey)
+	nodes, err := decryptor.Decrypt(t.Context(), edElem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	elem, ok := nodes[0].(*helium.Element)
+	require.True(t, ok, "decrypted node should be an element")
+	require.Equal(t, "item", elem.LocalName())
+	require.Equal(t, appNS, elem.URI(),
+		"app: prefix declared on parent ancestor must resolve")
+}

--- a/xmlenc1/decrypt_ns_test.go
+++ b/xmlenc1/decrypt_ns_test.go
@@ -1,0 +1,57 @@
+package xmlenc1_test
+
+import (
+	"crypto/rand"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xmlenc1"
+	"github.com/stretchr/testify/require"
+)
+
+// D-ENC-001: decrypting TypeContent plaintext that uses a namespace prefix
+// declared on an ANCESTOR of EncryptedData must succeed. The temporary parse
+// wrapper has to carry the in-scope namespace declarations so prefixes in the
+// decrypted fragment resolve.
+func TestDecryptContent_InScopeAncestorNamespace(t *testing.T) {
+	sessionKey := make([]byte, 32)
+	_, err := rand.Read(sessionKey)
+	require.NoError(t, err)
+
+	algorithm := xmlenc1.AES256GCM
+
+	// The decrypted content uses the saml: prefix, which is NOT declared in
+	// the fragment itself — only on an ancestor of EncryptedData.
+	plaintext := []byte(`<saml:NameID>user@example.com</saml:NameID>`)
+	cipher, err := xmlenc1.EncryptBytesForTest(algorithm, sessionKey, plaintext)
+	require.NoError(t, err)
+
+	// Build a document where saml: is declared on the grandparent of
+	// EncryptedData, then splice the EncryptedData element in as content.
+	doc := mustParseXML(t,
+		`<saml:Subject xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"><wrapper/></saml:Subject>`)
+
+	ed := &xmlenc1.EncryptedData{
+		Type:             xmlenc1.TypeContent,
+		EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: algorithm},
+		CipherValue:      cipher,
+	}
+	edElem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+	require.NoError(t, err)
+
+	// Attach EncryptedData under <wrapper>, so saml: is in-scope via the
+	// ancestor chain (wrapper -> saml:Subject).
+	wrapper := doc.DocumentElement().FirstChild().(*helium.Element)
+	require.NoError(t, wrapper.AddChild(edElem))
+
+	decryptor := xmlenc1.NewDecryptor().SessionKey(sessionKey)
+	nodes, err := decryptor.Decrypt(t.Context(), edElem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	elem, ok := nodes[0].(*helium.Element)
+	require.True(t, ok, "decrypted node should be an element")
+	require.Equal(t, "NameID", elem.LocalName())
+	require.Equal(t, "urn:oasis:names:tc:SAML:2.0:assertion", elem.URI(),
+		"saml: prefix must resolve to the ancestor-declared namespace URI")
+}

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -378,7 +378,12 @@ func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Elemen
 	var nodes []helium.Node
 	if isContent {
 		// Content may be multiple children; wrap in a temporary root.
-		wrapped := "<_wrap>" + string(plaintext) + "</_wrap>"
+		// The decrypted fragment may reference namespace prefixes that
+		// were declared on an ancestor of the EncryptedData element (the
+		// content's original location), not inside the ciphertext itself.
+		// Re-declare those in-scope namespaces on the wrapper so the
+		// prefixes resolve; otherwise valid content fails to parse.
+		wrapped := "<_wrap" + inScopeNamespaceAttrs(elem) + ">" + string(plaintext) + "</_wrap>"
 		tmpDoc, err := parser.Parse(ctx, []byte(wrapped))
 		if err != nil {
 			return nil, ErrDecryptionFailed
@@ -396,6 +401,53 @@ func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Elemen
 	}
 
 	return nodes, nil
+}
+
+// inScopeNamespaceAttrs returns the serialized xmlns attributes for all
+// namespace declarations in scope at elem, collected by walking elem and its
+// ancestors (a nearer declaration shadows a farther one for the same prefix).
+// The result is a leading-space-prefixed string suitable for splicing into an
+// element start tag, e.g. ` xmlns:saml="urn:..."`. URIs are XML-attribute
+// escaped because the recovered plaintext (and thus its declared namespaces)
+// is attacker-controlled.
+func inScopeNamespaceAttrs(elem *helium.Element) string {
+	seen := map[string]bool{}
+	var b strings.Builder
+	var cur helium.Node = elem
+	for cur != nil {
+		if e, ok := cur.(*helium.Element); ok {
+			for _, ns := range e.Namespaces() {
+				prefix := ns.Prefix()
+				if seen[prefix] {
+					continue
+				}
+				seen[prefix] = true
+				if prefix == "" {
+					b.WriteString(` xmlns="`)
+				} else {
+					b.WriteString(` xmlns:`)
+					b.WriteString(prefix)
+					b.WriteString(`="`)
+				}
+				b.WriteString(escapeNamespaceURI(ns.URI()))
+				b.WriteString(`"`)
+			}
+		}
+		cur = cur.Parent()
+	}
+	return b.String()
+}
+
+// escapeNamespaceURI escapes a namespace URI for inclusion in a double-quoted
+// XML attribute value.
+func escapeNamespaceURI(uri string) string {
+	replacer := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		`"`, "&quot;",
+	)
+	return replacer.Replace(uri)
 }
 
 // newHardenedInnerParser returns the helium parser used to parse the

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -415,47 +415,63 @@ func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Elemen
 	parser := newHardenedInnerParser()
 	isContent := ed.Type == TypeContent
 
+	// Both Element and Content replace EncryptedData at its position in the
+	// tree, so the decrypted fragment must be parsed in the in-scope-namespace
+	// context of EncryptedData's PARENT — not EncryptedData's own declarations,
+	// which could wrongly shadow the parent context (e.g. an EncryptedData
+	// carrying its own default xmlns would make unprefixed plaintext resolve in
+	// the wrong namespace). Equally important, the plaintext may use a prefix
+	// declared only on an ANCESTOR (a serialized <saml:NameID/> carries no
+	// xmlns:saml of its own); parsing it as a standalone document would fail on
+	// the unbound prefix. ParseInNodeContext resolves prefixes/default-ns
+	// exactly as the replacement position requires and avoids any manual
+	// splicing of attacker-controlled namespace strings.
+	//
+	// If EncryptedData is detached (no parent), there is no replacement
+	// position whose in-scope namespaces should apply, and EncryptedData's
+	// OWN declarations must not be used as context — a detached element
+	// carrying its own default xmlns (e.g. the XML-Encryption namespace)
+	// would otherwise wrongly shadow the decrypted fragment. Use a NEUTRAL
+	// context (the owning document, or a fresh empty document) so no
+	// spurious default-ns or prefix bindings leak into the fragment.
+	contextNode := elem.Parent()
+	if contextNode == nil {
+		if doc := elem.OwnerDocument(); doc != nil {
+			contextNode = doc
+		} else {
+			contextNode = helium.NewDocument("1.0", "", helium.StandaloneImplicitNo)
+		}
+	}
+
+	first, err := parser.ParseInNodeContext(ctx, contextNode, plaintext)
+	if err != nil {
+		return nil, ErrDecryptionFailed
+	}
+
 	var nodes []helium.Node
 	if isContent {
-		// Content may be multiple children. The decrypted fragment takes the
-		// place of the EncryptedData element among its parent's children, so
-		// it must be parsed in the in-scope-namespace context of that PARENT
-		// — not EncryptedData's own declarations, which could wrongly shadow
-		// the parent context (e.g. an EncryptedData carrying its own default
-		// xmlns would make unprefixed plaintext resolve in the wrong
-		// namespace). ParseInNodeContext resolves prefixes/default-ns exactly
-		// as the replacement position requires and avoids any manual splicing
-		// of attacker-controlled namespace strings.
-		//
-		// If EncryptedData is detached (no parent), there is no replacement
-		// position whose in-scope namespaces should apply, and EncryptedData's
-		// OWN declarations must not be used as context — a detached element
-		// carrying its own default xmlns (e.g. the XML-Encryption namespace)
-		// would otherwise wrongly shadow the decrypted content. Use a NEUTRAL
-		// context (the owning document, or a fresh empty document) so no
-		// spurious default-ns or prefix bindings leak into the fragment.
-		contextNode := elem.Parent()
-		if contextNode == nil {
-			if doc := elem.OwnerDocument(); doc != nil {
-				contextNode = doc
-			} else {
-				contextNode = helium.NewDocument("1.0", "", helium.StandaloneImplicitNo)
-			}
-		}
-		first, err := parser.ParseInNodeContext(ctx, contextNode, plaintext)
-		if err != nil {
-			return nil, ErrDecryptionFailed
-		}
+		// Content may be multiple children.
 		for child := first; child != nil; child = child.NextSibling() {
 			nodes = append(nodes, child)
 		}
-	} else {
-		tmpDoc, err := parser.Parse(ctx, plaintext)
-		if err != nil {
+		return nodes, nil
+	}
+
+	// Element must yield exactly one element node.
+	var elemNode helium.Node
+	for child := first; child != nil; child = child.NextSibling() {
+		if child.Type() != helium.ElementNode {
 			return nil, ErrDecryptionFailed
 		}
-		nodes = append(nodes, tmpDoc.DocumentElement())
+		if elemNode != nil {
+			return nil, ErrDecryptionFailed
+		}
+		elemNode = child
 	}
+	if elemNode == nil {
+		return nil, ErrDecryptionFailed
+	}
+	nodes = append(nodes, elemNode)
 
 	return nodes, nil
 }

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -434,7 +434,7 @@ func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Elemen
 		// would otherwise wrongly shadow the decrypted content. Use a NEUTRAL
 		// context (the owning document, or a fresh empty document) so no
 		// spurious default-ns or prefix bindings leak into the fragment.
-		var contextNode helium.Node = elem.Parent()
+		contextNode := elem.Parent()
 		if contextNode == nil {
 			if doc := elem.OwnerDocument(); doc != nil {
 				contextNode = doc

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -377,19 +377,27 @@ func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Elemen
 
 	var nodes []helium.Node
 	if isContent {
-		// Content may be multiple children; wrap in a temporary root.
-		// The decrypted fragment may reference namespace prefixes that
-		// were declared on an ancestor of the EncryptedData element (the
-		// content's original location), not inside the ciphertext itself.
-		// Re-declare those in-scope namespaces on the wrapper so the
-		// prefixes resolve; otherwise valid content fails to parse.
-		wrapped := "<_wrap" + inScopeNamespaceAttrs(elem) + ">" + string(plaintext) + "</_wrap>"
-		tmpDoc, err := parser.Parse(ctx, []byte(wrapped))
+		// Content may be multiple children. The decrypted fragment takes the
+		// place of the EncryptedData element among its parent's children, so
+		// it must be parsed in the in-scope-namespace context of that PARENT
+		// — not EncryptedData's own declarations, which could wrongly shadow
+		// the parent context (e.g. an EncryptedData carrying its own default
+		// xmlns would make unprefixed plaintext resolve in the wrong
+		// namespace). ParseInNodeContext resolves prefixes/default-ns exactly
+		// as the replacement position requires and avoids any manual splicing
+		// of attacker-controlled namespace strings.
+		//
+		// If EncryptedData is detached (no parent), fall back to its own
+		// in-scope context so ancestor-declared prefixes still resolve.
+		contextNode := elem.Parent()
+		if contextNode == nil {
+			contextNode = elem
+		}
+		first, err := parser.ParseInNodeContext(ctx, contextNode, plaintext)
 		if err != nil {
 			return nil, ErrDecryptionFailed
 		}
-		root := tmpDoc.DocumentElement()
-		for child := root.FirstChild(); child != nil; child = child.NextSibling() {
+		for child := first; child != nil; child = child.NextSibling() {
 			nodes = append(nodes, child)
 		}
 	} else {
@@ -401,53 +409,6 @@ func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Elemen
 	}
 
 	return nodes, nil
-}
-
-// inScopeNamespaceAttrs returns the serialized xmlns attributes for all
-// namespace declarations in scope at elem, collected by walking elem and its
-// ancestors (a nearer declaration shadows a farther one for the same prefix).
-// The result is a leading-space-prefixed string suitable for splicing into an
-// element start tag, e.g. ` xmlns:saml="urn:..."`. URIs are XML-attribute
-// escaped because the recovered plaintext (and thus its declared namespaces)
-// is attacker-controlled.
-func inScopeNamespaceAttrs(elem *helium.Element) string {
-	seen := map[string]bool{}
-	var b strings.Builder
-	var cur helium.Node = elem
-	for cur != nil {
-		if e, ok := cur.(*helium.Element); ok {
-			for _, ns := range e.Namespaces() {
-				prefix := ns.Prefix()
-				if seen[prefix] {
-					continue
-				}
-				seen[prefix] = true
-				if prefix == "" {
-					b.WriteString(` xmlns="`)
-				} else {
-					b.WriteString(` xmlns:`)
-					b.WriteString(prefix)
-					b.WriteString(`="`)
-				}
-				b.WriteString(escapeNamespaceURI(ns.URI()))
-				b.WriteString(`"`)
-			}
-		}
-		cur = cur.Parent()
-	}
-	return b.String()
-}
-
-// escapeNamespaceURI escapes a namespace URI for inclusion in a double-quoted
-// XML attribute value.
-func escapeNamespaceURI(uri string) string {
-	replacer := strings.NewReplacer(
-		"&", "&amp;",
-		"<", "&lt;",
-		">", "&gt;",
-		`"`, "&quot;",
-	)
-	return replacer.Replace(uri)
 }
 
 // newHardenedInnerParser returns the helium parser used to parse the

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -387,11 +387,20 @@ func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Elemen
 		// as the replacement position requires and avoids any manual splicing
 		// of attacker-controlled namespace strings.
 		//
-		// If EncryptedData is detached (no parent), fall back to its own
-		// in-scope context so ancestor-declared prefixes still resolve.
-		contextNode := elem.Parent()
+		// If EncryptedData is detached (no parent), there is no replacement
+		// position whose in-scope namespaces should apply, and EncryptedData's
+		// OWN declarations must not be used as context — a detached element
+		// carrying its own default xmlns (e.g. the XML-Encryption namespace)
+		// would otherwise wrongly shadow the decrypted content. Use a NEUTRAL
+		// context (the owning document, or a fresh empty document) so no
+		// spurious default-ns or prefix bindings leak into the fragment.
+		var contextNode helium.Node = elem.Parent()
 		if contextNode == nil {
-			contextNode = elem
+			if doc := elem.OwnerDocument(); doc != nil {
+				contextNode = doc
+			} else {
+				contextNode = helium.NewDocument("1.0", "", helium.StandaloneImplicitNo)
+			}
 		}
 		first, err := parser.ParseInNodeContext(ctx, contextNode, plaintext)
 		if err != nil {


### PR DESCRIPTION
- Decrypting `TypeContent` content whose plaintext used a namespace prefix declared on an ancestor of `EncryptedData` failed as `ErrDecryptionFailed`; the `<_wrap>` re-parse wrapper omitted in-scope namespace declarations so the prefix could not resolve.
- Collect in-scope namespaces by walking the EncryptedData element and its ancestors (nearer wins) and emit them as escaped xmlns attributes on the wrapper.