### PR TITLE
keep catalog error handler open for lazy loads

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -73,8 +73,13 @@ func (l Loader) clone() Loader {
 	return Loader{cfg: &cp}
 }
 
-// ErrorHandler returns a copy of the Loader that delivers warnings
-// to the given error handler during catalog parsing.
+// ErrorHandler returns a copy of the Loader that delivers warnings to the given
+// error handler during catalog parsing.
+//
+// The handler is retained by the returned Catalog and also receives diagnostics
+// from delegate / nextCatalog files loaded lazily at Resolve time. Load does not
+// close the handler; the caller owns its lifecycle and must close it (when it is
+// an io.Closer such as ErrorCollector) once the Catalog is no longer in use.
 func (l Loader) ErrorHandler(h helium.ErrorHandler) Loader {
 	l = l.clone()
 	l.cfg.errorHandler = h

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/catalog"
 	icatalog "github.com/lestrrat-go/helium/internal/catalog"
 	"github.com/lestrrat-go/helium/internal/heliumtest"
@@ -358,6 +359,43 @@ func TestNextCatalogFileURIRelativeEntry(t *testing.T) {
 	require.Equal(t, want, got)
 	require.True(t, strings.HasPrefix(got, "file:"),
 		"relative downstream uri must resolve to a file: URI, got %q", got)
+}
+
+// A nextCatalog pointing at a MALFORMED child catalog is loaded lazily at
+// Resolve time. The parse error from that lazy load must reach the caller's
+// ErrorHandler. The caller owns the handler lifecycle: Load does not close it,
+// so it is still live when the lazy load runs.
+func TestLazyLoadDiagnosticsDelivered(t *testing.T) {
+	dir := t.TempDir()
+
+	// Malformed child catalog: parses, but its <system> entry is missing the
+	// required uri attribute, which the loader reports via the ErrorHandler.
+	nextPath := filepath.Join(dir, "next.xml")
+	nextXML := `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <system systemId="http://example.com/missing"/>
+</catalog>`
+	require.NoError(t, os.WriteFile(nextPath, []byte(nextXML), 0o600))
+
+	rootXML := `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <nextCatalog catalog="` + filepath.ToSlash(nextPath) + `"/>
+</catalog>`
+	rootPath := filepath.Join(dir, "root.xml")
+	require.NoError(t, os.WriteFile(rootPath, []byte(rootXML), 0o600))
+
+	ec := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+
+	cat, err := catalog.NewLoader().ErrorHandler(ec).Load(t.Context(), rootPath)
+	require.NoError(t, err, "root catalog itself is well-formed")
+
+	// Triggering the lazy load of the malformed child must surface its parse
+	// error through the still-live handler.
+	cat.Resolve(t.Context(), "", "http://example.com/missing")
+
+	require.NoError(t, ec.Close())
+	require.NotEmpty(t, ec.Errors(),
+		"lazy-load parse error must be delivered to the caller's ErrorHandler")
 }
 
 func TestLoadError(t *testing.T) {

--- a/catalog/load.go
+++ b/catalog/load.go
@@ -54,13 +54,16 @@ func (l Loader) Load(ctx context.Context, filename string) (*Catalog, error) { /
 		eh = helium.NilErrorHandler{}
 	}
 
+	// The caller owns the ErrorHandler lifecycle: the returned Catalog retains
+	// this handler (via internalLoader) to deliver diagnostics from delegate /
+	// nextCatalog files that are loaded lazily at Resolve time. Closing it here
+	// would silently drop every later lazy-load diagnostic, so Load never closes
+	// a caller-supplied handler.
 	ic, err := loadInternal(ctx, filename, eh, cfg.maxBytes)
 	if err != nil {
-		closeHandler(eh)
 		return nil, err
 	}
 
-	closeHandler(eh)
 	return &Catalog{cat: ic}, nil
 }
 
@@ -429,13 +432,6 @@ func catalogMissingAttr(ctx context.Context, eh helium.ErrorHandler, elemName, v
 	}
 	if val2 == "" {
 		eh.Handle(ctx, fmt.Errorf("%s entry missing %s attribute", elemName, attr2))
-	}
-}
-
-// closeHandler closes the error handler if it implements io.Closer.
-func closeHandler(eh helium.ErrorHandler) {
-	if c, ok := eh.(io.Closer); ok {
-		_ = c.Close()
 	}
 }
 


### PR DESCRIPTION
- CAT-002 (handler-lifecycle defect, NOT a data race): catalog `Load` closed the caller-supplied `ErrorHandler` before returning, but the returned `Catalog` retains that same handler for delegate/nextCatalog files loaded lazily at `Resolve` time — so every lazy-load diagnostic was silently dropped, even single-threaded.
- Fix: `Load` no longer closes a caller-supplied handler; the caller owns its lifecycle. Behavior change: callers that relied on `Load` auto-closing their handler must now close it themselves (when it is an io.Closer, e.g. `ErrorCollector`).
- Added a fail-before/pass-after test that resolves through a nextCatalog to a malformed child catalog and asserts the diagnostic reaches the caller handler.