### PR TITLE
accept case-insensitive localhost in file uri

### DIFF
--- a/internal/cli/heliumcmd/safety.go
+++ b/internal/cli/heliumcmd/safety.go
@@ -354,7 +354,7 @@ func localFilePath(uri string) (string, error) {
 	if u.Scheme != "file" {
 		return "", fmt.Errorf("unsupported URI scheme %q: only file: and local paths are allowed", u.Scheme)
 	}
-	if u.Host != "" && u.Host != "localhost" {
+	if u.Host != "" && !strings.EqualFold(u.Host, "localhost") {
 		return "", fmt.Errorf("unsupported file URI host %q: only local files are allowed", u.Host)
 	}
 

--- a/internal/cli/heliumcmd/safety_internal_test.go
+++ b/internal/cli/heliumcmd/safety_internal_test.go
@@ -30,6 +30,11 @@ func TestLocalFilePath(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "/tmp/mod.xsl", got)
 	})
+	t.Run("file URI uppercase localhost host", func(t *testing.T) {
+		got, err := localFilePath("file://LOCALHOST/tmp/mod.xsl")
+		require.NoError(t, err)
+		require.Equal(t, "/tmp/mod.xsl", got)
+	})
 	t.Run("file URI percent-decoded", func(t *testing.T) {
 		got, err := localFilePath("file:///tmp/a%20b/mod.xsl")
 		require.NoError(t, err)


### PR DESCRIPTION
- `localFilePath` now compares the file: URI host with `strings.EqualFold`, so `file://LOCALHOST/...` resolves like `file://localhost/...` per RFC 8089/3986 (host is case-insensitive)