### PR TITLE
add xsd schemaError helper for fatal sites

### DIFF
--- a/xsd/check_element_consistent.go
+++ b/xsd/check_element_consistent.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 
-	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 )
 
@@ -136,8 +135,7 @@ func (c *compiler) checkContentModelConsistent(ctx context.Context, mg *ModelGro
 		}
 		if !c.declsConsistent(decls) {
 			msg := fmt.Sprintf("Two elements with the same name '%s' and namespace '%s', but different type definitions, appear in the content model.", qn.Local, qn.NS)
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(source, line, "complexType", component, msg), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(source, line, "complexType", component, msg))
 		}
 	}
 }
@@ -154,8 +152,7 @@ func (c *compiler) checkNamedGroupConsistent(ctx context.Context, mg *ModelGroup
 		}
 		if !c.declsConsistent(decls) {
 			msg := fmt.Sprintf("Two elements with the same name '%s' and namespace '%s', but different type definitions, appear in the content model.", qn.Local, qn.NS)
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(src.source, src.line, "group", component, msg), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(src.source, src.line, "group", component, msg))
 		}
 	}
 }

--- a/xsd/check_elements.go
+++ b/xsd/check_elements.go
@@ -97,62 +97,54 @@ func (c *compiler) checkGlobalElement(ctx context.Context, elem *helium.Element)
 
 	// name is required for global elements.
 	if name == "" {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "element",
-			"The attribute 'name' is required but missing."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaParserError(c.filename, line, local, "element",
+			"The attribute 'name' is required but missing."))
 	}
 
 	// ref is not allowed at global level.
 	if getAttr(elem, attrRef) != "" {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "element",
-			"The attribute 'ref' is not allowed."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaParserError(c.filename, line, local, "element",
+			"The attribute 'ref' is not allowed."))
 	}
 
 	// minOccurs is not allowed at global level.
 	if getAttr(elem, attrMinOccurs) != "" {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "element",
-			"The attribute 'minOccurs' is not allowed."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaParserError(c.filename, line, local, "element",
+			"The attribute 'minOccurs' is not allowed."))
 	}
 
 	// maxOccurs is not allowed at global level.
 	if getAttr(elem, attrMaxOccurs) != "" {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "element",
-			"The attribute 'maxOccurs' is not allowed."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaParserError(c.filename, line, local, "element",
+			"The attribute 'maxOccurs' is not allowed."))
 	}
 
 	// form is not allowed at global level.
 	if getAttr(elem, attrForm) != "" {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "element",
-			"The attribute 'form' is not allowed."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaParserError(c.filename, line, local, "element",
+			"The attribute 'form' is not allowed."))
 	}
 
 	// Validate 'final' attribute value.
 	if v := getAttr(elem, attrFinal); v != "" {
 		if !isValidFinal(v) {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, elemElement, attrFinal,
-				"The value '"+v+"' is not valid. Expected is '(#all | List of (extension | restriction))'."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserErrorAttr(c.filename, line, local, elemElement, attrFinal,
+				"The value '"+v+"' is not valid. Expected is '(#all | List of (extension | restriction))'."))
 		}
 	}
 
 	// Validate 'block' attribute value.
 	if v := getAttr(elem, attrBlock); v != "" {
 		if !isValidBlock(v) {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, elemElement, attrBlock,
-				"The value '"+v+"' is not valid. Expected is '(#all | List of (extension | restriction | substitution))'."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserErrorAttr(c.filename, line, local, elemElement, attrBlock,
+				"The value '"+v+"' is not valid. Expected is '(#all | List of (extension | restriction | substitution))'."))
 		}
 	}
 
 	// default and fixed are mutually exclusive.
 	if hasAttr(elem, attrDefault) && hasAttr(elem, attrFixed) {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "element",
-			"The attributes 'default' and 'fixed' are mutually exclusive."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaParserError(c.filename, line, local, "element",
+			"The attributes 'default' and 'fixed' are mutually exclusive."))
 	}
 
 	// type and inline complexType/simpleType are mutually exclusive.
@@ -166,14 +158,12 @@ func (c *compiler) checkGlobalElement(ctx context.Context, elem *helium.Element)
 				continue
 			}
 			if isXSDElement(ce, "complexType") {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, ce.Line(), ce.LocalName(), "element",
-					"The attribute 'type' and the <complexType> child are mutually exclusive."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserError(c.filename, ce.Line(), ce.LocalName(), "element",
+					"The attribute 'type' and the <complexType> child are mutually exclusive."))
 			}
 			if isXSDElement(ce, "simpleType") {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, ce.Line(), ce.LocalName(), "element",
-					"The attribute 'type' and the <simpleType> child are mutually exclusive."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserError(c.filename, ce.Line(), ce.LocalName(), "element",
+					"The attribute 'type' and the <simpleType> child are mutually exclusive."))
 			}
 		}
 	}
@@ -219,9 +209,8 @@ func (c *compiler) validateAllOccurs(ctx context.Context, elem *helium.Element) 
 		v := getAttr(elem, attrMinOccurs)
 		n, ok := parseNonNegativeOccurs(v, false)
 		if !ok || (n != 0 && n != 1) {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(src, line, local, elemAll, attrMinOccurs,
-				"The value '"+v+"' is not valid. Expected is '(0 | 1)'."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserErrorAttr(src, line, local, elemAll, attrMinOccurs,
+				"The value '"+v+"' is not valid. Expected is '(0 | 1)'."))
 		}
 	}
 
@@ -233,9 +222,8 @@ func (c *compiler) validateAllOccurs(ctx context.Context, elem *helium.Element) 
 		v := getAttr(elem, attrMaxOccurs)
 		n, ok := parseNonNegativeOccurs(v, true)
 		if !ok || n != 1 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(src, line, local, elemAll, attrMaxOccurs,
-				"The value '"+v+"' is not valid. Expected is '1'."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserErrorAttr(src, line, local, elemAll, attrMaxOccurs,
+				"The value '"+v+"' is not valid. Expected is '1'."))
 		}
 	}
 }
@@ -266,9 +254,8 @@ func (c *compiler) checkAllElementParticleOccurs(ctx context.Context, elem *heli
 		v := getAttr(elem, attrMaxOccurs)
 		n, ok := parseNonNegativeOccurs(v, true)
 		if ok && n != 0 && n != 1 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(src, line, local, "element",
-				"Invalid value for maxOccurs (must be 0 or 1)."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserError(src, line, local, "element",
+				"Invalid value for maxOccurs (must be 0 or 1)."))
 		}
 	}
 
@@ -276,9 +263,8 @@ func (c *compiler) checkAllElementParticleOccurs(ctx context.Context, elem *heli
 		v := getAttr(elem, attrMinOccurs)
 		n, ok := parseNonNegativeOccurs(v, false)
 		if ok && n != 0 && n != 1 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(src, line, local, "element",
-				"Invalid value for minOccurs (must be 0 or 1)."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserError(src, line, local, "element",
+				"Invalid value for minOccurs (must be 0 or 1)."))
 		}
 	}
 }
@@ -315,22 +301,19 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		if maxPresent && maxOcc != attrValUnbounded {
 			maxVal, ok := parseNonNegativeOccurs(maxOcc, true)
 			if !ok {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
-					"The value '"+maxOcc+"' is not valid. Expected is '(xs:nonNegativeInteger | unbounded)'."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
+					"The value '"+maxOcc+"' is not valid. Expected is '(xs:nonNegativeInteger | unbounded)'."))
 			} else if maxVal < 1 && effectiveMinOccurs(minOcc) >= 1 {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
-					"The value must be greater than or equal to 1."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
+					"The value must be greater than or equal to 1."))
 			}
 		}
 
 		// minOccurs must be a non-negative integer.
 		if minPresent {
 			if _, ok := parseNonNegativeOccurs(minOcc, false); !ok {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
-					"The value '"+minOcc+"' is not valid. Expected is 'xs:nonNegativeInteger'."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
+					"The value '"+minOcc+"' is not valid. Expected is 'xs:nonNegativeInteger'."))
 			}
 		}
 
@@ -341,26 +324,23 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 			minVal, minOK := parseNonNegativeOccurs(minOcc, false)
 			maxVal, maxOK := parseNonNegativeOccurs(maxOcc, true)
 			if minOK && maxOK && maxVal != Unbounded && (maxVal >= 1 || minVal < 1) && minVal > maxVal {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
-					"The value must not be greater than the value of 'maxOccurs'."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
+					"The value must not be greater than the value of 'maxOccurs'."))
 			}
 		}
 
 		// ref and name are mutually exclusive.
 		if name != "" {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "element",
-				"The attributes 'ref' and 'name' are mutually exclusive."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserError(c.filename, line, local, "element",
+				"The attributes 'ref' and 'name' are mutually exclusive."))
 		}
 
 		// Report first ref-restricted attribute found (alphabetical order).
 		notAllowedWithRef := []string{attrAbstract, attrBlock, attrDefault, attrFinal, attrFixed, attrForm, attrNillable, attrSubstitutionGroup, attrType}
 		for _, attr := range notAllowedWithRef {
 			if hasAttr(elem, attr) {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", attr,
-					"Only the attributes 'minOccurs', 'maxOccurs' and 'id' are allowed in addition to 'ref'."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserErrorAttr(c.filename, line, local, "element", attr,
+					"Only the attributes 'minOccurs', 'maxOccurs' and 'id' are allowed in addition to 'ref'."))
 				break // only report first
 			}
 		}
