### PR TITLE
default xmlenc encryption to AES-GCM

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -300,12 +300,13 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
 XML Encryption 1.1 (W3C xmlenc-core1). Encrypt and decrypt XML elements/content.
 
 - **NewEncryptor() → Encryptor** — create fluent builder for encryption (clone-on-write value type)
-  - `BlockAlgorithm(uri)`, `KeyTransportAlgorithm(uri)`, `RecipientPublicKey(key)`, `SessionKey(key)`, `KeyWrapAlgorithm(uri)`, `KeyEncryptionKey(kek)`, `OAEPDigest(uri)`, `OAEPMGF(uri)`, `OAEPParams(params)` — builder methods
+  - `BlockAlgorithm(uri)`, `AllowLegacyCBC(bool)`, `KeyTransportAlgorithm(uri)`, `RecipientPublicKey(key)`, `SessionKey(key)`, `KeyWrapAlgorithm(uri)`, `KeyEncryptionKey(kek)`, `OAEPDigest(uri)`, `OAEPMGF(uri)`, `OAEPParams(params)` — builder methods
   - `EncryptElement(ctx, elem)`, `EncryptContent(ctx, elem)` — terminal methods
 - **NewDecryptor() → Decryptor** — create fluent builder for decryption
-  - `PrivateKey(key)`, `KeyEncryptionKey(kek)`, `SessionKey(key)` — builder methods
+  - `PrivateKey(key)`, `KeyEncryptionKey(kek)`, `SessionKey(key)`, `AllowUnauthenticatedCBC(bool)` — builder methods
   - `Decrypt(ctx, elem)` — terminal method
 - Block encryption: AES-128/256-CBC, AES-128/256-GCM
+- Secure by default: unset `BlockAlgorithm` → `DefaultBlockAlgorithm` (AES-256-GCM). Selecting a CBC block algorithm for **encryption** requires `Encryptor.AllowLegacyCBC(true)`, else `ErrCBCEncryptionRequiresOptIn`. **Decryption** of CBC requires `Decryptor.AllowUnauthenticatedCBC(true)`, else `ErrCBCRequiresOptIn`
 - Key transport: RSA-OAEP (1.0 + 1.1 with configurable digest/MGF)
 - Key wrapping: AES-128/256-KeyWrap (RFC 3394)
 - Key sizes are bound to the declared algorithm URI on encrypt and decrypt (incl. after unwrap/key transport); mismatch → `KeySizeError`

--- a/xmlenc1/README.md
+++ b/xmlenc1/README.md
@@ -8,14 +8,22 @@ Import path: `github.com/lestrrat-go/helium/xmlenc1`
 
 ## Security
 
-- Prefer AES-GCM. The package binds the `EncryptionMethod/@Algorithm`
-  URI into the AEAD additional-authenticated-data so an attacker cannot
-  substitute a different algorithm URI on the wire.
+- Secure by default. `Encryptor` defaults to authenticated AES-256-GCM
+  (`DefaultBlockAlgorithm`) when no `BlockAlgorithm` is set. The package
+  binds the `EncryptionMethod/@Algorithm` URI into the AEAD
+  additional-authenticated-data so an attacker cannot substitute a
+  different algorithm URI on the wire.
 - AES-CBC is unauthenticated and vulnerable to padding-oracle attacks
-  (Jager/Somorovsky 2011). `Decryptor` refuses CBC by default and
-  returns `ErrCBCRequiresOptIn`. Pass `AllowUnauthenticatedCBC(true)`
-  only if you must accept legacy CBC and you have verified that
-  decryption errors are not exposed to remote attackers.
+  (Jager/Somorovsky 2011).
+  - **Encryption:** selecting a CBC `BlockAlgorithm` requires
+    `Encryptor.AllowLegacyCBC(true)`; otherwise encryption returns
+    `ErrCBCEncryptionRequiresOptIn`. Opt in only to produce ciphertext
+    for a legacy recipient that cannot accept AES-GCM.
+  - **Decryption:** `Decryptor` refuses CBC by default and returns
+    `ErrCBCRequiresOptIn`. Pass `AllowUnauthenticatedCBC(true)` only if
+    you must accept legacy CBC and you have verified that decryption
+    errors are not exposed to remote attackers. Decrypting existing CBC
+    ciphertext is not the vulnerability; emitting new CBC is.
 - The inner parser used on the decrypted plaintext has DTD loading,
   external entity resolution, and network access all disabled. Decrypted
   bytes are attacker-controlled, so a relaxed parser would constitute an

