### PR TITLE
dedup xslt3 execution-context helpers

### DIFF
--- a/xslt3/execute_copy.go
+++ b/xslt3/execute_copy.go
@@ -12,6 +12,29 @@ import (
 	"github.com/lestrrat-go/helium/xsd"
 )
 
+// emitAtomicText appends an atomic value to the current output as a text node.
+// Adjacent atomic values are separated by a single space per XSLT 3.0 §5.7.2;
+// prevWasAtomic tracks whether the previously emitted item was atomic and is
+// updated to true on success.
+func (ec *execContext) emitAtomicText(v xpath3.AtomicValue, prevWasAtomic *bool) error {
+	s, err := xpath3.AtomicToString(v)
+	if err != nil {
+		return err
+	}
+	if *prevWasAtomic {
+		sep := ec.resultDoc.CreateText([]byte(" "))
+		if err := ec.addNode(sep); err != nil {
+			return err
+		}
+	}
+	text := ec.resultDoc.CreateText([]byte(s))
+	if err := ec.addNode(text); err != nil {
+		return err
+	}
+	*prevWasAtomic = true
+	return nil
+}
+
 func (ec *execContext) execCopy(ctx context.Context, inst *copyInst) error {
 	contextNode := normalizeNode(ec.contextNode)
 
@@ -87,22 +110,10 @@ func (ec *execContext) execCopy(ctx context.Context, inst *copyInst) error {
 			case xpath3.AtomicValue:
 				// Atomic values: output as text, body is not evaluated.
 				// Adjacent atomic values are space-separated per XSLT 3.0 §5.7.2.
-				s, err := xpath3.AtomicToString(v)
-				if err != nil {
-					return err
-				}
 				out := ec.currentOutput()
-				if out.prevWasAtomic {
-					sep := ec.resultDoc.CreateText([]byte(" "))
-					if err := ec.addNode(sep); err != nil {
-						return err
-					}
-				}
-				text := ec.resultDoc.CreateText([]byte(s))
-				if err := ec.addNode(text); err != nil {
+				if err := ec.emitAtomicText(v, &out.prevWasAtomic); err != nil {
 					return err
 				}
-				out.prevWasAtomic = true
 			}
 		}
 		return nil
@@ -112,22 +123,10 @@ func (ec *execContext) execCopy(ctx context.Context, inst *copyInst) error {
 		// XSLT 3.0: context item may be an atomic value (e.g. inside
 		// xsl:for-each over a sequence of atomics). Copy it as text.
 		if av, ok := ec.contextItem.(xpath3.AtomicValue); ok {
-			s, err := xpath3.AtomicToString(av)
-			if err != nil {
-				return err
-			}
 			out := ec.currentOutput()
-			if out.prevWasAtomic {
-				sep := ec.resultDoc.CreateText([]byte(" "))
-				if err := ec.addNode(sep); err != nil {
-					return err
-				}
-			}
-			text := ec.resultDoc.CreateText([]byte(s))
-			if err := ec.addNode(text); err != nil {
+			if err := ec.emitAtomicText(av, &out.prevWasAtomic); err != nil {
 				return err
 			}
-			out.prevWasAtomic = true
 			return nil
 		}
 		return dynamicError(errCodeXTTE0945, "xsl:copy: no context item")
@@ -623,21 +622,9 @@ func (ec *execContext) execCopyOf(ctx context.Context, inst *copyOfInst) error {
 				}
 			}
 		case xpath3.AtomicValue:
-			s, err := xpath3.AtomicToString(v)
-			if err != nil {
+			if err := ec.emitAtomicText(v, &prevWasAtomic); err != nil {
 				return err
 			}
-			if prevWasAtomic {
-				sep := ec.resultDoc.CreateText([]byte(" "))
-				if err := ec.addNode(sep); err != nil {
-					return err
-				}
-			}
-			text := ec.resultDoc.CreateText([]byte(s))
-			if err := ec.addNode(text); err != nil {
-				return err
-			}
-			prevWasAtomic = true
 		}
 	}
 	out.prevWasAtomic = prevWasAtomic

--- a/xslt3/execute_element.go
+++ b/xslt3/execute_element.go
@@ -1167,6 +1167,18 @@ func prefixBoundTo(elem *helium.Element, prefix string) string {
 	return ""
 }
 
+// withV2TempOutput runs fn, treating its output as temporary output state
+// (XTDE1480) when the stylesheet declares an XSLT version below 3.0. XSLT 3.0
+// relaxes this restriction, so the depth is left untouched there.
+func (ec *execContext) withV2TempOutput(fn func() error) error {
+	isV2TempOutput := ec.stylesheet.version != "" && ec.stylesheet.version < "3.0"
+	if isV2TempOutput {
+		ec.temporaryOutputDepth++
+		defer func() { ec.temporaryOutputDepth-- }()
+	}
+	return fn()
+}
+
 func (ec *execContext) execComment(ctx context.Context, inst *commentInst) error {
 	var value string
 	if inst.Select != nil {
@@ -1178,14 +1190,12 @@ func (ec *execContext) execComment(ctx context.Context, inst *commentInst) error
 	} else if len(inst.Body) > 0 {
 		// XSLT 2.0: comment body is temporary output state (XTDE1480).
 		// XSLT 3.0 relaxes this restriction.
-		isV2TempOutput := ec.stylesheet.version != "" && ec.stylesheet.version < "3.0"
-		if isV2TempOutput {
-			ec.temporaryOutputDepth++
-		}
-		val, err := ec.evaluateBodyAsSequence(ctx, inst.Body)
-		if isV2TempOutput {
-			ec.temporaryOutputDepth--
-		}
+		var val xpath3.Sequence
+		err := ec.withV2TempOutput(func() error {
+			var err error
+			val, err = ec.evaluateBodyAsSequence(ctx, inst.Body)
+			return err
+		})
 		if err != nil {
 			return err
 		}
@@ -1242,14 +1252,12 @@ func (ec *execContext) execPI(ctx context.Context, inst *piInst) error {
 	} else if len(inst.Body) > 0 {
 		// XSLT 2.0: PI body is temporary output state (XTDE1480).
 		// XSLT 3.0 relaxes this restriction.
-		isV2TempOutput := ec.stylesheet.version != "" && ec.stylesheet.version < "3.0"
-		if isV2TempOutput {
-			ec.temporaryOutputDepth++
-		}
-		val, err := ec.evaluateBodyAsSequence(ctx, inst.Body)
-		if isV2TempOutput {
-			ec.temporaryOutputDepth--
-		}
+		var val xpath3.Sequence
+		err := ec.withV2TempOutput(func() error {
+			var err error
+			val, err = ec.evaluateBodyAsSequence(ctx, inst.Body)
+			return err
+		})
 		if err != nil {
 			return err
 		}
@@ -1290,14 +1298,12 @@ func (ec *execContext) execNamespace(ctx context.Context, inst *namespaceInst) e
 	} else if len(inst.Body) > 0 {
 		// XSLT 2.0: namespace body is temporary output state (XTDE1480).
 		// XSLT 3.0 relaxes this restriction.
-		isV2TempOutput := ec.stylesheet.version != "" && ec.stylesheet.version < "3.0"
-		if isV2TempOutput {
-			ec.temporaryOutputDepth++
-		}
-		val, bodyErr := ec.evaluateBody(ctx, inst.Body)
-		if isV2TempOutput {
-			ec.temporaryOutputDepth--
-		}
+		var val xpath3.Sequence
+		bodyErr := ec.withV2TempOutput(func() error {
+			var err error
+			val, err = ec.evaluateBody(ctx, inst.Body)
+			return err
+		})
 		if bodyErr != nil {
 			return bodyErr
 		}

--- a/xslt3/execute_globals.go
+++ b/xslt3/execute_globals.go
@@ -243,6 +243,16 @@ func (ec *execContext) invokeInitialFunction(ctx context.Context, cfg *transform
 	return ec.resultDoc, nil
 }
 
+// globalSourceNode returns the source document context node used when
+// evaluating global variables and params, or nil when the global context
+// item is absent (XPDY0002).
+func (ec *execContext) globalSourceNode() helium.Node {
+	if ec.globalContextAbsent {
+		return nil
+	}
+	return normalizeNode(ec.sourceDoc)
+}
+
 // evaluateGlobalVar evaluates a global variable on first access.
 func (ec *execContext) evaluateGlobalVar(ctx context.Context, v *variable) (xpath3.Sequence, error) {
 	if ec.globalEvaluating[v.Name] {
@@ -347,11 +357,7 @@ func (ec *execContext) evaluateGlobalVar(ctx context.Context, v *variable) (xpat
 	}
 
 	if v.Select != nil {
-		var sourceNode helium.Node
-		if !ec.globalContextAbsent {
-			sourceNode = normalizeNode(ec.sourceDoc)
-		}
-		result, err := ec.evalXPath(ctx, v.Select, sourceNode)
+		result, err := ec.evalXPath(ctx, v.Select, ec.globalSourceNode())
 		if err != nil {
 			return nil, fmt.Errorf("error evaluating global variable %q: %w", v.Name, err)
 		}
@@ -361,10 +367,7 @@ func (ec *execContext) evaluateGlobalVar(ctx context.Context, v *variable) (xpat
 		// context node, not whatever the current template context is. Save
 		// and restore ec.contextNode so that XPath expressions inside the
 		// body (e.g. value-of select="doc/a") resolve relative to "/".
-		var sourceNode helium.Node
-		if !ec.globalContextAbsent {
-			sourceNode = normalizeNode(ec.sourceDoc)
-		}
+		sourceNode := ec.globalSourceNode()
 		savedCtx := ec.contextNode
 		ec.contextNode = sourceNode
 		ec.temporaryOutputDepth++
@@ -447,11 +450,7 @@ func (ec *execContext) evaluateGlobalParam(ctx context.Context, p *param) (xpath
 	}
 
 	if p.Select != nil {
-		var sourceNode helium.Node
-		if !ec.globalContextAbsent {
-			sourceNode = normalizeNode(ec.sourceDoc)
-		}
-		result, err := ec.evalXPath(ctx, p.Select, sourceNode)
+		result, err := ec.evalXPath(ctx, p.Select, ec.globalSourceNode())
 		if err != nil {
 			return nil, fmt.Errorf("error evaluating global param %q: %w", p.Name, err)
 		}
@@ -459,10 +458,7 @@ func (ec *execContext) evaluateGlobalParam(ctx context.Context, p *param) (xpath
 	} else if len(p.Body) > 0 {
 		// Global param body must evaluate with the source document as
 		// context node (same as the Select path above).
-		var sourceNode helium.Node
-		if !ec.globalContextAbsent {
-			sourceNode = normalizeNode(ec.sourceDoc)
-		}
+		sourceNode := ec.globalSourceNode()
 		savedCtx := ec.contextNode
 		ec.contextNode = sourceNode
 		ec.temporaryOutputDepth++

--- a/xslt3/execute_resultdoc.go
+++ b/xslt3/execute_resultdoc.go
@@ -105,6 +105,17 @@ func moveChildren(src *helium.Document, dst *helium.Document) error {
 	return nil
 }
 
+// applyValidationResult records the schema type annotations and nilled
+// elements produced by a ValidateDoc call onto the execution context.
+func (ec *execContext) applyValidationResult(vr validateDocResult) {
+	for node, typeName := range vr.Annotations {
+		ec.annotateNode(node, typeName)
+	}
+	for elem := range vr.NilledElements {
+		ec.markNilled(elem)
+	}
+}
+
 // execDocument implements xsl:document: creates a document node wrapping
 // the result of executing the body.
 func (ec *execContext) execDocument(ctx context.Context, inst *documentInst) error {
@@ -169,12 +180,7 @@ func (ec *execContext) execDocument(ctx context.Context, inst *documentInst) err
 					return err
 				}
 			}
-			for node, typeName := range vr.Annotations {
-				ec.annotateNode(node, typeName)
-			}
-			for elem := range vr.NilledElements {
-				ec.markNilled(elem)
-			}
+			ec.applyValidationResult(vr)
 		}
 	}
 
@@ -611,12 +617,7 @@ func (ec *execContext) execResultDocument(ctx context.Context, inst *resultDocum
 						return err
 					}
 				}
-				for node, typeName := range vr.Annotations {
-					ec.annotateNode(node, typeName)
-				}
-				for elem := range vr.NilledElements {
-					ec.markNilled(elem)
-				}
+				ec.applyValidationResult(vr)
 			}
 			// Move validated children into the primary output.
 			primaryFrame := ec.outputStack[0]
@@ -878,12 +879,7 @@ func (ec *execContext) execResultDocument(ctx context.Context, inst *resultDocum
 					return err
 				}
 			}
-			for node, typeName := range vr.Annotations {
-				ec.annotateNode(node, typeName)
-			}
-			for elem := range vr.NilledElements {
-				ec.markNilled(elem)
-			}
+			ec.applyValidationResult(vr)
 		}
 	} else if inst.Validation == validationStrip {
 		root := findDocumentElement(tmpDoc)


### PR DESCRIPTION
- ec.globalSourceNode / applyValidationResult / withV2TempOutput / emitAtomicText
- collapses 4 repeated blocks each (XSLT3A-2..5)
- internal-only, net-negative, behavior-preserving