### PR TITLE
dedup shim locator and encoder token helpers

### DIFF
--- a/shim/decoder.go
+++ b/shim/decoder.go
@@ -142,12 +142,15 @@ func (d *Decoder) startSAXEmitter(ctx context.Context, r io.Reader) {
 		locator = loc2
 		return nil
 	}))
-	h.SetOnStartElementNS(sax.StartElementNSFunc(func(_ context.Context, localname, prefix string, uri string, namespaces []sax.Namespace, attrs []sax.Attribute) error {
-		line, col := 0, 0
+	pos := func() (line, col int) {
 		if locator != nil {
 			line = locator.LineNumber()
 			col = locator.ColumnNumber()
 		}
+		return
+	}
+	h.SetOnStartElementNS(sax.StartElementNSFunc(func(_ context.Context, localname, prefix string, uri string, namespaces []sax.Namespace, attrs []sax.Attribute) error {
+		line, col := pos()
 
 		// Push newly declared namespaces into the in-scope map
 		var prevs []nsPrev
@@ -200,11 +203,7 @@ func (d *Decoder) startSAXEmitter(ctx context.Context, r io.Reader) {
 		return push(se, rawSE, line, col)
 	}))
 	h.SetOnEndElementNS(sax.EndElementNSFunc(func(_ context.Context, localname, prefix string, uri string) error {
-		line, col := 0, 0
-		if locator != nil {
-			line = locator.LineNumber()
-			col = locator.ColumnNumber()
-		}
+		line, col := pos()
 
 		// Pop namespace declarations for this element
 		if len(nsScopePrevStack) > 0 {
@@ -226,29 +225,17 @@ func (d *Decoder) startSAXEmitter(ctx context.Context, r io.Reader) {
 		return push(ee, rawEE, line, col)
 	}))
 	h.SetOnCharacters(sax.CharactersFunc(func(_ context.Context, ch []byte) error {
-		line, col := 0, 0
-		if locator != nil {
-			line = locator.LineNumber()
-			col = locator.ColumnNumber()
-		}
+		line, col := pos()
 		cd := CharData(append([]byte(nil), ch...))
 		return push(cd, cd, line, col)
 	}))
 	h.SetOnIgnorableWhitespace(sax.IgnorableWhitespaceFunc(func(_ context.Context, ch []byte) error {
-		line, col := 0, 0
-		if locator != nil {
-			line = locator.LineNumber()
-			col = locator.ColumnNumber()
-		}
+		line, col := pos()
 		cd := CharData(append([]byte(nil), ch...))
 		return push(cd, cd, line, col)
 	}))
 	h.SetOnCDataBlock(sax.CDataBlockFunc(func(_ context.Context, value []byte) error {
-		line, col := 0, 0
-		if locator != nil {
-			line = locator.LineNumber()
-			col = locator.ColumnNumber()
-		}
+		line, col := pos()
 		cd := CharData(append([]byte(nil), value...))
 		select {
 		case d.events <- tokenEvent{tok: cd, rawTok: cd, line: line, col: col, cdata: true}:
@@ -258,11 +245,7 @@ func (d *Decoder) startSAXEmitter(ctx context.Context, r io.Reader) {
 		}
 	}))
 	h.SetOnComment(sax.CommentFunc(func(_ context.Context, value []byte) error {
-		line, col := 0, 0
-		if locator != nil {
-			line = locator.LineNumber()
-			col = locator.ColumnNumber()
-		}
+		line, col := pos()
 		c := Comment(append([]byte(nil), value...))
 		return push(c, c, line, col)
 	}))
@@ -270,11 +253,7 @@ func (d *Decoder) startSAXEmitter(ctx context.Context, r io.Reader) {
 		if target == lexicon.PrefixXML {
 			return nil // skip XML declaration
 		}
-		line, col := 0, 0
-		if locator != nil {
-			line = locator.LineNumber()
-			col = locator.ColumnNumber()
-		}
+		line, col := pos()
 		pi := ProcInst{Target: target, Inst: []byte(data)}
 		return push(pi, pi, line, col)
 	}))

--- a/shim/encoder.go
+++ b/shim/encoder.go
@@ -284,16 +284,34 @@ func (enc *Encoder) writeCharData(cd CharData) error {
 	return nil
 }
 
-func (enc *Encoder) writeComment(c Comment) error {
-	if bytes.Contains([]byte(c), endComment) {
-		return fmt.Errorf("xml: EncodeToken of Comment containing --> marker")
-	}
+// indentBeforeToken writes indentation before a standalone token (comment or
+// processing instruction) when indenting is enabled, skipping it right after a
+// start tag so empty-element formatting is preserved.
+func (enc *Encoder) indentBeforeToken() error {
 	if enc.indent != "" || enc.prefix != "" {
 		if enc.depth > 0 && !enc.lastWasStart {
 			if err := enc.writeIndent(enc.depth); err != nil {
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+// afterToken records that a non-text token was written, resetting the
+// start/text adjacency flags used for indentation.
+func (enc *Encoder) afterToken() {
+	enc.hasTokens = true
+	enc.lastWasStart = false
+	enc.lastWasText = false
+}
+
+func (enc *Encoder) writeComment(c Comment) error {
+	if bytes.Contains([]byte(c), endComment) {
+		return fmt.Errorf("xml: EncodeToken of Comment containing --> marker")
+	}
+	if err := enc.indentBeforeToken(); err != nil {
+		return err
 	}
 	if _, err := enc.w.WriteString("<!--"); err != nil {
 		return err
@@ -304,9 +322,7 @@ func (enc *Encoder) writeComment(c Comment) error {
 	if _, err := enc.w.WriteString("-->"); err != nil {
 		return err
 	}
-	enc.hasTokens = true
-	enc.lastWasStart = false
-	enc.lastWasText = false
+	enc.afterToken()
 	return nil
 }
 
@@ -320,12 +336,8 @@ func (enc *Encoder) writeProcInst(pi ProcInst) error {
 	if bytes.Contains(pi.Inst, endProcInst) {
 		return fmt.Errorf("xml: EncodeToken of ProcInst containing ?> marker")
 	}
-	if enc.indent != "" || enc.prefix != "" {
-		if enc.depth > 0 && !enc.lastWasStart {
-			if err := enc.writeIndent(enc.depth); err != nil {
-				return err
-			}
-		}
+	if err := enc.indentBeforeToken(); err != nil {
+		return err
 	}
 	if _, err := enc.w.WriteString("<?"); err != nil {
 		return err
@@ -344,9 +356,7 @@ func (enc *Encoder) writeProcInst(pi ProcInst) error {
 	if _, err := enc.w.WriteString("?>"); err != nil {
 		return err
 	}
-	enc.hasTokens = true
-	enc.lastWasStart = false
-	enc.lastWasText = false
+	enc.afterToken()
 	return nil
 }
 
@@ -363,9 +373,7 @@ func (enc *Encoder) writeDirective(d Directive) error {
 	if err := enc.w.WriteByte('>'); err != nil {
 		return err
 	}
-	enc.hasTokens = true
-	enc.lastWasStart = false
-	enc.lastWasText = false
+	enc.afterToken()
 	return nil
 }
 

--- a/shim/marshal.go
+++ b/shim/marshal.go
@@ -738,12 +738,8 @@ func (enc *Encoder) marshalComment(structVal, field reflect.Value) error {
 	if bytes.Contains(b, ddBytes) {
 		return fmt.Errorf(`xml: comments must not contain "--"`)
 	}
-	if enc.indent != "" || enc.prefix != "" {
-		if enc.depth > 0 && !enc.lastWasStart {
-			if err := enc.writeIndent(enc.depth); err != nil {
-				return err
-			}
-		}
+	if err := enc.indentBeforeToken(); err != nil {
+		return err
 	}
 	if _, err := enc.w.WriteString("<!--"); err != nil {
 		return err
@@ -759,9 +755,7 @@ func (enc *Encoder) marshalComment(structVal, field reflect.Value) error {
 	if _, err := enc.w.WriteString("-->"); err != nil {
 		return err
 	}
-	enc.hasTokens = true
-	enc.lastWasStart = false
-	enc.lastWasText = false
+	enc.afterToken()
 	return nil
 }
 


### PR DESCRIPTION
- pos() closure (7 SAX callbacks)
- indentBeforeToken / afterToken encoder helpers
- internal-only, net-negative, behavior-preserving