### PR TITLE
dedup xpath3 cast and constructor tails

### DIFF
--- a/xpath3/cast.go
+++ b/xpath3/cast.go
@@ -98,17 +98,8 @@ func CastAtomic(v AtomicValue, targetType string) (AtomicValue, error) {
 		}
 		n := iv.BigInt()
 		minVal, maxVal := integerTypeRange(targetType)
-		if minVal != nil && n.Cmp(minVal) < 0 {
-			return AtomicValue{}, &XPathError{
-				Code:    errCodeFORG0001,
-				Message: fmt.Sprintf("value %s out of range for %s", n.String(), targetType),
-			}
-		}
-		if maxVal != nil && n.Cmp(maxVal) > 0 {
-			return AtomicValue{}, &XPathError{
-				Code:    errCodeFORG0001,
-				Message: fmt.Sprintf("value %s out of range for %s", n.String(), targetType),
-			}
+		if err := checkBigIntRange(n, minVal, maxVal, targetType); err != nil {
+			return AtomicValue{}, err
 		}
 		return AtomicValue{TypeName: targetType, Value: n}, nil
 	}
@@ -672,4 +663,23 @@ func castError(value string, targetType string) *XPathError {
 		Code:    errCodeFORG0001,
 		Message: fmt.Sprintf("cannot cast %q to %s", value, targetType),
 	}
+}
+
+// checkBigIntRange reports a FORG0001 "out of range" error when n falls below
+// minVal or above maxVal (either bound may be nil to mean unbounded). The
+// min-then-max check order is significant for which bound a value violates.
+func checkBigIntRange(n, minVal, maxVal *big.Int, typeName string) error {
+	if minVal != nil && n.Cmp(minVal) < 0 {
+		return &XPathError{
+			Code:    errCodeFORG0001,
+			Message: fmt.Sprintf("value %s out of range for %s", n.String(), typeName),
+		}
+	}
+	if maxVal != nil && n.Cmp(maxVal) > 0 {
+		return &XPathError{
+			Code:    errCodeFORG0001,
+			Message: fmt.Sprintf("value %s out of range for %s", n.String(), typeName),
+		}
+	}
+	return nil
 }

--- a/xpath3/cast_numeric.go
+++ b/xpath3/cast_numeric.go
@@ -119,14 +119,9 @@ func castToInteger(v AtomicValue) (AtomicValue, error) {
 			return AtomicValue{TypeName: TypeInteger, Value: int64(1)}, nil
 		}
 		return AtomicValue{TypeName: TypeInteger, Value: int64(0)}, nil
-	case TypeString, TypeUntypedAtomic:
-		return CastFromString(v.StringVal(), TypeInteger)
 	default:
-		if isStringDerived(v.TypeName) {
-			return CastFromString(v.StringVal(), TypeInteger)
-		}
+		return castStringLikeOrFail(v, TypeInteger)
 	}
-	return AtomicValue{}, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("cannot cast %s to xs:integer", v.TypeName)}
 }
 
 func castToDecimal(v AtomicValue) (AtomicValue, error) {
@@ -149,14 +144,9 @@ func castToDecimal(v AtomicValue) (AtomicValue, error) {
 			return AtomicValue{TypeName: TypeDecimal, Value: big.NewRat(1, 1)}, nil
 		}
 		return AtomicValue{TypeName: TypeDecimal, Value: big.NewRat(0, 1)}, nil
-	case TypeString, TypeUntypedAtomic:
-		return CastFromString(v.StringVal(), TypeDecimal)
 	default:
-		if isStringDerived(v.TypeName) {
-			return CastFromString(v.StringVal(), TypeDecimal)
-		}
+		return castStringLikeOrFail(v, TypeDecimal)
 	}