--- a/xmlenc1/errors.go
+++ b/xmlenc1/errors.go
@@ -38,6 +38,18 @@ var (
 	// after evaluating the attack surface (e.g. ensuring decryption
 	// errors are not exposed to remote attackers).
 	ErrCBCRequiresOptIn = errors.New("xmlenc1: AES-CBC decryption requires AllowUnauthenticatedCBC(true)")
+
+	// ErrCBCEncryptionRequiresOptIn is returned when an Encryptor is
+	// configured to emit a new AES-CBC ciphertext (via a CBC
+	// BlockAlgorithm) but the caller has not opted in to legacy CBC
+	// encryption via Encryptor.AllowLegacyCBC(true).
+	//
+	// The Encryptor defaults to AES-256-GCM (authenticated). AES-CBC
+	// under XML Encryption 1.0 is unauthenticated and vulnerable to
+	// padding-oracle attacks (Jager/Somorovsky 2011); XML Encryption
+	// 1.1 deprecated it in favor of AES-GCM. Emitting new CBC
+	// ciphertext therefore requires an explicit acknowledgement.
+	ErrCBCEncryptionRequiresOptIn = errors.New("xmlenc1: AES-CBC encryption requires AllowLegacyCBC(true)")
 )
 
 // UnsupportedAlgorithmError is returned for unrecognized algorithm URIs.

