### PR TITLE
extract shared deep-copy core for tree copies

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -41,64 +41,18 @@ func CopyNode(src Node, targetDoc *Document) (Node, error) {
 }
 
 func copyElement(src *Element, doc *Document) (*Element, error) {
-	elem := doc.CreateElement(src.LocalName())
-
-	// Track which namespace prefixes have been declared on this element
-	declaredPrefixes := make(map[string]bool)
-
-	// Copy namespace declarations (nsDefs)
-	if nc, ok := Node(src).(NamespaceContainer); ok {
-		for _, ns := range nc.Namespaces() {
-			if err := elem.DeclareNamespace(ns.Prefix(), ns.URI()); err != nil {
-				return nil, err
-			}
-			declaredPrefixes[ns.Prefix()] = true
-		}
+	// The general copy path over-declares namespaces (load-bearing for
+	// streaming's fixNamespacesAfterCopy) and links with the preflighted
+	// AddChild, copying every node. See deepCopyOptions for the knobs.
+	dc := &deepCopier{dst: doc, opts: deepCopyOptions{overDeclareNS: true}}
+	node, err := dc.copyElement(src, nil, nil)
+	if err != nil {
+		return nil, err
 	}
-
-	// Copy the active namespace, adding a declaration if not already present.
-	if nsr, ok := Node(src).(Namespacer); ok {
-		if ns := nsr.Namespace(); ns != nil {
-			if ns.URI() != "" && !declaredPrefixes[ns.Prefix()] {
-				if err := elem.DeclareNamespace(ns.Prefix(), ns.URI()); err != nil {
-					return nil, err
-				}
-				declaredPrefixes[ns.Prefix()] = true
-			}
-			if err := elem.SetActiveNamespace(ns.Prefix(), ns.URI()); err != nil {
-				return nil, err
-			}
-		}
+	elem, ok := AsNode[*Element](node)
+	if !ok {
+		return nil, fmt.Errorf("helium: copyElement produced unexpected type %T", node)
 	}
-
-	// Copy attributes, preserving namespace information
-	for _, a := range src.Attributes() {
-		if a.URI() != "" {
-			ns, nsErr := doc.CreateNamespace(a.Prefix(), a.URI())
-			if nsErr != nil {
-				return nil, nsErr
-			}
-			if _, err := elem.SetAttributeNS(a.LocalName(), a.Value(), ns); err != nil {
-				return nil, err
-			}
-		} else {
-			if _, err := elem.SetAttribute(a.Name(), a.Value()); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	// Recursively copy children
-	for c := src.FirstChild(); c != nil; c = c.NextSibling() {
-		child, err := CopyNode(c, doc)
-		if err != nil {
-			return nil, err
-		}
-		if err := elem.AddChild(child); err != nil {
-			return nil, err
-		}
-	}
-
 	return elem, nil
 }
 
@@ -117,18 +71,11 @@ func CopyDoc(src *Document) (*Document, error) {
 		}
 	}
 
-	// Copy all children (except the DTD which was already handled).
-	for c := src.FirstChild(); c != nil; c = c.NextSibling() {
-		if c.Type() == DTDNode {
-			continue
-		}
-		child, err := CopyNode(c, dst)
-		if err != nil {
-			return nil, err
-		}
-		if err := dst.AddChild(child); err != nil {
-			return nil, err
-		}
+	// Copy all document children (the DTD was already handled) through the shared
+	// core in over-declare / AddChild mode, reproducing the historical behavior.
+	dc := &deepCopier{dst: dst, opts: deepCopyOptions{overDeclareNS: true}}
+	if err := dc.copyChildren(src, dst, nil, nil); err != nil {
+		return nil, err
 	}
 
 	return dst, nil

--- a/copy_core.go
+++ b/copy_core.go
@@ -1,0 +1,306 @@
+package helium
+
+import (
+	"maps"
+	"slices"
+)
+
+// deepCopyOptions configures the shared deep-copy core (deepCopier). It is the
+// single set of "speed/shape primitives" that every deep-copy site in the tree
+// layer is expressed through: the leaf-node copy switch, the attribute copy
+// loop, the namespace binding, and the child-linking strategy all live in one
+// place and are selected by these knobs.
+//
+// The defaults (the zero value) reproduce the historical helium.CopyDoc/CopyNode
+// behavior EXACTLY: over-declared namespaces and preflighted AddChild linking,
+// no filtering, no mapping. Callers that want the faster shape opt in.
+type deepCopyOptions struct {
+	// overDeclareNS selects the namespace-declaration strategy for elements.
+	//
+	// When true (the historical helium.CopyDoc behavior), every element
+	// re-declares its own nsDefs verbatim AND, if its active namespace is not
+	// among them, declares that too — i.e. it may emit a redundant declaration
+	// already in scope on an ancestor. This OVER-DECLARATION is load-bearing:
+	// streaming's fixNamespacesAfterCopy depends on it, so it must be preserved
+	// for the general copy path.
+	//
+	// When false (the strip-space fast path), the element reproduces its own
+	// declarations verbatim but binds its active namespace to a declaration
+	// already in scope (tracked via inScope) instead of re-declaring it, so the
+	// copy is not over-declared. A fallback declaration is emitted only for a
+	// degenerate source whose active namespace is not in scope anywhere.
+	overDeclareNS bool
+
+	// fastLink links children with AppendChildFast (no cycle/dup-attr preflight)
+	// when true. The copy core only ever builds a freshly-constructed,
+	// provably-acyclic, duplicate-free tree, so the preflight is pure overhead;
+	// the general path keeps AddChild (false) to remain byte-for-byte identical
+	// to the historical behavior on its callers.
+	fastLink bool
+
+	// omit, when non-nil, decides whether a node is dropped from the copy. It is
+	// the generalized node-filter predicate: strip-space passes a
+	// whitespace-omit filter; the general copy passes nil (copy everything). It
+	// receives the source node, its source parent element (nil at document
+	// level), and the per-element user state produced by enterElement.
+	omit func(src Node, parent *Element, state any) bool
+
+	// enterElement, when non-nil, derives the child user state for an element
+	// from its parent's state. strip-space uses it to thread xml:space="preserve"
+	// inheritance down the tree so omit can consult it. nil means "no state".
+	enterElement func(src *Element, parentState any) any
+
+	// onCopy, when non-nil, is invoked for every node that IS copied (not
+	// omitted), with the source node and its fresh copy. It backs caller-side
+	// bookkeeping such as the strip-space node map and ID-table rebuild.
+	onCopy func(src, cp Node)
+
+	// afterElementAttrs, when non-nil, is invoked for each copied element AFTER
+	// its attributes have been copied (but before its children), with the source
+	// and copy elements. strip-space uses it to map attribute correspondence,
+	// which requires the copy's attributes to already exist.
+	afterElementAttrs func(src, cp *Element)
+}
+
+// deepCopier carries the shared deep-copy state.
+type deepCopier struct {
+	dst  *Document
+	opts deepCopyOptions
+}
+
+// copyChildren copies the children of src (a document or element) into the
+// freshly-built parent, applying the filter and child-linking strategy.
+// inScope is the namespace scope on the COPY (used in exact mode); parentState
+// is the user state for src.
+func (dc *deepCopier) copyChildren(src Node, parent MutableNode, inScope map[string]*Namespace, parentState any) error {
+	srcElem, _ := AsNode[*Element](src)
+	for c := src.FirstChild(); c != nil; c = c.NextSibling() {
+		if c.Type() == DTDNode {
+			continue
+		}
+		child, err := dc.copyNode(c, srcElem, inScope, parentState)
+		if err != nil {
+			return err
+		}
+		if child == nil {
+			continue
+		}
+		if dc.opts.fastLink {
+			if err := appendFastChild(parent, child); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := parent.AddChild(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// copyNode copies a single source node. parent is the SOURCE parent element (nil
+// at document level), inScope is the copy-side namespace scope, and parentState
+// is the user state for parent. Returns (nil, nil) when the node is filtered out.
+func (dc *deepCopier) copyNode(src Node, parent *Element, inScope map[string]*Namespace, parentState any) (Node, error) {
+	switch src.Type() {
+	case ElementNode:
+		elem, ok := AsNode[*Element](src)
+		if !ok {
+			return CopyNode(src, dc.dst)
+		}
+		return dc.copyElement(elem, inScope, parentState)
+	case TextNode:
+		if dc.filtered(src, parent, parentState) {
+			return nil, nil //nolint:nilnil // omitted by filter
+		}
+		return dc.recorded(src, dc.dst.CreateText(slices.Clone(src.Content()))), nil
+	case CDATASectionNode:
+		if dc.filtered(src, parent, parentState) {
+			return nil, nil //nolint:nilnil // omitted by filter
+		}
+		return dc.recorded(src, dc.dst.CreateCDATASection(slices.Clone(src.Content()))), nil
+	case CommentNode:
+		if dc.filtered(src, parent, parentState) {
+			return nil, nil //nolint:nilnil // omitted by filter
+		}
+		return dc.recorded(src, dc.dst.CreateComment(slices.Clone(src.Content()))), nil
+	case ProcessingInstructionNode:
+		if dc.filtered(src, parent, parentState) {
+			return nil, nil //nolint:nilnil // omitted by filter
+		}
+		return dc.recorded(src, dc.dst.CreatePI(src.Name(), string(src.Content()))), nil
+	case EntityRefNode:
+		if dc.filtered(src, parent, parentState) {
+			return nil, nil //nolint:nilnil // omitted by filter
+		}
+		cp, err := dc.dst.CreateCharRef(src.Name())
+		if err != nil {
+			return nil, err
+		}
+		return dc.recorded(src, cp), nil
+	default:
+		// Mirror CopyNode for any other node type (e.g. NamespaceNode) so the
+		// copy stays faithful. These are never filtered.
+		cp, err := CopyNode(src, dc.dst)
+		if err != nil {
+			return nil, err
+		}
+		if cp != nil {
+			dc.record(src, cp)
+		}
+		return cp, nil
+	}
+}
+
+func (dc *deepCopier) filtered(src Node, parent *Element, state any) bool {
+	return dc.opts.omit != nil && dc.opts.omit(src, parent, state)
+}
+
+func (dc *deepCopier) record(src, cp Node) {
+	if dc.opts.onCopy != nil {
+		dc.opts.onCopy(src, cp)
+	}
+}
+
+// recorded records the mapping and returns cp for convenient inline use.
+func (dc *deepCopier) recorded(src, cp Node) Node {
+	dc.record(src, cp)
+	return cp
+}
+
+// copyElement copies an element. inScope maps each namespace prefix to the
+// *Namespace declaration in scope on the COPY. parentState is the user state of
+// the source parent element.
+func (dc *deepCopier) copyElement(src *Element, inScope map[string]*Namespace, parentState any) (Node, error) {
+	elem := dc.dst.CreateElement(src.LocalName())
+	dc.record(src, elem)
+
+	childScope, err := dc.bindNamespaces(src, elem, inScope)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := dc.copyAttributes(src, elem); err != nil {
+		return nil, err
+	}
+
+	if dc.opts.afterElementAttrs != nil {
+		dc.opts.afterElementAttrs(src, elem)
+	}
+
+	state := parentState
+	if dc.opts.enterElement != nil {
+		state = dc.opts.enterElement(src, parentState)
+	}
+
+	if err := dc.copyChildren(src, elem, childScope, state); err != nil {
+		return nil, err
+	}
+	return elem, nil
+}
+
+// bindNamespaces reproduces src's namespace declarations on elem and sets elem's
+// active namespace, honoring the over-declare vs exact mode. It returns the
+// child namespace scope (only meaningful in exact mode; nil in over-declare
+// mode, which does not track scope).
+func (dc *deepCopier) bindNamespaces(src, elem *Element, inScope map[string]*Namespace) (map[string]*Namespace, error) {
+	if dc.opts.overDeclareNS {
+		return nil, dc.bindNamespacesOverDeclare(src, elem)
+	}
+	return dc.bindNamespacesExact(src, elem, inScope)
+}
+
+// bindNamespacesOverDeclare reproduces the historical helium.copyElement
+// namespace behavior verbatim: declare every nsDefs entry, then declare the
+// active namespace too if it was not already declared, then set it active. This
+// can emit a declaration already in scope on an ancestor (over-declaration) and
+// is REQUIRED by streaming's fixNamespacesAfterCopy.
+func (dc *deepCopier) bindNamespacesOverDeclare(src, elem *Element) error {
+	declaredPrefixes := make(map[string]struct{})
+
+	if nc, ok := Node(src).(NamespaceContainer); ok {
+		for _, ns := range nc.Namespaces() {
+			if err := elem.DeclareNamespace(ns.Prefix(), ns.URI()); err != nil {
+				return err
+			}
+			declaredPrefixes[ns.Prefix()] = struct{}{}
+		}
+	}
+
+	if nsr, ok := Node(src).(Namespacer); ok {
+		if ns := nsr.Namespace(); ns != nil {
+			if _, declared := declaredPrefixes[ns.Prefix()]; ns.URI() != "" && !declared {
+				if err := elem.DeclareNamespace(ns.Prefix(), ns.URI()); err != nil {
+					return err
+				}
+			}
+			if err := elem.SetActiveNamespace(ns.Prefix(), ns.URI()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// bindNamespacesExact reproduces the strip-space fast-path namespace behavior:
+// declarations are reproduced verbatim, and the active namespace is bound to a
+// declaration already in scope instead of re-declaring it (no over-declaration).
+// A fallback declaration is emitted only when no in-scope declaration matches.
+func (dc *deepCopier) bindNamespacesExact(src, elem *Element, inScope map[string]*Namespace) (map[string]*Namespace, error) {
+	childScope := inScope
+	ownDecls := src.Namespaces()
+	if len(ownDecls) > 0 {
+		childScope = make(map[string]*Namespace, len(inScope)+len(ownDecls))
+		maps.Copy(childScope, inScope)
+		for _, ns := range ownDecls {
+			decl, err := dc.dst.CreateNamespace(ns.Prefix(), ns.URI())
+			if err != nil {
+				return nil, err
+			}
+			elem.AddNamespaceDecl(decl)
+			childScope[ns.Prefix()] = decl
+		}
+	}
+
+	if ns := src.Namespace(); ns != nil && ns.URI() != "" {
+		active := childScope[ns.Prefix()]
+		if active == nil || active.URI() != ns.URI() {
+			decl, err := dc.dst.CreateNamespace(ns.Prefix(), ns.URI())
+			if err != nil {
+				return nil, err
+			}
+			elem.AddNamespaceDecl(decl)
+			if len(ownDecls) == 0 {
+				childScope = make(map[string]*Namespace, len(inScope)+1)
+				maps.Copy(childScope, inScope)
+			}
+			childScope[ns.Prefix()] = decl
+			active = decl
+		}
+		elem.SetNs(active)
+	}
+	return childScope, nil
+}
+
+// copyAttributes copies src's attributes onto elem using the value-parsing
+// setters (SetAttribute/SetAttributeNS) so the copy is byte-for-byte identical,
+// including entity-reference handling. This loop is identical across all copy
+// sites.
+func (dc *deepCopier) copyAttributes(src, elem *Element) error {
+	for _, a := range src.Attributes() {
+		if a.URI() != "" {
+			ns, nsErr := dc.dst.CreateNamespace(a.Prefix(), a.URI())
+			if nsErr != nil {
+				return nsErr
+			}
+			if _, err := elem.SetAttributeNS(a.LocalName(), a.Value(), ns); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := elem.SetAttribute(a.Name(), a.Value()); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
- extract a shared unexported deep-copy core (`deepCopier`/`deepCopyOptions`) in helium: leaf-copy switch, attribute loop, namespace binding (over-declare AND exact modes), and child-linking (AddChild vs AppendChildFast) behind one set of knobs
- re-express `CopyDoc`/`CopyNode`/`copyElement` through the core in over-declare + AddChild mode, preserving observable behavior (over-declaration kept for streaming's fixNamespacesAfterCopy)
- strictly behavior-preserving: no golden/output changes; cross-package callers (xslt3 strip-space/copy-of, xmldsig1 enveloped clone) NOT migrated since that needs new public API (deferred, needs api decision)