@@ -375,9 +355,8 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 				continue
 			}
 			if isXSDElement(ce, elemComplexType) || isXSDElement(ce, elemSimpleType) {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, ce.Line(), ce.LocalName(), "element",
-					"The content is not valid. Expected is (annotation?)."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserError(c.filename, ce.Line(), ce.LocalName(), "element",
+					"The content is not valid. Expected is (annotation?)."))
 				break // only report first
 			}
 		}
@@ -393,22 +372,19 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		if maxPresent && maxOcc != attrValUnbounded {
 			maxVal, ok := parseNonNegativeOccurs(maxOcc, true)
 			if !ok {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
-					"The value '"+maxOcc+"' is not valid. Expected is '(xs:nonNegativeInteger | unbounded)'."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
+					"The value '"+maxOcc+"' is not valid. Expected is '(xs:nonNegativeInteger | unbounded)'."))
 			} else if maxVal < 1 && effectiveMinOccurs(minOcc) >= 1 {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
-					"The value must be greater than or equal to 1."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserErrorAttr(c.filename, line, local, "element", "maxOccurs",
+					"The value must be greater than or equal to 1."))
 			}
 		}
 
 		// minOccurs must be a non-negative integer.
 		if minPresent {
 			if _, ok := parseNonNegativeOccurs(minOcc, false); !ok {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
-					"The value '"+minOcc+"' is not valid. Expected is 'xs:nonNegativeInteger'."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
+					"The value '"+minOcc+"' is not valid. Expected is 'xs:nonNegativeInteger'."))
 			}
 		}
 
@@ -419,9 +395,8 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 			minVal, minOK := parseNonNegativeOccurs(minOcc, false)
 			maxVal, maxOK := parseNonNegativeOccurs(maxOcc, true)
 			if minOK && maxOK && maxVal != Unbounded && (maxVal >= 1 || minVal < 1) && minVal > maxVal {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
-					"The value must not be greater than the value of 'maxOccurs'."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserErrorAttr(c.filename, line, local, "element", "minOccurs",
+					"The value must not be greater than the value of 'maxOccurs'."))
 			}
 		}
 
@@ -429,24 +404,21 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		localNotAllowed := []string{attrAbstract, attrSubstitutionGroup, attrFinal}
 		for _, attr := range localNotAllowed {
 			if hasAttr(elem, attr) {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "element",
-					"The attribute '"+attr+"' is not allowed."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserError(c.filename, line, local, "element",
+					"The attribute '"+attr+"' is not allowed."))
 			}
 		}
 
 		// Validate 'block' attribute value.
 		if v := getAttr(elem, attrBlock); v != "" && !isValidBlock(v) {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "element", "block",
-				"The value '"+v+"' is not valid. Expected is '(#all | List of (extension | restriction | substitution))'."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserErrorAttr(c.filename, line, local, "element", "block",
+				"The value '"+v+"' is not valid. Expected is '(#all | List of (extension | restriction | substitution))'."))
 		}
 
 		// default and fixed mutually exclusive.
 		if hasAttr(elem, attrDefault) && hasAttr(elem, attrFixed) {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "element",
-				"The attributes 'default' and 'fixed' are mutually exclusive."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserError(c.filename, line, local, "element",
+				"The attributes 'default' and 'fixed' are mutually exclusive."))
 		}
 
 		// type and inline complexType/simpleType checks.
@@ -461,15 +433,13 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 			}
 			if isXSDElement(ce, elemComplexType) {
 				if hasType {
-					c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, ce.Line(), ce.LocalName(), "element",
-						"The attribute 'type' and the <complexType> child are mutually exclusive."), helium.ErrorLevelFatal))
-					c.errorCount++
+					c.schemaError(ctx, schemaParserError(c.filename, ce.Line(), ce.LocalName(), "element",
+						"The attribute 'type' and the <complexType> child are mutually exclusive."))
 				}
 			} else if isXSDElement(ce, elemSimpleType) {
 				if hasType {
-					c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, ce.Line(), ce.LocalName(), "element",
-						"The content is not valid. Expected is (annotation?, ((simpleType | complexType)?, (unique | key | keyref)*))."), helium.ErrorLevelFatal))
-					c.errorCount++
+					c.schemaError(ctx, schemaParserError(c.filename, ce.Line(), ce.LocalName(), "element",
+						"The content is not valid. Expected is (annotation?, ((simpleType | complexType)?, (unique | key | keyref)*))."))
 				}
 			}
 		}
@@ -488,23 +458,20 @@ func (c *compiler) checkAttributeUse(ctx context.Context, elem *helium.Element) 
 	if ref != "" {
 		// ref and name are mutually exclusive.
 		if getAttr(elem, attrName) != "" {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "attribute",
-				"The attribute 'name' is not allowed."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserError(c.filename, line, local, "attribute",
+				"The attribute 'name' is not allowed."))
 		}
 
 		// type not allowed with ref.
 		if getAttr(elem, attrType) != "" {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "attribute",
-				"The attribute 'type' is not allowed."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserError(c.filename, line, local, "attribute",
+				"The attribute 'type' is not allowed."))
 		}
 
 		// default and fixed are mutually exclusive.
 		if hasAttr(elem, attrDefault) && hasAttr(elem, attrFixed) {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "attribute",
-				"The attributes 'default' and 'fixed' are mutually exclusive."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserError(c.filename, line, local, "attribute",
+				"The attributes 'default' and 'fixed' are mutually exclusive."))
 		}
 
 		// If default is present, use must be optional (or absent, which
@@ -513,17 +480,15 @@ func (c *compiler) checkAttributeUse(ctx context.Context, elem *helium.Element) 
 		if hasAttr(elem, attrDefault) {
 			use := getAttr(elem, attrUse)
 			if use != "" && use != attrValOptional {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.diagSource(), line, local, "attribute",
-					"The value of the attribute 'use' must be 'optional' if the attribute 'default' is present."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserError(c.diagSource(), line, local, "attribute",
+					"The value of the attribute 'use' must be 'optional' if the attribute 'default' is present."))
 			}
 		}
 
 		// form not allowed with ref.
 		if getAttr(elem, attrForm) != "" {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "attribute",
-				"The attribute 'form' is not allowed."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserError(c.filename, line, local, "attribute",
+				"The attribute 'form' is not allowed."))
 		}
 
 		// simpleType child not allowed with ref.
@@ -536,43 +501,38 @@ func (c *compiler) checkAttributeUse(ctx context.Context, elem *helium.Element) 
 				continue
 			}
 			if isXSDElement(ce, elemSimpleType) {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, ce.Line(), ce.LocalName(), "attribute",
-					"The content is not valid. Expected is (annotation?)."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserError(c.filename, ce.Line(), ce.LocalName(), "attribute",
+					"The content is not valid. Expected is (annotation?)."))
 			}
 		}
 	} else {
 		// Attribute name must not be "xmlns".
 		if getAttr(elem, attrName) == lexicon.PrefixXMLNS {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "attribute", "name",
-				"The value of the attribute must not match 'xmlns'."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserErrorAttr(c.filename, line, local, "attribute", "name",
+				"The value of the attribute must not match 'xmlns'."))
 		}
 
 		// Qualified attribute must not be in the XSI namespace.
 		form := getAttr(elem, attrForm)
 		if form == "qualified" || (form == "" && c.schema.attrFormQualified) {
 			if c.schema.targetNamespace == lexicon.NamespaceXSI {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "attribute",
-					"The target namespace must not match '"+lexicon.NamespaceXSI+"'."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserError(c.filename, line, local, "attribute",
+					"The target namespace must not match '"+lexicon.NamespaceXSI+"'."))
 			}
 		}
 
 		// default and fixed are mutually exclusive.
 		if hasAttr(elem, attrDefault) && hasAttr(elem, attrFixed) {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "attribute",
-				"The attributes 'default' and 'fixed' are mutually exclusive."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserError(c.filename, line, local, "attribute",
+				"The attributes 'default' and 'fixed' are mutually exclusive."))
 		}
 
 		// If default is present, use must be optional (or absent, which defaults to optional).
 		if hasAttr(elem, attrDefault) {
 			use := getAttr(elem, attrUse)
 			if use != "" && use != attrValOptional {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "attribute",
-					"The value of the attribute 'use' must be 'optional' if the attribute 'default' is present."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserError(c.filename, line, local, "attribute",
+					"The value of the attribute 'use' must be 'optional' if the attribute 'default' is present."))
 			}
 		}
 
@@ -587,9 +547,8 @@ func (c *compiler) checkAttributeUse(ctx context.Context, elem *helium.Element) 
 					continue
 				}
 				if isXSDElement(ce, elemSimpleType) {
-					c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, ce.Line(), ce.LocalName(), "attribute",
-						"The attribute 'type' and the <simpleType> child are mutually exclusive."), helium.ErrorLevelFatal))
-					c.errorCount++
+					c.schemaError(ctx, schemaParserError(c.filename, ce.Line(), ce.LocalName(), "attribute",
+						"The attribute 'type' and the <simpleType> child are mutually exclusive."))
 				}
 			}
 		}
@@ -613,9 +572,8 @@ func (c *compiler) checkAnnotation(ctx context.Context, elem *helium.Element) {
 		if name == "id" {
 			continue
 		}
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "annotation",
-			"The attribute '"+name+"' is not allowed."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaParserError(c.filename, line, local, "annotation",
+			"The attribute '"+name+"' is not allowed."))
 	}
 
 	// Check for invalid content (non-element children like text nodes).
