### PR TITLE
route tiny ASCII char-class predicates to internal/xmlchar

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -9,7 +9,7 @@ shim           → helium, stream, enum, internal/encoding, internal/xmlchar
 xinclude       → helium, xpointer, internal/encoding, internal/iofs, internal/lexicon
                   → xpath1 (via xpointer)
                   → internal/xmlchar (via xpointer)
-xpath3         → helium, internal/xpath, internal/lexicon, internal/icu, internal/unparsedtext, internal/strcursor, internal/sequence, internal/xsdregex
+xpath3         → helium, internal/xpath, internal/lexicon, internal/icu, internal/unparsedtext, internal/strcursor, internal/sequence, internal/xsdregex, internal/xmlchar
 xslt3          → helium, xpath3, xsd, html, internal/lexicon, internal/sequence, internal/xpathstream, xslt3/internal/elements
 xsd            → helium, xpath1, internal/lexicon, internal/xsd/value, internal/xsdregex
 relaxng        → helium, internal/lexicon, internal/iofs, internal/xsd/value, internal/xmlchar
@@ -18,8 +18,8 @@ xpointer       → helium, xpath1, internal/xmlchar
 c14n           → helium
 xmldsig1       → helium, c14n, internal/lexicon
 xmlenc1        → helium
-html           → helium, sax, push
-catalog        → helium, internal/catalog, internal/lexicon
+html           → helium, sax, push, internal/xmlchar
+catalog        → helium, internal/catalog, internal/lexicon, internal/xmlchar
 stream         → internal/encoding, internal/xmlchar
 sax            → helium, enum
 helium (root)  → sax, enum, internal/encoding, internal/bitset, internal/parser, push, internal/stack
@@ -31,7 +31,7 @@ push → (none)
 internal/heliumtest → (none)
 internal/sequence → (none)
 internal/strcursor → (none)
-internal/unparsedtext → (none)
+internal/unparsedtext → internal/xmlchar
 internal/xsdregex → (none)
 internal/xsd/value → internal/lexicon
 internal/xpathstream → xpath3

--- a/catalog/load.go
+++ b/catalog/load.go
@@ -12,6 +12,7 @@ import (
 	helium "github.com/lestrrat-go/helium"
 	icatalog "github.com/lestrrat-go/helium/internal/catalog"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 )
 
 // goosWindows is the runtime.GOOS value for Windows. Drive-letter handling in
