### PR TITLE
reuse internal/unparsedtext percent-encoding validator

### DIFF
--- a/internal/unparsedtext/unparsedtext.go
+++ b/internal/unparsedtext/unparsedtext.go
@@ -702,13 +702,15 @@ func normalizeEncodingName(s string) string {
 }
 
 func parseURIReference(raw string) (*url.URL, error) {
-	if err := validatePercentEncoding(raw); err != nil {
+	if err := ValidatePercentEncoding(raw); err != nil {
 		return nil, err
 	}
 	return url.Parse(raw)
 }
 
-func validatePercentEncoding(uri string) error {
+// ValidatePercentEncoding verifies that every '%' in uri is followed by two
+// hexadecimal digits, returning a descriptive error otherwise.
+func ValidatePercentEncoding(uri string) error {
 	for i := 0; i < len(uri); i++ {
 		if uri[i] == '%' {
 			if i+2 >= len(uri) {

--- a/xpath3/functions_uri.go
+++ b/xpath3/functions_uri.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/unparsedtext"
 )
 
 func init() {
@@ -167,7 +168,7 @@ func fnResolveURI(ctx context.Context, args []Sequence) (Sequence, error) {
 // validateIRI checks that a string is a valid IRI reference.
 // Rejects characters that are not allowed in IRIs (like raw spaces).
 func validateIRI(s string) error {
-	if err := validatePercentEncoding(s); err != nil {
+	if err := unparsedtext.ValidatePercentEncoding(s); err != nil {
 		return err
 	}
 	// A URI reference may contain at most one '#' (fragment separator).

--- a/xpath3/uri_resolution.go
+++ b/xpath3/uri_resolution.go
@@ -2,8 +2,9 @@ package xpath3
 
 import (
 	"context"
-	"fmt"
 	"net/url"
+
+	"github.com/lestrrat-go/helium/internal/unparsedtext"
 )
 
 func baseURIFromContext(ctx context.Context) string {
@@ -14,7 +15,7 @@ func baseURIFromContext(ctx context.Context) string {
 }
 
 func parseURIReference(raw string) (*url.URL, error) {
-	if err := validatePercentEncoding(raw); err != nil {
+	if err := unparsedtext.ValidatePercentEncoding(raw); err != nil {
 		return nil, err
 	}
 	return url.Parse(raw)
@@ -57,21 +58,6 @@ func resolveURIReference(base, ref string) (string, error) {
 		result = uriToIRI(result)
 	}
 	return result, nil
-}
-
-func validatePercentEncoding(uri string) error {
-	for i := 0; i < len(uri); i++ {
-		if uri[i] == '%' {
-			if i+2 >= len(uri) {
-				return fmt.Errorf("incomplete percent-encoding at position %d", i)
-			}
-			if !isHexDigit(uri[i+1]) || !isHexDigit(uri[i+2]) {
-				return fmt.Errorf("invalid percent-encoding %%%c%c", uri[i+1], uri[i+2])
-			}
-			i += 2
-		}
-	}
-	return nil
 }
 
 func isHexDigit(b byte) bool {


### PR DESCRIPTION
- export ValidatePercentEncoding, delete xpath3 byte-identical copy
- net-negative, behavior-preserving, internal-only