### PR TITLE
make xslt3 union-split origin id globally unique

### DIFF
--- a/xslt3/compile_templates.go
+++ b/xslt3/compile_templates.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
@@ -14,6 +15,23 @@ import (
 var templateAllowedAttrs = map[string]struct{}{
 	"match": {}, xslAttrName: {}, "priority": {}, "mode": {}, "as": {},
 	xslAttrVisibility: {}, xslAttrUseWhen: {},
+}
+
+// splitOriginCounter is a process-global monotonic source for
+// template.splitOriginID. It must be global (not per-stylesheet) so that
+// union-pattern splits produced by independently compiled packages — which are
+// later merged into a single mode list via xsl:use-package — never collide on
+// the same id. Two unrelated union rules from different packages sharing an id
+// would make the on-multiple-match conflict checks treat a genuine
+// cross-package ambiguous match as a single non-conflicting rule.
+var splitOriginCounter atomic.Int64
+
+// nextSplitOriginID returns a fresh, globally-unique non-zero origin id for a
+// union-pattern split group. All branches of one union rule share the value it
+// returns; different union rules (including those from different packages)
+// always receive distinct values.
+func nextSplitOriginID() int64 {
+	return splitOriginCounter.Add(1)
 }
 
 func (c *compiler) compileTemplate(ctx context.Context, elem *helium.Element) error {
@@ -304,8 +322,15 @@ func (c *compiler) compileTemplate(ctx context.Context, elem *helium.Element) er
 			// single rule even when they have an empty body (no &Body[0]
 			// identity to compare). See hasConflictingMatch /
 			// hasConflictingAtomicMatch.
-			c.stylesheet.unionSplitCounter++
-			originID := c.stylesheet.unionSplitCounter
+			//
+			// The id must be unique across the entire compilation, not just
+			// within one stylesheet/package: under xsl:use-package, split
+			// templates from different packages are merged into one mode list,
+			// and a per-stylesheet counter (which restarts at 0 per compile)
+			// would hand identical ids to unrelated union rules from different
+			// packages, wrongly suppressing a genuine cross-package XTDE0540
+			// match. A process-global monotonic counter guarantees uniqueness.
+			originID := nextSplitOriginID()
 			for _, alt := range tmpl.Match.Alternatives {
 				split := *tmpl // shallow copy shares Body, Params, etc.
 				split.Match = &pattern{

--- a/xslt3/split_origin_id_test.go
+++ b/xslt3/split_origin_id_test.go
@@ -1,0 +1,95 @@
+package xslt3
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// splitOriginIDs compiles a stylesheet source and returns, per mode, the
+// non-zero splitOriginID values carried by union-split match templates.
+func splitOriginIDs(t *testing.T, src string) []int64 {
+	t.Helper()
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(src))
+	require.NoError(t, err)
+	ss, err := compile(context.Background(), doc, &compileConfig{})
+	require.NoError(t, err)
+	var ids []int64
+	for _, tmpls := range ss.modeTemplates {
+		for _, tmpl := range tmpls {
+			if tmpl.splitOriginID != 0 {
+				ids = append(ids, tmpl.splitOriginID)
+			}
+		}
+	}
+	return ids
+}
+
+// UNRES-8: the union-split origin id must be unique across the whole
+// compilation, not merely within a single stylesheet/package compile. A
+// per-stylesheet counter restarts at 0 for every compile(), so two independent
+// compiles would hand their first union split the same id — and under
+// xsl:use-package those splits can be merged into a single mode list where the
+// on-multiple-match conflict check treats equal ids as one rule, wrongly
+// suppressing a genuine cross-package XTDE0540. A process-global counter
+// guarantees splits from different compiles never collide.
+func TestSplitOriginIDUniqueAcrossCompiles(t *testing.T) {
+	const src = `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="a | b"/>
+</xsl:stylesheet>`
+
+	idsA := splitOriginIDs(t, src)
+	idsB := splitOriginIDs(t, src)
+	require.NotEmpty(t, idsA, "union pattern should produce at least one split")
+	require.NotEmpty(t, idsB)
+
+	// Within one compile, every branch of the SAME union rule shares one id.
+	for _, id := range idsA[1:] {
+		require.Equal(t, idsA[0], id, "branches of one union rule must share an origin id")
+	}
+	for _, id := range idsB[1:] {
+		require.Equal(t, idsB[0], id, "branches of one union rule must share an origin id")
+	}
+
+	// Across two independent compiles, the ids must NOT collide. With a
+	// per-stylesheet counter both would be 1; with a global counter they differ.
+	require.NotEqual(t, idsA[0], idsB[0],
+		"split origin ids from independent compiles must be distinct so cross-package conflicts are not suppressed")
+}
+
+// Distinct union rules within a single compile must also receive distinct
+// origin ids (one id per union rule, shared only among its own branches).
+func TestSplitOriginIDDistinctPerUnionRule(t *testing.T) {
+	const src = `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="a | b" mode="m1"/>
+  <xsl:template match="c | d" mode="m2"/>
+</xsl:stylesheet>`
+
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(src))
+	require.NoError(t, err)
+	ss, err := compile(context.Background(), doc, &compileConfig{})
+	require.NoError(t, err)
+
+	idByMode := map[string]int64{}
+	for mode, tmpls := range ss.modeTemplates {
+		for _, tmpl := range tmpls {
+			if tmpl.splitOriginID == 0 {
+				continue
+			}
+			if existing, ok := idByMode[mode]; ok {
+				require.Equal(t, existing, tmpl.splitOriginID,
+					"branches of the same union rule (mode %q) must share an id", mode)
+				continue
+			}
+			idByMode[mode] = tmpl.splitOriginID
+		}
+	}
+	require.Contains(t, idByMode, "m1")
+	require.Contains(t, idByMode, "m2")
+	require.NotEqual(t, idByMode["m1"], idByMode["m2"],
+		"different union rules must receive distinct origin ids")
+}

--- a/xslt3/stylesheet.go
+++ b/xslt3/stylesheet.go
@@ -141,7 +141,6 @@ type Stylesheet struct {
 	compilerImportSchemas []*xsd.Schema               // pre-compiled schemas from compiler (for fn:transform nested compiles)
 	maxResourceBytes      int64                       // per-resource read cap from compiler; 0 = MaxResourceBytes default, <0 = unbounded
 	allowExternalEntities bool                        // compile-time opt-in: legacy permissive external-entity parsing (for fn:transform nested compiles)
-	unionSplitCounter     int                         // monotonic id source for union-pattern split groups (template.splitOriginID)
 }
 
 // globalContextItemDef represents a compiled xsl:global-context-item declaration.
@@ -269,8 +268,10 @@ type template struct {
 	// pattern (P1 | P2) is split into separate template entries. All split
 	// branches of one rule share the same non-zero id so the on-multiple-match
 	// conflict checks can treat them as a single rule (spec bug 30402). 0 means
-	// the template was not produced by a union split.
-	splitOriginID int
+	// the template was not produced by a union split. The id is allocated from a
+	// process-global counter (nextSplitOriginID) so splits from independently
+	// compiled packages merged via xsl:use-package never collide.
+	splitOriginID int64
 }
 
 // variable is a compiled xsl:variable.


### PR DESCRIPTION
- `splitOriginID` was sourced from a per-`Stylesheet` `unionSplitCounter` that restarts at 0 each `compile()`; under `xsl:use-package` two union-split rules from different packages could share an id and have a genuine cross-package XTDE0540 suppressed.
- Replace the per-stylesheet counter with a process-global `atomic.Int64` (`nextSplitOriginID`); same-template splits still share one id, splits from distinct rules/compiles never collide.
- Coverage: in-package unit tests on the id invariant (unique across independent compiles; shared among one rule's branches; distinct across rules). A full use-package runtime repro is not constructible today because merged used-package union templates are not re-split into the parent mode list, so the collision is latent; the invariant test pins the fix.