### PR TITLE
reject malformed catalog entry uris

### DIFF
--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -370,3 +370,57 @@ func TestNilCatalog(t *testing.T) {
 	require.Equal(t, "", c.Resolve(t.Context(), "foo", "bar"))
 	require.Equal(t, "", c.ResolveURI(t.Context(), "foo"))
 }
+
+// captureHandler records every error delivered to it.
+type captureHandler struct {
+	errs []error
+}
+
+func (h *captureHandler) Handle(_ context.Context, err error) {
+	h.errs = append(h.errs, err)
+}
+
+// A catalog entry whose uri is a syntactically malformed URI must be reported
+// through the error handler and skipped, while well-formed entries in the same
+// catalog still load. Regression for CAT-008: ResolveURI used to silently
+// accept the raw malformed value, storing it as a usable mapping.
+func TestMalformedEntryURIReportedAndSkipped(t *testing.T) {
+	dir := t.TempDir()
+	catPath, err := filepath.Abs(filepath.Join(dir, "catalog.xml"))
+	require.NoError(t, err)
+
+	// "%zz" is invalid percent-encoding and is rejected by url.Parse when
+	// resolved against the catalog's file: base URI.
+	xml := `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <uri name="http://example.com/bad" uri="%zz"/>
+  <uri name="http://example.com/good" uri="good.xml"/>
+</catalog>`
+	require.NoError(t, os.WriteFile(catPath, []byte(xml), 0o600))
+
+	// Reference the catalog via a file:// URI so its base URI carries a scheme;
+	// relative entry URIs are then resolved in URI space, where "%zz" is
+	// rejected by url.Parse. (A bare OS-path base resolves relative entries as
+	// OS paths and never invokes url.Parse.)
+	slashPath := filepath.ToSlash(catPath)
+	if !strings.HasPrefix(slashPath, "/") {
+		slashPath = "/" + slashPath
+	}
+	catURI := (&url.URL{Scheme: "file", Path: slashPath}).String()
+
+	h := &captureHandler{}
+	cat, err := catalog.NewLoader().ErrorHandler(h).Load(context.Background(), catURI)
+	require.NoError(t, err)
+
+	// The malformed entry was reported.
+	require.NotEmpty(t, h.errs, "malformed entry URI must be reported")
+
+	// The malformed entry is not stored as a usable mapping.
+	require.Equal(t, "", cat.ResolveURI(context.Background(), "http://example.com/bad"),
+		"malformed entry must not resolve")
+
+	// The well-formed entry still loaded and resolves.
+	got := cat.ResolveURI(context.Background(), "http://example.com/good")
+	require.NotEqual(t, "", got, "well-formed entry must still load")
+	require.True(t, strings.HasSuffix(got, "good.xml"), "got %q", got)
+}