-	return AtomicValue{}, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("cannot cast %s to xs:decimal", v.TypeName)}
 }
 
 func castToBoolean(v AtomicValue) (AtomicValue, error) {
@@ -173,28 +163,18 @@ func castToBoolean(v AtomicValue) (AtomicValue, error) {
 		return AtomicValue{TypeName: TypeBoolean, Value: f != 0 && !math.IsNaN(f)}, nil
 	case TypeDecimal:
 		return AtomicValue{TypeName: TypeBoolean, Value: v.BigRat().Sign() != 0}, nil
-	case TypeString, TypeUntypedAtomic:
-		return CastFromString(v.StringVal(), TypeBoolean)
 	default:
-		if isStringDerived(v.TypeName) {
-			return CastFromString(v.StringVal(), TypeBoolean)
-		}
+		return castStringLikeOrFail(v, TypeBoolean)
 	}
-	return AtomicValue{}, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("cannot cast %s to xs:boolean", v.TypeName)}
 }
 
 func castToBase64Binary(v AtomicValue) (AtomicValue, error) {
 	switch v.TypeName {
 	case TypeHexBinary:
 		return AtomicValue{TypeName: TypeBase64Binary, Value: v.BytesVal()}, nil
-	case TypeString, TypeUntypedAtomic:
-		return CastFromString(v.StringVal(), TypeBase64Binary)
 	default:
-		if isStringDerived(v.TypeName) {
-			return CastFromString(v.StringVal(), TypeBase64Binary)
-		}
+		return castStringLikeOrFail(v, TypeBase64Binary)
 	}
-	return AtomicValue{}, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("cannot cast %s to xs:base64Binary", v.TypeName)}
 }
 
 // xsdBase64Encoding is base64.StdEncoding with Strict() to reject non-zero
@@ -219,12 +199,20 @@ func castToHexBinary(v AtomicValue) (AtomicValue, error) {
 	switch v.TypeName {
 	case TypeBase64Binary:
 		return AtomicValue{TypeName: TypeHexBinary, Value: v.BytesVal()}, nil
-	case TypeString, TypeUntypedAtomic:
-		return CastFromString(v.StringVal(), TypeHexBinary)
 	default:
-		if isStringDerived(v.TypeName) {
-			return CastFromString(v.StringVal(), TypeHexBinary)
-		}
+		return castStringLikeOrFail(v, TypeHexBinary)
 	}
-	return AtomicValue{}, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("cannot cast %s to xs:hexBinary", v.TypeName)}
+}
+
+// castStringLikeOrFail casts a string-like source (xs:string, xs:untypedAtomic,
+// or any string-derived type) to targetType via CastFromString. Any other
+// source type yields XPTY0004. It is the shared fallthrough tail for the
+// non-string cast helpers; targetType doubles as the error message literal
+// since the Type* constants are their own lexical names (e.g. "xs:integer").
+func castStringLikeOrFail(v AtomicValue, targetType string) (AtomicValue, error) {
+	switch {
+	case v.TypeName == TypeString || v.TypeName == TypeUntypedAtomic || isStringDerived(v.TypeName):
+		return CastFromString(v.StringVal(), targetType)
+	}
+	return AtomicValue{}, &XPathError{Code: lexicon.ErrXPTY0004, Message: fmt.Sprintf("cannot cast %s to %s", v.TypeName, targetType)}
 }

