### PR TITLE
fix result-document base uri to base output uri

### DIFF
--- a/xslt3/execute_resultdoc.go
+++ b/xslt3/execute_resultdoc.go
@@ -767,16 +767,13 @@ func (ec *execContext) execResultDocument(ctx context.Context, inst *resultDocum
 	// Secondary output: execute body into a temporary document.
 	tmpDoc := helium.NewDefaultDocument()
 
-	// Set the document URL so that base-uri() returns the correct value.
-	// Resolve relative href against the stylesheet base URI.
-	resolvedHref := href
-	if ec.stylesheet.baseURI != "" {
-		resolved := helium.BuildURI(href, ec.stylesheet.baseURI)
-		if resolved != "" {
-			resolvedHref = resolved
-		}
-	}
-	tmpDoc.SetURL(resolvedHref)
+	// Set the document URL so that base-uri() returns the correct value. Per XSLT
+	// 3.0 §26.2 a secondary result document's base URI is its href resolved
+	// against the BASE OUTPUT URI, NOT the stylesheet base URI. ec.currentOutputURI
+	// already holds exactly that value: it was set above (canonicalResultURIKey of
+	// href against the saved base output URI) and is the same scheme-preserving
+	// canonical URI used as the XTDE1490 duplicate-detection key.
+	tmpDoc.SetURL(ec.currentOutputURI)
 
 	// PREFLIGHT (symmetric with the primary path): evaluate the secondary
 	// effective output definition — which evaluates EVERY error-prone

--- a/xslt3/resultdoc_uri_test.go
+++ b/xslt3/resultdoc_uri_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xslt3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -251,6 +252,43 @@ func TestResultDocumentPrimaryValidationStrictAppliesOverrides(t *testing.T) {
 	require.NotNil(t, od, "resolved output def must be populated after Do")
 	require.Equal(t, "yes", od.Standalone,
 		"the validation=strict primary result-document's standalone override must reach the effective output def")
+}
+
+// ENG-006: per XSLT 3.0 §26.2 a secondary result document's base URI is its href
+// resolved against the BASE OUTPUT URI, NOT against the stylesheet's base URI. So
+// base-uri()/Document.URL() on the delivered secondary tree must reflect the base
+// output URI. (Regression: the secondary path set the document URL by resolving
+// href against ec.stylesheet.baseURI, yielding the stylesheet dir
+// "file:///style/dir/secondary.xml" instead of the output dir
+// "file:///out/secondary.xml".)
+func TestResultDocumentSecondaryBaseURIFromOutputURI(t *testing.T) {
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:result-document href="secondary.xml"><a/></xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`))
+	require.NoError(t, err)
+
+	// Compile with a stylesheet base URI that DIFFERS from the base output URI so
+	// a wrong (stylesheet-relative) resolution is distinguishable from the correct
+	// (output-relative) one.
+	ss, err := xslt3.NewCompiler().
+		BaseURI("file:///style/dir/main.xsl").
+		Compile(t.Context(), doc)
+	require.NoError(t, err)
+
+	collector := &resultDocCollect{docs: map[string]*helium.Document{}}
+	_, err = ss.Transform(parseTransformSource(t)).
+		BaseOutputURI("file:///out/main.xml").
+		ResultDocumentHandler(collector).
+		Do(t.Context())
+	require.NoError(t, err)
+
+	got, ok := collector.docs["secondary.xml"]
+	require.True(t, ok, "the secondary result document must be delivered")
+	require.Equal(t, "file:///out/secondary.xml", got.URL(),
+		"a secondary result document's base URI must be its href resolved against the base output URI, not the stylesheet base URI")
 }
 
 // XTDE1490 duplicate detection must collapse dot-segments in ABSOLUTE hrefs.


### PR DESCRIPTION
- ENG-006: secondary `xsl:result-document` base URI now resolves href against the base OUTPUT URI per XSLT 3.0 §26.2, not the stylesheet base URI
- set the secondary tmpDoc URL to the already-computed canonical currentOutputURI (XTDE1490 key) instead of BuildURI(href, stylesheet.baseURI)
- added regression test: href="secondary.xml" + base output `file:///out/` yields base-uri `file:///out/secondary.xml`
