### PR TITLE
dedup xpath1 node fns, dispatch, type tests

### DIFF
--- a/xpath1/eval.go
+++ b/xpath1/eval.go
@@ -402,27 +402,25 @@ func evalBinaryExpr(ctx context.Context, ec *evalContext, e BinaryExpr) (*Result
 }
 
 func evalOr(ctx context.Context, ec *evalContext, e BinaryExpr) (*Result, error) {
-	left, err := eval(ctx, ec, e.Left)
-	if err != nil {
-		return nil, err
-	}
-	if resultToBoolean(left) {
-		return &Result{Type: BooleanResult, Bool: true}, nil
-	}
-	right, err := eval(ctx, ec, e.Right)
-	if err != nil {
-		return nil, err
-	}
-	return &Result{Type: BooleanResult, Bool: resultToBoolean(right)}, nil
+	return evalShortCircuit(ctx, ec, e, true)
 }
 
 func evalAnd(ctx context.Context, ec *evalContext, e BinaryExpr) (*Result, error) {
+	return evalShortCircuit(ctx, ec, e, false)
+}
+
+// evalShortCircuit evaluates a boolean "or" (shortOn==true) or "and"
+// (shortOn==false) expression. The left operand is always evaluated; when its
+// boolean value equals shortOn, that value is returned without evaluating the
+// right operand. Otherwise the right operand (and its error) is evaluated and
+// its boolean value returned.
+func evalShortCircuit(ctx context.Context, ec *evalContext, e BinaryExpr, shortOn bool) (*Result, error) {
 	left, err := eval(ctx, ec, e.Left)
 	if err != nil {
 		return nil, err
 	}
-	if !resultToBoolean(left) {
-		return &Result{Type: BooleanResult, Bool: false}, nil
+	if resultToBoolean(left) == shortOn {
+		return &Result{Type: BooleanResult, Bool: shortOn}, nil
 	}
 	right, err := eval(ctx, ec, e.Right)
 	if err != nil {

--- a/xpath1/functions.go
+++ b/xpath1/functions.go
@@ -118,9 +118,16 @@ func evalFunctionCall(ctx context.Context, ec *evalContext, fc FunctionCall) (*R
 		return nil, fmt.Errorf("%w: %s", ErrUnknownFunction, fc.Name)
 	}
 
+	return callResolvedFn(ctx, ec, fn, fc.Args)
+}
+
+// callResolvedFn pre-evaluates the argument expressions left-to-right (returning
+// early on the first error), stashes the evalContext as the FunctionContext, and
+// invokes the already-resolved (non-nil) function.
+func callResolvedFn(ctx context.Context, ec *evalContext, fn Function, exprs []Expr) (*Result, error) {
 	// Pre-evaluate all arguments.
-	args := make([]*Result, len(fc.Args))
-	for i, expr := range fc.Args {
+	args := make([]*Result, len(exprs))
+	for i, expr := range exprs {
 		r, err := eval(ctx, ec, expr)
 		if err != nil {
 			return nil, err
@@ -150,20 +157,7 @@ func evalNamespacedFunctionCall(ctx context.Context, ec *evalContext, fc Functio
 		return nil, fmt.Errorf("%w: {%s}%s", ErrUnknownFunction, uri, fc.Name)
 	}
 
-	// Pre-evaluate all arguments.
-	args := make([]*Result, len(fc.Args))
-	for i, expr := range fc.Args {
-		r, err := eval(ctx, ec, expr)
-		if err != nil {
-			return nil, err
-		}
-		args[i] = r
-	}
-
-	// Stash the evalContext as FunctionContext in the context.Context
-	// so functions can retrieve it via GetFunctionContext.
-	fctx := withFunctionContext(ctx, ec)
-	return fn.Eval(fctx, args) //nolint:wrapcheck
+	return callResolvedFn(ctx, ec, fn, fc.Args)
 }
 
 // --- Node-set functions ---
@@ -240,7 +234,10 @@ func collectIDValues(r *Result) []string {
 	return strings.Fields(resultToString(r))
 }
 
-func fnLocalName(ec *evalContext, args []*Result) (*Result, error) {
+// nodeStringFn implements the common shape of local-name(), namespace-uri(),
+// and name(): take an optional node-set argument (defaulting to the context
+// node), then map the selected node through f to a string result.
+func nodeStringFn(ec *evalContext, args []*Result, f func(helium.Node) string) (*Result, error) {
 	n, ok, err := nodeArgOrContext(ec, args)
 	if err != nil {
 		return nil, err
@@ -248,29 +245,19 @@ func fnLocalName(ec *evalContext, args []*Result) (*Result, error) {
 	if !ok {
 		return &Result{Type: StringResult}, nil
 	}
-	return &Result{Type: StringResult, String: localNameOf(n)}, nil
+	return &Result{Type: StringResult, String: f(n)}, nil
+}
+
+func fnLocalName(ec *evalContext, args []*Result) (*Result, error) {
+	return nodeStringFn(ec, args, localNameOf)
 }
 
 func fnNamespaceURI(ec *evalContext, args []*Result) (*Result, error) {
-	n, ok, err := nodeArgOrContext(ec, args)
-	if err != nil {
-		return nil, err
-	}
-	if !ok {
-		return &Result{Type: StringResult}, nil
-	}
-	return &Result{Type: StringResult, String: nodeNamespaceURI(n)}, nil
+	return nodeStringFn(ec, args, nodeNamespaceURI)
 }
 
 func fnName(ec *evalContext, args []*Result) (*Result, error) {
-	n, ok, err := nodeArgOrContext(ec, args)
-	if err != nil {
-		return nil, err
-	}
-	if !ok {
-		return &Result{Type: StringResult}, nil
-	}
-	return &Result{Type: StringResult, String: nameOf(n)}, nil
+	return nodeStringFn(ec, args, nameOf)
 }
 
 // nameOf returns the XPath name() of a node. Per the XPath spec, name()

--- a/xpath1/parser.go
+++ b/xpath1/parser.go
@@ -563,26 +563,11 @@ func (p *parser) parseNodeTest(_ AxisType) (NodeTest, error) {
 func (p *parser) parseNodeTypeTest(name string) (NodeTest, bool, error) {
 	switch name {
 	case "node":
-		p.lexer.Next() // (
-		if p.lexer.Peek().Type != TokenRParen {
-			return nil, true, errExpectedRParenAfterNode
-		}
-		p.lexer.Next() // )
-		return TypeTest{Type: NodeTestNode}, true, nil
+		return p.parseEmptyTypeTest(NodeTestNode, errExpectedRParenAfterNode)
 	case "text":
-		p.lexer.Next()
-		if p.lexer.Peek().Type != TokenRParen {
-			return nil, true, errExpectedRParenAfterText
-		}
-		p.lexer.Next()
-		return TypeTest{Type: NodeTestText}, true, nil
+		return p.parseEmptyTypeTest(NodeTestText, errExpectedRParenAfterText)
 	case "comment":
-		p.lexer.Next()
-		if p.lexer.Peek().Type != TokenRParen {
-			return nil, true, errExpectedRParenAfterComment
-		}
-		p.lexer.Next()
-		return TypeTest{Type: NodeTestComment}, true, nil
+		return p.parseEmptyTypeTest(NodeTestComment, errExpectedRParenAfterComment)
 	case "processing-instruction":
 		p.lexer.Next()
 		target := ""
@@ -596,6 +581,19 @@ func (p *parser) parseNodeTypeTest(name string) (NodeTest, bool, error) {
 		return PITest{Target: target}, true, nil
 	}
 	return nil, false, nil
+}
+
+// parseEmptyTypeTest consumes the empty "()" of a node-type test such as
+// node(), text(), or comment(), returning a TypeTest of the given type. The
+// distinct errSentinel preserves errors.Is identity for each keyword's
+// missing-RParen diagnostic.
+func (p *parser) parseEmptyTypeTest(nt NodeTestType, errSentinel error) (NodeTest, bool, error) {
+	p.lexer.Next() // (
+	if p.lexer.Peek().Type != TokenRParen {
+		return nil, true, errSentinel
+	}
+	p.lexer.Next() // )
+	return TypeTest{Type: nt}, true, nil
 }
 
 // parseQNameTest parses a prefix:local or prefix:* name test, given that the


### PR DESCRIPTION
- nodeStringFn (3 fns), callResolvedFn (2 sites)
- parseEmptyTypeTest (3 arms), evalShortCircuit (or/and)
- internal-only, net-negative, behavior-preserving