### PR TITLE
fix node positional focus in xsl:for-each-group

### DIFF
--- a/xslt3/compile_patterns.go
+++ b/xslt3/compile_patterns.go
@@ -767,6 +767,15 @@ func (p *pattern) matchPattern(ctx context.Context, ec *execContext, node helium
 // group-starting-with / group-ending-with over non-node sequences (XSLT 3.0).
 func (p *pattern) matchPatternItem(ctx context.Context, ec *execContext, item xpath3.Item) bool {
 	if ni, ok := item.(xpath3.NodeItem); ok {
+		// A positional predicate over the context item, e.g. ".[position()=3]",
+		// must see the focus of the population being grouped (position/size set
+		// by the caller in ec.position/ec.size), not the document-order focus
+		// that matchPattern re-establishes for the node. This mirrors the atomic
+		// branch below (ENG-005): evaluate each predicate directly with the node
+		// as context item and the population focus already in scope.
+		if p.matchNodeContextItemPositional(ctx, ec, ni.Node) {
+			return true
+		}
 		return p.matchPattern(ctx, ec, ni.Node)
 	}
 
@@ -826,6 +835,65 @@ func (p *pattern) matchPatternItem(ctx context.Context, ec *execContext, item xp
 		}
 		seq := result.Sequence()
 		if seq != nil && sequence.Len(seq) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// matchNodeContextItemPositional handles ".[pred]" pattern alternatives for a
+// node item during for-each-group boundary evaluation. It evaluates each such
+// alternative's predicates with the node as the context item and the population
+// focus (ec.position/ec.size) already in scope, so that positional predicates
+// like position()=3 are tested against the node's position within the population
+// being grouped rather than its document-order position. It returns true only
+// when a ".[pred]" alternative matches; non-".[pred]" alternatives are left for
+// the caller to handle via matchPattern.
+func (p *pattern) matchNodeContextItemPositional(ctx context.Context, ec *execContext, node helium.Node) bool {
+	var ctxAlts []xpath3.FilterExpr
+	for _, alt := range p.Alternatives {
+		fe, ok := alt.expr.(xpath3.FilterExpr)
+		if !ok {
+			continue
+		}
+		if _, isCtxItem := fe.Expr.(xpath3.ContextItemExpr); !isCtxItem {
+			continue
+		}
+		ctxAlts = append(ctxAlts, fe)
+	}
+	if len(ctxAlts) == 0 {
+		return false
+	}
+
+	saved := ec.xpathDefaultNS
+	savedHas := ec.hasXPathDefaultNS
+	savedGroups := ec.regexGroups
+	savedContext := ec.contextNode
+	savedCurrent := ec.currentNode
+	savedItem := ec.contextItem
+	savedInPattern := ec.inPatternMatch
+	savedPatternNS := ec.patternNamespaces
+	ec.xpathDefaultNS = p.xpathDefaultNS
+	ec.hasXPathDefaultNS = p.hasXPathDefaultNS
+	ec.regexGroups = nil
+	ec.contextNode = node
+	ec.currentNode = node
+	ec.contextItem = xpath3.NodeItem{Node: node}
+	ec.inPatternMatch = true
+	ec.patternNamespaces = p.nsBindings
+	defer func() {
+		ec.xpathDefaultNS = saved
+		ec.hasXPathDefaultNS = savedHas
+		ec.regexGroups = savedGroups
+		ec.contextNode = savedContext
+		ec.currentNode = savedCurrent
+		ec.contextItem = savedItem
+		ec.inPatternMatch = savedInPattern
+		ec.patternNamespaces = savedPatternNS
+	}()
+
+	for _, fe := range ctxAlts {
+		if ec.matchContextItemPredicates(ctx, fe.Predicates) {
 			return true
 		}
 	}

--- a/xslt3/for_each_group_focus_test.go
+++ b/xslt3/for_each_group_focus_test.go
@@ -77,6 +77,77 @@ func TestForEachGroupEndingWithPositionalPattern(t *testing.T) {
 	require.Contains(t, out, "<group>4,5</group>")
 }
 
+// TestForEachGroupStartingWithNodePositionalPattern verifies that a positional
+// pattern in group-starting-with sees the per-item focus of the population when
+// the population is a sequence of element NODES (UNRES-7, #684 follow-up). The
+// node path previously delegated straight to matchPattern, which re-established
+// the node's document-order focus and ignored ec.position/ec.size, so
+// position()=3 never matched and the items collapsed into a single group. The
+// fix routes ".[pred]" alternatives through the population focus, splitting
+// before the 3rd node.
+func TestForEachGroupStartingWithNodePositionalPattern(t *testing.T) {
+	ctx := t.Context()
+	xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each-group select="root/item" group-starting-with=".[position()=3]">
+        <group><xsl:value-of select="string-join(current-group()!string(@n), ',')"/></group>
+      </xsl:for-each-group>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`
+
+	doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+	require.NoError(t, err)
+	ss, err := xslt3.CompileStylesheet(ctx, doc)
+	require.NoError(t, err)
+	src, err := helium.NewParser().Parse(ctx, []byte(
+		`<root><item n="1"/><item n="2"/><item n="3"/><item n="4"/><item n="5"/></root>`))
+	require.NoError(t, err)
+	out, err := ss.Transform(src).Serialize(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, strings.Count(out, "<group>"),
+		"node positional pattern should split into two groups, got: %s", out)
+	require.Contains(t, out, "<group>1,2</group>")
+	require.Contains(t, out, "<group>3,4,5</group>")
+}
+
+// TestForEachGroupEndingWithNodePositionalPattern verifies the same per-item
+// focus handling for group-ending-with over element NODES (UNRES-7). A group
+// ends at the 3rd node of the population.
+func TestForEachGroupEndingWithNodePositionalPattern(t *testing.T) {
+	ctx := t.Context()
+	xsltSrc := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each-group select="root/item" group-ending-with=".[position()=3]">
+        <group><xsl:value-of select="string-join(current-group()!string(@n), ',')"/></group>
+      </xsl:for-each-group>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`
+
+	doc, err := helium.NewParser().Parse(ctx, []byte(xsltSrc))
+	require.NoError(t, err)
+	ss, err := xslt3.CompileStylesheet(ctx, doc)
+	require.NoError(t, err)
+	src, err := helium.NewParser().Parse(ctx, []byte(
+		`<root><item n="1"/><item n="2"/><item n="3"/><item n="4"/><item n="5"/></root>`))
+	require.NoError(t, err)
+	out, err := ss.Transform(src).Serialize(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, strings.Count(out, "<group>"),
+		"node positional pattern should split into two groups, got: %s", out)
+	require.Contains(t, out, "<group>1,2,3</group>")
+	require.Contains(t, out, "<group>4,5</group>")
+}
+
 // TestForEachGroupStartingWithNumericLiteralPattern verifies the numeric-literal
 // positional predicate (the atomic branch of matchContextItemPredicates) does an
 // exact float compare, not a truncating int compare. position()=2.7 is never


### PR DESCRIPTION
- xsl:for-each-group node-item positional patterns (e.g. group-starting-with/group-ending-with `.[position()=3]`) now use the item's position within the population, matching the atomic-item fix in #684
- route `.[pred]` pattern alternatives for node items through the population focus instead of the node's document-order focus