--- a/catalog/load.go
+++ b/catalog/load.go
@@ -270,7 +270,11 @@ func loadFromBytes(ctx context.Context, data []byte, baseURI string, eh helium.E
 // parseEntries walks child elements of parent and appends catalog entries.
 func parseEntries(ctx context.Context, parent *helium.Element, prefer icatalog.Prefer, baseURI string, entries *[]icatalog.Entry, eh helium.ErrorHandler) {
 	if v := getAttrNS(parent, lexicon.AttrBase, lexicon.NamespaceXML); v != "" {
-		baseURI = icatalog.ResolveURI(baseURI, v)
+		if resolved, err := icatalog.ResolveURI(baseURI, v); err != nil {
+			eh.Handle(ctx, fmt.Errorf("catalog: %s attribute: %w", lexicon.AttrBase, err))
+		} else {
+			baseURI = resolved
+		}
 	}
 
 	for child := parent.FirstChild(); child != nil; child = child.NextSibling() {
@@ -287,7 +291,11 @@ func parseEntries(ctx context.Context, parent *helium.Element, prefer icatalog.P
 
 		elemBase := baseURI
 		if v := getAttrNS(elem, lexicon.AttrBase, lexicon.NamespaceXML); v != "" {
-			elemBase = icatalog.ResolveURI(baseURI, v)
+			if resolved, err := icatalog.ResolveURI(baseURI, v); err != nil {
+				eh.Handle(ctx, fmt.Errorf("catalog: %s attribute: %w", lexicon.AttrBase, err))
+			} else {
+				elemBase = resolved
+			}
 		}
 
 		elemPrefer := prefer
@@ -298,7 +306,10 @@ func parseEntries(ctx context.Context, parent *helium.Element, prefer icatalog.P
 		switch localName {
 		case lexicon.ElemPublic:
 			pubID := icatalog.NormalizePublicID(getAttr(elem, lexicon.AttrPublicID))
-			uri := icatalog.ResolveURI(elemBase, getAttr(elem, lexicon.AttrURI))
+			uri, ok := resolveEntryURI(ctx, eh, elemBase, getAttr(elem, lexicon.AttrURI))
+			if !ok {
+				continue
+			}
 			if pubID == "" || uri == "" {
 				catalogMissingAttr(ctx, eh, localName, pubID, lexicon.AttrPublicID, uri, lexicon.AttrURI)
 			} else {
@@ -311,7 +322,10 @@ func parseEntries(ctx context.Context, parent *helium.Element, prefer icatalog.P
 			}
 		case lexicon.ElemSystem:
 			sysID := getAttr(elem, lexicon.AttrSystemID)
-			uri := icatalog.ResolveURI(elemBase, getAttr(elem, lexicon.AttrURI))
+			uri, ok := resolveEntryURI(ctx, eh, elemBase, getAttr(elem, lexicon.AttrURI))
+			if !ok {
+				continue
+			}
 			if sysID == "" || uri == "" {
 				catalogMissingAttr(ctx, eh, localName, sysID, lexicon.AttrSystemID, uri, lexicon.AttrURI)
 			} else {
@@ -323,7 +337,10 @@ func parseEntries(ctx context.Context, parent *helium.Element, prefer icatalog.P
 			}
 		case lexicon.ElemRewriteSystem:
 			startString := getAttr(elem, lexicon.AttrSystemIDStartString)
-			prefix := icatalog.ResolveURI(elemBase, getAttr(elem, lexicon.AttrRewritePrefix))
+			prefix, ok := resolveEntryURI(ctx, eh, elemBase, getAttr(elem, lexicon.AttrRewritePrefix))
+			if !ok {
+				continue
+			}
 			if startString == "" || prefix == "" {
 				catalogMissingAttr(ctx, eh, localName, startString, lexicon.AttrSystemIDStartString, prefix, lexicon.AttrRewritePrefix)
 			} else {
@@ -335,7 +352,10 @@ func parseEntries(ctx context.Context, parent *helium.Element, prefer icatalog.P
 			}
 		case lexicon.ElemDelegatePublic:
 			startString := icatalog.NormalizePublicID(getAttr(elem, lexicon.AttrPublicIDStartString))
-			catFile := icatalog.ResolveURI(elemBase, getAttr(elem, lexicon.AttrCatalog))
+			catFile, ok := resolveEntryURI(ctx, eh, elemBase, getAttr(elem, lexicon.AttrCatalog))
+			if !ok {
+				continue
+			}
 			if startString == "" || catFile == "" {
 				catalogMissingAttr(ctx, eh, localName, startString, lexicon.AttrPublicIDStartString, catFile, lexicon.AttrCatalog)
 			} else {
@@ -348,7 +368,10 @@ func parseEntries(ctx context.Context, parent *helium.Element, prefer icatalog.P
 			}
 		case lexicon.ElemDelegateSystem:
 			startString := getAttr(elem, lexicon.AttrSystemIDStartString)
-			catFile := icatalog.ResolveURI(elemBase, getAttr(elem, lexicon.AttrCatalog))
+			catFile, ok := resolveEntryURI(ctx, eh, elemBase, getAttr(elem, lexicon.AttrCatalog))
+			if !ok {
+				continue
+			}
 			if startString == "" || catFile == "" {
 				catalogMissingAttr(ctx, eh, localName, startString, lexicon.AttrSystemIDStartString, catFile, lexicon.AttrCatalog)
 			} else {
@@ -360,7 +383,10 @@ func parseEntries(ctx context.Context, parent *helium.Element, prefer icatalog.P
 			}
 		case lexicon.ElemURI:
 			name := getAttr(elem, lexicon.AttrName)
-			uri := icatalog.ResolveURI(elemBase, getAttr(elem, lexicon.AttrURI))
+			uri, ok := resolveEntryURI(ctx, eh, elemBase, getAttr(elem, lexicon.AttrURI))
+			if !ok {
+				continue
+			}
 			if name == "" || uri == "" {
 				catalogMissingAttr(ctx, eh, localName, name, lexicon.AttrName, uri, lexicon.AttrURI)
 			} else {
@@ -372,7 +398,10 @@ func parseEntries(ctx context.Context, parent *helium.Element, prefer icatalog.P
 			}
 		case lexicon.ElemRewriteURI:
 			startString := getAttr(elem, lexicon.AttrURIStartString)
-			prefix := icatalog.ResolveURI(elemBase, getAttr(elem, lexicon.AttrRewritePrefix))
+			prefix, ok := resolveEntryURI(ctx, eh, elemBase, getAttr(elem, lexicon.AttrRewritePrefix))
+			if !ok {
+				continue
+			}
 			if startString == "" || prefix == "" {
 				catalogMissingAttr(ctx, eh, localName, startString, lexicon.AttrURIStartString, prefix, lexicon.AttrRewritePrefix)
 			} else {
@@ -384,7 +413,10 @@ func parseEntries(ctx context.Context, parent *helium.Element, prefer icatalog.P
 			}
 		case lexicon.ElemDelegateURI:
 			startString := getAttr(elem, lexicon.AttrURIStartString)
-			catFile := icatalog.ResolveURI(elemBase, getAttr(elem, lexicon.AttrCatalog))
+			catFile, ok := resolveEntryURI(ctx, eh, elemBase, getAttr(elem, lexicon.AttrCatalog))
+			if !ok {
+				continue
+			}
 			if startString == "" || catFile == "" {
 				catalogMissingAttr(ctx, eh, localName, startString, lexicon.AttrURIStartString, catFile, lexicon.AttrCatalog)
 			} else {
@@ -395,7 +427,10 @@ func parseEntries(ctx context.Context, parent *helium.Element, prefer icatalog.P
 				})
 			}
 		case lexicon.ElemNextCatalog:
-			catFile := icatalog.ResolveURI(elemBase, getAttr(elem, lexicon.AttrCatalog))
+			catFile, ok := resolveEntryURI(ctx, eh, elemBase, getAttr(elem, lexicon.AttrCatalog))
+			if !ok {
+				continue
+			}
 			if catFile == "" {
 				eh.Handle(ctx, fmt.Errorf("%s entry missing %s attribute", localName, lexicon.AttrCatalog))
 			} else {
@@ -420,6 +455,19 @@ func documentElement(doc *helium.Document) *helium.Element {
 		}
 	}
 	return nil
+}
+
+// resolveEntryURI resolves a catalog entry's URI/prefix/catalog attribute
+// against base. When the value is a syntactically malformed URI that url.Parse
+// rejects, the error is reported through eh and ok is false so the caller skips
+// the entry rather than storing the raw, unresolved value as a usable mapping.
+func resolveEntryURI(ctx context.Context, eh helium.ErrorHandler, base, value string) (string, bool) {
+	resolved, err := icatalog.ResolveURI(base, value)
+	if err != nil {
+		eh.Handle(ctx, fmt.Errorf("catalog: %w", err))
+		return "", false
+	}
+	return resolved, true
 }
 
 // catalogMissingAttr reports which required attributes are missing on a catalog entry.

--- a/internal/catalog/uri.go
+++ b/internal/catalog/uri.go
@@ -8,23 +8,30 @@ import (
 )
 
 // ResolveURI resolves value against base. If value already has a scheme, or
-// base is empty, value is returned as-is. When base carries a URI scheme (e.g.
-// "file:///..."), the reference is resolved in URI space via
-// (*url.URL).ResolveReference, which handles path-absolute ("/abs/x"),
-// relative ("x"), and absolute-URI references correctly. When base is a
-// non-URI local path, OS-path semantics apply: an absolute value is returned
-// unchanged and a relative value is joined against the base directory.
+// base is empty, value is returned as-is once it parses as a valid URI. When
+// base carries a URI scheme (e.g. "file:///..."), the reference is resolved in
+// URI space via (*url.URL).ResolveReference, which handles path-absolute
+// ("/abs/x"), relative ("x"), and absolute-URI references correctly. When base
+// is a non-URI local path, OS-path semantics apply: an absolute value is
+// returned unchanged and a relative value is joined against the base directory.
 //
 // A non-nil error is returned when base or value is a syntactically malformed
-// URI that url.Parse rejects. In that case the returned string is empty so a
-// malformed catalog entry is never silently stored as a usable mapping; the
-// caller is expected to report the error and skip the entry.
+// URI that url.Parse rejects -- including an absolute value that already
+// carries a scheme. In that case the returned string is empty so a malformed
+// catalog entry is never silently stored as a usable mapping; the caller is
+// expected to report the error and skip the entry.
 func ResolveURI(base, value string) (string, error) {
 	if value == "" {
 		return "", nil
 	}
 
+	// An absolute value carrying a scheme must still be validated; a malformed
+	// absolute URI (e.g. bad percent-encoding) must not bypass url.Parse and be
+	// stored raw. Once validated, it stands on its own regardless of base.
 	if HasScheme(value) {
+		if _, err := url.Parse(value); err != nil {
+			return "", fmt.Errorf("malformed URI %q: %w", value, err)
+		}
 		return value, nil
 	}
 

--- a/internal/catalog/uri.go
+++ b/internal/catalog/uri.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"fmt"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -13,17 +14,22 @@ import (
 // relative ("x"), and absolute-URI references correctly. When base is a
 // non-URI local path, OS-path semantics apply: an absolute value is returned
 // unchanged and a relative value is joined against the base directory.
-func ResolveURI(base, value string) string {
+//
+// A non-nil error is returned when base or value is a syntactically malformed
+// URI that url.Parse rejects. In that case the returned string is empty so a
+// malformed catalog entry is never silently stored as a usable mapping; the
+// caller is expected to report the error and skip the entry.
+func ResolveURI(base, value string) (string, error) {
 	if value == "" {
-		return ""
+		return "", nil
 	}
 
 	if HasScheme(value) {
-		return value
+		return value, nil
 	}
 
 	if base == "" {
-		return value
+		return value, nil
 	}
 
 	// When base has a URI scheme, resolve in URI space. A path-absolute
@@ -32,22 +38,22 @@ func ResolveURI(base, value string) string {
 	if HasScheme(base) {
 		baseURL, err := url.Parse(base)
 		if err != nil {
-			return value
+			return "", fmt.Errorf("malformed base URI %q: %w", base, err)
 		}
 		ref, err := url.Parse(value)
 		if err != nil {
-			return value
+			return "", fmt.Errorf("malformed URI %q: %w", value, err)
 		}
-		return baseURL.ResolveReference(ref).String()
+		return baseURL.ResolveReference(ref).String(), nil
 	}
 
 	// Non-URI local-path base: apply OS-path semantics. An absolute value is
 	// returned unchanged; a relative one is joined against the base directory.
 	if filepath.IsAbs(value) {
-		return value
+		return value, nil
 	}
 
-	return filepath.Join(filepath.Dir(base), value)
+	return filepath.Join(filepath.Dir(base), value), nil
 }
 
 // HasScheme checks if s looks like a URI with a scheme (e.g., "http://...").

--- a/internal/catalog/uri_test.go
+++ b/internal/catalog/uri_test.go
@@ -88,6 +88,24 @@ func TestResolveURI(t *testing.T) {
 			expect:  "",
 			wantErr: true,
 		},
+		{
+			// A malformed ABSOLUTE URI carrying a scheme must not bypass
+			// validation. url.Parse rejects the invalid percent-encoding, so an
+			// error is surfaced and no usable mapping is produced.
+			name:    "malformed absolute uri with scheme",
+			base:    fileCatalogURI,
+			value:   "http://example.com/%zz",
+			expect:  "",
+			wantErr: true,
+		},
+		{
+			// A well-formed absolute URI with a scheme still resolves, even with
+			// an empty base.
+			name:   "well-formed absolute uri empty base",
+			base:   "",
+			value:  "http://example.com/asset.xml",
+			expect: "http://example.com/asset.xml",
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/catalog/uri_test.go
+++ b/internal/catalog/uri_test.go
@@ -18,10 +18,11 @@ func TestResolveURI(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name   string
-		base   string
-		value  string
-		expect string
+		name    string
+		base    string
+		value   string
+		expect  string
+		wantErr bool
 	}{
 		{
 			name:   "empty value",
@@ -77,11 +78,28 @@ func TestResolveURI(t *testing.T) {
 			value:  "asset.xml",
 			expect: "asset.xml",
 		},
+		{
+			// A malformed reference (invalid percent-encoding) against a URI
+			// base must surface an error and yield no usable mapping, rather
+			// than silently returning the raw value.
+			name:    "malformed value against file base",
+			base:    fileCatalogURI,
+			value:   "%zz",
+			expect:  "",
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expect, catalog.ResolveURI(tc.base, tc.value))
+			got, err := catalog.ResolveURI(tc.base, tc.value)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Equal(t, "", got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expect, got)
 		})
 	}
 }


### PR DESCRIPTION
- CAT-008: `internal/catalog.ResolveURI` returned the raw value when `url.Parse` failed, silently storing a malformed catalog entry URI as a usable mapping
- now returns an error; `parseEntries` reports it via the catalog error handler and skips the malformed entry, while well-formed entries still load
