### PR TITLE
fix de/fr/it number-word spell-out in xpath3 and xslt3

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -99,6 +99,10 @@ linters:
           - misspell
         path: html/entities.go
       - linters:
+          - misspell
+          - goconst
+        path: (xpath3/format_integer|xslt3/number_words)
+      - linters:
           - godoclint
         path: (^|/)internal/
     paths:

--- a/xpath3/format_integer.go
+++ b/xpath3/format_integer.go
@@ -919,6 +919,9 @@ func int64ToGermanWords(n int64) string {
 	if n == 0 {
 		return "null"
 	}
+	if n < 0 {
+		return "minus " + int64ToGermanWords(-n)
+	}
 	ones := []string{"", "eins", "zwei", "drei", "vier", "fünf", "sechs", "sieben", "acht", "neun", "zehn",
 		"elf", "zwölf", "dreizehn", "vierzehn", "fünfzehn", "sechzehn", "siebzehn", "achtzehn", "neunzehn"}
 	tens := []string{"", "", "zwanzig", "dreißig", "vierzig", "fünfzig", "sechzig", "siebzig", "achtzig", "neunzig"}
@@ -935,6 +938,44 @@ func int64ToGermanWords(n int64) string {
 			unit = "ein"
 		}
 		return unit + "und" + tens[n/10]
+	}
+	if n < 1000 {
+		w := ones[n/100]
+		if w == "eins" {
+			w = "ein"
+		}
+		w += "hundert"
+		if n%100 != 0 {
+			w += int64ToGermanWords(n % 100)
+		}
+		return w
+	}
+	if n < 1000000 {
+		q := n / 1000
+		w := ""
+		if q == 1 {
+			w = "ein"
+		} else {
+			w = int64ToGermanWords(q)
+		}
+		w += "tausend"
+		if n%1000 != 0 {
+			w += int64ToGermanWords(n % 1000)
+		}
+		return w
+	}
+	if n < 1000000000 {
+		q := n / 1000000
+		w := ""
+		if q == 1 {
+			w = "eine Million "
+		} else {
+			w = int64ToGermanWords(q) + " Millionen "
+		}
+		if n%1000000 != 0 {
+			w += int64ToGermanWords(n % 1000000)
+		}
+		return w
 	}
 	return fmt.Sprintf("%d", n)
 }
