### PR TITLE
reject SHA-1 by default in xmldsig verify

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -281,9 +281,10 @@ Generic push parser infrastructure shared by both XML and HTML push parsers.
 XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
 
 - **NewSigner() → Signer** — create fluent builder for signing (clone-on-write value type)
-  - `SignatureAlgorithm(uri)`, `CanonicalizationMethod(uri)`, `Reference(ReferenceConfig)`, `KeyInfo(KeyInfoBuilder)`, `SignatureID(id)` — builder methods
+  - `SignatureAlgorithm(uri)`, `CanonicalizationMethod(uri)`, `Reference(ReferenceConfig)`, `KeyInfo(KeyInfoBuilder)`, `SignatureID(id)`, `AllowSHA1(bool)` — builder methods
   - `SignEnveloped(ctx, doc, parent, key)`, `SignEnveloping(ctx, doc, content, key)`, `SignDetached(ctx, doc, key)` — terminal methods
-- **NewVerifier(KeySource) → Verifier** — create fluent builder for verification
+- **NewVerifier(KeySource) → Verifier** — create fluent builder for verification (clone-on-write value type)
+  - `AllowSHA1(bool)` — builder method
   - `Verify(ctx, doc)`, `VerifyElement(ctx, doc, sigElem)` — terminal methods
 - **NewEnvelopedReference() → ReferenceConfig** — SAML-optimized defaults (enveloped + ExcC14N + SHA-256)
 - Key sources: `StaticKey(key)`, `X509CertKeySource(cert)`, `KeySourceFunc`
@@ -291,7 +292,8 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
 - Transforms: `Enveloped()`, `C14NTransform(uri)`, `ExcC14NTransform(prefixes...)`
 - Algorithms: RSA-SHA1/SHA256, ECDSA-SHA256/SHA384, HMAC-SHA1/SHA256, Ed25519
 - Digests: SHA-1, SHA-256, SHA-384, SHA-512
-- Errors: `ErrNoKeySource` sentinel — returned by verify when no usable KeySource is configured (nil cfg, untyped-nil, or typed-nil KeySource/func)
+- **SHA-1 rejected by default** (rsa-sha1/hmac-sha1/sha1) on both sign and verify → `ErrWeakAlgorithm`; opt in with `Signer.AllowSHA1(true)` / `Verifier.AllowSHA1(true)` for legacy interop. SHA-256+ unaffected.
+- Errors: `ErrNoKeySource` sentinel — returned by verify when no usable KeySource is configured (nil cfg, untyped-nil, or typed-nil KeySource/func); `ErrWeakAlgorithm` — SHA-1 used without opt-in
 - Files: `xmldsig1.go` (API), `constants.go`, `algorithms.go`, `sign.go`, `verify.go`, `transforms.go`, `keyinfo.go`, `errors.go`
 - Imports: helium, c14n/
 

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -294,7 +294,7 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
 - Digests: SHA-1, SHA-256, SHA-384, SHA-512
 - **SHA-1 rejected by default** (rsa-sha1/hmac-sha1/sha1) on both sign and verify → `ErrWeakAlgorithm`; opt in with `Signer.AllowSHA1(true)` / `Verifier.AllowSHA1(true)` for legacy interop. SHA-256+ unaffected.
 - Errors: `ErrNoKeySource` sentinel — returned by verify when no usable KeySource is configured (nil cfg, untyped-nil, or typed-nil KeySource/func); `ErrWeakAlgorithm` — SHA-1 used without opt-in
-- Files: `xmldsig1.go` (API), `constants.go`, `algorithms.go`, `sign.go`, `verify.go`, `transforms.go`, `keyinfo.go`, `errors.go`
+- Files: `xmldsig1.go` (API), `constants.go`, `algorithms.go`, `weak_algorithm.go`, `sign.go`, `verify.go`, `transforms.go`, `keyinfo.go`, `errors.go`
 - Imports: helium, c14n/
 
 ## xmlenc1/

--- a/examples/xmldsig1_sha1_optin_example_test.go
+++ b/examples/xmldsig1_sha1_optin_example_test.go
@@ -1,0 +1,62 @@
+package examples_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xmldsig1"
+)
+
+// Example_xmldsig1_sha1_optin demonstrates the explicit opt-in required to
+// produce and verify legacy SHA-1 signatures. SHA-1 (rsa-sha1, hmac-sha1, and
+// the sha1 digest) is rejected by default with ErrWeakAlgorithm; call
+// AllowSHA1(true) on both the Signer and the Verifier only when you must
+// interoperate with a legacy system that cannot be upgraded.
+func Example_xmldsig1_sha1_optin() {
+	const src = `<root Id="doc1"><data>Hello, World!</data></root>`
+
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(src))
+	if err != nil {
+		fmt.Printf("parse error: %s\n", err)
+		return
+	}
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		fmt.Printf("keygen error: %s\n", err)
+		return
+	}
+
+	// Produce a legacy SHA-1 signature (discouraged). AllowSHA1(true) is
+	// required; without it SignEnveloped returns ErrWeakAlgorithm.
+	signer := xmldsig1.NewSigner().
+		AllowSHA1(true).
+		SignatureAlgorithm(xmldsig1.AlgRSASHA1).
+		Reference(xmldsig1.ReferenceConfig{
+			URI:             "",
+			DigestAlgorithm: xmldsig1.DigestSHA1,
+			Transforms:      []xmldsig1.Transform{xmldsig1.Enveloped(), xmldsig1.ExcC14NTransform()},
+		})
+
+	if err := signer.SignEnveloped(context.Background(), doc, doc.DocumentElement(), key); err != nil {
+		fmt.Printf("sign error: %s\n", err)
+		return
+	}
+
+	// Verify the legacy SHA-1 signature. The default verifier rejects SHA-1,
+	// so AllowSHA1(true) is required here as well.
+	_, err = xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).
+		AllowSHA1(true).
+		Verify(context.Background(), doc)
+	if err != nil {
+		fmt.Printf("verification failed: %s\n", err)
+		return
+	}
+
+	fmt.Println("legacy SHA-1 signature valid")
+	// Output:
+	// legacy SHA-1 signature valid
+}