@@ -630,9 +588,8 @@ func (c *compiler) checkAnnotation(ctx context.Context, elem *helium.Element) {
 		}
 	}
 	if hasInvalidContent {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "annotation",
-			"The content is not valid. Expected is (appinfo | documentation)*."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaParserError(c.filename, line, local, "annotation",
+			"The content is not valid. Expected is (appinfo | documentation)*."))
 	}
 
 	// Check children (appinfo, documentation).
@@ -666,9 +623,8 @@ func (c *compiler) checkAppinfo(ctx context.Context, elem *helium.Element) {
 		if name == attrSource {
 			continue
 		}
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "appinfo",
-			"The attribute '"+name+"' is not allowed."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaParserError(c.filename, line, local, "appinfo",
+			"The attribute '"+name+"' is not allowed."))
 	}
 }
 
@@ -693,16 +649,14 @@ func (c *compiler) checkDocumentation(ctx context.Context, elem *helium.Element)
 		if name == attrSource {
 			continue
 		}
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, line, local, "documentation",
-			"The attribute '"+name+"' is not allowed."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaParserError(c.filename, line, local, "documentation",
+			"The attribute '"+name+"' is not allowed."))
 	}
 
 	// Validate xml:lang value after attribute checks.
 	if langValue != "" && !languageRegex.MatchString(langValue) {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, line, local, "documentation",
+		c.schemaError(ctx, schemaParserErrorAttr(c.filename, line, local, "documentation",
 			helium.ClarkName(lexicon.NamespaceXML, lexicon.AttrLang),
-			"'"+langValue+"' is not a valid value of the atomic type 'xs:language'."), helium.ErrorLevelFatal))
-		c.errorCount++
+			"'"+langValue+"' is not a valid value of the atomic type 'xs:language'."))
 	}
 }

--- a/xsd/check_facets.go
+++ b/xsd/check_facets.go
@@ -244,8 +244,7 @@ func (c *compiler) checkListUnionFacetApplicability(ctx context.Context, td *Typ
 			continue
 		}
 		msg := fmt.Sprintf("The facet '%s' is not allowed.", fp.name)
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component, msg), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component, msg))
 	}
 
 	return false
@@ -278,8 +277,7 @@ func (c *compiler) checkAtomicFacetApplicability(ctx context.Context, td *TypeDe
 
 	report := func(facet string) {
 		msg := fmt.Sprintf("The facet '%s' is not allowed on types derived from the type %s.", facet, primitive)
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component, msg), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component, msg))
 	}
 
 	rangeRejected := false
@@ -375,8 +373,7 @@ func (c *compiler) checkFacetValueAgainstBase(ctx context.Context, td *TypeDef, 
 		}
 		msg := fmt.Sprintf("The value '%s' of the facet '%s' is not a valid value of the base type '%s'.",
 			*rf.value, rf.name, typeDisplayName(base))
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component, msg), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component, msg))
 	}
 }
 
@@ -437,8 +434,7 @@ func (c *compiler) checkEnumValueAgainstBase(ctx context.Context, td *TypeDef, f
 		}
 		msg := fmt.Sprintf("The value '%s' of the facet 'enumeration' is not a valid value of the base type '%s'.",
 			ev, typeDisplayName(base))
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component, msg), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component, msg))
 	}
 }
 
@@ -497,9 +493,8 @@ func (c *compiler) checkEnumQNameAndNotation(ctx context.Context) {
 		// direct atomic xs:NOTATION restriction base. A NOTATION carrier is allowed
 		// only when it is itself enumeration-derived.
 		if notationUsedWithoutEnumeration(td) {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, e.src.line, "simpleType", component,
-				"It is an error if the base type is the built-in 'NOTATION' and there is no 'enumeration' facet."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, e.src.line, "simpleType", component,
+				"It is an error if the base type is the built-in 'NOTATION' and there is no 'enumeration' facet."))
 		}
 
 		// Validate each enumeration literal's QName/NOTATION prefix binding,
@@ -516,8 +511,7 @@ func (c *compiler) checkEnumQNameAndNotation(ctx context.Context) {
 			}
 			if c.enumLiteralHasUnboundQName(ctx, ev, enumNS, td, variety) {
 				msg := fmt.Sprintf("The value '%s' is not a valid value of the atomic type '%s'.", ev, typeDisplayName(td))
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, e.src.line, "simpleType", component, msg), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaComponentError(c.filename, e.src.line, "simpleType", component, msg))
 			}
 		}
 	}
@@ -728,9 +722,8 @@ func (c *compiler) checkNotationOnDeclarations(ctx context.Context) {
 		if hasEffectiveEnumeration(td) {
 			continue
 		}
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, e.src.line, e.src.elemName, elemElement,
-			"It is an error if the type definition is the built-in 'NOTATION' and there is no 'enumeration' facet."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaParserError(c.filename, e.src.line, e.src.elemName, elemElement,
+			"It is an error if the type definition is the built-in 'NOTATION' and there is no 'enumeration' facet."))
 	}
 
 	// Attributes: every attribute use is tracked in attrUseSources.
@@ -763,9 +756,8 @@ func (c *compiler) checkNotationOnDeclarations(ctx context.Context) {
 		if hasEffectiveEnumeration(td) {
 			continue
 		}
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, a.src.line, a.src.local, elemAttribute,
-			"It is an error if the type definition is the built-in 'NOTATION' and there is no 'enumeration' facet."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaParserError(c.filename, a.src.line, a.src.local, elemAttribute,
+			"It is an error if the type definition is the built-in 'NOTATION' and there is no 'enumeration' facet."))
 	}
 }
 
@@ -773,19 +765,16 @@ func (c *compiler) checkNotationOnDeclarations(ctx context.Context) {
 // both specified on the same type definition.
 func (c *compiler) checkFacetMutualExclusion(ctx context.Context, fs *FacetSet, line int, component string) {
 	if fs.Length != nil && (fs.MinLength != nil || fs.MaxLength != nil) {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-			"It is an error for both 'length' and either of 'minLength' or 'maxLength' to be specified on the same type definition."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+			"It is an error for both 'length' and either of 'minLength' or 'maxLength' to be specified on the same type definition."))
 	}
 	if fs.MaxInclusive != nil && fs.MaxExclusive != nil {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-			"It is an error for both 'maxInclusive' and 'maxExclusive' to be specified."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+			"It is an error for both 'maxInclusive' and 'maxExclusive' to be specified."))
 	}
 	if fs.MinInclusive != nil && fs.MinExclusive != nil {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-			"It is an error for both 'minInclusive' and 'minExclusive' to be specified."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+			"It is an error for both 'minInclusive' and 'minExclusive' to be specified."))
 	}
 }
 
@@ -811,9 +800,8 @@ func (c *compiler) checkFacetSameTypeConsistency(ctx context.Context, td *TypeDe
 	// rejected as "not allowed", so this check must not run there.
 	lengthFacetsApplicable := variety == TypeVarietyList || (variety == TypeVarietyAtomic && lengthApplicable)
 	if lengthFacetsApplicable && fs.MinLength != nil && fs.MaxLength != nil && *fs.MinLength > *fs.MaxLength {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-			"It is an error for the value of 'minLength' to be greater than the value of 'maxLength'."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+			"It is an error for the value of 'minLength' to be greater than the value of 'maxLength'."))
 	}
 
 	// Digit consistency (fractionDigits > totalDigits). The digit facets are
@@ -823,9 +811,8 @@ func (c *compiler) checkFacetSameTypeConsistency(ctx context.Context, td *TypeDe
 	// totalDigits and fractionDigits must report ONLY the two applicability errors).
 	digitFacetsApplicable := variety == TypeVarietyAtomic && decimalFamily
 	if digitFacetsApplicable && fs.FractionDigits != nil && fs.TotalDigits != nil && *fs.FractionDigits > *fs.TotalDigits {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-			"It is an error for the value of 'fractionDigits' to be greater than the value of 'totalDigits'."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+			"It is an error for the value of 'fractionDigits' to be greater than the value of 'totalDigits'."))
 	}
 
 	// Range-bound ORDERING consistency (min/max{Inclusive,Exclusive}) is only
@@ -876,30 +863,26 @@ func (c *compiler) checkFacetSameTypeConsistency(ctx context.Context, td *TypeDe
 
 	if fs.MinInclusive != nil && fs.MaxInclusive != nil {
 		if v, ok := cmp(*fs.MinInclusive, *fs.MaxInclusive); ok && v > 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				"It is an error for the value of 'minInclusive' to be greater than the value of 'maxInclusive'."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				"It is an error for the value of 'minInclusive' to be greater than the value of 'maxInclusive'."))
 		}
 	}
 	if fs.MinExclusive != nil && fs.MaxExclusive != nil {
 		if v, ok := cmp(*fs.MinExclusive, *fs.MaxExclusive); ok && v >= 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				"It is an error for the value of 'minExclusive' to be greater than or equal to the value of 'maxExclusive'."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				"It is an error for the value of 'minExclusive' to be greater than or equal to the value of 'maxExclusive'."))
 		}
 	}
 	if fs.MinExclusive != nil && fs.MaxInclusive != nil {
 		if v, ok := cmp(*fs.MinExclusive, *fs.MaxInclusive); ok && v >= 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				"It is an error for the value of 'minExclusive' to be greater than or equal to the value of 'maxInclusive'."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				"It is an error for the value of 'minExclusive' to be greater than or equal to the value of 'maxInclusive'."))
 		}
 	}
 	if fs.MinInclusive != nil && fs.MaxExclusive != nil {
 		if v, ok := cmp(*fs.MinInclusive, *fs.MaxExclusive); ok && v >= 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				"It is an error for the value of 'minInclusive' to be greater than or equal to the value of 'maxExclusive'."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				"It is an error for the value of 'minInclusive' to be greater than or equal to the value of 'maxExclusive'."))
 		}
 	}
 }
