### PR TITLE
route char-class predicates to internal/xmlchar

### DIFF
--- a/internal/xmlchar/xmlchar.go
+++ b/internal/xmlchar/xmlchar.go
@@ -15,6 +15,17 @@ func IsChar(r rune) bool {
 	return (r >= 0x100 && r <= 0xD7FF) || (r >= 0xE000 && r <= 0xFFFD) || (r >= 0x10000 && r <= 0x10FFFF)
 }
 
+// IsAllSpace reports whether every byte of b is XML 1.0 §2.3 whitespace (the S
+// production: #x20 | #x9 | #xD | #xA). An empty slice is all-space.
+func IsAllSpace(b []byte) bool {
+	for _, c := range b {
+		if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
+			return false
+		}
+	}
+	return true
+}
+
 // IsNCNameStartChar checks the XML 1.0 NCName start character production.
 // NCNameStartChar ::= [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6]
 //

--- a/internal/xsd/value/validate.go
+++ b/internal/xsd/value/validate.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 )
 
 // ValidateBuiltin validates a value against a builtin XSD type's lexical space.
@@ -575,89 +576,15 @@ func validateGMonthDay(value string) error {
 	return nil
 }
 
-// isNameStartChar reports whether r is a valid XML 1.0 NameStartChar.
-// (https://www.w3.org/TR/xml/#NT-NameStartChar) The colon is handled by the
-// caller, since NCName forbids it while Name allows it.
-func isNameStartChar(r rune) bool {
-	switch {
-	case r == '_':
-		return true
-	case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z':
-		return true
-	case r >= 0xC0 && r <= 0xD6, r >= 0xD8 && r <= 0xF6, r >= 0xF8 && r <= 0x2FF:
-		return true
-	case r >= 0x370 && r <= 0x37D, r >= 0x37F && r <= 0x1FFF:
-		return true
-	case r >= 0x200C && r <= 0x200D, r >= 0x2070 && r <= 0x218F:
-		return true
-	case r >= 0x2C00 && r <= 0x2FEF, r >= 0x3001 && r <= 0xD7FF:
-		return true
-	case r >= 0xF900 && r <= 0xFDCF, r >= 0xFDF0 && r <= 0xFFFD:
-		return true
-	case r >= 0x10000 && r <= 0xEFFFF:
-		return true
-	}
-	return false
-}
-
-// isNameChar reports whether r is a valid XML 1.0 NameChar (excluding the
-// colon, which the caller decides on per type).
-// (https://www.w3.org/TR/xml/#NT-NameChar)
-func isNameChar(r rune) bool {
-	switch {
-	case isNameStartChar(r):
-		return true
-	case r == '-', r == '.':
-		return true
-	case r >= '0' && r <= '9':
-		return true
-	case r == 0xB7:
-		return true
-	case r >= 0x0300 && r <= 0x036F:
-		return true
-	case r >= 0x203F && r <= 0x2040:
-		return true
-	}
-	return false
-}
-
-// isXMLName reports whether value is a valid XML Name (or NCName when
-// allowColon is false), per the XML 1.0 NameStartChar/NameChar productions.
-func isXMLName(value string, allowColon bool) bool {
-	if value == "" {
-		return false
-	}
-	// Ranging a Go string decodes invalid UTF-8 bytes as U+FFFD, which the XML
-	// Name char ranges happen to admit; reject malformed encodings outright so a
-	// raw 0xFF byte does not masquerade as a valid Name character.
-	if !utf8.ValidString(value) {
-		return false
-	}
-	for i, r := range value {
-		colon := r == ':'
-		if i == 0 {
-			if (colon && allowColon) || isNameStartChar(r) {
-				continue
-			}
-			return false
-		}
-		if (colon && allowColon) || isNameChar(r) {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
 func validateNCName(value string) error {
-	if !isXMLName(value, false) {
+	if !xmlchar.IsValidNCName(value) {
 		return fmt.Errorf("invalid NCName")
 	}
 	return nil
 }
 
 func validateName(value string) error {
-	if !isXMLName(value, true) {
+	if !xmlchar.IsValidName(value) {
 		return fmt.Errorf("invalid Name")
 	}
 	return nil
@@ -673,7 +600,7 @@ func isNMTOKEN(value string) bool {
 		return false
 	}
 	for _, r := range value {
-		if r == ':' || isNameChar(r) {
+		if r == ':' || xmlchar.IsNCNameChar(r) {
 			continue
 		}
 		return false

--- a/valid.go
+++ b/valid.go
@@ -412,7 +412,7 @@ func checkStandaloneWhitespace(ctx context.Context, extSubset *DTD, elem *Elemen
 		return
 	}
 	for child := range Children(elem) {
-		if child.Type() == TextNode && isBlankContent(child.Content()) {
+		if child.Type() == TextNode && xmlchar.IsAllSpace(child.Content()) {
 			vctx.addf(ctx, "standalone: element %s declared in the external subset contains white spaces nodes", name)
 			return
 		}
@@ -506,23 +506,13 @@ func collectChildElements(elem *Element) []string {
 			// whitespace) but non-whitespace text is an error. We skip
 			// whitespace-only text and treat non-whitespace as a mismatch
 			// that will be caught by the content model check.
-			if !isBlankContent(child.Content()) {
+			if !xmlchar.IsAllSpace(child.Content()) {
 				// Use a sentinel to cause content model mismatch
 				children = append(children, "#text")
 			}
 		}
 	}
 	return children
-}
-
-// isBlankContent returns true if the byte slice contains only whitespace.
-func isBlankContent(b []byte) bool {
-	for _, c := range b {
-		if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
-			return false
-		}
-	}
-	return true
 }
 
 // matchContentModel validates a sequence of child element names against

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -7,6 +7,7 @@ import (
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 	"github.com/lestrrat-go/helium/internal/xsd/value"
 )
 
@@ -696,7 +697,7 @@ func (vc *validationContext) validateElementContent(ctx context.Context, elem *h
 					// like NBSP (U+00A0) are NOT ignorable in element-only content,
 					// so strings.TrimSpace (which strips all Unicode space) must not
 					// be used here.
-					if !isBlank(child.Content()) {
+					if !xmlchar.IsAllSpace(child.Content()) {
 						msg := "Character content other than whitespace is not allowed because the content type is 'element-only'."
 						vc.reportValidityError(ctx, vc.filename, elem.Line(), elemDisplayName(elem), msg)
 						return fmt.Errorf("text content in element-only type")
@@ -889,7 +890,7 @@ func (vc *validationContext) validateEmptyContent(ctx context.Context, elem *hel
 			vc.reportValidityError(ctx, vc.filename, ce.Line(), ce.LocalName(), "This element is not expected.")
 			return fmt.Errorf("not expected")
 		case helium.TextNode, helium.CDATASectionNode:
-			if !isBlank(child.Content()) {
+			if !xmlchar.IsAllSpace(child.Content()) {
 				vc.reportValidityError(ctx, vc.filename, elem.Line(), elem.LocalName(), "Character content is not allowed, because the type definition is simple.")
 				return fmt.Errorf("not expected")
 			}
@@ -1198,15 +1199,6 @@ func elemTextContent(elem *helium.Element) string {
 	return string(buf)
 }
 
-func isBlank(b []byte) bool {
-	for _, c := range b {
-		if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
-			return false
-		}
-	}
-	return true
-}
-
 // checkXsiNil parses the element's xsi:nil attribute as an xs:boolean (after
 // whitespace collapse). It returns whether the element is nilled ("true"/"1").
 // "false"/"0" and an absent attribute mean not-nilled. Any other lexical form
@@ -1269,7 +1261,7 @@ func (vc *validationContext) validateNilledElement(ctx context.Context, elem *he
 				"This element is not expected, because the element '"+dn+"' is nilled.")
 			return fmt.Errorf("content in nilled element")
 		case helium.TextNode, helium.CDATASectionNode:
-			if !isBlank(child.Content()) {
+			if !xmlchar.IsAllSpace(child.Content()) {
 				vc.reportValidityError(ctx, vc.filename, elem.Line(), dn,
 					"Character content is not allowed, because the element is nilled.")
 				return fmt.Errorf("content in nilled element")

--- a/xslt3/compile.go
+++ b/xslt3/compile.go
@@ -877,16 +877,7 @@ func (c *compiler) checkQNamePrefix(_ context.Context, name, context string) err
 }
 
 func isValidQName(s string) bool {
-	if s == "" {
-		return false
-	}
-	parts := strings.SplitN(s, ":", 2)
-	for _, p := range parts {
-		if !xmlchar.IsValidNCName(p) {
-			return false
-		}
-	}
-	return true
+	return xmlchar.IsValidQName(s)
 }
 
 // resolveShadowAttributes processes shadow attributes on an XSLT element.

--- a/xslt3/compile.go
+++ b/xslt3/compile.go
@@ -524,10 +524,6 @@ func resolveQName(qname string, nsBindings map[string]string) string {
 	return qname
 }
 
-// isValidQName checks whether s is a valid xs:QName (NCName or NCName:NCName).
-// A minimal check: must be non-empty, no whitespace, no leading/trailing dots,
-// and if there is a colon there must be valid NCName parts on both sides.
-
 // isValidEQName checks whether s is a valid EQName (Q{uri}local).
 func isValidEQName(s string) bool {
 	if !strings.HasPrefix(s, "Q{") {
@@ -874,10 +870,6 @@ func (c *compiler) checkQNamePrefix(_ context.Context, name, context string) err
 		}
 	}
 	return nil
-}
-
-func isValidQName(s string) bool {
-	return xmlchar.IsValidQName(s)
 }
 
 // resolveShadowAttributes processes shadow attributes on an XSLT element.

--- a/xslt3/compile_formats.go
+++ b/xslt3/compile_formats.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 	"github.com/lestrrat-go/helium/xpath3"
 	"github.com/lestrrat-go/helium/xsd"
 )
@@ -109,7 +110,7 @@ func (c *compiler) compileKey(ctx context.Context, elem *helium.Element) error {
 	if name == "" {
 		return staticError(errCodeXTSE0110, "xsl:key requires name attribute")
 	}
-	if !isValidQName(name) && !isValidEQName(name) {
+	if !xmlchar.IsValidQName(name) && !isValidEQName(name) {
 		return staticError(errCodeXTSE0020, "invalid name %q on xsl:key", name)
 	}
 
@@ -251,7 +252,7 @@ func (c *compiler) compileOutput(ctx context.Context, elem *helium.Element) erro
 			default:
 				return staticError(errCodeXTSE1570, "invalid output method %q", methodStr)
 			}
-		} else if !isValidQName(methodStr) && !isValidEQName(methodStr) {
+		} else if !xmlchar.IsValidQName(methodStr) && !isValidEQName(methodStr) {
 			return staticError(errCodeXTSE1570, "invalid output method %q", methodStr)
 		}
 	}
@@ -727,7 +728,7 @@ func (c *compiler) compileAttributeSet(ctx context.Context, elem *helium.Element
 	if name == "" {
 		return staticError(errCodeXTSE0110, "xsl:attribute-set requires name attribute")
 	}
-	if !isValidQName(name) && !isValidEQName(name) {
+	if !xmlchar.IsValidQName(name) && !isValidEQName(name) {
 		return staticError(errCodeXTSE0020, "invalid name %q on xsl:attribute-set", name)
 	}
 	if err := c.checkQNamePrefix(ctx, name, "xsl:attribute-set"); err != nil {
@@ -895,7 +896,7 @@ func (c *compiler) compileDecimalFormat(ctx context.Context, elem *helium.Elemen
 	name := getAttr(elem, xslAttrName)
 	qn := xpath3.QualifiedName{}
 	if name != "" {
-		if !isValidQName(name) && !isValidEQName(name) {
+		if !xmlchar.IsValidQName(name) && !isValidEQName(name) {
 			return staticError(errCodeXTSE0020, "invalid name %q on xsl:decimal-format", name)
 		}
 		qn = xpath3.QualifiedName{Name: name}

--- a/xslt3/compile_instructions.go
+++ b/xslt3/compile_instructions.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/sequence"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 	"github.com/lestrrat-go/helium/xpath3"
 )
 
@@ -477,7 +478,7 @@ func (c *compiler) useWhenFunctionAvailable(_ context.Context, args []xpath3.Seq
 	name, _ := xpath3.AtomicToString(av)
 
 	// XTDE1400: function name must be a valid QName
-	if !strings.HasPrefix(name, "Q{") && !isValidQName(name) {
+	if !strings.HasPrefix(name, "Q{") && !xmlchar.IsValidQName(name) {
 		return nil, dynamicError(errCodeXTDE1400,
 			"function-available: %q is not a valid QName", name)
 	}

--- a/xslt3/compile_instructions_flow.go
+++ b/xslt3/compile_instructions_flow.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 )
 
 func (c *compiler) compileApplyTemplates(ctx context.Context, elem *helium.Element) (*applyTemplatesInst, error) {
@@ -18,7 +19,7 @@ func (c *compiler) compileApplyTemplates(ctx context.Context, elem *helium.Eleme
 	mode := strings.TrimSpace(getAttr(elem, "mode"))
 	// Validate mode name is a valid QName.
 	if mode != "" && mode[0] != '#' {
-		if !isValidQName(mode) && !isValidEQName(mode) {
+		if !xmlchar.IsValidQName(mode) && !isValidEQName(mode) {
 			return nil, staticError(errCodeXTSE0550, "invalid mode name %q on xsl:apply-templates", mode)
 		}
 		// XTSE0280: check for undeclared prefix.

--- a/xslt3/compile_streaming.go
+++ b/xslt3/compile_streaming.go
@@ -802,7 +802,7 @@ func (c *compiler) compileMerge(ctx context.Context, elem *helium.Element) (inst
 
 	// XTSE0020: merge-source name must be a valid xs:QName.
 	for _, src := range inst.Sources {
-		if src.Name != "" && !isValidQName(src.Name) {
+		if src.Name != "" && !xmlchar.IsValidQName(src.Name) {
 			return nil, staticError(errCodeXTSE0020, "xsl:merge-source @name %q is not a valid xs:QName", src.Name)
 		}
 	}

--- a/xslt3/compile_templates.go
+++ b/xslt3/compile_templates.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 	"github.com/lestrrat-go/helium/xpath3"
 )
 
@@ -106,7 +107,7 @@ func (c *compiler) compileTemplate(ctx context.Context, elem *helium.Element) er
 	}
 
 	nameAttr := strings.TrimSpace(getAttr(elem, "name"))
-	if nameAttr != "" && !isValidQName(nameAttr) && !isValidEQName(nameAttr) {
+	if nameAttr != "" && !xmlchar.IsValidQName(nameAttr) && !isValidEQName(nameAttr) {
 		return staticError(errCodeXTSE0020, "invalid name %q on xsl:template", nameAttr)
 	}
 	if nameAttr != "" {
@@ -164,7 +165,7 @@ func (c *compiler) compileTemplate(ctx context.Context, elem *helium.Element) er
 		seenModes := make(map[string]struct{}, len(modeFields))
 		hasAll := false
 		for _, m := range modeFields {
-			if m[0] != '#' && !isValidQName(m) && !isValidEQName(m) {
+			if m[0] != '#' && !xmlchar.IsValidQName(m) && !isValidEQName(m) {
 				return staticError(errCodeXTSE0550, "invalid mode name %q on xsl:template", m)
 			}
 			// XTSE0280: check for undeclared prefix in mode name.
@@ -599,7 +600,7 @@ func (c *compiler) compileParamDef(ctx context.Context, elem *helium.Element) (*
 	if name == "" {
 		return nil, staticError(errCodeXTSE0110, "xsl:param requires name attribute")
 	}
-	if !isValidQName(name) && !isValidEQName(name) {
+	if !xmlchar.IsValidQName(name) && !isValidEQName(name) {
 		return nil, staticError(errCodeXTSE0020, "invalid name %q on xsl:param", name)
 	}
 
@@ -728,7 +729,7 @@ func (c *compiler) compileGlobalVariable(ctx context.Context, elem *helium.Eleme
 	if name == "" {
 		return staticError(errCodeXTSE0110, "xsl:variable requires name attribute")
 	}
-	if !isValidQName(name) && !isValidEQName(name) {
+	if !xmlchar.IsValidQName(name) && !isValidEQName(name) {
 		return staticError(errCodeXTSE0020, "invalid name %q on xsl:variable", name)
 	}
 

--- a/xslt3/execute_element.go
+++ b/xslt3/execute_element.go
@@ -22,7 +22,7 @@ func (ec *execContext) execElement(ctx context.Context, inst *elementInst) error
 
 	// XTDE0820: validate computed name is a valid QName
 	name = strings.TrimSpace(name)
-	if name == "" || !isValidQName(name) {
+	if name == "" || !xmlchar.IsValidQName(name) {
 		return dynamicError(errCodeXTDE0820,
 			"invalid element name %q: not a valid QName", name)
 	}
@@ -626,7 +626,7 @@ func validateComputedAttributeName(name string, inst *attributeInst) error {
 	}
 
 	// XTDE0850: name must be a valid QName
-	if !isValidQName(name) && !isValidEQName(name) {
+	if !xmlchar.IsValidQName(name) && !isValidEQName(name) {
 		return dynamicError(errCodeXTDE0850,
 			"xsl:attribute name %q is not a valid QName", name)
 	}

--- a/xslt3/functions_introspect.go
+++ b/xslt3/functions_introspect.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/sequence"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 	"github.com/lestrrat-go/helium/xpath3"
 )
 
@@ -23,7 +24,7 @@ func (ec *execContext) fnElementAvailable(_ context.Context, args []xpath3.Seque
 	name, _ := xpath3.AtomicToString(av)
 
 	// XTDE1440: element name must be a valid QName or EQName
-	if !strings.HasPrefix(name, "Q{") && !isValidQName(name) {
+	if !strings.HasPrefix(name, "Q{") && !xmlchar.IsValidQName(name) {
 		return nil, dynamicError(errCodeXTDE1440,
 			"element-available: %q is not a valid EQName", name)
 	}
@@ -75,7 +76,7 @@ func (ec *execContext) fnFunctionAvailable(_ context.Context, args []xpath3.Sequ
 	name, _ := xpath3.AtomicToString(av)
 
 	// XTDE1400: function name must be a valid QName or EQName
-	if !strings.HasPrefix(name, "Q{") && !isValidQName(name) {
+	if !strings.HasPrefix(name, "Q{") && !xmlchar.IsValidQName(name) {
 		return nil, dynamicError(errCodeXTDE1400,
 			"function-available: %q is not a valid QName", name)
 	}
@@ -174,7 +175,7 @@ func (ec *execContext) fnTypeAvailable(_ context.Context, args []xpath3.Sequence
 	name, _ := xpath3.AtomicToString(av)
 
 	// XTDE1428: type name must be a valid QName or EQName
-	if !strings.HasPrefix(name, "Q{") && !isValidQName(name) {
+	if !strings.HasPrefix(name, "Q{") && !xmlchar.IsValidQName(name) {
 		return nil, dynamicError(errCodeXTDE1428,
 			"type-available: %q is not a valid EQName", name)
 	}
@@ -315,7 +316,7 @@ func (ec *execContext) accumulatorLookup(
 		return xpath3.EmptySequence(), nil //nolint:nilerr // accumulator lookup returns empty on string conversion failure
 	}
 	// XTDE3340: validate the name is a valid EQName
-	if !isValidQName(name) && !isValidEQName(name) {
+	if !xmlchar.IsValidQName(name) && !isValidEQName(name) {
 		return nil, dynamicError(errCodeXTDE3340, "%q is not a valid EQName for %s", name, fnName)
 	}
 	name = resolveQName(name, ec.stylesheet.namespaces)

--- a/xslt3/functions_key.go
+++ b/xslt3/functions_key.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/sequence"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 	"github.com/lestrrat-go/helium/xpath3"
 )
 
@@ -183,7 +184,7 @@ func (ec *execContext) fnSystemProperty(ctx context.Context, args []xpath3.Seque
 	}
 
 	// XTDE1390: validate that the argument is a valid QName or EQName.
-	if !strings.HasPrefix(name, "Q{") && !isValidQName(name) {
+	if !strings.HasPrefix(name, "Q{") && !xmlchar.IsValidQName(name) {
 		return nil, dynamicError(errCodeXTDE1390,
 			"system-property argument %q is not a valid QName", name)
 	}


### PR DESCRIPTION
- xsd/value reuses xmlchar Name/NCName predicates (A1)
- new xmlchar.IsAllSpace for root+xsd whitespace scans (lex-2)
- xslt3 reuses xmlchar.IsValidQName (A3)
- net-negative, behavior-preserving, internal-only