--- a/xmlenc1/keysize_test.go
+++ b/xmlenc1/keysize_test.go
@@ -25,17 +25,23 @@ func TestEncrypt_BlockKeySizeMismatch(t *testing.T) {
 		name string
 		alg  string
 		size int // wrong size
+		cbc  bool
 	}{
-		{"aes256-gcm with 16-byte key", xmlenc1.AES256GCM, 16},
-		{"aes128-gcm with 32-byte key", xmlenc1.AES128GCM, 32},
-		{"aes256-cbc with 16-byte key", xmlenc1.AES256CBC, 16},
-		{"aes128-cbc with 24-byte key", xmlenc1.AES128CBC, 24},
+		{"aes256-gcm with 16-byte key", xmlenc1.AES256GCM, 16, false},
+		{"aes128-gcm with 32-byte key", xmlenc1.AES128GCM, 32, false},
+		{"aes256-cbc with 16-byte key", xmlenc1.AES256CBC, 16, true},
+		{"aes128-cbc with 24-byte key", xmlenc1.AES128CBC, 24, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			doc := mustParseXML(t, `<root><a>hi</a></root>`)
 			enc := xmlenc1.NewEncryptor().
 				BlockAlgorithm(tc.alg).
 				SessionKey(randKey(t, tc.size))
+			// Opt in to CBC so the failure exercises the key-size
+			// binding rather than the CBC encryption opt-in gate.
+			if tc.cbc {
+				enc = enc.AllowLegacyCBC(true)
+			}
 			_, err := enc.EncryptElement(t.Context(), doc.DocumentElement())
 			require.Error(t, err)
 			var kse *xmlenc1.KeySizeError
@@ -174,6 +180,9 @@ func TestSessionKey_CorrectSizeRoundTrip(t *testing.T) {
 			enc := xmlenc1.NewEncryptor().
 				BlockAlgorithm(tc.alg).
 				SessionKey(key)
+			if tc.cbc {
+				enc = enc.AllowLegacyCBC(true)
+			}
 			edElem, err := enc.EncryptElement(t.Context(), doc.DocumentElement())
 			require.NoError(t, err)
 

--- a/xmlenc1/security_test.go
+++ b/xmlenc1/security_test.go
@@ -26,6 +26,7 @@ func TestDecryptCBC_DefaultDenied(t *testing.T) {
 
 	encryptor := xmlenc1.NewEncryptor().
 		BlockAlgorithm(xmlenc1.AES128CBC).
+		AllowLegacyCBC(true).
 		SessionKey(sessionKey)
 	edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
 	require.NoError(t, err)
@@ -46,6 +47,7 @@ func TestDecryptCBC_OptInAllowed(t *testing.T) {
 
 	encryptor := xmlenc1.NewEncryptor().
 		BlockAlgorithm(xmlenc1.AES128CBC).
+		AllowLegacyCBC(true).
 		SessionKey(sessionKey)
 	edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
 	require.NoError(t, err)
@@ -239,6 +241,93 @@ func TestDecryptCBC_PaddingOracle_IndistinguishableErrors(t *testing.T) {
 		"error B leaks padding state: %v", errB)
 	require.False(t, errors.Is(errB, xmlenc1.ErrInvalidPadding),
 		"error B is distinguishable as ErrInvalidPadding: %v", errB)
+}
+
+// D-ENC-003: the Encryptor must default to authenticated AES-GCM. A
+// caller that sets no BlockAlgorithm gets AES-256-GCM, and the emitted
+// EncryptedData advertises a GCM URI (never an unauthenticated CBC URI).
+func TestEncrypt_DefaultsToGCM(t *testing.T) {
+	sessionKey := make([]byte, 32) // AES-256 session key
+	_, err := rand.Read(sessionKey)
+	require.NoError(t, err)
+
+	doc := mustParseXML(t, samlAssertion)
+
+	// No BlockAlgorithm set.
+	encryptor := xmlenc1.NewEncryptor().SessionKey(sessionKey)
+	edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	xml, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, xml, xmlenc1.AES256GCM, "default block algorithm must be AES-256-GCM")
+	require.NotContains(t, xml, "cbc", "default must never emit a CBC algorithm URI")
+
+	// A default Decryptor (no CBC opt-in) must round-trip GCM ciphertext.
+	decryptor := xmlenc1.NewDecryptor().SessionKey(sessionKey)
+	nodes, err := decryptor.Decrypt(t.Context(), edElem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	s, err := helium.WriteString(nodes[0])
+	require.NoError(t, err)
+	require.Contains(t, s, "user@example.com")
+}
+
+// D-ENC-003: selecting a CBC BlockAlgorithm without AllowLegacyCBC must
+// be refused with ErrCBCEncryptionRequiresOptIn and emit no ciphertext.
+func TestEncryptCBC_DefaultDenied(t *testing.T) {
+	for _, alg := range []string{xmlenc1.AES128CBC, xmlenc1.AES256CBC} {
+		sessionKey := make([]byte, 16)
+		if alg == xmlenc1.AES256CBC {
+			sessionKey = make([]byte, 32)
+		}
+		_, err := rand.Read(sessionKey)
+		require.NoError(t, err)
+
+		doc := mustParseXML(t, samlAssertion)
+		encryptor := xmlenc1.NewEncryptor().
+			BlockAlgorithm(alg).
+			SessionKey(sessionKey)
+		_, err = encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+		require.Error(t, err)
+		require.ErrorIs(t, err, xmlenc1.ErrCBCEncryptionRequiresOptIn)
+
+		// Nothing should have been serialized into the tree.
+		xml, werr := helium.WriteString(doc)
+		require.NoError(t, werr)
+		require.NotContains(t, xml, elemEncryptedData)
+		require.Contains(t, xml, "user@example.com")
+	}
+}
+
+// D-ENC-003: with AllowLegacyCBC(true), CBC encryption works (legacy
+// interop) and round-trips against a CBC-opted-in Decryptor.
+func TestEncryptCBC_OptInAllowed(t *testing.T) {
+	sessionKey := make([]byte, 16)
+	_, err := rand.Read(sessionKey)
+	require.NoError(t, err)
+
+	doc := mustParseXML(t, samlAssertion)
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES128CBC).
+		AllowLegacyCBC(true).
+		SessionKey(sessionKey)
+	edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	xml, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, xml, xmlenc1.AES128CBC)
+
+	decryptor := xmlenc1.NewDecryptor().
+		SessionKey(sessionKey).
+		AllowUnauthenticatedCBC(true)
+	nodes, err := decryptor.Decrypt(t.Context(), edElem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	s, err := helium.WriteString(nodes[0])
+	require.NoError(t, err)
+	require.Contains(t, s, "user@example.com")
 }
 
 // swapEncryptionMethodAlgorithm finds the EncryptionMethod child of

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -23,7 +23,12 @@ type encryptConfig struct {
 	oaepParams       []byte
 	keyWrapAlgorithm string
 	keyEncryptionKey []byte
+	allowLegacyCBC   bool
 }
+
+// DefaultBlockAlgorithm is the block encryption algorithm an Encryptor
+// uses when no BlockAlgorithm is set. It is authenticated AES-256-GCM.
+const DefaultBlockAlgorithm = AES256GCM
 
 // Encryptor encrypts XML elements or content. It uses clone-on-write
 // semantics: each builder method returns a new Encryptor and the original
@@ -45,10 +50,33 @@ func (e Encryptor) clone() Encryptor {
 	return Encryptor{cfg: &cp}
 }
 
-// BlockAlgorithm sets the block encryption algorithm URI.
+// BlockAlgorithm sets the block encryption algorithm URI. If never set,
+// the Encryptor defaults to [DefaultBlockAlgorithm] (authenticated
+// AES-256-GCM).
+//
+// Selecting an AES-CBC algorithm (AES128CBC / AES256CBC) additionally
+// requires AllowLegacyCBC(true): CBC under XML Encryption 1.0 is
+// unauthenticated and padding-oracle-prone, so emitting new CBC
+// ciphertext is gated behind an explicit opt-in. Without it, encryption
+// returns [ErrCBCEncryptionRequiresOptIn].
 func (e Encryptor) BlockAlgorithm(uri string) Encryptor {
 	e = e.clone()
 	e.cfg.blockAlgorithm = uri
+	return e
+}
+
+// AllowLegacyCBC opts the Encryptor in to emitting unauthenticated
+// AES-CBC ciphertext when a CBC BlockAlgorithm is selected.
+//
+// The Encryptor defaults to authenticated AES-GCM. AES-CBC under XML
+// Encryption 1.0 is unauthenticated and vulnerable to padding-oracle
+// attacks (Jager/Somorovsky 2011); XML Encryption 1.1 deprecated it in
+// favor of AES-GCM. Set this to true only when you must produce
+// ciphertext for a legacy recipient that cannot accept AES-GCM. This
+// does not affect decryption (see Decryptor.AllowUnauthenticatedCBC).
+func (e Encryptor) AllowLegacyCBC(v bool) Encryptor {
+	e = e.clone()
+	e.cfg.allowLegacyCBC = v
 	return e
 }
 
@@ -122,8 +150,20 @@ func (e Encryptor) EncryptContent(ctx context.Context, elem *helium.Element) (*h
 }
 
 func encrypt(_ context.Context, cfg *encryptConfig, elem *helium.Element, encType string) (*helium.Element, error) {
-	if cfg.blockAlgorithm == "" {
-		return nil, fmt.Errorf("%w: block algorithm not set", ErrMissingConfig)
+	// Secure by default: an unset block algorithm uses authenticated
+	// AES-256-GCM rather than refusing or falling back to CBC.
+	blockAlgorithm := cfg.blockAlgorithm
+	if blockAlgorithm == "" {
+		blockAlgorithm = DefaultBlockAlgorithm
+	}
+
+	// Emitting new unauthenticated CBC ciphertext requires an explicit
+	// opt-in. Decryption of existing CBC ciphertext is unaffected.
+	switch blockAlgorithm {
+	case AES128CBC, AES256CBC:
+		if !cfg.allowLegacyCBC {
+			return nil, ErrCBCEncryptionRequiresOptIn
+		}
 	}
 
 	hasKeyTransport := cfg.recipientPubKey != nil && cfg.keyTransport != ""
@@ -135,7 +175,7 @@ func encrypt(_ context.Context, cfg *encryptConfig, elem *helium.Element, encTyp
 	}
 
 	// Get or generate session key.
-	keySize, err := keySizeForAlgorithm(cfg.blockAlgorithm)
+	keySize, err := keySizeForAlgorithm(blockAlgorithm)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +191,7 @@ func encrypt(_ context.Context, cfg *encryptConfig, elem *helium.Element, encTyp
 	// Bind the declared block-algorithm URI to the session-key length so
 	// a user-supplied SessionKey cannot make us emit, e.g., an AES-256
 	// URI while actually encrypting with AES-128.
-	if err := validateKeySize(cfg.blockAlgorithm, sessionKey); err != nil {
+	if err := validateKeySize(blockAlgorithm, sessionKey); err != nil {
 		return nil, err
 	}
 
@@ -167,7 +207,7 @@ func encrypt(_ context.Context, cfg *encryptConfig, elem *helium.Element, encTyp
 	}
 
 	// Block encrypt.
-	cipherValue, err := blockEncrypt(cfg.blockAlgorithm, sessionKey, []byte(plaintext))
+	cipherValue, err := blockEncrypt(blockAlgorithm, sessionKey, []byte(plaintext))
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +248,7 @@ func encrypt(_ context.Context, cfg *encryptConfig, elem *helium.Element, encTyp
 	// Build EncryptedData.
 	ed := &EncryptedData{
 		Type:             encType,
-		EncryptionMethod: &EncryptionMethod{Algorithm: cfg.blockAlgorithm},
+		EncryptionMethod: &EncryptionMethod{Algorithm: blockAlgorithm},
 		EncryptedKey:     encKey,
 		CipherValue:      cipherValue,
 	}

--- a/xmlenc1/xmlenc1_test.go
+++ b/xmlenc1/xmlenc1_test.go
@@ -37,6 +37,7 @@ func TestEncryptDecryptElementRSAOAEP_AES128CBC(t *testing.T) {
 
 	encryptor := xmlenc1.NewEncryptor().
 		BlockAlgorithm(xmlenc1.AES128CBC).
+		AllowLegacyCBC(true).
 		KeyTransportAlgorithm(xmlenc1.RSAOAEP).
 		RecipientPublicKey(&key.PublicKey)
 
@@ -197,6 +198,7 @@ func TestEncryptDecryptWithAESKeyWrap(t *testing.T) {
 
 	encryptor := xmlenc1.NewEncryptor().
 		BlockAlgorithm(xmlenc1.AES256CBC).
+		AllowLegacyCBC(true).
 		KeyWrapAlgorithm(xmlenc1.AES256KeyWrap).
 		KeyEncryptionKey(kek)
 
@@ -223,6 +225,7 @@ func TestEncryptDecryptWithSessionKey(t *testing.T) {
 
 	encryptor := xmlenc1.NewEncryptor().
 		BlockAlgorithm(xmlenc1.AES128CBC).
+		AllowLegacyCBC(true).
 		SessionKey(sessionKey)
 
 	edElem, err := encryptor.EncryptElement(t.Context(), elem)
@@ -239,7 +242,7 @@ func TestEncryptDecryptWithSessionKey(t *testing.T) {
 }
 
 func TestEncryptorImmutability(t *testing.T) {
-	e1 := xmlenc1.NewEncryptor().BlockAlgorithm(xmlenc1.AES128CBC)
+	e1 := xmlenc1.NewEncryptor().BlockAlgorithm(xmlenc1.AES128CBC).AllowLegacyCBC(true)
 	e2 := e1.BlockAlgorithm(xmlenc1.AES256GCM)
 
 	// e1 should still be AES128CBC (not modified by e2).
@@ -266,9 +269,10 @@ func TestEncryptNoConfig(t *testing.T) {
 
 func TestEncryptNoKey(t *testing.T) {
 	doc := mustParseXML(t, samlAssertion)
-	encryptor := xmlenc1.NewEncryptor().BlockAlgorithm(xmlenc1.AES128CBC)
+	encryptor := xmlenc1.NewEncryptor().BlockAlgorithm(xmlenc1.AES256GCM)
 	_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
 	require.Error(t, err)
+	require.ErrorIs(t, err, xmlenc1.ErrMissingConfig)
 }
 
 func TestDecryptWrongKey(t *testing.T) {
@@ -278,6 +282,7 @@ func TestDecryptWrongKey(t *testing.T) {
 
 	encryptor := xmlenc1.NewEncryptor().
 		BlockAlgorithm(xmlenc1.AES128CBC).
+		AllowLegacyCBC(true).
 		KeyTransportAlgorithm(xmlenc1.RSAOAEP).
 		RecipientPublicKey(&key1.PublicKey)
 
@@ -305,6 +310,7 @@ func TestAESKeyWrapRFC3394(t *testing.T) {
 
 	encryptor := xmlenc1.NewEncryptor().
 		BlockAlgorithm(xmlenc1.AES256CBC).
+		AllowLegacyCBC(true).
 		KeyWrapAlgorithm(xmlenc1.AES256KeyWrap).
 		KeyEncryptionKey(kek).
 		SessionKey(keyData)
@@ -645,6 +651,7 @@ func TestEncryptElementPreservesSiblingOrder(t *testing.T) {
 
 			encryptor := xmlenc1.NewEncryptor().
 				BlockAlgorithm(xmlenc1.AES128CBC).
+				AllowLegacyCBC(true).
 				KeyTransportAlgorithm(xmlenc1.RSAOAEP).
 				RecipientPublicKey(&key.PublicKey)
 
@@ -664,6 +671,7 @@ func TestEncryptElementRootInPlace(t *testing.T) {
 
 	encryptor := xmlenc1.NewEncryptor().
 		BlockAlgorithm(xmlenc1.AES128CBC).
+		AllowLegacyCBC(true).
 		KeyTransportAlgorithm(xmlenc1.RSAOAEP).
 		RecipientPublicKey(&key.PublicKey)
 


### PR DESCRIPTION
- `Encryptor` now defaults to authenticated AES-256-GCM (`DefaultBlockAlgorithm`) when no `BlockAlgorithm` is set, instead of erroring
- selecting a CBC block algorithm for encryption now requires `Encryptor.AllowLegacyCBC(true)`, else `ErrCBCEncryptionRequiresOptIn`
- CBC decryption is unchanged (still gated by `Decryptor.AllowUnauthenticatedCBC`); existing CBC ciphertext still decrypts
- BREAKING default change for encryption: callers relying on a default CBC selection or unset-algorithm error must adapt