@@ -914,31 +897,26 @@ func (c *compiler) checkFacetBaseRestriction(ctx context.Context, td *TypeDef, f
 
 	// Length facets.
 	if fs.MinLength != nil && base.MinLength != nil && *fs.MinLength < *base.MinLength {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-			fmt.Sprintf("The 'minLength' value '%d' is less than the 'minLength' value of the base type '%d'.", *fs.MinLength, *base.MinLength)), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+			fmt.Sprintf("The 'minLength' value '%d' is less than the 'minLength' value of the base type '%d'.", *fs.MinLength, *base.MinLength)))
 	}
 	if fs.MaxLength != nil && base.MaxLength != nil && *fs.MaxLength > *base.MaxLength {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-			fmt.Sprintf("The 'maxLength' value '%d' is greater than the 'maxLength' value of the base type '%d'.", *fs.MaxLength, *base.MaxLength)), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+			fmt.Sprintf("The 'maxLength' value '%d' is greater than the 'maxLength' value of the base type '%d'.", *fs.MaxLength, *base.MaxLength)))
 	}
 	if fs.Length != nil && base.Length != nil && *fs.Length != *base.Length {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-			fmt.Sprintf("The 'length' value '%d' does not match the 'length' value of the base type '%d'.", *fs.Length, *base.Length)), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+			fmt.Sprintf("The 'length' value '%d' does not match the 'length' value of the base type '%d'.", *fs.Length, *base.Length)))
 	}
 
 	// Digit facets.
 	if fs.TotalDigits != nil && base.TotalDigits != nil && *fs.TotalDigits > *base.TotalDigits {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-			fmt.Sprintf("The 'totalDigits' value '%d' is greater than the 'totalDigits' value of the base type '%d'.", *fs.TotalDigits, *base.TotalDigits)), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+			fmt.Sprintf("The 'totalDigits' value '%d' is greater than the 'totalDigits' value of the base type '%d'.", *fs.TotalDigits, *base.TotalDigits)))
 	}
 	if fs.FractionDigits != nil && base.FractionDigits != nil && *fs.FractionDigits > *base.FractionDigits {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-			fmt.Sprintf("The 'fractionDigits' value '%d' is greater than the 'fractionDigits' value of the base type '%d'.", *fs.FractionDigits, *base.FractionDigits)), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+			fmt.Sprintf("The 'fractionDigits' value '%d' is greater than the 'fractionDigits' value of the base type '%d'.", *fs.FractionDigits, *base.FractionDigits)))
 	}
 
 	// Inclusive/exclusive boundary facets vs base. These compare a derived bound
@@ -978,114 +956,98 @@ func (c *compiler) checkFacetBaseRestriction(ctx context.Context, td *TypeDef, f
 
 	if fs.MaxInclusive != nil && base.MaxInclusive != nil {
 		if v, ok := rangeCmp(*fs.MaxInclusive, *base.MaxInclusive); ok && v > 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The 'maxInclusive' value '%s' is greater than the 'maxInclusive' value of the base type '%s'.", *fs.MaxInclusive, *base.MaxInclusive)), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				fmt.Sprintf("The 'maxInclusive' value '%s' is greater than the 'maxInclusive' value of the base type '%s'.", *fs.MaxInclusive, *base.MaxInclusive)))
 		}
 	}
 	if fs.MaxInclusive != nil && base.MaxExclusive != nil {
 		if v, ok := rangeCmp(*fs.MaxInclusive, *base.MaxExclusive); ok && v >= 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The 'maxInclusive' value '%s' must be less than the 'maxExclusive' value of the base type '%s'.", *fs.MaxInclusive, *base.MaxExclusive)), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				fmt.Sprintf("The 'maxInclusive' value '%s' must be less than the 'maxExclusive' value of the base type '%s'.", *fs.MaxInclusive, *base.MaxExclusive)))
 		}
 	}
 	if fs.MaxInclusive != nil && base.MinInclusive != nil {
 		if v, ok := rangeCmp(*fs.MaxInclusive, *base.MinInclusive); ok && v < 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The 'maxInclusive' value '%s' is less than the 'minInclusive' value of the base type '%s'.", *fs.MaxInclusive, *base.MinInclusive)), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				fmt.Sprintf("The 'maxInclusive' value '%s' is less than the 'minInclusive' value of the base type '%s'.", *fs.MaxInclusive, *base.MinInclusive)))
 		}
 	}
 	if fs.MaxInclusive != nil && base.MinExclusive != nil {
 		if v, ok := rangeCmp(*fs.MaxInclusive, *base.MinExclusive); ok && v <= 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The 'maxInclusive' value '%s' must be greater than the 'minExclusive' value of the base type '%s'.", *fs.MaxInclusive, *base.MinExclusive)), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				fmt.Sprintf("The 'maxInclusive' value '%s' must be greater than the 'minExclusive' value of the base type '%s'.", *fs.MaxInclusive, *base.MinExclusive)))
 		}
 	}
 	if fs.MaxExclusive != nil && base.MaxExclusive != nil {
 		if v, ok := rangeCmp(*fs.MaxExclusive, *base.MaxExclusive); ok && v > 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The 'maxExclusive' value '%s' is greater than the 'maxExclusive' value of the base type '%s'.", *fs.MaxExclusive, *base.MaxExclusive)), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				fmt.Sprintf("The 'maxExclusive' value '%s' is greater than the 'maxExclusive' value of the base type '%s'.", *fs.MaxExclusive, *base.MaxExclusive)))
 		}
 	}
 	if fs.MaxExclusive != nil && base.MaxInclusive != nil {
 		if v, ok := rangeCmp(*fs.MaxExclusive, *base.MaxInclusive); ok && v > 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The 'maxExclusive' value '%s' is greater than the 'maxInclusive' value of the base type '%s'.", *fs.MaxExclusive, *base.MaxInclusive)), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				fmt.Sprintf("The 'maxExclusive' value '%s' is greater than the 'maxInclusive' value of the base type '%s'.", *fs.MaxExclusive, *base.MaxInclusive)))
 		}
 	}
 	if fs.MaxExclusive != nil && base.MinInclusive != nil {
 		if v, ok := rangeCmp(*fs.MaxExclusive, *base.MinInclusive); ok && v <= 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The 'maxExclusive' value '%s' must be greater than the 'minInclusive' value of the base type '%s'.", *fs.MaxExclusive, *base.MinInclusive)), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				fmt.Sprintf("The 'maxExclusive' value '%s' must be greater than the 'minInclusive' value of the base type '%s'.", *fs.MaxExclusive, *base.MinInclusive)))
 		}
 	}
 	if fs.MaxExclusive != nil && base.MinExclusive != nil {
 		if v, ok := rangeCmp(*fs.MaxExclusive, *base.MinExclusive); ok && v <= 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The 'maxExclusive' value '%s' must be greater than the 'minExclusive' value of the base type '%s'.", *fs.MaxExclusive, *base.MinExclusive)), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				fmt.Sprintf("The 'maxExclusive' value '%s' must be greater than the 'minExclusive' value of the base type '%s'.", *fs.MaxExclusive, *base.MinExclusive)))
 		}
 	}
 	if fs.MinInclusive != nil && base.MinInclusive != nil {
 		if v, ok := rangeCmp(*fs.MinInclusive, *base.MinInclusive); ok && v < 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The 'minInclusive' value '%s' is less than the 'minInclusive' value of the base type '%s'.", *fs.MinInclusive, *base.MinInclusive)), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				fmt.Sprintf("The 'minInclusive' value '%s' is less than the 'minInclusive' value of the base type '%s'.", *fs.MinInclusive, *base.MinInclusive)))
 		}
 	}
 	if fs.MinInclusive != nil && base.MinExclusive != nil {
 		if v, ok := rangeCmp(*fs.MinInclusive, *base.MinExclusive); ok && v <= 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The 'minInclusive' value '%s' must be greater than the 'minExclusive' value of the base type '%s'.", *fs.MinInclusive, *base.MinExclusive)), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				fmt.Sprintf("The 'minInclusive' value '%s' must be greater than the 'minExclusive' value of the base type '%s'.", *fs.MinInclusive, *base.MinExclusive)))
 		}
 	}
 	if fs.MinInclusive != nil && base.MaxInclusive != nil {
 		if v, ok := rangeCmp(*fs.MinInclusive, *base.MaxInclusive); ok && v > 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The 'minInclusive' value '%s' is greater than the 'maxInclusive' value of the base type '%s'.", *fs.MinInclusive, *base.MaxInclusive)), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				fmt.Sprintf("The 'minInclusive' value '%s' is greater than the 'maxInclusive' value of the base type '%s'.", *fs.MinInclusive, *base.MaxInclusive)))
 		}
 	}
 	if fs.MinInclusive != nil && base.MaxExclusive != nil {
 		if v, ok := rangeCmp(*fs.MinInclusive, *base.MaxExclusive); ok && v >= 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The 'minInclusive' value '%s' must be less than the 'maxExclusive' value of the base type '%s'.", *fs.MinInclusive, *base.MaxExclusive)), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				fmt.Sprintf("The 'minInclusive' value '%s' must be less than the 'maxExclusive' value of the base type '%s'.", *fs.MinInclusive, *base.MaxExclusive)))
 		}
 	}
 	if fs.MinExclusive != nil && base.MinExclusive != nil {
 		if v, ok := rangeCmp(*fs.MinExclusive, *base.MinExclusive); ok && v < 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The 'minExclusive' value '%s' is less than the 'minExclusive' value of the base type '%s'.", *fs.MinExclusive, *base.MinExclusive)), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				fmt.Sprintf("The 'minExclusive' value '%s' is less than the 'minExclusive' value of the base type '%s'.", *fs.MinExclusive, *base.MinExclusive)))
 		}
 	}
 	if fs.MinExclusive != nil && base.MinInclusive != nil {
 		if v, ok := rangeCmp(*fs.MinExclusive, *base.MinInclusive); ok && v < 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The 'minExclusive' value '%s' is less than the 'minInclusive' value of the base type '%s'.", *fs.MinExclusive, *base.MinInclusive)), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				fmt.Sprintf("The 'minExclusive' value '%s' is less than the 'minInclusive' value of the base type '%s'.", *fs.MinExclusive, *base.MinInclusive)))
 		}
 	}
 	if fs.MinExclusive != nil && base.MaxInclusive != nil {
 		if v, ok := rangeCmp(*fs.MinExclusive, *base.MaxInclusive); ok && v > 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The 'minExclusive' value '%s' is greater than the 'maxInclusive' value of the base type '%s'.", *fs.MinExclusive, *base.MaxInclusive)), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				fmt.Sprintf("The 'minExclusive' value '%s' is greater than the 'maxInclusive' value of the base type '%s'.", *fs.MinExclusive, *base.MaxInclusive)))
 		}
 	}
 	if fs.MinExclusive != nil && base.MaxExclusive != nil {
 		if v, ok := rangeCmp(*fs.MinExclusive, *base.MaxExclusive); ok && v >= 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The 'minExclusive' value '%s' must be less than the 'maxExclusive' value of the base type '%s'.", *fs.MinExclusive, *base.MaxExclusive)), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				fmt.Sprintf("The 'minExclusive' value '%s' must be less than the 'maxExclusive' value of the base type '%s'.", *fs.MinExclusive, *base.MaxExclusive)))
 		}
 	}
 }