@@ -221,21 +222,17 @@ func fileURIPath(p string) string {
 func fileURIPathFor(goos, p string) string {
 	// On Windows, detect a drive-letter path of the form "/C:/...": a leading
 	// slash followed by a single ASCII letter and a colon, and strip the slash.
-	if goos == goosWindows && len(p) >= 3 && p[0] == '/' && isASCIILetter(p[1]) && p[2] == ':' {
+	if goos == goosWindows && len(p) >= 3 && p[0] == '/' && xmlchar.IsASCIILetter(p[1]) && p[2] == ':' {
 		p = p[1:]
 	}
 	return filepath.FromSlash(p)
-}
-
-func isASCIILetter(c byte) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 }
 
 // hasDriveLetterPrefix reports whether s begins with a Windows drive-letter
 // prefix such as "C:\" or "C:/". This is checked independently of the host OS
 // so a drive-letter reference is never mistaken for a URI scheme.
 func hasDriveLetterPrefix(s string) bool {
-	return len(s) >= 3 && isASCIILetter(s[0]) && s[1] == ':' &&
+	return len(s) >= 3 && xmlchar.IsASCIILetter(s[0]) && s[1] == ':' &&
 		(s[2] == '\\' || s[2] == '/')
 }
 

--- a/html/parser.go
+++ b/html/parser.go
@@ -12,6 +12,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/lestrrat-go/helium/internal/strcursor"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 )
 
 // insertMode tracks the parser's insertion context.
@@ -1065,10 +1066,10 @@ func (p *parser) scanNumericCharRef() (codepoint int, haveDigits bool) {
 	_ = p.cur.Advance(1) // skip '#'
 	if p.cur.Peek() == 'x' || p.cur.Peek() == 'X' {
 		_ = p.cur.Advance(1) // skip 'x'
-		hexStr := p.parseWhile(isHexDigit)
+		hexStr := p.parseWhile(xmlchar.IsHexDigit)
 		codepoint, haveDigits = parseNumericCharRef(hexStr, 16)
 	} else {
-		numStr := p.parseWhile(isDigit)
+		numStr := p.parseWhile(xmlchar.IsASCIIDigit)
 		codepoint, haveDigits = parseNumericCharRef(numStr, 10)
 	}
 	if p.cur.Peek() == ';' {
@@ -1173,10 +1174,10 @@ func (p *parser) parseCharRefBounded(ctx context.Context, limit int) {
 	if p.cur.Peek() == '#' {
 		_ = p.cur.Advance(1) // skip '#'
 		base := 10
-		pred := isDigit
+		pred := xmlchar.IsASCIIDigit
 		if p.cur.Peek() == 'x' || p.cur.Peek() == 'X' {
 			base = 16
-			pred = isHexDigit
+			pred = xmlchar.IsHexDigit
 			_ = p.cur.Advance(1) // skip 'x'
 		}
 		// Consume the digit run in bounded chunks, accumulating the code point
@@ -2276,19 +2277,11 @@ func isASCIIAlpha(b byte) bool {
 }
 
 func isNameChar(b byte) bool {
-	return isASCIIAlpha(b) || isDigit(b) || b == ':' || b == '-' || b == '_' || b == '.'
-}
-
-func isDigit(b byte) bool {
-	return b >= '0' && b <= '9'
-}
-
-func isHexDigit(b byte) bool {
-	return isDigit(b) || (b >= 'a' && b <= 'f') || (b >= 'A' && b <= 'F')
+	return isASCIIAlpha(b) || xmlchar.IsASCIIDigit(b) || b == ':' || b == '-' || b == '_' || b == '.'
 }
 
 func isAlphanumeric(b byte) bool {
-	return isASCIIAlpha(b) || isDigit(b)
+	return isASCIIAlpha(b) || xmlchar.IsASCIIDigit(b)
 }
 
 func isWhitespaceByte(b byte) bool {

--- a/internal/iofs/iofs.go
+++ b/internal/iofs/iofs.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 )
 
 // goosWindows is the runtime.GOOS value for Windows. Drive-letter handling in
@@ -79,12 +81,8 @@ func FileURIToPath(ref string) (string, error) {
 // untouched. goos is threaded explicitly so the conversion is deterministically
 // testable on a non-Windows CI host.
 func fileURIPathFor(goos, p string) string {
-	if goos == goosWindows && len(p) >= 3 && p[0] == '/' && isASCIILetter(p[1]) && p[2] == ':' {
+	if goos == goosWindows && len(p) >= 3 && p[0] == '/' && xmlchar.IsASCIILetter(p[1]) && p[2] == ':' {
 		p = p[1:]
 	}
 	return filepath.FromSlash(p)
-}
-
-func isASCIILetter(c byte) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 }

--- a/internal/unparsedtext/unparsedtext.go
+++ b/internal/unparsedtext/unparsedtext.go
@@ -32,6 +32,7 @@ import (
 
 	iencoding "github.com/lestrrat-go/helium/internal/encoding"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 )
 
 // URIResolver resolves a URI to a readable stream.
@@ -716,17 +717,13 @@ func ValidatePercentEncoding(uri string) error {
 			if i+2 >= len(uri) {
 				return fmt.Errorf("incomplete percent-encoding at position %d", i)
 			}
-			if !isHexDigit(uri[i+1]) || !isHexDigit(uri[i+2]) {
+			if !xmlchar.IsHexDigit(uri[i+1]) || !xmlchar.IsHexDigit(uri[i+2]) {
 				return fmt.Errorf("invalid percent-encoding %%%c%c", uri[i+1], uri[i+2])
 			}
 			i += 2
 		}
 	}
 	return nil
-}
-
-func isHexDigit(b byte) bool {
-	return (b >= '0' && b <= '9') || (b >= 'a' && b <= 'f') || (b >= 'A' && b <= 'F')
 }
 
 func isWindowsDriveScheme(parsed *url.URL) bool {

--- a/internal/xmlchar/xmlchar.go
+++ b/internal/xmlchar/xmlchar.go
@@ -121,6 +121,21 @@ func isEncNameStart(c byte) bool {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 }
 
+// IsHexDigit reports whether b is an ASCII hexadecimal digit ([0-9a-fA-F]).
+func IsHexDigit(b byte) bool {
+	return (b >= '0' && b <= '9') || (b >= 'a' && b <= 'f') || (b >= 'A' && b <= 'F')
+}
+
+// IsASCIILetter reports whether b is an ASCII letter ([a-zA-Z]).
+func IsASCIILetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+// IsASCIIDigit reports whether b is an ASCII decimal digit ([0-9]).
+func IsASCIIDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}
+
 func isEncNameChar(c byte) bool {
 	return isEncNameStart(c) || (c >= '0' && c <= '9') ||
 		c == '.' || c == '_' || c == '-'

--- a/xpath3/functions_uri.go
+++ b/xpath3/functions_uri.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/unparsedtext"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 )
 
 func init() {
@@ -70,7 +71,7 @@ func fnIRIToURI(_ context.Context, args []Sequence) (Sequence, error) {
 	var b strings.Builder
 	for i := range len(s) {
 		c := s[i]
-		if c == '%' && i+2 < len(s) && isHexDigit(s[i+1]) && isHexDigit(s[i+2]) {
+		if c == '%' && i+2 < len(s) && xmlchar.IsHexDigit(s[i+1]) && xmlchar.IsHexDigit(s[i+2]) {
 			// Already percent-encoded: pass through
 			b.WriteByte(c)
 			continue

--- a/xpath3/uri_resolution.go
+++ b/xpath3/uri_resolution.go
@@ -60,10 +60,6 @@ func resolveURIReference(base, ref string) (string, error) {
 	return result, nil
 }
 
-func isHexDigit(b byte) bool {
-	return (b >= '0' && b <= '9') || (b >= 'a' && b <= 'f') || (b >= 'A' && b <= 'F')
-}
-
 func indexScheme(raw string) int {
 	for i := range len(raw) {
 		switch raw[i] {


### PR DESCRIPTION
- xmlchar.IsHexDigit/IsASCIILetter/IsASCIIDigit
- delete duplicate copies in unparsedtext, xpath3, html, iofs, catalog; inline at call sites
- net-negative, behavior-preserving, internal-only