### PR TITLE
validate xsl:sort order/case-order/stable

### DIFF
--- a/xslt3/compile_instructions_flow.go
+++ b/xslt3/compile_instructions_flow.go
@@ -483,6 +483,14 @@ func (c *compiler) compileSortKey(ctx context.Context, elem *helium.Element) (*s
 		sk.Collation = avt
 	}
 
+	if stable := getAttr(elem, "stable"); stable != "" {
+		avt, err := compileAVT(stable, c.nsBindings)
+		if err != nil {
+			return nil, err
+		}
+		sk.Stable = avt
+	}
+
 	return sk, nil
 }
 

--- a/xslt3/compile_streaming.go
+++ b/xslt3/compile_streaming.go
@@ -956,7 +956,7 @@ func (c *compiler) compileMergeKey(ctx context.Context, elem *helium.Element) (*
 	}
 
 	mk := &mergeKey{
-		Order: "ascending", // default
+		Order: sortOrderAscending, // default
 	}
 
 	// Track collation-related attributes for sort verification.

--- a/xslt3/sort.go
+++ b/xslt3/sort.go
@@ -27,6 +27,11 @@ type sortKey struct {
 	Stable    *avt // "yes"/"no"/"true"/"false"/"1"/"0"
 }
 
+const (
+	sortOrderAscending  = "ascending"
+	sortOrderDescending = "descending"
+)
+
 // sortMode determines how a sort level compares keys.
 type sortMode uint8
 
