### PR TITLE
extract internal/iolimit bounded-read helper

### DIFF
--- a/internal/iolimit/iolimit.go
+++ b/internal/iolimit/iolimit.go
@@ -1,0 +1,24 @@
+// Package iolimit provides a bounded read-all helper shared by the parser,
+// xinclude, and xslt3 resource loaders. It is a stdlib-only leaf package and
+// never imports back into helium.
+package iolimit
+
+import (
+	"io"
+	"math"
+)
+
+// ReadAll reads from r through a LimitReader sized limit+1 (overflow-guarded for
+// limit==math.MaxInt64), so a source exactly at the cap is accepted while
+// anything larger is detected. It returns the raw bytes, exceeded=true when more
+// than limit bytes were read, and any read error. It formats no error and picks
+// no sentinel: callers map exceeded to their own error and choose the
+// error-vs-size ordering.
+func ReadAll(r io.Reader, limit int64) (data []byte, exceeded bool, err error) {
+	readLimit := limit
+	if readLimit < math.MaxInt64 {
+		readLimit++
+	}
+	data, err = io.ReadAll(io.LimitReader(r, readLimit))
+	return data, int64(len(data)) > limit, err
+}

--- a/parser_entity_decl.go
+++ b/parser_entity_decl.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/lestrrat-go/helium/enum"
+	"github.com/lestrrat-go/helium/internal/iolimit"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/sax"
 	"github.com/lestrrat-go/pdebug"
@@ -602,12 +603,12 @@ func (pctx *parserCtx) parseExternalEntityPrivate(ctx context.Context, uri, exte
 	// "/dev/zero") cannot exhaust memory. LimitReader allows one extra byte so a
 	// content length exactly at the cap is accepted while anything larger is
 	// detected.
-	content, err := io.ReadAll(io.LimitReader(input, externalEntityMaxBytes+1))
+	content, exceeded, err := iolimit.ReadAll(input, externalEntityMaxBytes)
 	closeInput()
 	if err != nil {
 		return nil, pctx.error(ctx, fmt.Errorf("reading external entity: %w", err))
 	}
-	if int64(len(content)) > externalEntityMaxBytes {
+	if exceeded {
 		return nil, pctx.error(ctx, fmt.Errorf("external entity (URI=%s) exceeds maximum size of %d bytes", uri, externalEntityMaxBytes))
 	}
 

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"errors"
 	"io"
-	"math"
 	"net/url"
 	"path/filepath"
 	"strings"
 
 	"github.com/lestrrat-go/helium/enum"
 	"github.com/lestrrat-go/helium/internal/iofs"
+	"github.com/lestrrat-go/helium/internal/iolimit"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/strcursor"
 	"github.com/lestrrat-go/helium/sax"
@@ -449,17 +449,7 @@ func (t *TreeBuilder) ExternalSubset(ctxif context.Context, name, eid, uri strin
 	if limit <= 0 {
 		limit = MaxExternalDTDSize
 	}
-	// Read one byte past the cap so a source that under-reports (or lies about)
-	// its size is still caught, but guard against overflow: int64(limit)+1
-	// wraps to a negative value for limit==math.MaxInt on 64-bit platforms,
-	// which would make io.LimitReader read zero bytes and silently skip a valid
-	// DTD.
-	limit64 := int64(limit)
-	readLimit := limit64
-	if readLimit < math.MaxInt64 {
-		readLimit++
-	}
-	data, readErr := io.ReadAll(io.LimitReader(f, readLimit))
+	data, exceeded, readErr := iolimit.ReadAll(f, int64(limit))
 	// Close the file immediately once the bounded read completes, before the
 	// already-buffered DTD is parsed, so the descriptor is not held open for
 	// the lifetime of the parse.
@@ -468,7 +458,7 @@ func (t *TreeBuilder) ExternalSubset(ctxif context.Context, name, eid, uri strin
 	// Enforce the cap authoritatively against the bytes actually read, before
 	// inspecting the read error: a reader that returns n>0 alongside a
 	// non-EOF error on the cap-crossing read must still be rejected.
-	if int64(len(data)) > limit64 {
+	if exceeded {
 		return ErrExternalDTDTooLarge
 	}
 	// A non-EOF read error (e.g. io.ErrUnexpectedEOF or a transport failure)

--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"math"
 	"net/url"
 	"path"
 	"path/filepath"
@@ -17,6 +16,7 @@ import (
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/encoding"
 	"github.com/lestrrat-go/helium/internal/iofs"
+	"github.com/lestrrat-go/helium/internal/iolimit"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/xpointer"
 )
@@ -692,18 +692,9 @@ func (p *processor) readCapped(r io.Reader) ([]byte, error) {
 	if limit <= 0 {
 		limit = MaxIncludeSize
 	}
-	limit64 := int64(limit)
 
-	// Read one byte past the cap so a resource exactly at the limit succeeds
-	// while anything larger is detected, guarding against overflow when
-	// limit==math.MaxInt on 64-bit platforms (int64(limit)+1 would wrap).
-	readLimit := limit64
-	if readLimit < math.MaxInt64 {
-		readLimit++
-	}
-
-	data, err := io.ReadAll(io.LimitReader(r, readLimit))
-	if int64(len(data)) > limit64 {
+	data, exceeded, err := iolimit.ReadAll(r, int64(limit))
+	if exceeded {
 		return nil, ErrIncludeTooLarge
 	}
 	if err != nil {

--- a/xslt3/resource_limit.go
+++ b/xslt3/resource_limit.go
@@ -3,7 +3,8 @@ package xslt3
 import (
 	"errors"
 	"io"
-	"math"
+
+	"github.com/lestrrat-go/helium/internal/iolimit"
 )
 
 // MaxResourceBytes is the default maximum number of bytes read from a single
@@ -50,16 +51,8 @@ func readResourceBounded(r io.Reader, limit int64) ([]byte, error) {
 		return data, nil
 	}
 
-	// Read one byte past the cap so a resource exactly at the limit succeeds
-	// while anything larger is detected. Guard against overflow even though the
-	// fixed limit is well below math.MaxInt64.
-	readLimit := limit
-	if readLimit < math.MaxInt64 {
-		readLimit++
-	}
-
-	data, err := io.ReadAll(io.LimitReader(r, readLimit))
-	if int64(len(data)) > limit {
+	data, exceeded, err := iolimit.ReadAll(r, limit)
+	if exceeded {
 		return nil, ErrResourceTooLarge
 	}
 	if err != nil {


### PR DESCRIPTION
- new leaf internal/iolimit raw-return ReadAll(limit)
- 4 callers reuse it, each keeps own sentinel/error + ordering
- net-negative, behavior-preserving, internal-only