### PR TITLE
dedup xslt3 streamability body walks

### DIFF
--- a/xslt3/streamability.go
+++ b/xslt3/streamability.go
@@ -676,3 +676,23 @@ func exprUsesCurrent(expr xpath3.Expr) bool {
 	})
 	return found
 }
+
+// bodyMatchesExpr reports whether any expression in the instruction body (or
+// any nested child body) satisfies pred. Traversal visits an instruction's own
+// expressions first, then recurses into child instructions, short-circuiting on
+// the first match. nil expressions are skipped before pred is called.
+func bodyMatchesExpr(body []instruction, pred func(*xpath3.Expression) bool) bool {
+	for _, inst := range body {
+		for _, expr := range getInstructionExprs(inst) {
+			if expr != nil && pred(expr) {
+				return true
+			}
+		}
+		for _, children := range getChildInstructions(inst) {
+			if bodyMatchesExpr(children, pred) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/xslt3/streamability_analysis.go
+++ b/xslt3/streamability_analysis.go
@@ -1,8 +1,6 @@
 package xslt3
 
 import (
-	"slices"
-
 	"github.com/lestrrat-go/helium/internal/xpathstream"
 	"github.com/lestrrat-go/helium/xpath3"
 )
@@ -530,18 +528,5 @@ func exprPathBaseIsGrounding(expr xpath3.Expr) bool {
 // bodyHasDownwardNavigation returns true if any instruction in the body
 // has an expression that navigates downward (child/descendant axis).
 func bodyHasDownwardNavigation(body []instruction) bool {
-	for _, inst := range body {
-		for _, expr := range getInstructionExprs(inst) {
-			if expr == nil {
-				continue
-			}
-			if xpathstream.ExprHasDownwardStep(expr) {
-				return true
-			}
-		}
-		if slices.ContainsFunc(getChildInstructions(inst), bodyHasDownwardNavigation) {
-			return true
-		}
-	}
-	return false
+	return bodyMatchesExpr(body, xpathstream.ExprHasDownwardStep)
 }

--- a/xslt3/streamability_functions.go
+++ b/xslt3/streamability_functions.go
@@ -456,31 +456,10 @@ func isContextItemArg(expr xpath3.Expr) bool {
 // where each entry independently strides into child elements.
 // Grounding functions are skipped — their arguments produce grounded data.
 func countCrawlingSelectionsInner(ss *Stylesheet, expr xpath3.Expr, _ bool) int {
-	expr = derefXPathExpr(expr)
-	count := 0
-	xpathstream.WalkExpr(expr, func(e xpath3.Expr) bool {
-		e = derefXPathExpr(e)
-		if fc, ok := e.(xpath3.FunctionCall); ok && isGroundingExprSS(ss, fc) {
-			return false // grounding function — result is grounded
-		}
-		if lp, ok := e.(xpath3.LocationPath); ok {
-			for _, step := range lp.Steps {
-				switch step.Axis {
-				case xpath3.AxisDescendant, xpath3.AxisDescendantOrSelf:
-					count++
-					return false
-				}
-			}
-		}
-		if ps, ok := e.(xpath3.PathStepExpr); ok {
-			if ps.DescOrSelf {
-				count++
-				return false
-			}
-		}
-		return true
+	return countCrawlingSelections(expr, func(e xpath3.Expr) bool {
+		fc, ok := e.(xpath3.FunctionCall)
+		return ok && isGroundingExprSS(ss, fc) // grounding function — result is grounded
 	})
-	return count
 }
 
 // countDeepCrawlingSelections counts crawling (descendant/descendant-or-self)
@@ -488,10 +467,21 @@ func countCrawlingSelectionsInner(ss *Stylesheet, expr xpath3.Expr, _ bool) int 
 // multiple independent crawling paths in map constructor entries even when
 // each is wrapped in a grounding function like head().
 func countDeepCrawlingSelections(expr xpath3.Expr) int {
+	return countCrawlingSelections(expr, nil)
+}
+
+// countCrawlingSelections counts crawling (descendant/descendant-or-self)
+// selections in expr. If skip is non-nil, any subtree whose root matches skip
+// is not descended into (used to stop at grounding functions). Traversal and
+// short-circuiting match WalkExpr's pre-order visit.
+func countCrawlingSelections(expr xpath3.Expr, skip func(xpath3.Expr) bool) int {
 	expr = derefXPathExpr(expr)
 	count := 0
 	xpathstream.WalkExpr(expr, func(e xpath3.Expr) bool {
 		e = derefXPathExpr(e)
+		if skip != nil && skip(e) {
+			return false
+		}
 		if lp, ok := e.(xpath3.LocationPath); ok {
 			for _, step := range lp.Steps {
 				switch step.Axis {

--- a/xslt3/streamability_instructions.go
+++ b/xslt3/streamability_instructions.go
@@ -638,15 +638,7 @@ func checkSourceDocCurrentGroup(body []instruction) error {
 // sourceDocBodyUsesCurrentGroup checks if any expression in the source-document
 // body uses current-group().
 func sourceDocBodyUsesCurrentGroup(body []instruction) bool {
-	for _, inst := range body {
-		if slices.ContainsFunc(getInstructionExprs(inst), exprUsesCurrentGroup) {
-			return true
-		}
-		if slices.ContainsFunc(getChildInstructions(inst), sourceDocBodyUsesCurrentGroup) {
-			return true
-		}
-	}
-	return false
+	return bodyMatchesExpr(body, exprUsesCurrentGroup)
 }
 
 // patternHasNonMotionlessPredicate returns true if any alternative in the
@@ -740,20 +732,7 @@ func exprIsContextItem(expr *xpath3.Expression) bool {
 // bodyUsesCurrentGroup returns true if any instruction in the body
 // uses current-group() in any expression.
 func bodyUsesCurrentGroup(body []instruction) bool {
-	for _, bi := range body {
-		for _, expr := range getInstructionExprs(bi) {
-			if expr == nil {
-				continue
-			}
-			if xpathstream.ExprUsesFunction(expr, lexicon.FnCurrentGroup) {
-				return true
-			}
-		}
-		if slices.ContainsFunc(getChildInstructions(bi), bodyUsesCurrentGroup) {
-			return true
-		}
-	}
-	return false
+	return bodyMatchesExpr(body, exprUsesCurrentGroup)
 }
 
 // exprUsesCurrentGroupConsumingly checks if an expression uses current-group()


### PR DESCRIPTION
- extract bodyMatchesExpr (3 walkers → wrappers)
- share crawling-selection counter core
- internal-only, net-negative, behavior-preserving