### PR TITLE
match urn:publicid prefix case-insensitively

### DIFF
--- a/internal/catalog/urn.go
+++ b/internal/catalog/urn.go
@@ -21,7 +21,10 @@ const urnPrefix = "urn:publicid:"
 //     %23 → #
 //     %25 → %
 func UnwrapURN(urn string) string {
-	if !strings.HasPrefix(urn, urnPrefix) {
+	// The URN scheme and namespace identifier are case-insensitive per
+	// RFC 8141 / the OASIS catalog spec, so match the "urn:publicid:" prefix
+	// case-insensitively while preserving the case of the payload that follows.
+	if len(urn) < len(urnPrefix) || !strings.EqualFold(urn[:len(urnPrefix)], urnPrefix) {
 		return ""
 	}
 	rest := urn[len(urnPrefix):]

--- a/internal/catalog/urn_test.go
+++ b/internal/catalog/urn_test.go
@@ -1,0 +1,29 @@
+package catalog_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/internal/catalog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnwrapURN(t *testing.T) {
+	t.Run("case-insensitive scheme and namespace", func(t *testing.T) {
+		want := catalog.UnwrapURN("urn:publicid:foo")
+		require.Equal(t, "foo", want)
+
+		// URN scheme + namespace identifier are case-insensitive per
+		// RFC 8141 / OASIS catalog spec; uppercase prefix must also match.
+		require.Equal(t, want, catalog.UnwrapURN("URN:PUBLICID:foo"))
+		require.Equal(t, want, catalog.UnwrapURN("Urn:PublicId:foo"))
+	})
+
+	t.Run("payload case preserved", func(t *testing.T) {
+		require.Equal(t, "FooBar", catalog.UnwrapURN("URN:PUBLICID:FooBar"))
+	})
+
+	t.Run("not a publicid urn", func(t *testing.T) {
+		require.Equal(t, "", catalog.UnwrapURN("urn:isbn:0451450523"))
+		require.Equal(t, "", catalog.UnwrapURN("http://example.com/foo"))
+	})
+}


### PR DESCRIPTION
- CAT-009: `UnwrapURN` matched the `urn:publicid:` prefix case-sensitively; URN scheme + namespace identifier are case-insensitive per RFC 8141 / OASIS catalog spec.
- Match the prefix with `strings.EqualFold`, preserving the unwrapped public-identifier payload case.