--- a/xpath3/functions_constructors.go
+++ b/xpath3/functions_constructors.go
@@ -91,23 +91,24 @@ func init() {
 	registerNS(NSXS, "IDREFS", 1, 1, makeXSTokenList(TypeIDREFS, TypeIDREF, reNCName))
 	registerNS(NSXS, "ENTITIES", 1, 1, makeXSTokenList(TypeENTITIES, TypeENTITY, reNCName))
 
-	// Gregorian date part types
+	// Gregorian date part types. CastAtomic/CastFromString perform the
+	// per-type lexical validation, so these share the generic constructor.
 	for _, entry := range []struct {
 		name     string
 		typeName string
-		re       *regexp.Regexp
 	}{
-		{"gDay", TypeGDay, reGDay},
-		{"gMonth", TypeGMonth, reGMonth},
-		{"gMonthDay", TypeGMonthDay, reGMonthDay},
-		{"gYear", TypeGYear, reGYear},
-		{"gYearMonth", TypeGYearMonth, reGYearMonth},
+		{"gDay", TypeGDay},
+		{"gMonth", TypeGMonth},
+		{"gMonthDay", TypeGMonthDay},
+		{"gYear", TypeGYear},
+		{"gYearMonth", TypeGYearMonth},
 	} {
-		registerNS(NSXS, entry.name, 1, 1, makeXSGregorian(entry.typeName, entry.re))
+		registerNS(NSXS, entry.name, 1, 1, makeXSConstructor(entry.typeName))
 	}
 
-	// xs:dateTimeStamp — dateTime with required timezone
-	registerNS(NSXS, "dateTimeStamp", 1, 1, makeXSDateTimeStamp())
+	// xs:dateTimeStamp — dateTime with required timezone. CastAtomic enforces
+	// the mandatory-timezone rule, so the generic constructor suffices.
+	registerNS(NSXS, "dateTimeStamp", 1, 1, makeXSConstructor(TypeDateTimeStamp))
 
 	// xs:error — always raises an error (used for type checking tests)
 	registerNS(NSXS, "error", 1, 1, fnXSError)
@@ -173,11 +174,8 @@ func makeXSIntegerRangeBig(typeName string, minBig, maxBig *big.Int) func(contex
 			return nil, err
 		}
 		n := iv.BigInt()
-		if (minBig != nil && n.Cmp(minBig) < 0) || (maxBig != nil && n.Cmp(maxBig) > 0) {
-			return nil, &XPathError{
-				Code:    errCodeFORG0001,
-				Message: fmt.Sprintf("value %s out of range for %s", n.String(), typeName),
-			}
+		if err := checkBigIntRange(n, minBig, maxBig, typeName); err != nil {
+			return nil, err
 		}
 		return SingleAtomic(AtomicValue{TypeName: typeName, Value: n}), nil
 	}
@@ -266,24 +264,6 @@ var (
 	reGYear      = regexp.MustCompile(`^-?(\d{4,})(Z|[+-]\d{2}:\d{2})?$`)
 	reGYearMonth = regexp.MustCompile(`^-?(\d{4,})-(\d{2})(Z|[+-]\d{2}:\d{2})?$`)
 )
-
-// makeXSGregorian returns a constructor for xs:gDay, xs:gMonth, xs:gMonthDay, xs:gYear, xs:gYearMonth.
-func makeXSGregorian(typeName string, _ *regexp.Regexp) func(context.Context, []Sequence) (Sequence, error) {
-	return func(_ context.Context, args []Sequence) (Sequence, error) {
-		a, empty, err := atomizeConstructorArg(args[0], typeName)
-		if err != nil {
-			return nil, err
-		}
-		if empty {
-			return nil, nil
-		}
-		result, err := CastAtomic(a, typeName)
-		if err != nil {
-			return nil, err
-		}
-		return SingleAtomic(result), nil
-	}
-}
 
 // validateGregorianValue performs additional validation beyond regex matching.
 func validateGregorianValue(typeName, s string) bool {
@@ -410,25 +390,6 @@ func hasValidGregorianYearDigits(y string) bool {
 		return false
 	}
 	return len(y) == 4 || y[0] != '0'
-}
-
-func makeXSDateTimeStamp() func(context.Context, []Sequence) (Sequence, error) {
-	return func(_ context.Context, args []Sequence) (Sequence, error) {
-		a, empty, err := atomizeConstructorArg(args[0], TypeDateTimeStamp)
-		if err != nil {
-			return nil, err
-		}
-		if empty {
-			return nil, nil
-		}
-		// CastAtomic handles whitespace-trimmed string/date/dateTime inputs,
-		// same-type identity, and the mandatory-timezone rule for dateTimeStamp.
-		dts, err := CastAtomic(a, TypeDateTimeStamp)
-		if err != nil {
-			return nil, err
-		}
-		return SingleAtomic(dts), nil
-	}
 }
 
 func atomizeConstructorArg(seq Sequence, typeName string) (AtomicValue, bool, error) {


### PR DESCRIPTION
- reuse makeXSConstructor for gYear/dateTimeStamp ctors
- castStringLikeOrFail tail (5 casts)
- checkBigIntRange (FORG0001)
- internal-only, net-negative, behavior-preserving