### PR TITLE
dedup helium dtd writer and attr iteration

### DIFF
--- a/element.go
+++ b/element.go
@@ -368,13 +368,8 @@ func (n *Element) spliceOutAttribute(p *Attribute) {
 // the live attribute nodes. Use ForEachAttribute to avoid the slice allocation.
 func (n Element) Attributes() []*Attribute {
 	attrs := []*Attribute{}
-	for attr := n.properties; attr != nil; {
+	for attr := n.properties; attr != nil; attr = attr.NextAttribute() {
 		attrs = append(attrs, attr)
-		next, ok := AsNode[*Attribute](attr.NextSibling())
-		if !ok {
-			break
-		}
-		attr = next
 	}
 
 	return attrs
@@ -393,14 +388,9 @@ func (n Element) Attributes() []*Attribute {
 // chain is attribute-only by construction (field typed *Attribute,
 // only *Attribute nodes are ever linked in).
 func (n Element) ForEachAttribute(fn func(*Attribute) bool) {
-	for attr := n.properties; attr != nil; {
+	for attr := n.properties; attr != nil; attr = attr.NextAttribute() {
 		if !fn(attr) {
 			return
 		}
-		next, ok := AsNode[*Attribute](attr.NextSibling())
-		if !ok {
-			return
-		}
-		attr = next
 	}
 }

--- a/writer_dtd.go
+++ b/writer_dtd.go
@@ -74,13 +74,21 @@ func (d *writeSession) dumpEnumeration(out io.Writer, n Enumeration) error {
 	return d.err
 }
 
-func (d *writeSession) dumpElementDeclPrologue(out io.Writer, n *ElementDecl) {
-	d.writeString(out, "<!ELEMENT ")
-	if n.prefix != "" {
-		d.writeString(out, n.prefix)
+// writePrefixedName emits an optionally namespace-prefixed name as
+// "prefix:name" (or just "name" when prefix is empty), preserving the
+// writeString order so the sticky-error handling is identical to the
+// inline sequences it replaces.
+func (d *writeSession) writePrefixedName(out io.Writer, prefix, name string) {
+	if prefix != "" {
+		d.writeString(out, prefix)
 		d.writeString(out, ":")
 	}
-	d.writeString(out, n.name)
+	d.writeString(out, name)
+}
+
+func (d *writeSession) dumpElementDeclPrologue(out io.Writer, n *ElementDecl) {
+	d.writeString(out, "<!ELEMENT ")
+	d.writePrefixedName(out, n.prefix, n.name)
 }
 
 func (d *writeSession) dumpElementContent(out io.Writer, n *ElementContent, glob bool) error {
@@ -100,11 +108,7 @@ func (d *writeSession) dumpElementContent(out io.Writer, n *ElementContent, glob
 	case ElementContentPCDATA:
 		d.writeString(out, "#PCDATA")
 	case ElementContentElement:
-		if n.prefix != "" {
-			d.writeString(out, n.prefix)
-			d.writeString(out, ":")
-		}
-		d.writeString(out, n.name)
+		d.writePrefixedName(out, n.prefix, n.name)
 	case ElementContentSeq:
 		switch n.c1.ctype {
 		case ElementContentOr, ElementContentSeq:
@@ -334,11 +338,7 @@ func (d *writeSession) dumpAttributeDecl(out io.Writer, n *AttributeDecl) error 
 	d.writeString(out, "<!ATTLIST ")
 	d.writeString(out, n.elem)
 	d.writeString(out, " ")
-	if n.prefix != "" {
-		d.writeString(out, n.prefix)
-		d.writeString(out, ":")
-	}
-	d.writeString(out, n.name)
+	d.writePrefixedName(out, n.prefix, n.name)
 	switch n.atype {
 	case enum.AttrCDATA:
 		d.writeString(out, " CDATA")

--- a/writer_xhtml.go
+++ b/writer_xhtml.go
@@ -192,7 +192,7 @@ func (d *writeSession) dumpXHTMLAttrList(out io.Writer, e *Element) error {
 	var langAttr, xmlLangAttr, nameAttr, idAttr *Attribute
 	localName := e.LocalName()
 
-	for attr := e.properties; attr != nil; {
+	for attr := e.properties; attr != nil; attr = attr.NextAttribute() {
 		attrName := attr.Name()
 
 		// The attribute name is emitted verbatim below. Validate it just like
@@ -232,12 +232,6 @@ func (d *writeSession) dumpXHTMLAttrList(out io.Writer, e *Element) error {
 			}
 		}
 		d.writeString(out, `"`)
-
-		next, ok := AsNode[*Attribute](attr.NextSibling())
-		if !ok {
-			break
-		}
-		attr = next
 	}
 
 	if nameAttr != nil && idAttr == nil && xhtmlNameIDElements[localName] {
@@ -267,17 +261,12 @@ func (d *writeSession) headHasContentTypeMeta(head *Element) bool {
 		if !ok || ce.LocalName() != "meta" {
 			continue
 		}
-		for attr := ce.properties; attr != nil; {
+		for attr := ce.properties; attr != nil; attr = attr.NextAttribute() {
 			if attr.ns == nil && strings.EqualFold(attr.Name(), "http-equiv") {
 				if strings.EqualFold(attr.Value(), "Content-Type") {
 					return true
 				}
 			}
-			next, ok := AsNode[*Attribute](attr.NextSibling())
-			if !ok {
-				break
-			}
-			attr = next
 		}
 	}
 	return false


### PR DESCRIPTION
- writePrefixedName (3 sites)
- use existing NextAttribute() for 4 attr loops (writer.go loop left as-is)
- internal-only, net-negative, behavior-preserving