--- a/xsd/check_upa.go
+++ b/xsd/check_upa.go
@@ -3,8 +3,6 @@ package xsd
 import (
 	"context"
 	"slices"
-
-	helium "github.com/lestrrat-go/helium"
 )
 
 const componentLocalComplexType = "local complex type"
@@ -21,9 +19,8 @@ func (c *compiler) checkUPA(ctx context.Context, td *TypeDef, src typeDefSource)
 		if !src.isLocal {
 			component = td.Name.Local
 		}
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, src.line, "complexType", component,
-			"The content model is not determinist."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType", component,
+			"The content model is not determinist."))
 	}
 }
 

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -327,6 +327,15 @@ func (c *compiler) diagSourceOrRecorded(recorded string) string {
 	return c.diagSource()
 }
 
+// schemaError emits a fatal schema-compilation diagnostic and increments the
+// compiler's error count. It collapses the repeated
+// errorHandler.Handle(NewLeveledError(msg, ErrorLevelFatal)) + errorCount++
+// pair used throughout the compiler.
+func (c *compiler) schemaError(ctx context.Context, msg string) {
+	c.errorHandler.Handle(ctx, helium.NewLeveledError(msg, helium.ErrorLevelFatal))
+	c.errorCount++
+}
+
 func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cfg *compileConfig) (*Schema, error) {
 	root := findDocumentElement(doc)
 	if root == nil {
@@ -394,9 +403,8 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 	// Parse blockDefault attribute.
 	if v := getAttr(root, attrBlockDefault); v != "" {
 		if !isValidBlock(v) && c.filename != "" {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, root.Line(), root.LocalName(), elemSchema, attrBlockDefault,
-				"The value '"+v+"' is not valid. Expected is '(#all | List of (extension | restriction | substitution))'."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserErrorAttr(c.filename, root.Line(), root.LocalName(), elemSchema, attrBlockDefault,
+				"The value '"+v+"' is not valid. Expected is '(#all | List of (extension | restriction | substitution))'."))
 		} else {
 			c.schema.blockDefault = parseBlockFlags(v)
 		}
@@ -405,9 +413,8 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 	// Parse finalDefault attribute.
 	if v := getAttr(root, attrFinalDefault); v != "" {
 		if !isValidFinalDefault(v) && c.filename != "" {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.filename, root.Line(), root.LocalName(), elemSchema, attrFinalDefault,
-				"The value '"+v+"' is not valid. Expected is '(#all | List of (extension | restriction | list | union))'."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserErrorAttr(c.filename, root.Line(), root.LocalName(), elemSchema, attrFinalDefault,
+				"The value '"+v+"' is not valid. Expected is '(#all | List of (extension | restriction | list | union))'."))
 		} else {
 			c.schema.finalDefault = parseFinalFlags(v)
 		}
@@ -544,20 +551,16 @@ func (c *compiler) checkKeyRefRefers(ctx context.Context) {
 		}
 		if idc.Refer == "" {
 			msg := fmt.Sprintf("The keyref identity-constraint '%s' has no 'refer' attribute naming a key or unique.", idc.Name)
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(
-				schemaParserErrorAttr(source, idc.Line, elemKeyRef, elemKeyRef, attrRefer, msg),
-				helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx,
+				schemaParserErrorAttr(source, idc.Line, elemKeyRef, elemKeyRef, attrRefer, msg))
 			continue
 		}
 		if _, ok := keyNames[idc.ReferQName]; ok {
 			continue
 		}
 		msg := fmt.Sprintf("The keyref identity-constraint '%s' references the unknown key or unique '%s'.", idc.Name, idc.Refer)
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(
-			schemaParserErrorAttr(source, idc.Line, elemKeyRef, elemKeyRef, attrRefer, msg),
-			helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx,
+			schemaParserErrorAttr(source, idc.Line, elemKeyRef, elemKeyRef, attrRefer, msg))
 	}
 }
 

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -200,10 +200,9 @@ func (c *compiler) loadInclude(ctx context.Context, location string, includeElem
 		if c.filename != "" {
 			displayLoc = schemaDisplayLoc(c.filename, location)
 		}
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, includeElem.Line(),
+		c.schemaError(ctx, schemaParserError(c.filename, includeElem.Line(),
 			includeElem.LocalName(), elemInclude,
-			"The target namespace '"+incTargetNS+"' of the included/redefined schema '"+displayLoc+"' differs from '"+c.schema.targetNamespace+"' of the including/redefining schema."), helium.ErrorLevelFatal))
-		c.errorCount++
+			"The target namespace '"+incTargetNS+"' of the included/redefined schema '"+displayLoc+"' differs from '"+c.schema.targetNamespace+"' of the including/redefining schema."))
 		return nil
 	}
 
@@ -304,10 +303,9 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 		if c.filename != "" {
 			displayLoc = schemaDisplayLoc(c.filename, location)
 		}
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, redefineElem.Line(),
+		c.schemaError(ctx, schemaParserError(c.filename, redefineElem.Line(),
 			redefineElem.LocalName(), elemRedefine,
-			"The target namespace '"+incTargetNS+"' of the included/redefined schema '"+displayLoc+"' differs from '"+c.schema.targetNamespace+"' of the including/redefining schema."), helium.ErrorLevelFatal))
-		c.errorCount++
+			"The target namespace '"+incTargetNS+"' of the included/redefined schema '"+displayLoc+"' differs from '"+c.schema.targetNamespace+"' of the including/redefining schema."))
 		return nil
 	}
 
@@ -656,10 +654,9 @@ func (c *compiler) loadImport(ctx context.Context, location, ns string, importEl
 		if c.filename != "" {
 			displayLoc = schemaDisplayLoc(c.filename, location)
 		}
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, importElem.Line(),
+		c.schemaError(ctx, schemaParserError(c.filename, importElem.Line(),
 			importElem.LocalName(), elemImport,
-			"The namespace '"+impTargetNS+"' of the imported schema '"+displayLoc+"' differs from the requested namespace '"+ns+"'."), helium.ErrorLevelFatal))
-		c.errorCount++
+			"The namespace '"+impTargetNS+"' of the imported schema '"+displayLoc+"' differs from the requested namespace '"+ns+"'."))
 		return nil
 	}
 

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -58,8 +58,7 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 			if edecl.IsRef {
 				if src, hasSrc := c.elemRefSources[edecl]; hasSrc && c.filename != "" {
 					msg := fmt.Sprintf("The QName value '{%s}%s' does not resolve to a(n) element declaration.", qn.NS, qn.Local)
-					c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.diagSourceOrRecorded(src.source), src.line, src.elemName, elemElement, attrRef, msg), helium.ErrorLevelFatal))
-					c.errorCount++
+					c.schemaError(ctx, schemaParserErrorAttr(c.diagSourceOrRecorded(src.source), src.line, src.elemName, elemElement, attrRef, msg))
 				}
 				edecl.Type = &TypeDef{Name: qn, ContentType: ContentTypeSimple}
 				continue
