### PR TITLE
document intentional non-consolidations

### DIFF
--- a/internal/xsd/value/compare.go
+++ b/internal/xsd/value/compare.go
@@ -628,6 +628,11 @@ func CompareFloatFacetBound(a, b, builtinLocal string) (int, bool) {
 	return compareFloat(a, b, builtinLocal == lexicon.TypeFloat)
 }
 
+// xsdDateTime is a deliberately separate date/time model from xpath3's
+// time.Time-based date path (xpath3/cast_datetime.go). time.Time cannot hold the
+// arbitrary expanded years or exact fractional seconds that XSD 1.1 date/time
+// value-space comparison requires (see the year and sec fields below), so the
+// two parsers are not consolidated despite accepting the same lexical forms.
 type xsdDateTime struct {
 	// year is held with arbitrary precision so that valid expanded years
 	// (e.g. 999999999999999999999999) compare correctly rather than

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1931,6 +1931,10 @@ func validateWithParams(value, typeName string, params []*param) int {
 // and falling back to it would silently compare lengths in the wrong unit. A
 // value that has passed lexical validation for typeName decodes successfully, so
 // this only guards against an undecodable value reaching the facet check.
+//
+// xsd has a same-named facetLength (xsd/simplevalue_facets.go) that deliberately
+// approximates binary lengths instead of strict-decoding; the two are kept
+// separate on purpose — see that function's comment.
 func facetLength(value, typeName string) (int, bool) {
 	switch typeName {
 	case "NMTOKENS", "IDREFS", "ENTITIES":

--- a/xsd/simplevalue_facets.go
+++ b/xsd/simplevalue_facets.go
@@ -393,6 +393,12 @@ func countFractionDigits(value string) int {
 
 // facetLength returns the effective length of a value for facet checking.
 // The interpretation depends on the builtin base type.
+//
+// Deliberately NOT shared with relaxng's same-named facetLength
+// (relaxng/validate.go): this approximates hexBinary length as len/2 and
+// base64Binary as len*3/4, whereas relaxng strict-decodes the binary value (and
+// also handles list types). They are kept separate because adopting the strict
+// variant here would change xsd's golden-validated facet error output.
 func facetLength(value, builtinLocal string) int {
 	switch builtinLocal {
 	case "hexBinary":


### PR DESCRIPTION
- xsd/relaxng facetLength: note the deliberate approximate-vs-strict split (both sides cross-reference)
- internal/xsd/value xsdDateTime: note the deliberate time.Time-vs-big.Int/Rat split with xpath3
- comment-only; no code/behavior change