### PR TITLE
try catalog delegates longest-prefix first

### DIFF
--- a/internal/catalog/resolve.go
+++ b/internal/catalog/resolve.go
@@ -3,8 +3,31 @@ package catalog
 import (
 	"context"
 	"errors"
+	"sort"
 	"strings"
 )
+
+// matchingDelegates collects the delegate entries (of the given type whose
+// start-string prefixes the identifier) and returns them ordered
+// most-specific-first: longest matching start-string first, as required by the
+// OASIS XML Catalogs spec. Ties preserve document order (stable sort).
+func (c *Catalog) matchingDelegates(typ EntryType, id string) []*Entry {
+	var matches []*Entry
+	for i := range c.Entries {
+		e := &c.Entries[i]
+		if e.Type != typ {
+			continue
+		}
+		if !strings.HasPrefix(id, e.Name) {
+			continue
+		}
+		matches = append(matches, e)
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		return len(matches[i].Name) > len(matches[j].Name)
+	})
+	return matches
+}
 
 // CatalogBreak is a sentinel returned internally to signal "delegates were
 // tried but all failed" — stops nextCatalog fallback (the libxml2 "cut"
@@ -266,14 +289,7 @@ func (c *Catalog) resolveURI(ctx context.Context, st *resolveState, uri string) 
 func (c *Catalog) resolveDelegateSystem(ctx context.Context, st *resolveState, sysID string) string {
 	seen := make(map[string]struct{}, MaxDelegates)
 
-	for i := range c.Entries {
-		e := &c.Entries[i]
-		if e.Type != EntryDelegateSystem {
-			continue
-		}
-		if !strings.HasPrefix(sysID, e.Name) {
-			continue
-		}
+	for _, e := range c.matchingDelegates(EntryDelegateSystem, sysID) {
 		if _, dup := seen[e.URL]; dup {
 			continue
 		}
@@ -301,15 +317,8 @@ func (c *Catalog) resolveDelegateSystem(ctx context.Context, st *resolveState, s
 func (c *Catalog) resolveDelegatePublic(ctx context.Context, st *resolveState, pubID string) string {
 	seen := make(map[string]struct{}, MaxDelegates)
 
-	for i := range c.Entries {
-		e := &c.Entries[i]
-		if e.Type != EntryDelegatePublic {
-			continue
-		}
+	for _, e := range c.matchingDelegates(EntryDelegatePublic, pubID) {
 		if e.Prefer != PreferPublic {
-			continue
-		}
-		if !strings.HasPrefix(pubID, e.Name) {
 			continue
 		}
 		if _, dup := seen[e.URL]; dup {
@@ -339,14 +348,7 @@ func (c *Catalog) resolveDelegatePublic(ctx context.Context, st *resolveState, p
 func (c *Catalog) resolveDelegateURI(ctx context.Context, st *resolveState, uri string) string {
 	seen := make(map[string]struct{}, MaxDelegates)
 
-	for i := range c.Entries {
-		e := &c.Entries[i]
-		if e.Type != EntryDelegateURI {
-			continue
-		}
-		if !strings.HasPrefix(uri, e.Name) {
-			continue
-		}
+	for _, e := range c.matchingDelegates(EntryDelegateURI, uri) {
 		if _, dup := seen[e.URL]; dup {
 			continue
 		}

--- a/internal/catalog/resolve_test.go
+++ b/internal/catalog/resolve_test.go
@@ -294,6 +294,117 @@ func (l *countingLoader) Load(_ context.Context, filename string) (*catalog.Cata
 	return &cp, nil
 }
 
+// Per the OASIS XML Catalogs spec, matching delegate entries must be tried
+// most-specific-first: the entry with the longest matching start-string is
+// followed before shorter ones. Here the longer prefix points at a catalog
+// that resolves the identifier; if document order were used the shorter
+// (earlier) delegate would be tried first and a recordingLoader would observe
+// the wrong load order.
+func TestDelegateLongestPrefixFirst(t *testing.T) {
+	t.Parallel()
+
+	specific := &catalog.Catalog{
+		Entries: []catalog.Entry{
+			{Type: catalog.EntrySystem, Name: "http://example.com/sub/foo.dtd", URL: "file:///specific.dtd"},
+			{Type: catalog.EntryURI, Name: "http://example.com/sub/foo.xsd", URL: "file:///specific.xsd"},
+			{Type: catalog.EntryPublic, Name: "-//Example//Sub Pub//EN", URL: "file:///specific-pub.dtd"},
+		},
+		Prefer: catalog.PreferPublic,
+	}
+	general := &catalog.Catalog{
+		Entries: []catalog.Entry{
+			{Type: catalog.EntrySystem, Name: "http://example.com/sub/foo.dtd", URL: "file:///general.dtd"},
+			{Type: catalog.EntryURI, Name: "http://example.com/sub/foo.xsd", URL: "file:///general.xsd"},
+			{Type: catalog.EntryPublic, Name: "-//Example//Sub Pub//EN", URL: "file:///general-pub.dtd"},
+		},
+		Prefer: catalog.PreferPublic,
+	}
+
+	const generalXML = "general.xml"
+	const specificXML = "specific.xml"
+
+	newLoader := func() *recordingLoader {
+		return &recordingLoader{
+			cats: map[string]*catalog.Catalog{
+				generalXML:  general,
+				specificXML: specific,
+			},
+		}
+	}
+
+	t.Run("delegateSystem", func(t *testing.T) {
+		t.Parallel()
+		loader := newLoader()
+		// Entries listed shorter-prefix-first in document order; the longer
+		// prefix must still be tried first.
+		root := &catalog.Catalog{
+			Entries: []catalog.Entry{
+				{Type: catalog.EntryDelegateSystem, Name: "http://example.com/", URL: generalXML},
+				{Type: catalog.EntryDelegateSystem, Name: "http://example.com/sub/", URL: specificXML},
+			},
+			Loader: loader,
+		}
+		got := root.Resolve(t.Context(), "", "http://example.com/sub/foo.dtd")
+		require.Equal(t, "file:///specific.dtd", got)
+		require.Equal(t, specificXML, loader.first(), "longest matching delegateSystem prefix must be tried first")
+	})
+
+	t.Run("delegatePublic", func(t *testing.T) {
+		t.Parallel()
+		loader := newLoader()
+		root := &catalog.Catalog{
+			Entries: []catalog.Entry{
+				{Type: catalog.EntryDelegatePublic, Name: "-//Example//", URL: generalXML, Prefer: catalog.PreferPublic},
+				{Type: catalog.EntryDelegatePublic, Name: "-//Example//Sub", URL: specificXML, Prefer: catalog.PreferPublic},
+			},
+			Loader: loader,
+			Prefer: catalog.PreferPublic,
+		}
+		got := root.Resolve(t.Context(), "-//Example//Sub Pub//EN", "")
+		require.Equal(t, "file:///specific-pub.dtd", got)
+		require.Equal(t, specificXML, loader.first(), "longest matching delegatePublic prefix must be tried first")
+	})
+
+	t.Run("delegateURI", func(t *testing.T) {
+		t.Parallel()
+		loader := newLoader()
+		root := &catalog.Catalog{
+			Entries: []catalog.Entry{
+				{Type: catalog.EntryDelegateURI, Name: "http://example.com/", URL: generalXML},
+				{Type: catalog.EntryDelegateURI, Name: "http://example.com/sub/", URL: specificXML},
+			},
+			Loader: loader,
+		}
+		got := root.ResolveURI(t.Context(), "http://example.com/sub/foo.xsd")
+		require.Equal(t, "file:///specific.xsd", got)
+		require.Equal(t, specificXML, loader.first(), "longest matching delegateURI prefix must be tried first")
+	})
+}
+
+// recordingLoader records the order in which catalog URLs are loaded.
+type recordingLoader struct {
+	mu    sync.Mutex
+	order []string
+	cats  map[string]*catalog.Catalog
+}
+
+func (l *recordingLoader) Load(_ context.Context, filename string) (*catalog.Catalog, error) {
+	l.mu.Lock()
+	l.order = append(l.order, filename)
+	cat := l.cats[filename]
+	l.mu.Unlock()
+	return cat, nil
+}
+
+func (l *recordingLoader) first() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.order) == 0 {
+		return ""
+	}
+	return l.order[0]
+}
+
 func TestVisitedCacheSkipsDuplicate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/catalog/resolve_test.go
+++ b/internal/catalog/resolve_test.go
@@ -15,6 +15,8 @@ const sharedCatalogXML = "shared.xml"
 
 const missingCatalogXML = "missing.xml"
 
+const exampleBase = "http://example.com/"
+
 func TestResolveURIUnwrapsURN(t *testing.T) {
 	t.Parallel()
 
@@ -96,7 +98,7 @@ func TestResolveURIIgnoresDelegateSystem(t *testing.T) {
 
 	cat := &catalog.Catalog{
 		Entries: []catalog.Entry{
-			{Type: catalog.EntryDelegateSystem, Name: "http://example.com/", URL: sharedCatalogXML},
+			{Type: catalog.EntryDelegateSystem, Name: exampleBase, URL: sharedCatalogXML},
 		},
 		Loader: loader,
 		Prefer: catalog.PreferPublic,
@@ -146,7 +148,7 @@ func TestConcurrentResolveSharedCatalog(t *testing.T) {
 	// nextCatalog fallback (uri leaf).
 	root := &catalog.Catalog{
 		Entries: []catalog.Entry{
-			{Type: catalog.EntryDelegateSystem, Name: "http://example.com/", URL: "sys.xml"},
+			{Type: catalog.EntryDelegateSystem, Name: exampleBase, URL: "sys.xml"},
 			{Type: catalog.EntryDelegatePublic, Name: "-//Example//", URL: "pub.xml", Prefer: catalog.PreferPublic},
 			{Type: catalog.EntryNextCatalog, URL: "uri.xml"},
 		},
@@ -339,7 +341,7 @@ func TestDelegateLongestPrefixFirst(t *testing.T) {
 		// prefix must still be tried first.
 		root := &catalog.Catalog{
 			Entries: []catalog.Entry{
-				{Type: catalog.EntryDelegateSystem, Name: "http://example.com/", URL: generalXML},
+				{Type: catalog.EntryDelegateSystem, Name: exampleBase, URL: generalXML},
 				{Type: catalog.EntryDelegateSystem, Name: "http://example.com/sub/", URL: specificXML},
 			},
 			Loader: loader,
@@ -370,7 +372,7 @@ func TestDelegateLongestPrefixFirst(t *testing.T) {
 		loader := newLoader()
 		root := &catalog.Catalog{
 			Entries: []catalog.Entry{
-				{Type: catalog.EntryDelegateURI, Name: "http://example.com/", URL: generalXML},
+				{Type: catalog.EntryDelegateURI, Name: exampleBase, URL: generalXML},
 				{Type: catalog.EntryDelegateURI, Name: "http://example.com/sub/", URL: specificXML},
 			},
 			Loader: loader,
@@ -523,7 +525,7 @@ func TestNoLoaderDoesNotPanic(t *testing.T) {
 		{
 			name: "delegateSystem",
 			entries: []catalog.Entry{
-				{Type: catalog.EntryDelegateSystem, Name: "http://example.com/", URL: missingCatalogXML},
+				{Type: catalog.EntryDelegateSystem, Name: exampleBase, URL: missingCatalogXML},
 			},
 			resolve: func(c *catalog.Catalog) string {
 				return c.Resolve(context.Background(), "", "http://example.com/x")
@@ -541,7 +543,7 @@ func TestNoLoaderDoesNotPanic(t *testing.T) {
 		{
 			name: "delegateURI",
 			entries: []catalog.Entry{
-				{Type: catalog.EntryDelegateURI, Name: "http://example.com/", URL: missingCatalogXML},
+				{Type: catalog.EntryDelegateURI, Name: exampleBase, URL: missingCatalogXML},
 			},
 			resolve: func(c *catalog.Catalog) string {
 				return c.ResolveURI(context.Background(), "http://example.com/x")


### PR DESCRIPTION
- CAT-006: try matching catalog delegate entries most-specific-first (longest matching start-string) per the OASIS XML Catalogs spec, instead of document order
- applies to delegatePublic / delegateSystem / delegateURI