--- a/xmldsig1/README.md
+++ b/xmldsig1/README.md
@@ -83,3 +83,34 @@ func Example_xmldsig1_sign_verify() {
 ```
 source: [examples/xmldsig1_sign_verify_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xmldsig1_sign_verify_example_test.go)
 <!-- END INCLUDE -->
+
+## Security: SHA-1 rejected by default
+
+SHA-1-based algorithms (`rsa-sha1`, `hmac-sha1`, and the `sha1` digest) are
+**rejected by default** for both signing and verification. SHA-1 is
+cryptographically weak; accepting it silently exposes callers to algorithm
+downgrade and collision attacks. When a SHA-1 algorithm is encountered without
+an explicit opt-in, the operation fails with `ErrWeakAlgorithm`.
+
+If you must interoperate with a legacy system that cannot be upgraded, opt in
+explicitly:
+
+```go
+// Verify a legacy SHA-1 signature.
+_, err := xmldsig1.NewVerifier(keySource).
+    AllowSHA1(true).
+    Verify(ctx, doc)
+
+// Produce a legacy SHA-1 signature (discouraged).
+err := xmldsig1.NewSigner().
+    AllowSHA1(true).
+    SignatureAlgorithm(xmldsig1.AlgRSASHA1).
+    Reference(ref).
+    SignEnveloped(ctx, doc, parent, key)
+```
+
+> **Note (breaking default change):** earlier versions accepted SHA-1
+> signatures and digests without any opt-in. Code that relied on verifying
+> SHA-1 signatures must now call `Verifier.AllowSHA1(true)`; code that produced
+> SHA-1 signatures must call `Signer.AllowSHA1(true)`. SHA-256 and stronger
+> algorithms are unaffected.

--- a/xmldsig1/README.md
+++ b/xmldsig1/README.md
@@ -93,21 +93,76 @@ downgrade and collision attacks. When a SHA-1 algorithm is encountered without
 an explicit opt-in, the operation fails with `ErrWeakAlgorithm`.
 
 If you must interoperate with a legacy system that cannot be upgraded, opt in
-explicitly:
+explicitly by calling `AllowSHA1(true)` on both the `Signer` and the
+`Verifier`, as shown in the example below:
 
+<!-- INCLUDE(examples/xmldsig1_sha1_optin_example_test.go) -->
 ```go
-// Verify a legacy SHA-1 signature.
-_, err := xmldsig1.NewVerifier(keySource).
-    AllowSHA1(true).
-    Verify(ctx, doc)
+package examples_test
 
-// Produce a legacy SHA-1 signature (discouraged).
-err := xmldsig1.NewSigner().
+import (
+  "context"
+  "crypto/rand"
+  "crypto/rsa"
+  "fmt"
+
+  "github.com/lestrrat-go/helium"
+  "github.com/lestrrat-go/helium/xmldsig1"
+)
+
+// Example_xmldsig1_sha1_optin demonstrates the explicit opt-in required to
+// produce and verify legacy SHA-1 signatures. SHA-1 (rsa-sha1, hmac-sha1, and
+// the sha1 digest) is rejected by default with ErrWeakAlgorithm; call
+// AllowSHA1(true) on both the Signer and the Verifier only when you must
+// interoperate with a legacy system that cannot be upgraded.
+func Example_xmldsig1_sha1_optin() {
+  const src = `<root Id="doc1"><data>Hello, World!</data></root>`
+
+  doc, err := helium.NewParser().Parse(context.Background(), []byte(src))
+  if err != nil {
+    fmt.Printf("parse error: %s\n", err)
+    return
+  }
+
+  key, err := rsa.GenerateKey(rand.Reader, 2048)
+  if err != nil {
+    fmt.Printf("keygen error: %s\n", err)
+    return
+  }
+
+  // Produce a legacy SHA-1 signature (discouraged). AllowSHA1(true) is
+  // required; without it SignEnveloped returns ErrWeakAlgorithm.
+  signer := xmldsig1.NewSigner().
     AllowSHA1(true).
     SignatureAlgorithm(xmldsig1.AlgRSASHA1).
-    Reference(ref).
-    SignEnveloped(ctx, doc, parent, key)
+    Reference(xmldsig1.ReferenceConfig{
+      URI:             "",
+      DigestAlgorithm: xmldsig1.DigestSHA1,
+      Transforms:      []xmldsig1.Transform{xmldsig1.Enveloped(), xmldsig1.ExcC14NTransform()},
+    })
+
+  if err := signer.SignEnveloped(context.Background(), doc, doc.DocumentElement(), key); err != nil {
+    fmt.Printf("sign error: %s\n", err)
+    return
+  }
+
+  // Verify the legacy SHA-1 signature. The default verifier rejects SHA-1,
+  // so AllowSHA1(true) is required here as well.
+  _, err = xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).
+    AllowSHA1(true).
+    Verify(context.Background(), doc)
+  if err != nil {
+    fmt.Printf("verification failed: %s\n", err)
+    return
+  }
+
+  fmt.Println("legacy SHA-1 signature valid")
+  // Output:
+  // legacy SHA-1 signature valid
+}
 ```
+source: [examples/xmldsig1_sha1_optin_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xmldsig1_sha1_optin_example_test.go)
+<!-- END INCLUDE -->
 
 > **Note (breaking default change):** earlier versions accepted SHA-1
 > signatures and digests without any opt-in. Code that relied on verifying

--- a/xmldsig1/algorithms.go
+++ b/xmldsig1/algorithms.go
@@ -15,43 +15,56 @@ import (
 
 type signatureAlgorithm struct {
 	hash crypto.Hash // 0 for Ed25519 (no pre-hash)
+	weak bool        // true for SHA-1-based algorithms (rejected by default)
 }
 
 type digestAlgorithm struct {
 	hash crypto.Hash
+	weak bool // true for SHA-1 (rejected by default)
 }
 
 var signatureAlgorithms = map[string]signatureAlgorithm{
-	AlgRSASHA1:     {hash: crypto.SHA1},
+	AlgRSASHA1:     {hash: crypto.SHA1, weak: true},
 	AlgRSASHA256:   {hash: crypto.SHA256},
 	AlgECDSASHA256: {hash: crypto.SHA256},
 	AlgECDSASHA384: {hash: crypto.SHA384},
-	AlgHMACSHA1:    {hash: crypto.SHA1},
+	AlgHMACSHA1:    {hash: crypto.SHA1, weak: true},
 	AlgHMACSHA256:  {hash: crypto.SHA256},
 	AlgEd25519:     {hash: 0},
 }
 
 var digestAlgorithms = map[string]digestAlgorithm{
-	DigestSHA1:   {hash: crypto.SHA1},
+	DigestSHA1:   {hash: crypto.SHA1, weak: true},
 	DigestSHA256: {hash: crypto.SHA256},
 	DigestSHA384: {hash: crypto.SHA384},
 	DigestSHA512: {hash: crypto.SHA512},
 }
 
-func computeDigest(algURI string, data []byte) ([]byte, error) {
+// computeDigest hashes data with the algorithm identified by algURI. SHA-1 is
+// rejected with ErrWeakAlgorithm unless allowSHA1 is true.
+func computeDigest(algURI string, data []byte, allowSHA1 bool) ([]byte, error) {
 	da, ok := digestAlgorithms[algURI]
 	if !ok {
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedAlgorithm, algURI)
+	}
+	if da.weak && !allowSHA1 {
+		return nil, fmt.Errorf("%w: %s", ErrWeakAlgorithm, algURI)
 	}
 	h := da.hash.New()
 	h.Write(data)
 	return h.Sum(nil), nil
 }
 
-func signBytes(algURI string, key any, data []byte) ([]byte, error) {
+// signBytes signs data with the algorithm identified by algURI. SHA-1-based
+// signature algorithms are rejected with ErrWeakAlgorithm unless allowSHA1 is
+// true.
+func signBytes(algURI string, key any, data []byte, allowSHA1 bool) ([]byte, error) {
 	sa, ok := signatureAlgorithms[algURI]
 	if !ok {
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedAlgorithm, algURI)
+	}
+	if sa.weak && !allowSHA1 {
+		return nil, fmt.Errorf("%w: %s", ErrWeakAlgorithm, algURI)
 	}
 
 	switch algURI {
@@ -66,10 +79,16 @@ func signBytes(algURI string, key any, data []byte) ([]byte, error) {
 	}
 }
 
-func verifyBytes(algURI string, key any, data, sig []byte) error {
+// verifyBytes verifies sig over data with the algorithm identified by algURI.
+// SHA-1-based signature algorithms are rejected with ErrWeakAlgorithm unless
+// allowSHA1 is true.
+func verifyBytes(algURI string, key any, data, sig []byte, allowSHA1 bool) error {
 	sa, ok := signatureAlgorithms[algURI]
 	if !ok {
 		return fmt.Errorf("%w: %s", ErrUnsupportedAlgorithm, algURI)
+	}
+	if sa.weak && !allowSHA1 {
+		return fmt.Errorf("%w: %s", ErrWeakAlgorithm, algURI)
 	}
 
 	switch algURI {

--- a/xmldsig1/base64_whitespace_internal_test.go
+++ b/xmldsig1/base64_whitespace_internal_test.go
@@ -92,7 +92,7 @@ func TestVerifyLineWrappedDigestValue(t *testing.T) {
 
 	canonical, err := canonicalizeSubtree(ExcC14N10, signedInfo, nil)
 	require.NoError(t, err)
-	sigBytes, err := signBytes(AlgRSASHA256, key, canonical)
+	sigBytes, err := signBytes(AlgRSASHA256, key, canonical, false)
 	require.NoError(t, err)
 	setText(t, sigValue, base64.StdEncoding.EncodeToString(sigBytes))
 

--- a/xmldsig1/empty_references_internal_test.go
+++ b/xmldsig1/empty_references_internal_test.go
@@ -50,7 +50,7 @@ func TestEmptyReferencesRejected(t *testing.T) {
 	// Recompute a valid SignatureValue over the reference-free SignedInfo.
 	canonical, err := canonicalizeSubtree(ExcC14N10, signedInfo, nil)
 	require.NoError(t, err)
-	sigBytes, err := signBytes(AlgRSASHA256, key, canonical)
+	sigBytes, err := signBytes(AlgRSASHA256, key, canonical, false)
 	require.NoError(t, err)
 
 	sigValueElem := findChild(t, sigElem, "SignatureValue")

--- a/xmldsig1/errors.go
+++ b/xmldsig1/errors.go
@@ -18,6 +18,12 @@ var (
 	// ErrUnsupportedAlgorithm is returned for unrecognized algorithm URIs.
 	ErrUnsupportedAlgorithm = errors.New("xmldsig1: unsupported algorithm")
 
+	// ErrWeakAlgorithm is returned when a SHA-1-based signature or digest
+	// algorithm is encountered while SHA-1 is not allowed. SHA-1 is rejected
+	// by default; opt in with Verifier.AllowSHA1(true) (for verification) or
+	// Signer.AllowSHA1(true) (for signing) to accept it for legacy interop.
+	ErrWeakAlgorithm = errors.New("xmldsig1: weak algorithm SHA-1 not allowed")
+
 	// ErrUnsupportedTransform is returned for unrecognized transform URIs.
 	ErrUnsupportedTransform = errors.New("xmldsig1: unsupported transform")
 

--- a/xmldsig1/reference_namespace_test.go
+++ b/xmldsig1/reference_namespace_test.go
@@ -59,7 +59,7 @@ func TestForeignNamespaceReferenceRejected(t *testing.T) {
 	// namespace check on the Reference count.
 	canonical, err := canonicalizeSubtree(ExcC14N10, signedInfo, nil)
 	require.NoError(t, err)
-	sigBytes, err := signBytes(AlgRSASHA256, key, canonical)
+	sigBytes, err := signBytes(AlgRSASHA256, key, canonical, false)
 	require.NoError(t, err)
 
 	sigValueElem := findChild(t, sigElem, "SignatureValue")
@@ -118,7 +118,7 @@ func TestDSig11NamespaceReferenceRejected(t *testing.T) {
 	// core-namespace check on the Reference count.
 	canonical, err := canonicalizeSubtree(ExcC14N10, signedInfo, nil)
 	require.NoError(t, err)
-	sigBytes, err := signBytes(AlgRSASHA256, key, canonical)
+	sigBytes, err := signBytes(AlgRSASHA256, key, canonical, false)
 	require.NoError(t, err)
 
 	sigValueElem := findChild(t, sigElem, "SignatureValue")

--- a/xmldsig1/sign.go
+++ b/xmldsig1/sign.go
@@ -17,6 +17,12 @@ func signEnveloped(ctx context.Context, cfg *signerConfig, doc *helium.Document,
 		return fmt.Errorf("%w: signature algorithm not set", ErrInvalidSignature)
 	}
 
+	// Reject weak (SHA-1) algorithms before building or mutating any nodes, so a
+	// rejected default-SHA-1 request leaves the input tree untouched.
+	if err := preflightSignerWeakAlgorithms(cfg); err != nil {
+		return err
+	}
+
 	sigElem, signedInfo, sigValueElem, err := buildSignatureSkeleton(doc, cfg)
 	if err != nil {
 		return err
@@ -64,6 +70,13 @@ func signEnveloping(ctx context.Context, cfg *signerConfig, doc *helium.Document
 	}
 	if cfg.signatureAlgorithm == "" {
 		return nil, fmt.Errorf("%w: signature algorithm not set", ErrInvalidSignature)
+	}
+
+	// Reject weak (SHA-1) algorithms before building nodes or moving caller
+	// content into the <Object>, so a rejected default-SHA-1 request leaves the
+	// input nodes unmoved and the input tree untouched.
+	if err := preflightSignerWeakAlgorithms(cfg); err != nil {
+		return nil, err
 	}
 
 	sigElem, signedInfo, sigValueElem, err := buildSignatureSkeleton(doc, cfg)
@@ -119,6 +132,11 @@ func signDetached(ctx context.Context, cfg *signerConfig, doc *helium.Document, 
 	}
 	if cfg.signatureAlgorithm == "" {
 		return nil, fmt.Errorf("%w: signature algorithm not set", ErrInvalidSignature)
+	}
+
+	// Reject weak (SHA-1) algorithms before building or mutating any nodes.
+	if err := preflightSignerWeakAlgorithms(cfg); err != nil {
+		return nil, err
 	}
 
 	sigElem, signedInfo, sigValueElem, err := buildSignatureSkeleton(doc, cfg)

--- a/xmldsig1/sign.go
+++ b/xmldsig1/sign.go
@@ -29,7 +29,7 @@ func signEnveloped(ctx context.Context, cfg *signerConfig, doc *helium.Document,
 
 	// Process references: compute digests and add Reference elements.
 	for _, ref := range cfg.references {
-		if err := processReference(ctx, doc, sigElem, signedInfo, ref); err != nil {
+		if err := processReference(ctx, doc, sigElem, signedInfo, ref, cfg.allowSHA1); err != nil {
 			// Detach the signature on failure.
 			helium.UnlinkNode(sigElem)
 			return err
@@ -90,7 +90,7 @@ func signEnveloping(ctx context.Context, cfg *signerConfig, doc *helium.Document
 	}
 
 	for _, ref := range cfg.references {
-		if err := processReference(ctx, doc, sigElem, signedInfo, ref); err != nil {
+		if err := processReference(ctx, doc, sigElem, signedInfo, ref, cfg.allowSHA1); err != nil {
 			return nil, err
 		}
 	}
@@ -127,7 +127,7 @@ func signDetached(ctx context.Context, cfg *signerConfig, doc *helium.Document, 
 	}
 
 	for _, ref := range cfg.references {
-		if err := processReference(ctx, doc, sigElem, signedInfo, ref); err != nil {
+		if err := processReference(ctx, doc, sigElem, signedInfo, ref, cfg.allowSHA1); err != nil {
 			return nil, err
 		}
 	}
@@ -208,7 +208,7 @@ func buildSignatureSkeleton(doc *helium.Document, cfg *signerConfig) (*helium.El
 
 // processReference computes the digest for a single Reference and adds the
 // Reference element to SignedInfo.
-func processReference(_ context.Context, doc *helium.Document, sigElem, signedInfo *helium.Element, ref ReferenceConfig) error {
+func processReference(_ context.Context, doc *helium.Document, sigElem, signedInfo *helium.Element, ref ReferenceConfig, allowSHA1 bool) error {
 	// Resolve the reference target.
 	target, err := resolveReference(doc, ref.URI)
 	if err != nil {
@@ -265,8 +265,9 @@ func processReference(_ context.Context, doc *helium.Document, sigElem, signedIn
 		return err
 	}
 
-	// Compute digest.
-	digest, err := computeDigest(ref.DigestAlgorithm, canonical)
+	// Compute digest. A SHA-1 digest is rejected unless the caller opted in
+	// via Signer.AllowSHA1(true).
+	digest, err := computeDigest(ref.DigestAlgorithm, canonical, allowSHA1)
 	if err != nil {
 		return err
 	}
@@ -386,7 +387,7 @@ func computeAndSetSignatureValue(cfg *signerConfig, sigElem *helium.Element, sig
 		return err
 	}
 
-	sigBytes, err := signBytes(cfg.signatureAlgorithm, key, canonical)
+	sigBytes, err := signBytes(cfg.signatureAlgorithm, key, canonical, cfg.allowSHA1)
 	if err != nil {
 		return err
 	}

--- a/xmldsig1/transform_namespace_test.go
+++ b/xmldsig1/transform_namespace_test.go
@@ -83,7 +83,7 @@ func TestForeignNamespaceTransformRejected(t *testing.T) {
 	// namespace check on the Transform element.
 	canonical, err := canonicalizeSubtree(ExcC14N10, signedInfo, nil)
 	require.NoError(t, err)
-	sigBytes, err := signBytes(AlgRSASHA256, key, canonical)
+	sigBytes, err := signBytes(AlgRSASHA256, key, canonical, false)
 	require.NoError(t, err)
 
 	sigValueElem := findChild(t, sigElem, "SignatureValue")

--- a/xmldsig1/transform_reject_test.go
+++ b/xmldsig1/transform_reject_test.go
@@ -31,7 +31,7 @@ func TestVerifyReferenceRejectsUnsupportedTransform(t *testing.T) {
 		},
 	}
 
-	_, err = verifyReference(doc, nil, ref)
+	_, err = verifyReference(doc, nil, ref, false)
 	require.ErrorIs(t, err, ErrUnsupportedTransform)
 }
 
@@ -56,7 +56,7 @@ func TestVerifyReferenceRejectsUnsupportedTransformWithEnveloped(t *testing.T) {
 		},
 	}
 
-	_, err = verifyReference(doc, sigElem, ref)
+	_, err = verifyReference(doc, sigElem, ref, false)
 	require.ErrorIs(t, err, ErrUnsupportedTransform)
 
 	// The Signature element must have been reattached, not left detached.
@@ -79,7 +79,7 @@ func TestUnsupportedTransformErrorWrapping(t *testing.T) {
 		},
 	}
 
-	_, refErr := verifyReference(doc, nil, ref)
+	_, refErr := verifyReference(doc, nil, ref, false)
 	require.Error(t, refErr)
 
 	// Wrap in the actual type callers receive and confirm errors.Is still

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -67,6 +67,14 @@ func verifySignature(ctx context.Context, cfg *verifierConfig, doc *helium.Docum
 		return nil, err
 	}
 
+	// Reject weak (SHA-1) signature/digest algorithms before resolving KeyInfo
+	// or invoking KeySource, so a rejected SHA-1 input returns ErrWeakAlgorithm
+	// without triggering key resolution or surfacing unrelated key/signature
+	// errors.
+	if err := preflightParsedWeakAlgorithms(parsed, cfg.allowSHA1); err != nil {
+		return nil, err
+	}
+
 	// Resolve key.
 	var keyInfoData *KeyInfoData
 	if parsed.keyInfoElem != nil {

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -87,8 +87,9 @@ func verifySignature(ctx context.Context, cfg *verifierConfig, doc *helium.Docum
 		return nil, err
 	}
 
-	// Verify signature value.
-	if err := verifyBytes(parsed.signatureAlg, key, canonical, parsed.signatureValue); err != nil {
+	// Verify signature value. SHA-1-based signature algorithms are rejected
+	// here unless the caller opted in via Verifier.AllowSHA1(true).
+	if err := verifyBytes(parsed.signatureAlg, key, canonical, parsed.signatureValue, cfg.allowSHA1); err != nil {
 		return nil, &VerificationError{Reference: -1, Err: err}
 	}
 
@@ -96,7 +97,7 @@ func verifySignature(ctx context.Context, cfg *verifierConfig, doc *helium.Docum
 	// confirm that the element they intend to consume is actually covered.
 	result := &VerifyResult{Signature: sigElem}
 	for i, ref := range parsed.references {
-		target, err := verifyReference(doc, sigElem, ref)
+		target, err := verifyReference(doc, sigElem, ref, cfg.allowSHA1)
 		if err != nil {
 			return nil, &VerificationError{Reference: i, URI: ref.uri, Err: err}
 		}
@@ -110,7 +111,7 @@ func verifySignature(ctx context.Context, cfg *verifierConfig, doc *helium.Docum
 	return result, nil
 }
 
-func verifyReference(doc *helium.Document, sigElem *helium.Element, ref parsedReference) (*helium.Element, error) {
+func verifyReference(doc *helium.Document, sigElem *helium.Element, ref parsedReference, allowSHA1 bool) (*helium.Element, error) {
 	target, err := resolveReference(doc, ref.uri)
 	if err != nil {
 		return nil, err
@@ -183,8 +184,9 @@ func verifyReference(doc *helium.Document, sigElem *helium.Element, ref parsedRe
 		return nil, err
 	}
 
-	// Compute and compare digest.
-	computed, err := computeDigest(ref.digestAlgorithm, canonical)
+	// Compute and compare digest. A SHA-1 digest is rejected unless the
+	// caller opted in via Verifier.AllowSHA1(true).
+	computed, err := computeDigest(ref.digestAlgorithm, canonical, allowSHA1)
 	if err != nil {
 		return nil, err
 	}

--- a/xmldsig1/weak_algorithm.go
+++ b/xmldsig1/weak_algorithm.go
@@ -1,0 +1,66 @@
+package xmldsig1
+
+import "fmt"
+
+// rejectWeakSignatureAlgorithm returns ErrWeakAlgorithm if algURI names a
+// SHA-1-based signature algorithm and allowSHA1 is false. Unknown algorithms
+// pass through here (they are rejected later by signBytes/verifyBytes with
+// ErrUnsupportedAlgorithm); this gate is concerned solely with the weak-algorithm
+// policy.
+func rejectWeakSignatureAlgorithm(algURI string, allowSHA1 bool) error {
+	sa, ok := signatureAlgorithms[algURI]
+	if !ok {
+		return nil
+	}
+	if sa.weak && !allowSHA1 {
+		return fmt.Errorf("%w: %s", ErrWeakAlgorithm, algURI)
+	}
+	return nil
+}
+
+// rejectWeakDigestAlgorithm returns ErrWeakAlgorithm if algURI names a
+// SHA-1-based digest algorithm and allowSHA1 is false. Unknown algorithms pass
+// through here (they are rejected later by computeDigest).
+func rejectWeakDigestAlgorithm(algURI string, allowSHA1 bool) error {
+	da, ok := digestAlgorithms[algURI]
+	if !ok {
+		return nil
+	}
+	if da.weak && !allowSHA1 {
+		return fmt.Errorf("%w: %s", ErrWeakAlgorithm, algURI)
+	}
+	return nil
+}
+
+// preflightSignerWeakAlgorithms validates the signer's weak-algorithm policy
+// BEFORE any DOM mutation or node moves. Every sign entry point calls this
+// first so that a rejected default-SHA-1 request returns ErrWeakAlgorithm
+// without moving caller content into an <Object>, adding a Signature element,
+// or otherwise mutating the input tree.
+func preflightSignerWeakAlgorithms(cfg *signerConfig) error {
+	if err := rejectWeakSignatureAlgorithm(cfg.signatureAlgorithm, cfg.allowSHA1); err != nil {
+		return err
+	}
+	for _, ref := range cfg.references {
+		if err := rejectWeakDigestAlgorithm(ref.DigestAlgorithm, cfg.allowSHA1); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// preflightParsedWeakAlgorithms validates a parsed signature's weak-algorithm
+// policy BEFORE KeyInfo/key resolution. The verify path calls this right after
+// parsing so that a rejected SHA-1 input returns ErrWeakAlgorithm without
+// invoking KeySource or surfacing unrelated key/signature errors.
+func preflightParsedWeakAlgorithms(parsed *parsedSignature, allowSHA1 bool) error {
+	if err := rejectWeakSignatureAlgorithm(parsed.signatureAlg, allowSHA1); err != nil {
+		return err
+	}
+	for _, ref := range parsed.references {
+		if err := rejectWeakDigestAlgorithm(ref.digestAlgorithm, allowSHA1); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/xmldsig1/weak_algorithm_preflight_test.go
+++ b/xmldsig1/weak_algorithm_preflight_test.go
@@ -1,0 +1,151 @@
+package xmldsig1_test
+
+import (
+	"context"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xmldsig1"
+	"github.com/stretchr/testify/require"
+)
+
+// countSignatureDescendants reports how many ds:Signature / Object elements (by
+// local name) appear under n. Used to assert that a rejected sign call did not
+// graft any signature structure onto the caller's nodes.
+func countLocalElements(n helium.Node, localName string) int {
+	count := 0
+	elem, ok := helium.AsNode[*helium.Element](n)
+	if !ok {
+		return 0
+	}
+	name := elem.Name()
+	for i := range len(name) {
+		if name[i] == ':' {
+			name = name[i+1:]
+			break
+		}
+	}
+	if name == localName {
+		count++
+	}
+	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
+		count += countLocalElements(child, localName)
+	}
+	return count
+}
+
+// TestSignEnvelopingSHA1LeavesInputUnmutated asserts that a default (SHA-1)
+// SignEnveloping call returns ErrWeakAlgorithm AND leaves the caller's content
+// nodes unmoved — not grafted into a new <Object>, and still children of their
+// original parent.
+func TestSignEnvelopingSHA1LeavesInputUnmutated(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, `<root><payload>hello</payload></root>`)
+
+	root := doc.DocumentElement()
+	payload := root.FirstChild()
+	require.NotNil(t, payload)
+	originalParent := payload.Parent()
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA1).
+		Reference(xmldsig1.ReferenceConfig{
+			URI:             "",
+			DigestAlgorithm: xmldsig1.DigestSHA1,
+			Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+		})
+
+	sig, err := signer.SignEnveloping(t.Context(), doc, []helium.Node{payload}, key)
+	require.Error(t, err)
+	require.ErrorIs(t, err, xmldsig1.ErrWeakAlgorithm)
+	require.Nil(t, sig)
+
+	// The payload must still be parented where it was; it must NOT have been
+	// moved into an Object element.
+	require.Same(t, originalParent, payload.Parent(), "content node was moved despite rejection")
+	require.Equal(t, 0, countLocalElements(root, "Object"), "an Object element was created despite rejection")
+	require.Equal(t, 0, countLocalElements(root, "Signature"), "a Signature element was created despite rejection")
+}
+
+// TestSignEnvelopedSHA1DigestLeavesInputUnmutated asserts that a SHA-1 digest
+// (with a strong signature algorithm) is also rejected up front for the
+// enveloped path, without adding a Signature element to the parent.
+func TestSignEnvelopedSHA1DigestLeavesInputUnmutated(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+	parent := doc.DocumentElement()
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.ReferenceConfig{
+			URI:             "",
+			DigestAlgorithm: xmldsig1.DigestSHA1,
+			Transforms:      []xmldsig1.Transform{xmldsig1.Enveloped(), xmldsig1.ExcC14NTransform()},
+		})
+
+	err := signer.SignEnveloped(t.Context(), doc, parent, key)
+	require.Error(t, err)
+	require.ErrorIs(t, err, xmldsig1.ErrWeakAlgorithm)
+	require.Equal(t, 0, countLocalElements(parent, "Signature"), "a Signature element was added despite rejection")
+}
+
+// panicKeySource records whether ResolveKey was invoked and panics if so, so a
+// verify path that resolves the key before rejecting weak algorithms is caught.
+type panicKeySource struct {
+	called *bool
+}
+
+func (p panicKeySource) ResolveKey(_ context.Context, _ *xmldsig1.KeyInfoData, _ string) (any, error) {
+	*p.called = true
+	panic("ResolveKey must not be called for a rejected weak-algorithm signature")
+}
+
+// TestVerifySHA1RejectedBeforeKeyResolution asserts that verifying a SHA-1
+// signature returns ErrWeakAlgorithm WITHOUT invoking KeySource.
+func TestVerifySHA1RejectedBeforeKeyResolution(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := signRSASHA1Doc(t, key)
+
+	called := false
+	verifier := xmldsig1.NewVerifier(panicKeySource{called: &called})
+
+	_, err := verifier.Verify(t.Context(), doc)
+	require.Error(t, err)
+	require.ErrorIs(t, err, xmldsig1.ErrWeakAlgorithm)
+	require.False(t, called, "KeySource.ResolveKey was invoked despite weak-algorithm rejection")
+}
+
+// TestVerifySHA1AcceptedWithOptInCallsKeySource confirms the opt-in path still
+// resolves the key and verifies successfully.
+func TestVerifySHA1AcceptedWithOptInCallsKeySource(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := signRSASHA1Doc(t, key)
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).AllowSHA1(true)
+	_, err := verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+}
+
+// TestSignEnvelopingSHA1AcceptedWithOptIn confirms opt-in enveloping signing
+// still works end-to-end.
+func TestSignEnvelopingSHA1AcceptedWithOptIn(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, `<wrapper/>`)
+
+	payload := doc.CreateElement("payload")
+	require.NoError(t, payload.AddChild(doc.CreateText([]byte("data"))))
+
+	signer := xmldsig1.NewSigner().
+		AllowSHA1(true).
+		SignatureAlgorithm(xmldsig1.AlgRSASHA1).
+		Reference(xmldsig1.ReferenceConfig{
+			URI:             "",
+			DigestAlgorithm: xmldsig1.DigestSHA1,
+			Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+		})
+
+	sig, err := signer.SignEnveloping(t.Context(), doc, []helium.Node{payload}, key)
+	require.NoError(t, err)
+	require.NotNil(t, sig)
+	require.Equal(t, 1, countLocalElements(sig, "Object"))
+}

--- a/xmldsig1/xmldsig1.go
+++ b/xmldsig1/xmldsig1.go
@@ -33,6 +33,7 @@ type signerConfig struct {
 	references         []ReferenceConfig
 	keyInfoBuilder     KeyInfoBuilder
 	signatureID        string
+	allowSHA1          bool
 }
 
 // Signer creates XML Digital Signatures. It uses clone-on-write semantics:
@@ -93,6 +94,16 @@ func (s Signer) SignatureID(id string) Signer {
 	return s
 }
 
+// AllowSHA1 controls whether SHA-1-based signature and digest algorithms
+// (rsa-sha1, hmac-sha1, sha1) may be used when signing. SHA-1 is rejected by
+// default; pass true to opt in for legacy interoperability. SHA-1 is
+// cryptographically weak and should not be used for new signatures.
+func (s Signer) AllowSHA1(allow bool) Signer {
+	s = s.clone()
+	s.cfg.allowSHA1 = allow
+	return s
+}
+
 // SignEnveloped creates an enveloped signature inside the given parent
 // element of the document. The key is a crypto.Signer (rsa.PrivateKey,
 // ecdsa.PrivateKey, ed25519.PrivateKey) or []byte for HMAC.
@@ -115,9 +126,11 @@ func (s Signer) SignDetached(ctx context.Context, doc *helium.Document, key any)
 // verifierConfig holds the configuration for a Verifier.
 type verifierConfig struct {
 	keySource KeySource
+	allowSHA1 bool
 }
 
-// Verifier verifies XML Digital Signatures. It uses clone-on-write semantics.
+// Verifier verifies XML Digital Signatures. It uses clone-on-write semantics:
+// each builder method returns a new Verifier and the original is never mutated.
 type Verifier struct {
 	cfg *verifierConfig
 }
@@ -125,6 +138,26 @@ type Verifier struct {
 // NewVerifier creates a new Verifier with the given key source.
 func NewVerifier(ks KeySource) Verifier {
 	return Verifier{cfg: &verifierConfig{keySource: ks}}
+}
+
+func (v Verifier) clone() Verifier {
+	if v.cfg == nil {
+		return Verifier{cfg: &verifierConfig{}}
+	}
+	cp := *v.cfg
+	return Verifier{cfg: &cp}
+}
+
+// AllowSHA1 controls whether SHA-1-based signature and digest algorithms
+// (rsa-sha1, hmac-sha1, sha1) are accepted during verification. SHA-1 is
+// rejected by default; pass true to opt in for verifying legacy signatures.
+// SHA-1 is cryptographically weak and accepting it exposes callers to
+// downgrade and collision risks, so only enable it when interoperating with
+// systems that cannot be upgraded.
+func (v Verifier) AllowSHA1(allow bool) Verifier {
+	v = v.clone()
+	v.cfg.allowSHA1 = allow
+	return v
 }
 
 // Verify verifies the Signature element in the document. The document must

--- a/xmldsig1/xmldsig1_test.go
+++ b/xmldsig1/xmldsig1_test.go
@@ -80,7 +80,36 @@ func TestSignVerifyRoundTripRSASHA256(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// signRSASHA1Doc signs samlAssertion with rsa-sha1 + sha1 digest, opting in to
+// SHA-1 on the signer (required since SHA-1 is rejected by default).
+func signRSASHA1Doc(t *testing.T, key *rsa.PrivateKey) *helium.Document {
+	t.Helper()
+	doc := mustParseXML(t, samlAssertion)
+	signer := xmldsig1.NewSigner().
+		AllowSHA1(true).
+		SignatureAlgorithm(xmldsig1.AlgRSASHA1).
+		Reference(xmldsig1.ReferenceConfig{
+			URI:             "",
+			DigestAlgorithm: xmldsig1.DigestSHA1,
+			Transforms:      []xmldsig1.Transform{xmldsig1.Enveloped(), xmldsig1.ExcC14NTransform()},
+		})
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+	return doc
+}
+
 func TestSignVerifyRoundTripRSASHA1(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := signRSASHA1Doc(t, key)
+
+	// SHA-1 verification must be opted into; the default verifier rejects it.
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).AllowSHA1(true)
+	_, err := verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+}
+
+// TestSignSHA1RejectedByDefault confirms that signing with SHA-1 is rejected
+// unless Signer.AllowSHA1(true) is set.
+func TestSignSHA1RejectedByDefault(t *testing.T) {
 	key := generateRSAKey(t)
 	doc := mustParseXML(t, samlAssertion)
 
@@ -93,10 +122,46 @@ func TestSignVerifyRoundTripRSASHA1(t *testing.T) {
 		})
 
 	err := signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key)
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.ErrorIs(t, err, xmldsig1.ErrWeakAlgorithm)
+}
+
+// TestVerifySHA1RejectedByDefault confirms an rsa-sha1 + sha1 signature is
+// rejected by the default verifier with ErrWeakAlgorithm.
+func TestVerifySHA1RejectedByDefault(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := signRSASHA1Doc(t, key)
 
 	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
-	_, err = verifier.Verify(t.Context(), doc)
+	_, err := verifier.Verify(t.Context(), doc)
+	require.Error(t, err)
+	require.ErrorIs(t, err, xmldsig1.ErrWeakAlgorithm)
+}
+
+// TestVerifySHA1AcceptedWithOptIn confirms the same signature verifies once
+// SHA-1 is opted in on the verifier.
+func TestVerifySHA1AcceptedWithOptIn(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := signRSASHA1Doc(t, key)
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey)).AllowSHA1(true)
+	_, err := verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+}
+
+// TestVerifySHA256AcceptedByDefault confirms strong algorithms still verify
+// without any opt-in.
+func TestVerifySHA256AcceptedByDefault(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.NewEnvelopedReference())
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err := verifier.Verify(t.Context(), doc)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
- Reject SHA-1 signature/digest algorithms (rsa-sha1, hmac-sha1, sha1) by default on both sign and verify, returning `ErrWeakAlgorithm`
- Add opt-in `Verifier.AllowSHA1(bool)` / `Signer.AllowSHA1(bool)` for legacy interop; SHA-256+ unaffected
- BREAKING default change: previously SHA-1 was accepted with no gate
