### PR TITLE
fix xslt3 union-pattern self-conflict false positive

### DIFF
--- a/xslt3/compile_templates.go
+++ b/xslt3/compile_templates.go
@@ -293,6 +293,13 @@ func (c *compiler) compileTemplate(ctx context.Context, elem *helium.Element) er
 		templates := []*template{tmpl}
 		if !hasExplicitPriority && len(tmpl.Match.Alternatives) > 1 {
 			templates = nil
+			// All split branches of one union rule share a stable origin id so
+			// the on-multiple-match conflict checks can recognize them as a
+			// single rule even when they have an empty body (no &Body[0]
+			// identity to compare). See hasConflictingMatch /
+			// hasConflictingAtomicMatch.
+			c.stylesheet.unionSplitCounter++
+			originID := c.stylesheet.unionSplitCounter
 			for _, alt := range tmpl.Match.Alternatives {
 				split := *tmpl // shallow copy shares Body, Params, etc.
 				split.Match = &pattern{
@@ -302,6 +309,7 @@ func (c *compiler) compileTemplate(ctx context.Context, elem *helium.Element) er
 					nsBindings:     tmpl.Match.nsBindings,
 				}
 				split.Priority = alt.priority
+				split.splitOriginID = originID
 				splitCopy := split // allocate separate heap object
 				templates = append(templates, &splitCopy)
 			}

--- a/xslt3/execute_templates.go
+++ b/xslt3/execute_templates.go
@@ -195,10 +195,10 @@ func (ec *execContext) hasConflictingMatch(ctx context.Context, node helium.Node
 			if tmpl.ImportPrec == best.ImportPrec && tmpl.Priority < best.Priority {
 				return false
 			}
-			// Split union pattern branches share the same Body slice; they
-			// originate from the same template rule and should not be
-			// treated as conflicting (spec bug 30402).
-			if len(tmpl.Body) > 0 && len(best.Body) > 0 && &tmpl.Body[0] == &best.Body[0] {
+			// Split union pattern branches originate from the same template
+			// rule and should not be treated as conflicting with each other
+			// (spec bug 30402). They carry a shared non-zero splitOriginID.
+			if tmpl.splitOriginID != 0 && tmpl.splitOriginID == best.splitOriginID {
 				continue
 			}
 			if tmpl.Match != nil && tmpl.Match.matchPattern(ctx, ec, node) {
@@ -263,7 +263,9 @@ func (ec *execContext) hasConflictingAtomicMatch(ctx context.Context, item xpath
 			if tmpl.ImportPrec == best.ImportPrec && tmpl.Priority < best.Priority {
 				return false
 			}
-			if len(tmpl.Body) > 0 && len(best.Body) > 0 && &tmpl.Body[0] == &best.Body[0] {
+			// Split union pattern branches share a non-zero splitOriginID; they
+			// originate from the same rule and must not self-conflict.
+			if tmpl.splitOriginID != 0 && tmpl.splitOriginID == best.splitOriginID {
 				continue
 			}
 			if tmpl.Match != nil && ec.matchAtomicPattern(ctx, tmpl.Match, item) {

--- a/xslt3/stylesheet.go
+++ b/xslt3/stylesheet.go
@@ -141,6 +141,7 @@ type Stylesheet struct {
 	compilerImportSchemas []*xsd.Schema               // pre-compiled schemas from compiler (for fn:transform nested compiles)
 	maxResourceBytes      int64                       // per-resource read cap from compiler; 0 = MaxResourceBytes default, <0 = unbounded
 	allowExternalEntities bool                        // compile-time opt-in: legacy permissive external-entity parsing (for fn:transform nested compiles)
+	unionSplitCounter     int                         // monotonic id source for union-pattern split groups (template.splitOriginID)
 }
 
 // globalContextItemDef represents a compiled xsl:global-context-item declaration.
@@ -264,6 +265,12 @@ type template struct {
 	Version          string      // effective version (from template or stylesheet)
 	OwnerPackage     *Stylesheet // package that defined this template (nil = main stylesheet)
 	OriginalTemplate *template   // original template being overridden (for xsl:original calls)
+	// splitOriginID identifies the originating template rule when a union match
+	// pattern (P1 | P2) is split into separate template entries. All split
+	// branches of one rule share the same non-zero id so the on-multiple-match
+	// conflict checks can treat them as a single rule (spec bug 30402). 0 means
+	// the template was not produced by a union split.
+	splitOriginID int
 }
 
 // variable is a compiled xsl:variable.

--- a/xslt3/union_pattern_conflict_test.go
+++ b/xslt3/union_pattern_conflict_test.go
@@ -1,0 +1,51 @@
+package xslt3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xslt3"
+	"github.com/stretchr/testify/require"
+)
+
+// ENG-007: an empty-body template with a union match pattern is split into
+// separate rules sharing no Body[0] identity. When a single node matches more
+// than one branch of the union (overlapping alternatives), the split branches
+// must not be flagged as conflicting with each other under
+// on-multiple-match="fail".
+func TestUnionPatternEmptyBodyNoFalseConflict(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/"><out><xsl:apply-templates select="root/*"/></out></xsl:template>
+  <xsl:template match="node() | *"/>
+</xsl:stylesheet>`)
+
+	source, err := helium.NewParser().Parse(t.Context(), []byte(`<root><a/></root>`))
+	require.NoError(t, err)
+
+	result, err := ss.Transform(source).
+		OnMultipleMatch(xslt3.OnMultipleMatchFail).
+		Serialize(t.Context())
+	require.NoError(t, err, "split union branches must not self-conflict")
+	require.Contains(t, result, "<out/>")
+}
+
+// A genuine conflict between two DIFFERENT templates of equal precedence and
+// priority must still raise XTDE0540 under on-multiple-match="fail".
+func TestUnionPatternGenuineConflictStillFails(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/"><out><xsl:apply-templates select="root/*"/></out></xsl:template>
+  <xsl:template match="a" priority="1"><x/></xsl:template>
+  <xsl:template match="a" priority="1"><y/></xsl:template>
+</xsl:stylesheet>`)
+
+	source, err := helium.NewParser().Parse(t.Context(), []byte(`<root><a/></root>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(source).
+		OnMultipleMatch(xslt3.OnMultipleMatchFail).
+		Serialize(t.Context())
+	require.Error(t, err, "genuine conflict must raise XTDE0540")
+	require.Contains(t, err.Error(), "XTDE0540")
+}


### PR DESCRIPTION
- ENG-007: empty-body union match pattern (`match="node() | *"`) no longer raises a false XTDE0540 under on-multiple-match="fail"
- split union branches now share a stable `splitOriginID` compared in `hasConflictingMatch`/`hasConflictingAtomicMatch` instead of the fragile `&Body[0]` identity that empty bodies lack