@@ -1033,9 +1074,12 @@ func int64ToFrenchWords(n int64) string {
 	if n == 0 {
 		return "zéro"
 	}
+	if n < 0 {
+		return "moins " + int64ToFrenchWords(-n)
+	}
 	ones := []string{"", "un", "deux", "trois", "quatre", "cinq", "six", "sept", "huit", "neuf", "dix",
 		"onze", "douze", "treize", "quatorze", "quinze", "seize", "dix-sept", "dix-huit", "dix-neuf"}
-	tens := []string{"", "", "vingt", "trente", "quarantine", "cinquante", "soixante", "soixante", "quatre-vingt", "quatre-vingt"}
+	tens := []string{"", "", "vingt", "trente", "quarante", "cinquante", "soixante", "soixante", "quatre-vingt", "quatre-vingt"}
 
 	if n < 20 {
 		return ones[n]
@@ -1044,7 +1088,7 @@ func int64ToFrenchWords(n int64) string {
 		t := n / 10
 		u := n % 10
 		if t == 7 || t == 9 {
-			return tens[t] + "-" + ones[u+10]
+			u += 10
 		}
 		if u == 0 {
 			if t == 8 {
@@ -1052,10 +1096,45 @@ func int64ToFrenchWords(n int64) string {
 			}
 			return tens[t]
 		}
-		if u == 1 && t != 8 {
-			return tens[t] + " et un"
+		sep := "-"
+		if u == 1 && t != 8 && t != 9 {
+			sep = " et "
 		}
-		return tens[t] + "-" + ones[u]
+		if u == 11 && t == 7 {
+			sep = " et "
+		}
+		return tens[t] + sep + ones[u]
+	}
+	if n < 1000 {
+		q := n / 100
+		w := ""
+		if q == 1 {
+			w = "cent"
+		} else {
+			w = ones[q] + " cent"
+		}
+		r := n % 100
+		if r == 0 && q > 1 {
+			w += "s"
+		}
+		if r != 0 {
+			w += " " + int64ToFrenchWords(r)
+		}
+		return w
+	}
+	if n < 1000000 {
+		q := n / 1000
+		w := ""
+		if q == 1 {
+			w = "mille"
+		} else {
+			w = int64ToFrenchWords(q) + " mille"
+		}
+		r := n % 1000
+		if r != 0 {
+			w += " " + int64ToFrenchWords(r)
+		}
+		return w
 	}
 	return fmt.Sprintf("%d", n)
 }
@@ -1083,6 +1162,9 @@ func int64ToItalianWords(n int64) string {
 	if n == 0 {
 		return "zero"
 	}
+	if n < 0 {
+		return "meno " + int64ToItalianWords(-n)
+	}
 	ones := []string{"", "uno", "due", "tre", "quattro", "cinque", "sei", "sette", "otto", "nove", "dieci",
 		"undici", "dodici", "tredici", "quattordici", "quindici", "sedici", "diciassette", "diciotto", "diciannove"}
 	tens := []string{"", "", "venti", "trenta", "quaranta", "cinquanta", "sessanta", "settanta", "ottanta", "novanta"}
@@ -1101,6 +1183,34 @@ func int64ToItalianWords(n int64) string {
 			base = base[:len(base)-1]
 		}
 		return base + ones[u]
+	}
+	if n < 1000 {
+		q := n / 100
+		w := ""
+		if q == 1 {
+			w = "cento"
+		} else {
+			w = ones[q] + "cento"
+		}
+		r := n % 100
+		if r != 0 {
+			w += int64ToItalianWords(r)
+		}
+		return w
+	}
+	if n < 1000000 {
+		q := n / 1000
+		w := ""
+		if q == 1 {
+			w = "mille"
+		} else {
+			w = int64ToItalianWords(q) + "mila"
+		}
+		r := n % 1000
+		if r != 0 {
+			w += int64ToItalianWords(r)
+		}
+		return w
 	}
 	return fmt.Sprintf("%d", n)
 }

--- a/xpath3/format_integer_test.go
+++ b/xpath3/format_integer_test.go
@@ -116,6 +116,56 @@ func TestFormatIntegerCJK(t *testing.T) {
 	}
 }
 
+// German/French/Italian cardinal spell-out (picture "w") must be complete
+// beyond 100 (hundreds, thousands, millions) and free of the historical
+// "quarantine" typo for French 40. Previously these degraded to decimal digits
+// above 100 and emitted "quarantine" for 40-49. Reference algorithm is shared
+// with xslt3/number_words.go.
+func TestFormatIntegerWordsCardinal(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		value  string
+		lang   string
+		expect string
+	}{
+		// French: typo fix + completeness
+		{"40", "fr", "quarante"},
+		{"41", "fr", "quarante et un"},
+		{"42", "fr", "quarante-deux"},
+		{"71", "fr", "soixante et onze"},
+		{"80", "fr", "quatre-vingts"},
+		{"81", "fr", "quatre-vingt-un"},
+		{"91", "fr", "quatre-vingt-onze"},
+		{"100", "fr", "cent"},
+		{"123", "fr", "cent vingt-trois"},
+		{"200", "fr", "deux cents"},
+		{"201", "fr", "deux cent un"},
+		{"1000", "fr", "mille"},
+		{"2345", "fr", "deux mille trois cent quarante-cinq"},
+		// German: completeness
+		{"40", "de", "vierzig"},
+		{"100", "de", "einhundert"},
+		{"123", "de", "einhundertdreiundzwanzig"},
+		{"1000", "de", "eintausend"},
+		{"2345", "de", "zweitausenddreihundertfünfundvierzig"},
+		{"1000000", "de", "eine million "},
+		{"2000000", "de", "zwei millionen "},
+		// Italian: completeness
+		{"40", "it", "quaranta"},
+		{"100", "it", "cento"},
+		{"123", "it", "centoventitre"},
+		{"1000", "it", "mille"},
+		{"2345", "it", "duemilatrecentoquarantacinque"},
+	}
+	for _, tc := range cases {
+		expr := `format-integer(` + tc.value + `, "w", "` + tc.lang + `")`
+		result, err := evaluate(t.Context(), nil, expr)
+		require.NoError(t, err, expr)
+		require.Equal(t, tc.expect, result.StringValue(), expr)
+	}
+}
+
 // The atomize-first rewrite must not materialize a large sequence just to reject
 // it on cardinality — it stops at the second atomized item.
 func TestStringArgRejectsLongSequencePromptly(t *testing.T) {

--- a/xslt3/number_words.go
+++ b/xslt3/number_words.go
@@ -436,7 +436,7 @@ func frenchCardinal(n int) string {
 		return ones[n]
 	}
 	if n < 100 {
-		tens := []string{"", "", "vingt", "trente", "quarantine", "cinquante", "soixante", "soixante", "quatre-vingt", "quatre-vingt"}
+		tens := []string{"", "", "vingt", "trente", "quarante", "cinquante", "soixante", "soixante", "quatre-vingt", "quatre-vingt"}
 		t := n / 10
 		o := n % 10
 		if t == 7 || t == 9 {

--- a/xslt3/number_words_test.go
+++ b/xslt3/number_words_test.go
@@ -1,0 +1,24 @@
+package xslt3
+
+import "testing"
+
+func TestFrenchCardinalTens(t *testing.T) {
+	cases := []struct {
+		n    int
+		want string
+	}{
+		{40, "quarante"},
+		{41, "quarante et un"},
+		{42, "quarante-deux"},
+		{45, "quarante-cinq"},
+		{49, "quarante-neuf"},
+		{71, "soixante et onze"},
+		{80, "quatre-vingts"},
+		{91, "quatre-vingt-onze"},
+	}
+	for _, tc := range cases {
+		if got := frenchCardinal(tc.n); got != tc.want {
+			t.Errorf("frenchCardinal(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
- fix French quarantine->quarante typo in xpath3/format_integer.go and xslt3/number_words.go
- complete de/fr/it spell-out beyond 100 (was degrading to digits)
- add tests in both packages