@@ -79,8 +78,7 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 				// silently compile and validate as if the type existed.
 				if src, hasSrc := c.elemRefSources[edecl]; hasSrc && c.filename != "" {
 					msg := fmt.Sprintf("The QName value '{%s}%s' does not resolve to a(n) type definition.", qn.NS, qn.Local)
-					c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaElemDeclErrorAttr(c.diagSourceOrRecorded(src.source), src.line, src.elemName, attrType, msg), helium.ErrorLevelFatal))
-					c.errorCount++
+					c.schemaError(ctx, schemaElemDeclErrorAttr(c.diagSourceOrRecorded(src.source), src.line, src.elemName, attrType, msg))
 				}
 				td = &TypeDef{Name: qn, ContentType: ContentTypeSimple}
 				c.schema.types[qn] = td
@@ -347,9 +345,8 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 				if !src.isLocal {
 					component = "complex type '" + td.Name.Local + "'"
 				}
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.diagSourceOrRecorded(src.source), src.line, "complexType", component,
-					"The content type of both, the type and its base type, must either 'mixed' or 'element-only'."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaComponentError(c.diagSourceOrRecorded(src.source), src.line, "complexType", component,
+					"The content type of both, the type and its base type, must either 'mixed' or 'element-only'."))
 			}
 			continue
 		}
@@ -368,9 +365,8 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 				if !src.isLocal {
 					component = "complex type '" + td.Name.Local + "'"
 				}
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.diagSourceOrRecorded(src.source), src.line, "complexType", component,
-					"The 'all' model group needs to be the only child of the model group."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaComponentError(c.diagSourceOrRecorded(src.source), src.line, "complexType", component,
+					"The 'all' model group needs to be the only child of the model group."))
 			}
 			continue
 		}
@@ -540,8 +536,7 @@ func (c *compiler) checkExtensionAttrDuplicates(ctx context.Context, td *TypeDef
 			component = td.Name.Local
 		}
 		msg := fmt.Sprintf("Duplicate attribute use '%s'.", au.Name.Local)
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.diagSourceOrRecorded(src.source), src.line, "complexType", component, msg), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.diagSourceOrRecorded(src.source), src.line, "complexType", component, msg))
 	}
 }
 
@@ -606,8 +601,7 @@ func (c *compiler) checkDuplicateAttrUses(ctx context.Context) {
 					component = td.Name.Local
 				}
 				msg := fmt.Sprintf("Duplicate attribute use '%s'.", au.Name.Local)
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.diagSourceOrRecorded(src.source), src.line, "complexType", component, msg), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaComponentError(c.diagSourceOrRecorded(src.source), src.line, "complexType", component, msg))
 				continue
 			}
 			seen[au.Name] = true
@@ -761,8 +755,7 @@ func (c *compiler) reportCircularAttrGroupRef(ctx context.Context, ce *helium.El
 		return
 	}
 	msg := fmt.Sprintf("Circular reference to the attribute group '%s' defined.", formatAttrQName(groupQN))
-	c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.diagSource(), ce.Line(), ce.LocalName(), "attributeGroup", msg), helium.ErrorLevelFatal))
-	c.errorCount++
+	c.schemaError(ctx, schemaParserError(c.diagSource(), ce.Line(), ce.LocalName(), "attributeGroup", msg))
 }
 
 // checkCircularAttrGroupRefs detects INDIRECT xs:attributeGroup reference cycles
@@ -865,8 +858,7 @@ func (c *compiler) reportCircularAttrGroupRefQName(ctx context.Context, targetQN
 		return
 	}
 	msg := fmt.Sprintf("Circular reference to the attribute group '%s' defined.", formatAttrQName(targetQN))
-	c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.diagSourceOrRecorded(edgeSrc.source), edgeSrc.line, "attributeGroup", "attributeGroup", msg), helium.ErrorLevelFatal))
-	c.errorCount++
+	c.schemaError(ctx, schemaParserError(c.diagSourceOrRecorded(edgeSrc.source), edgeSrc.line, "attributeGroup", "attributeGroup", msg))
 }
 
 // reportAttrGroupDuplicate emits the ag-props-correct.2 duplicate-attribute-use
@@ -874,8 +866,7 @@ func (c *compiler) reportCircularAttrGroupRefQName(ctx context.Context, targetQN
 func (c *compiler) reportAttrGroupDuplicate(ctx context.Context, ownerQN, name QName) {
 	src := c.attrGroupSources[ownerQN]
 	msg := fmt.Sprintf("Duplicate attribute use '%s'.", name.Local)
-	c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.diagSourceOrRecorded(src.source), src.line, "attributeGroup", "attributeGroup", msg), helium.ErrorLevelFatal))
-	c.errorCount++
+	c.schemaError(ctx, schemaParserError(c.diagSourceOrRecorded(src.source), src.line, "attributeGroup", "attributeGroup", msg))
 }
 
 // checkAllGroupRef enforces the constraints on an xs:group reference that
@@ -910,9 +901,8 @@ func (c *compiler) checkAllGroupRef(ctx context.Context, placeholder *ModelGroup
 	// time this deferred check runs, so the recorded source is used.
 	file := c.diagSourceOrRecorded(src.source)
 	if src.nested {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(file, src.line, src.local, elemGroup,
-			"A model group definition is referenced, but it contains an 'all' model group, which cannot be contained by model groups."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaParserError(file, src.line, src.local, elemGroup,
+			"A model group definition is referenced, but it contains an 'all' model group, which cannot be contained by model groups."))
 		return
 	}
 
@@ -938,9 +928,8 @@ func (c *compiler) checkAllGroupRef(ctx context.Context, placeholder *ModelGroup
 	if n != Unbounded && n < 1 && placeholder.MinOccurs >= 1 {
 		return
 	}
-	c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(file, src.line, src.local, elemGroup,
-		"The particle's {max occurs} must be 1, since the reference resolves to an 'all' model group."), helium.ErrorLevelFatal))
-	c.errorCount++
+	c.schemaError(ctx, schemaParserError(file, src.line, src.local, elemGroup,
+		"The particle's {max occurs} must be 1, since the reference resolves to an 'all' model group."))
 }
 
 // modelGroupHasContent reports whether mg carries any actual content particle
@@ -1000,8 +989,7 @@ func (c *compiler) reportUnresolvedTypeRef(ctx context.Context, owner *TypeDef, 
 		}
 	}
 	msg := fmt.Sprintf("The QName value '{%s}%s' does not resolve to a(n) type definition.", qn.NS, qn.Local)
-	c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.diagSourceOrRecorded(src.source), src.line, elemKind, component, msg), helium.ErrorLevelFatal))
-	c.errorCount++
+	c.schemaError(ctx, schemaComponentError(c.diagSourceOrRecorded(src.source), src.line, elemKind, component, msg))
 }
 
 // checkAttrUseConstraints validates each attribute use's default/fixed value
@@ -1040,8 +1028,7 @@ func (c *compiler) checkAttrUseConstraints(ctx context.Context) {
 		}
 		if err := td.Validate(ctx, *val, it.src.nsMap); err != nil {
 			msg := fmt.Sprintf("The value '%s' is not a valid value of the atomic type '%s'.", *val, typeDisplayName(td))
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.diagSourceOrRecorded(it.src.source), it.src.line, it.src.local, "attribute", it.src.local, msg), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserErrorAttr(c.diagSourceOrRecorded(it.src.source), it.src.line, it.src.local, "attribute", it.src.local, msg))
 		}
 	}
 }
@@ -1084,16 +1071,14 @@ func (c *compiler) checkRestrictionAttrs(ctx context.Context, td *TypeDef) {
 			// Check use consistency: optional cannot restrict required.
 			if baseAU.Required && !au.Required {
 				msg := fmt.Sprintf("The 'optional' attribute use is inconsistent with the corresponding 'required' attribute use of the base complex type definition %s.", baseQualified)
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, src.line, "complexType",
-					component+", attribute use '"+au.Name.Local+"'", msg), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType",
+					component+", attribute use '"+au.Name.Local+"'", msg))
 			}
 		} else if td.BaseType.AnyAttribute == nil {
 			// No matching attribute and no wildcard in base.
 			msg := fmt.Sprintf("Neither a matching attribute use, nor a matching wildcard exists in the base complex type definition %s.", baseQualified)
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, src.line, "complexType",
-				component+", attribute use '"+au.Name.Local+"'", msg), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType",
+				component+", attribute use '"+au.Name.Local+"'", msg))
 		}
 	}
 
@@ -1109,8 +1094,7 @@ func (c *compiler) checkRestrictionAttrs(ctx context.Context, td *TypeDef) {
 		derived, found := derivedAttrs[baseAU.Name.Local]
 		if !found || derived.Prohibited {
 			msg := fmt.Sprintf("A matching attribute use for the 'required' attribute use '%s' of the base complex type definition %s is missing.", baseAU.Name.Local, baseQualified)
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, src.line, "complexType", component, msg), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType", component, msg))
 		}
 	}
 
@@ -1119,14 +1103,12 @@ func (c *compiler) checkRestrictionAttrs(ctx context.Context, td *TypeDef) {
 		// 4.1: Base must also have a wildcard.
 		if td.BaseType.AnyAttribute == nil {
 			msg := fmt.Sprintf("The complex type definition has an attribute wildcard, but the base complex type definition %s does not have one.", baseQualified)
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, src.line, "complexType", component, msg), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType", component, msg))
 		} else {
 			// 4.2: Derived namespace must be subset of base namespace.
 			if !wildcardNSSubset(td.AnyAttribute, td.BaseType.AnyAttribute) {
 				msg := fmt.Sprintf("The attribute wildcard is not a valid subset of the wildcard in the base complex type definition %s.", baseQualified)
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, src.line, "complexType", component, msg), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType", component, msg))
 			}
 			// 4.3: Derived processContents must be >= base strength (strict > lax > skip).
 			// libxml2 attributes this error to the base type's source location.
