### PR TITLE
thread caller params to atomic template rules

### DIFF
--- a/xslt3/execute_apply.go
+++ b/xslt3/execute_apply.go
@@ -166,7 +166,7 @@ func (ec *execContext) execApplyTemplates(ctx context.Context, inst *applyTempla
 			continue
 		}
 
-		if err := ec.dispatchApplyTemplatesItem(ctx, item, inst, mode); err != nil {
+		if err := ec.dispatchApplyTemplatesItem(ctx, item, inst, mode, paramValues); err != nil {
 			return err
 		}
 	}
@@ -178,13 +178,13 @@ func (ec *execContext) execApplyTemplates(ctx context.Context, inst *applyTempla
 // (atomic value, array, or map) per the XSLT 3.0 rules: try template matching
 // first, then the built-in rules for arrays/maps, then fall back to built-in
 // text output unless the mode's on-no-match skips unmatched atomic items.
-func (ec *execContext) dispatchApplyTemplatesItem(ctx context.Context, item xpath3.Item, inst *applyTemplatesInst, mode string) error {
+func (ec *execContext) dispatchApplyTemplatesItem(ctx context.Context, item xpath3.Item, inst *applyTemplatesInst, mode string, paramValues map[string]xpath3.Sequence) error {
 	tmpl, err := ec.findAtomicTemplate(ctx, item, mode)
 	if err != nil {
 		return err
 	}
 	if tmpl != nil {
-		return ec.executeAtomicTemplate(ctx, tmpl, item, mode)
+		return ec.executeAtomicTemplate(ctx, tmpl, item, mode, paramValues)
 	}
 	// Built-in template rule for arrays: apply-templates to each member.
 	if arr, ok := item.(xpath3.ArrayItem); ok {
@@ -193,7 +193,7 @@ func (ec *execContext) dispatchApplyTemplatesItem(ctx context.Context, item xpat
 			if err != nil {
 				return err
 			}
-			if err := ec.applyTemplatesToSequence(ctx, member, inst, mode); err != nil {
+			if err := ec.applyTemplatesToSequence(ctx, member, inst, mode, paramValues); err != nil {
 				return err
 			}
 		}
@@ -202,7 +202,7 @@ func (ec *execContext) dispatchApplyTemplatesItem(ctx context.Context, item xpat
 	// Built-in template rule for maps: apply-templates to each value.
 	if m, ok := item.(xpath3.MapItem); ok {
 		return m.ForEach(func(_ xpath3.AtomicValue, val xpath3.Sequence) error {
-			return ec.applyTemplatesToSequence(ctx, val, inst, mode)
+			return ec.applyTemplatesToSequence(ctx, val, inst, mode, paramValues)
 		})
 	}
 	// Check mode's on-no-match: for "deep-skip" and "shallow-skip",
@@ -229,10 +229,10 @@ func (ec *execContext) dispatchApplyTemplatesItem(ctx context.Context, item xpat
 
 // applyTemplatesToSequence applies templates to each item in a sequence,
 // implementing the built-in template rules for arrays and maps (XSLT 3.0).
-func (ec *execContext) applyTemplatesToSequence(ctx context.Context, seq xpath3.Sequence, inst *applyTemplatesInst, mode string) error {
+func (ec *execContext) applyTemplatesToSequence(ctx context.Context, seq xpath3.Sequence, inst *applyTemplatesInst, mode string, paramValues map[string]xpath3.Sequence) error {
 	for item := range sequence.Items(seq) {
 		if ni, ok := item.(xpath3.NodeItem); ok {
-			if err := ec.applyTemplates(ctx, ni.Node, mode, nil); err != nil {
+			if err := ec.applyTemplates(ctx, ni.Node, mode, paramValues); err != nil {
 				return err
 			}
 			continue
@@ -242,7 +242,7 @@ func (ec *execContext) applyTemplatesToSequence(ctx context.Context, seq xpath3.
 			return err
 		}
 		if tmpl != nil {
-			if err := ec.executeAtomicTemplate(ctx, tmpl, item, mode); err != nil {
+			if err := ec.executeAtomicTemplate(ctx, tmpl, item, mode, paramValues); err != nil {
 				return err
 			}
 			continue
@@ -253,7 +253,7 @@ func (ec *execContext) applyTemplatesToSequence(ctx context.Context, seq xpath3.
 				if err != nil {
 					return err
 				}
-				if err := ec.applyTemplatesToSequence(ctx, member, inst, mode); err != nil {
+				if err := ec.applyTemplatesToSequence(ctx, member, inst, mode, paramValues); err != nil {
 					return err
 				}
 			}
@@ -261,7 +261,7 @@ func (ec *execContext) applyTemplatesToSequence(ctx context.Context, seq xpath3.
 		}
 		if m, ok := item.(xpath3.MapItem); ok {
 			if err := m.ForEach(func(_ xpath3.AtomicValue, val xpath3.Sequence) error {
-				return ec.applyTemplatesToSequence(ctx, val, inst, mode)
+				return ec.applyTemplatesToSequence(ctx, val, inst, mode, paramValues)
 			}); err != nil {
 				return err
 			}
@@ -519,7 +519,11 @@ func (ec *execContext) execCallTemplate(ctx context.Context, inst *callTemplateI
 			val = xpath3.EmptySequence()
 		}
 
-		if p.As != "" && val != nil && sequence.Len(val) > 0 {
+		// Type-check against the declared as type. A caller-supplied empty
+		// sequence is nil, so check whenever the value came from the caller
+		// (XTTE0590) even when nil; for defaults a nil value is left to the
+		// default-handling logic above.
+		if p.As != "" && (val != nil || fromCaller) {
 			st := parseSequenceType(p.As)
 			errCode := errCodeXTTE0570
 			if fromCaller {
@@ -595,7 +599,7 @@ func (ec *execContext) execNextMatch(ctx context.Context, inst *nextMatchInst) e
 				continue
 			}
 			if foundCurrent && tmpl.Match != nil && ec.matchAtomicPattern(ctx, tmpl.Match, ec.contextItem) {
-				return ec.executeAtomicTemplate(ctx, tmpl, ec.contextItem, mode)
+				return ec.executeAtomicTemplate(ctx, tmpl, ec.contextItem, mode, pv)
 			}
 		}
 		// No next match for atomic items — output string value as built-in rule
@@ -713,7 +717,7 @@ func (ec *execContext) execApplyImports(ctx context.Context, inst *applyImportsI
 				continue
 			}
 			if tmpl.Match != nil && ec.matchAtomicPattern(ctx, tmpl.Match, ec.contextItem) {
-				return ec.executeAtomicTemplate(ctx, tmpl, ec.contextItem, mode)
+				return ec.executeAtomicTemplate(ctx, tmpl, ec.contextItem, mode, pv)
 			}
 		}
 		// Built-in rule for atomic values: output string value

--- a/xslt3/execute_templates.go
+++ b/xslt3/execute_templates.go
@@ -312,7 +312,7 @@ func (ec *execContext) matchAtomicPattern(ctx context.Context, p *pattern, item 
 }
 
 // executeAtomicTemplate executes a template with an atomic item as context.
-func (ec *execContext) executeAtomicTemplate(ctx context.Context, tmpl *template, item xpath3.Item, mode string) error {
+func (ec *execContext) executeAtomicTemplate(ctx context.Context, tmpl *template, item xpath3.Item, mode string, paramOverrides ...map[string]xpath3.Sequence) error {
 	savedContext := ec.contextNode
 	savedCurrent := ec.currentNode
 	savedMode := ec.currentMode
@@ -334,49 +334,72 @@ func (ec *execContext) executeAtomicTemplate(ctx context.Context, tmpl *template
 	ec.pushVarScope()
 	defer ec.popVarScope()
 
-	// Set template parameters with defaults (similar to executeTemplate).
+	// Collect param overrides supplied by the caller (via xsl:with-param).
+	var po map[string]xpath3.Sequence
+	if len(paramOverrides) > 0 {
+		po = paramOverrides[0]
+	}
+
+	// Set param values: use with-param overrides when available, else defaults.
+	// Tunnel params receive from ec.tunnelParams, not from regular overrides.
 	for _, p := range tmpl.Params {
 		var val xpath3.Sequence
+		fromCaller := false
 
 		if p.Tunnel {
 			if ec.tunnelParams != nil {
 				if v, ok := ec.tunnelParams[p.Name]; ok {
 					val = v
-					ec.setVar(p.Name, val)
-					continue
+					fromCaller = true
 				}
 			}
-		}
-
-		if p.Required {
-			return dynamicError(errCodeXTDE0700, "required parameter $%s was not supplied", p.Name)
-		}
-
-		if p.Select != nil {
-			result, err := ec.xpathEvaluator(ctx).ContextItem(item).Evaluate(ec.xpathContext(ctx), p.Select, nil)
-			if err != nil {
-				return err
+		} else if po != nil {
+			if v, ok := po[p.Name]; ok {
+				val = v
+				fromCaller = true
 			}
-			val = result.Sequence()
-		} else if len(p.Body) > 0 {
-			ec.temporaryOutputDepth++
-			var err error
-			if p.As != "" {
-				val, err = ec.evaluateBodyAsSequence(ctx, p.Body)
+		}
+
+		if !fromCaller {
+			// XTDE0700: required parameter not supplied
+			if p.Required {
+				return dynamicError(errCodeXTDE0700, "required parameter $%s was not supplied", p.Name)
+			}
+
+			if p.Select != nil {
+				result, err := ec.xpathEvaluator(ctx).ContextItem(item).Evaluate(ec.xpathContext(ctx), p.Select, nil)
+				if err != nil {
+					return err
+				}
+				val = result.Sequence()
+			} else if len(p.Body) > 0 {
+				ec.temporaryOutputDepth++
+				var err error
+				if p.As != "" {
+					val, err = ec.evaluateBodyAsSequence(ctx, p.Body)
+				} else {
+					val, err = ec.evaluateBody(ctx, p.Body)
+				}
+				ec.temporaryOutputDepth--
+				if err != nil {
+					return err
+				}
 			} else {
-				val, err = ec.evaluateBody(ctx, p.Body)
+				val = xpath3.EmptySequence()
 			}
-			ec.temporaryOutputDepth--
-			if err != nil {
-				return err
-			}
-		} else {
-			val = xpath3.EmptySequence()
 		}
 
-		if p.As != "" && val != nil && sequence.Len(val) > 0 {
+		// Type-check against the declared as type. A caller-supplied empty
+		// sequence is nil, so check whenever the value came from the caller
+		// (XTTE0590) even when nil; for defaults a nil value is left to the
+		// default-handling logic above.
+		if p.As != "" && (val != nil || fromCaller) {
 			st := parseSequenceType(p.As)
-			checked, err := checkSequenceType(ctx, val, st, errCodeXTTE0570, "param $"+p.Name, ec)
+			errCode := errCodeXTTE0570
+			if fromCaller {
+				errCode = errCodeXTTE0590
+			}
+			checked, err := checkSequenceType(ctx, val, st, errCode, "param $"+p.Name, ec)
 			if err != nil {
 				return err
 			}
@@ -554,8 +577,11 @@ func (ec *execContext) executeTemplate(ctx context.Context, tmpl *template, node
 			}
 		}
 
-		// Type check against the declared as type
-		if p.As != "" && val != nil && sequence.Len(val) > 0 {
+		// Type check against the declared as type. A caller-supplied empty
+		// sequence is nil, so check whenever the value came from the caller
+		// (XTTE0590) even when nil; for defaults a nil value is left to the
+		// default-handling logic above.
+		if p.As != "" && (val != nil || fromCaller) {
 			st := parseSequenceType(p.As)
 			errCode := errCodeXTTE0570
 			if fromCaller {

--- a/xslt3/execute_transform.go
+++ b/xslt3/execute_transform.go
@@ -387,7 +387,7 @@ func executeTransform(ctx context.Context, source *helium.Document, ss *Styleshe
 						return nil, tErr
 					}
 					if tmpl != nil {
-						if err := ec.executeAtomicTemplate(ctx, tmpl, v, resolvedMode); err != nil {
+						if err := ec.executeAtomicTemplate(ctx, tmpl, v, resolvedMode, initialModeParams); err != nil {
 							ec.tunnelParams = savedTunnel
 							return nil, err
 						}

--- a/xslt3/template_params_atomic_test.go
+++ b/xslt3/template_params_atomic_test.go
@@ -1,0 +1,64 @@
+package xslt3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xslt3"
+	"github.com/stretchr/testify/require"
+)
+
+// ENG-001: a template rule matching an ATOMIC item with a required param
+// supplied via xsl:with-param must succeed (no XTDE0700) and the param value
+// must be visible in the template body.
+func TestApplyTemplatesAtomicRequiredParamSupplied(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:apply-templates select="1">
+        <xsl:with-param name="p" select="'supplied'"/>
+      </xsl:apply-templates>
+    </out>
+  </xsl:template>
+
+  <xsl:template match=".[. instance of xs:integer]">
+    <xsl:param name="p" as="xs:string" required="yes"/>
+    <got><xsl:value-of select="$p"/></got>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	source := parseTransformSource(t)
+	result, err := xslt3.TransformString(t.Context(), source, ss)
+	require.NoError(t, err)
+	require.Contains(t, result, "<got>supplied</got>")
+}
+
+// ENG-002: a caller-supplied empty sequence () for a param with
+// as="xs:string" (cardinality exactly-one) must raise XTTE0590, not pass
+// silently.
+func TestCallTemplateEmptySequenceForExactlyOneParamFails(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:call-template name="show">
+        <xsl:with-param name="p" select="()"/>
+      </xsl:call-template>
+    </out>
+  </xsl:template>
+
+  <xsl:template name="show">
+    <xsl:param name="p" as="xs:string"/>
+    <q><xsl:value-of select="$p"/></q>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	source := parseTransformSource(t)
+	_, err := xslt3.TransformString(t.Context(), source, ss)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "XTTE0590")
+}


### PR DESCRIPTION
- ENG-001: thread caller with-param values into atomic-item template dispatch (executeAtomicTemplate, dispatchApplyTemplatesItem, applyTemplatesToSequence, initial-mode atomic branch) so a required param matching an atomic item no longer wrongly raises XTDE0700
- ENG-002: type-check caller-supplied empty sequence () for params with an as-type so as="xs:string" (exactly-one) correctly raises XTTE0590