@@ -111,20 +116,20 @@ func (ks keyedSlice[T]) convertAutoNumeric(level int) {
 func buildResolvedSort(ctx context.Context, ec *execContext, sortKeys []*sortKey) (resolvedSort, error) {
 	levels := make([]resolvedLevel, len(sortKeys))
 	for i, sk := range sortKeys {
-		order := "ascending"
+		order := sortOrderAscending
 		if sk.Order != nil {
 			var err error
 			order, err = sk.Order.evaluate(ctx, ec.contextNode)
 			if err != nil {
 				return resolvedSort{}, err
 			}
-			if order != "ascending" && order != "descending" {
+			if order != sortOrderAscending && order != sortOrderDescending {
 				return resolvedSort{}, dynamicError(errCodeXTDE0030,
 					"invalid order %q in xsl:sort; must be \"ascending\" or \"descending\"", order)
 			}
 		}
 		levels[i] = resolvedLevel{
-			desc: order == "descending",
+			desc: order == sortOrderDescending,
 		}
 		if sk.Collation != nil {
 			uri, err := sk.Collation.evaluate(ctx, ec.contextNode)
@@ -154,14 +159,14 @@ func buildResolvedSort(ctx context.Context, ec *execContext, sortKeys []*sortKey
 }
 
 func resolveLevel1(ctx context.Context, ec *execContext, sk *sortKey) (resolvedLevel, error) {
-	order := "ascending"
+	order := sortOrderAscending
 	if sk.Order != nil {
 		var err error
 		order, err = sk.Order.evaluate(ctx, ec.contextNode)
 		if err != nil {
 			return resolvedLevel{}, err
 		}
-		if order != "ascending" && order != "descending" {
+		if order != sortOrderAscending && order != sortOrderDescending {
 			return resolvedLevel{}, dynamicError(errCodeXTDE0030,
 				"invalid order %q in xsl:sort; must be \"ascending\" or \"descending\"", order)
 		}
@@ -177,7 +182,7 @@ func resolveLevel1(ctx context.Context, ec *execContext, sk *sortKey) (resolvedL
 				"invalid language tag %q in xsl:sort", lang)
 		}
 	}
-	rl := resolvedLevel{desc: order == "descending"}
+	rl := resolvedLevel{desc: order == sortOrderDescending}
 	if sk.Collation != nil {
 		uri, err := sk.Collation.evaluate(ctx, ec.contextNode)
 		if err != nil {
@@ -248,7 +253,7 @@ func validateSortKeyAttrs(ctx context.Context, ec *execContext, sk *sortKey) err
 		if err != nil {
 			return err
 		}
-		if order != "ascending" && order != "descending" {
+		if order != sortOrderAscending && order != sortOrderDescending {
 			return dynamicError(errCodeXTDE0030,
 				"invalid order %q in xsl:sort; must be \"ascending\" or \"descending\"", order)
 		}

--- a/xslt3/sort.go
+++ b/xslt3/sort.go
@@ -24,6 +24,7 @@ type sortKey struct {
 	CaseOrder *avt          // "upper-first" or "lower-first"
 	Lang      *avt
 	Collation *avt // collation URI
+	Stable    *avt // "yes"/"no"/"true"/"false"/"1"/"0"
 }
 
 // sortMode determines how a sort level compares keys.
@@ -117,6 +118,10 @@ func buildResolvedSort(ctx context.Context, ec *execContext, sortKeys []*sortKey
 			if err != nil {
 				return resolvedSort{}, err
 			}
+			if order != "ascending" && order != "descending" {
+				return resolvedSort{}, dynamicError(errCodeXTDE0030,
+					"invalid order %q in xsl:sort; must be \"ascending\" or \"descending\"", order)
+			}
 		}
 		levels[i] = resolvedLevel{
 			desc: order == "descending",
@@ -133,7 +138,10 @@ func buildResolvedSort(ctx context.Context, ec *execContext, sortKeys []*sortKey
 			}
 			levels[i].compare = cmpFn
 		} else if sk.Lang != nil || sk.CaseOrder != nil {
-			uri := buildImplicitCollationURI(ctx, ec, sk)
+			uri, err := buildImplicitCollationURI(ctx, ec, sk)
+			if err != nil {
+				return resolvedSort{}, err
+			}
 			if uri != "" {
 				cmpFn, err := xpath3.ResolveCollationCompareFunc(uri)
 				if err == nil {
@@ -152,6 +160,10 @@ func resolveLevel1(ctx context.Context, ec *execContext, sk *sortKey) (resolvedL
 		order, err = sk.Order.evaluate(ctx, ec.contextNode)
 		if err != nil {
 			return resolvedLevel{}, err
+		}
+		if order != "ascending" && order != "descending" {
+			return resolvedLevel{}, dynamicError(errCodeXTDE0030,
+				"invalid order %q in xsl:sort; must be \"ascending\" or \"descending\"", order)
 		}
 	}
 	// XTDE0030: validate lang attribute value
@@ -179,7 +191,10 @@ func resolveLevel1(ctx context.Context, ec *execContext, sk *sortKey) (resolvedL
 		rl.compare = cmpFn
 	} else if sk.Lang != nil || sk.CaseOrder != nil {
 		// Build a UCA collation from lang/case-order when no explicit collation.
-		uri := buildImplicitCollationURI(ctx, ec, sk)
+		uri, err := buildImplicitCollationURI(ctx, ec, sk)
+		if err != nil {
+			return resolvedLevel{}, err
+		}
 		if uri != "" {
 			cmpFn, err := xpath3.ResolveCollationCompareFunc(uri)
 			if err == nil {
@@ -191,35 +206,63 @@ func resolveLevel1(ctx context.Context, ec *execContext, sk *sortKey) (resolvedL
 }
 
 // buildImplicitCollationURI constructs a UCA collation URI from lang and
-// case-order attributes when no explicit collation is specified.
-func buildImplicitCollationURI(ctx context.Context, ec *execContext, sk *sortKey) string {
+// case-order attributes when no explicit collation is specified. An evaluated
+// case-order that is neither "upper-first" nor "lower-first" raises XTDE0030.
+func buildImplicitCollationURI(ctx context.Context, ec *execContext, sk *sortKey) (string, error) {
 	var params []string
 	if sk.Lang != nil {
 		lang, err := sk.Lang.evaluate(ctx, ec.contextNode)
-		if err == nil && lang != "" {
+		if err != nil {
+			return "", err
+		}
+		if lang != "" {
 			params = append(params, "lang="+lang)
 		}
 	}
 	if sk.CaseOrder != nil {
 		co, err := sk.CaseOrder.evaluate(ctx, ec.contextNode)
-		if err == nil && co != "" {
-			switch co {
-			case "upper-first":
-				params = append(params, "caseFirst=upper")
-			case "lower-first":
-				params = append(params, "caseFirst=lower")
-			}
+		if err != nil {
+			return "", err
+		}
+		switch co {
+		case "upper-first":
+			params = append(params, "caseFirst=upper")
+		case "lower-first":
+			params = append(params, "caseFirst=lower")
+		default:
+			return "", dynamicError(errCodeXTDE0030,
+				"invalid case-order %q in xsl:sort; must be \"upper-first\" or \"lower-first\"", co)
 		}
 	}
 	if len(params) == 0 {
-		return ""
+		return "", nil
 	}
-	return "http://www.w3.org/2013/collation/UCA?" + strings.Join(params, ";")
+	return "http://www.w3.org/2013/collation/UCA?" + strings.Join(params, ";"), nil
 }
 
-// validateSortKeyAttrs validates sort key attribute values (lang, collation, etc.)
-// regardless of whether there are nodes to sort.
+// validateSortKeyAttrs validates sort key attribute values (order, case-order,
+// lang, collation, stable) regardless of whether there are nodes to sort.
 func validateSortKeyAttrs(ctx context.Context, ec *execContext, sk *sortKey) error {
+	if sk.Order != nil {
+		order, err := sk.Order.evaluate(ctx, ec.contextNode)
+		if err != nil {
+			return err
+		}
+		if order != "ascending" && order != "descending" {
+			return dynamicError(errCodeXTDE0030,
+				"invalid order %q in xsl:sort; must be \"ascending\" or \"descending\"", order)
+		}
+	}
+	if sk.CaseOrder != nil {
+		co, err := sk.CaseOrder.evaluate(ctx, ec.contextNode)
+		if err != nil {
+			return err
+		}
+		if co != "upper-first" && co != "lower-first" {
+			return dynamicError(errCodeXTDE0030,
+				"invalid case-order %q in xsl:sort; must be \"upper-first\" or \"lower-first\"", co)
+		}
+	}
 	if sk.Lang != nil {
 		lang, err := sk.Lang.evaluate(ctx, ec.contextNode)
 		if err != nil {
@@ -228,6 +271,19 @@ func validateSortKeyAttrs(ctx context.Context, ec *execContext, sk *sortKey) err
 		if !isValidLanguageTag(lang) {
 			return dynamicError(errCodeXTDE0030,
 				"invalid language tag %q in xsl:sort", lang)
+		}
+	}
+	if sk.Stable != nil {
+		stable, err := sk.Stable.evaluate(ctx, ec.contextNode)
+		if err != nil {
+			return err
+		}
+		// helium always performs a stable sort; the evaluated value is
+		// validated for conformance but does not change sort behavior
+		// (honoring stable="no" via an unstable sort is out of scope).
+		if _, ok := parseXSDBool(stable); !ok {
+			return dynamicError(errCodeXTDE0030,
+				"invalid stable %q in xsl:sort; must be a valid xs:boolean", stable)
 		}
 	}
 	if sk.Collation != nil {
@@ -1064,6 +1120,15 @@ func (ec *execContext) execPerformSort(ctx context.Context, inst *performSortIns
 			return err
 		}
 	}
+	// Validate sort key attributes even when the selected sequence is empty
+	// (e.g. a bad collation must still raise XTDE1035). sortNodes/sortGroups
+	// validate regardless of input; mirror that for the empty-input case here.
+	for _, sk := range inst.Sort {
+		if err := validateSortKeyAttrs(ctx, ec, sk); err != nil {
+			return err
+		}
+	}
+
 	if seq == nil || sequence.Len(seq) == 0 {
 		return nil
 	}

--- a/xslt3/sort_validate_test.go
+++ b/xslt3/sort_validate_test.go
@@ -1,0 +1,121 @@
+package xslt3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// ENG-003: an evaluated xsl:sort order that is neither "ascending" nor
+// "descending" must raise XTDE0030 instead of silently sorting ascending.
+func TestSortInvalidOrderRaisesXTDE0030(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="." order="bogus"/>
+        <xsl:value-of select="."/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root><item>b</item><item>a</item></root>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(doc).Serialize(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "XTDE0030")
+}
+
+// ENG-003: an evaluated xsl:sort case-order that is neither "upper-first"
+// nor "lower-first" must raise XTDE0030.
+func TestSortInvalidCaseOrderRaisesXTDE0030(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="." case-order="bogus"/>
+        <xsl:value-of select="."/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root><item>b</item><item>a</item></root>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(doc).Serialize(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "XTDE0030")
+}
+
+// ENG-003: a stable AVT must be parsed and evaluated without error, and a
+// valid order must still produce a correctly sorted result.
+func TestSortStableAVTEvaluates(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="." stable="{if (true()) then 'yes' else 'no'}" order="ascending"/>
+        <xsl:value-of select="."/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root><item>b</item><item>a</item><item>c</item></root>`))
+	require.NoError(t, err)
+
+	result, err := ss.Transform(doc).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, result, ">abc<")
+}
+
+// ENG-003: an invalid evaluated stable value must raise XTDE0030.
+func TestSortInvalidStableRaisesXTDE0030(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="." stable="{'bogus'}"/>
+        <xsl:value-of select="."/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root><item>b</item><item>a</item></root>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(doc).Serialize(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "XTDE0030")
+}
+
+// ENG-004: xsl:perform-sort over an EMPTY sequence must still validate its
+// sort keys, so an invalid collation raises XTDE1035 even with no input.
+func TestPerformSortEmptyValidatesCollation(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <out>
+      <xsl:perform-sort select="()">
+        <xsl:sort select="." collation="http://example.com/does-not-exist"/>
+      </xsl:perform-sort>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root/>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(doc).Serialize(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "XTDE1035")
+}


### PR DESCRIPTION
- ENG-003: parse/evaluate xsl:sort `stable` AVT; validate evaluated `order` ∈ {ascending,descending}, `case-order` ∈ {upper-first,lower-first}, and `stable` as xs:boolean, raising XTDE0030 on invalid (previously silently sorted ascending / ignored). helium always sorts stably; honoring `stable="no"` via an unstable sort is out of scope.
- ENG-004: xsl:perform-sort now validates sort-key attributes before the empty-input early return, so a bad collation raises XTDE1035 even over an empty selected sequence.