@@ -1140,8 +1122,7 @@ func (c *compiler) checkRestrictionAttrs(ctx context.Context, td *TypeDef) {
 					}
 				}
 				msg := fmt.Sprintf("The {process contents} of the attribute wildcard is weaker than the one in the base complex type definition %s.", baseQualified)
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, errLine, "complexType", errComponent, msg), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaComponentError(c.filename, errLine, "complexType", errComponent, msg))
 			}
 		}
 	}
@@ -1340,10 +1321,8 @@ func (c *compiler) checkCircularSubstGroup(ctx context.Context, edecl *ElementDe
 				msg := fmt.Sprintf("The element declaration '%s' defines a circular substitution group to element declaration '%s'.",
 					edecl.Name.Local, current.Local)
 				errStr := schemaElemDeclError(c.filename, src.line, edecl.Name.Local, msg)
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(errStr, helium.ErrorLevelFatal))
-				c.errorCount++
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(errStr, helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, errStr)
+				c.schemaError(ctx, errStr)
 			}
 			return
 		}
@@ -1373,34 +1352,30 @@ func (c *compiler) checkFinalOnTypes(ctx context.Context) {
 				if src.isLocal {
 					component = componentLocalComplexType
 				}
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, src.line, "complexType", component,
-					"Derivation by extension is forbidden by the base type '"+td.BaseType.Name.Local+"'."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType", component,
+					"Derivation by extension is forbidden by the base type '"+td.BaseType.Name.Local+"'."))
 			}
 			if td.Derivation == DerivationRestriction && baseFinal&FinalRestriction != 0 {
 				component := td.Name.Local
 				if src.isLocal {
 					component = componentLocalComplexType
 				}
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, src.line, "complexType", component,
-					"Derivation by restriction is forbidden by the base type '"+td.BaseType.Name.Local+"'."), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType", component,
+					"Derivation by restriction is forbidden by the base type '"+td.BaseType.Name.Local+"'."))
 			}
 		}
 
 		// simpleType list: check if item type forbids list derivation.
 		if td.Variety == TypeVarietyList && td.ItemType != nil && td.ItemType.Final&FinalList != 0 {
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, src.line, "simpleType", td.Name.Local,
-				"Derivation by list is forbidden by the item type '"+td.ItemType.Name.Local+"'."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaComponentError(c.filename, src.line, "simpleType", td.Name.Local,
+				"Derivation by list is forbidden by the item type '"+td.ItemType.Name.Local+"'."))
 		}
 		// simpleType union: check if any member type forbids union derivation.
 		if td.Variety == TypeVarietyUnion {
 			for _, member := range td.MemberTypes {
 				if member.Final&FinalUnion != 0 {
-					c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.filename, src.line, "simpleType", td.Name.Local,
-						"Derivation by union is forbidden by the member type '"+member.Name.Local+"'."), helium.ErrorLevelFatal))
-					c.errorCount++
+					c.schemaError(ctx, schemaComponentError(c.filename, src.line, "simpleType", td.Name.Local,
+						"Derivation by union is forbidden by the member type '"+member.Name.Local+"'."))
 				}
 			}
 		}
@@ -1421,16 +1396,14 @@ func (c *compiler) checkFinalOnSubstGroups(ctx context.Context) {
 		for _, member := range members {
 			if head.Final&FinalExtension != 0 && derivationUsesMethod(member.Type, head.Type, DerivationExtension) {
 				if src, ok := c.globalElemSources[member]; ok {
-					c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaElemDeclError(c.filename, src.line, member.Name.Local,
-						"The substitution group affiliation is forbidden by the head element's final value."), helium.ErrorLevelFatal))
-					c.errorCount++
+					c.schemaError(ctx, schemaElemDeclError(c.filename, src.line, member.Name.Local,
+						"The substitution group affiliation is forbidden by the head element's final value."))
 				}
 			}
 			if head.Final&FinalRestriction != 0 && derivationUsesMethod(member.Type, head.Type, DerivationRestriction) {
 				if src, ok := c.globalElemSources[member]; ok {
-					c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaElemDeclError(c.filename, src.line, member.Name.Local,
-						"The substitution group affiliation is forbidden by the head element's final value."), helium.ErrorLevelFatal))
-					c.errorCount++
+					c.schemaError(ctx, schemaElemDeclError(c.filename, src.line, member.Name.Local,
+						"The substitution group affiliation is forbidden by the head element's final value."))
 				}
 			}
 		}
@@ -1530,8 +1503,6 @@ func (c *compiler) reportUnboundQNamePrefix(ctx context.Context, elem *helium.El
 		return
 	}
 	msg := fmt.Sprintf("The QName value '%s' uses the namespace prefix '%s', which is not bound to a namespace.", ref, prefix)
-	c.errorHandler.Handle(ctx, helium.NewLeveledError(
-		schemaComponentError(c.diagSource(), elem.Line(), elem.LocalName(), "QName value", msg),
-		helium.ErrorLevelFatal))
-	c.errorCount++
+	c.schemaError(ctx,
+		schemaComponentError(c.diagSource(), elem.Line(), elem.LocalName(), "QName value", msg))
 }

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -113,9 +113,8 @@ func (c *compiler) validateOccursAttrs(ctx context.Context, elem *helium.Element
 		n, ok := parseNonNegativeOccurs(v, false)
 		if !ok {
 			minOK = false
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(src, line, local, xsdElem, attrMinOccurs,
-				"The value '"+v+"' is not valid. Expected is 'xs:nonNegativeInteger'."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserErrorAttr(src, line, local, xsdElem, attrMinOccurs,
+				"The value '"+v+"' is not valid. Expected is 'xs:nonNegativeInteger'."))
 		} else {
 			minVal = n
 		}
@@ -127,9 +126,8 @@ func (c *compiler) validateOccursAttrs(ctx context.Context, elem *helium.Element
 		n, ok := parseNonNegativeOccurs(v, true)
 		if !ok {
 			maxOK = false
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(src, line, local, xsdElem, attrMaxOccurs,
-				"The value '"+v+"' is not valid. Expected is '(xs:nonNegativeInteger | unbounded)'."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserErrorAttr(src, line, local, xsdElem, attrMaxOccurs,
+				"The value '"+v+"' is not valid. Expected is '(xs:nonNegativeInteger | unbounded)'."))
 		} else {
 			maxVal = n
 		}
@@ -147,9 +145,8 @@ func (c *compiler) validateOccursAttrs(ctx context.Context, elem *helium.Element
 		}
 		if effMin >= 1 {
 			maxBelowOne = true
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(src, line, local, xsdElem, attrMaxOccurs,
-				"The value must be greater than or equal to 1."), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserErrorAttr(src, line, local, xsdElem, attrMaxOccurs,
+				"The value must be greater than or equal to 1."))
 		}
 	}
 
@@ -157,9 +154,8 @@ func (c *compiler) validateOccursAttrs(ctx context.Context, elem *helium.Element
 	// can never be exceeded). Suppress this when the ">= 1" rule already fired on
 	// maxOccurs; libxml2 reports only the maxOccurs error there.
 	if minPresent && maxPresent && minOK && maxOK && maxVal != Unbounded && !maxBelowOne && minVal > maxVal {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(src, line, local, xsdElem, attrMinOccurs,
-			"The value must not be greater than the value of 'maxOccurs'."), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaParserErrorAttr(src, line, local, xsdElem, attrMinOccurs,
+			"The value must not be greater than the value of 'maxOccurs'."))
 	}
 }
 
@@ -196,9 +192,8 @@ func (c *compiler) readProcessContents(ctx context.Context, elem *helium.Element
 	default:
 		if c.filename != "" {
 			msg := fmt.Sprintf("'%s' is not a valid value of the union type '#processContents'.", v)
-			c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.diagSource(), elem.Line(),
-				elem.LocalName(), elem.LocalName(), attrProcessContents, msg), helium.ErrorLevelFatal))
-			c.errorCount++
+			c.schemaError(ctx, schemaParserErrorAttr(c.diagSource(), elem.Line(),
+				elem.LocalName(), elem.LocalName(), attrProcessContents, msg))
 		}
 		return ProcessStrict
 	}
@@ -214,9 +209,8 @@ func (c *compiler) validateWildcardNamespace(ctx context.Context, elem *helium.E
 		return
 	}
 	reject := func(msg string) {
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.diagSource(), elem.Line(),
-			elem.LocalName(), elem.LocalName(), attrNamespace, msg), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaParserErrorAttr(c.diagSource(), elem.Line(),
+			elem.LocalName(), elem.LocalName(), attrNamespace, msg))
 	}
 
 	// The "##any" / "##other" keywords are EXACT singleton lexical forms: the
@@ -332,9 +326,8 @@ func (c *compiler) readBooleanAttr(ctx context.Context, elem *helium.Element, at
 		return v
 	}
 	msg := fmt.Sprintf("'%s' is not a valid value of the atomic type 'xs:boolean'.", normalizeWhiteSpace(getAttr(elem, attr), "collapse"))
-	c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserErrorAttr(c.diagSource(), elem.Line(),
-		elem.LocalName(), elem.LocalName(), attr, msg), helium.ErrorLevelFatal))
-	c.errorCount++
+	c.schemaError(ctx, schemaParserErrorAttr(c.diagSource(), elem.Line(),
+		elem.LocalName(), elem.LocalName(), attr, msg))
 	return false
 }
 
@@ -423,9 +416,8 @@ func (c *compiler) readAttributeUseDecl(ctx context.Context, elem *helium.Elemen
 			}
 			td, err := c.parseSimpleType(ctx, ce)
 			if err != nil {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, ce.Line(),
-					ce.LocalName(), "attribute", err.Error()), helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx, schemaParserError(c.filename, ce.Line(),
+					ce.LocalName(), "attribute", err.Error()))
 				break
 			}
 			au.Type = td
@@ -516,10 +508,9 @@ func (c *compiler) reportDuplicateComponent(ctx context.Context, elem *helium.El
 	if source == "" {
 		source = c.filename
 	}
-	c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(source, elem.Line(),
+	c.schemaError(ctx, schemaParserError(source, elem.Line(),
 		elem.LocalName(), component,
-		kind+" "+qnDisplay+" does already exist."), helium.ErrorLevelFatal))
-	c.errorCount++
+		kind+" "+qnDisplay+" does already exist."))
 }
 
 func (c *compiler) parseLocalElement(ctx context.Context, elem *helium.Element) (*Particle, error) {
@@ -816,10 +807,8 @@ func (c *compiler) resolveIDCReferQName(ctx context.Context, elem *helium.Elemen
 		if ns == "" && prefix != "" {
 			msg := fmt.Sprintf("The keyref identity-constraint '%s' has a 'refer' attribute '%s' whose namespace prefix '%s' is not bound.", idc.Name, refer, prefix)
 			if c.filename != "" {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(
-					schemaParserErrorAttr(c.filename, idc.Line, elemKeyRef, elemKeyRef, attrRefer, msg),
-					helium.ErrorLevelFatal))
-				c.errorCount++
+				c.schemaError(ctx,
+					schemaParserErrorAttr(c.filename, idc.Line, elemKeyRef, elemKeyRef, attrRefer, msg))
 			}
 			return QName{}, true
 		}
@@ -844,8 +833,6 @@ func (c *compiler) reportIDCXPathError(ctx context.Context, kind string, line in
 		noun = "field"
 	}
 	msg := fmt.Sprintf("The %s XPath '%s' is not a valid %s expression: %s.", noun, xpath, noun, cause)
-	c.errorHandler.Handle(ctx, helium.NewLeveledError(
-		schemaParserErrorAttr(c.filename, line, kind, kind, attrXPath, msg),
-		helium.ErrorLevelFatal))
-	c.errorCount++
+	c.schemaError(ctx,
+		schemaParserErrorAttr(c.filename, line, kind, kind, attrXPath, msg))
 }

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -111,9 +111,8 @@ func (c *compiler) parseComplexType(ctx context.Context, elem *helium.Element) (
 		if c.filename == "" {
 			return
 		}
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.diagSource(), ce.Line(),
-			elem.LocalName(), componentLocalComplexType, what), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.diagSource(), ce.Line(),
+			elem.LocalName(), componentLocalComplexType, what))
 	}
 
 	for child := range helium.Children(elem) {
@@ -329,9 +328,8 @@ func (c *compiler) parseRestriction(ctx context.Context, elem *helium.Element, t
 		if c.filename == "" {
 			return
 		}
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.diagSource(), ce.Line(),
-			elem.LocalName(), componentLocalComplexType, what), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.diagSource(), ce.Line(),
+			elem.LocalName(), componentLocalComplexType, what))
 	}
 
 	// Parse child model groups and attributes.
@@ -346,19 +344,17 @@ func (c *compiler) parseRestriction(ctx context.Context, elem *helium.Element, t
 		if isXSDElement(ce, elemSequence) || isXSDElement(ce, elemChoice) || isXSDElement(ce, elemAll) || isXSDElement(ce, elemGroup) {
 			if directAttrChild != "" {
 				if c.filename != "" {
-					c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.diagSource(), ce.Line(),
+					c.schemaError(ctx, schemaComponentError(c.diagSource(), ce.Line(),
 						elem.LocalName(), componentLocalComplexType,
-						fmt.Sprintf("The content model particle '%s' must appear before the attribute declaration '%s'.", ce.LocalName(), directAttrChild)), helium.ErrorLevelFatal))
-					c.errorCount++
+						fmt.Sprintf("The content model particle '%s' must appear before the attribute declaration '%s'.", ce.LocalName(), directAttrChild)))
 				}
 				continue
 			}
 			if contentModelChild != "" {
 				if c.filename != "" {
-					c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.diagSource(), ce.Line(),
+					c.schemaError(ctx, schemaComponentError(c.diagSource(), ce.Line(),
 						elem.LocalName(), componentLocalComplexType,
-						fmt.Sprintf("A complex type definition must not have more than one content model particle (found '%s' after '%s').", ce.LocalName(), contentModelChild)), helium.ErrorLevelFatal))
-					c.errorCount++
+						fmt.Sprintf("A complex type definition must not have more than one content model particle (found '%s' after '%s').", ce.LocalName(), contentModelChild)))
 				}
 				continue
 			}
@@ -472,9 +468,8 @@ func (c *compiler) parseExtension(ctx context.Context, elem *helium.Element, td 
 		if c.filename == "" {
 			return
 		}
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.diagSource(), ce.Line(),
-			elem.LocalName(), componentLocalComplexType, what), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.diagSource(), ce.Line(),
+			elem.LocalName(), componentLocalComplexType, what))
 	}
 
 	// Parse child content model (if any).
@@ -489,19 +484,17 @@ func (c *compiler) parseExtension(ctx context.Context, elem *helium.Element, td 
 		if isXSDElement(ce, elemSequence) || isXSDElement(ce, elemChoice) || isXSDElement(ce, elemAll) || isXSDElement(ce, elemGroup) {
 			if directAttrChild != "" {
 				if c.filename != "" {
-					c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.diagSource(), ce.Line(),
+					c.schemaError(ctx, schemaComponentError(c.diagSource(), ce.Line(),
 						elem.LocalName(), componentLocalComplexType,
-						fmt.Sprintf("The content model particle '%s' must appear before the attribute declaration '%s'.", ce.LocalName(), directAttrChild)), helium.ErrorLevelFatal))
-					c.errorCount++
+						fmt.Sprintf("The content model particle '%s' must appear before the attribute declaration '%s'.", ce.LocalName(), directAttrChild)))
 				}
 				continue
 			}
 			if contentModelChild != "" {
 				if c.filename != "" {
-					c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.diagSource(), ce.Line(),
+					c.schemaError(ctx, schemaComponentError(c.diagSource(), ce.Line(),
 						elem.LocalName(), componentLocalComplexType,
-						fmt.Sprintf("A complex type definition must not have more than one content model particle (found '%s' after '%s').", ce.LocalName(), contentModelChild)), helium.ErrorLevelFatal))
-					c.errorCount++
+						fmt.Sprintf("A complex type definition must not have more than one content model particle (found '%s' after '%s').", ce.LocalName(), contentModelChild)))
 				}
 				continue
 			}
@@ -648,9 +641,8 @@ func (c *compiler) parseSimpleContentChildren(ctx context.Context, derivation *h
 		if c.filename == "" {
 			return
 		}
-		c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.diagSource(), ae.Line(),
-			derivation.LocalName(), componentLocalComplexType, what), helium.ErrorLevelFatal))
-		c.errorCount++
+		c.schemaError(ctx, schemaComponentError(c.diagSource(), ae.Line(),
+			derivation.LocalName(), componentLocalComplexType, what))
 	}
 
 	for child := range helium.Children(derivation) {
@@ -908,10 +900,9 @@ func (c *compiler) parseFacets(ctx context.Context, restriction *helium.Element)
 			fs.Patterns = append(fs.Patterns, val)
 			re, rerr := xsdregex.Compile(val)
 			if rerr != nil {
-				c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserError(c.filename, ce.Line(),
+				c.schemaError(ctx, schemaParserError(c.filename, ce.Line(),
 					ce.LocalName(), "pattern",
-					fmt.Sprintf("The value '%s' is not a valid regular expression: %s.", val, rerr)), helium.ErrorLevelFatal))
-				c.errorCount++
+					fmt.Sprintf("The value '%s' is not a valid regular expression: %s.", val, rerr)))
 			}
 			fs.compiledPatterns = append(fs.compiledPatterns, re)
 		}

--- a/xsd/restriction_particle.go
+++ b/xsd/restriction_particle.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"slices"
 
-	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 )
 
@@ -96,8 +95,7 @@ func (c *compiler) reportInvalidRestriction(ctx context.Context, td, base *TypeD
 	}
 	baseQualified := "'{" + base.Name.NS + "}" + base.Name.Local + "'"
 	msg := "The content model is not a valid restriction of the content model of the base complex type definition " + baseQualified + "."
-	c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaComponentError(c.diagSourceOrRecorded(src.source), src.line, "complexType", component, msg), helium.ErrorLevelFatal))
-	c.errorCount++
+	c.schemaError(ctx, schemaComponentError(c.diagSourceOrRecorded(src.source), src.line, "complexType", component, msg))
 }
 
 // particleValidRestriction reports whether the restriction particle r is a valid


### PR DESCRIPTION
- c.schemaError collapses ~143 Handle(Fatal)+errorCount++ pairs
- identical message/level/order; golden suite green
- internal-only, net-negative, behavior-preserving