### PR TITLE
fix codeql trigger branch master to main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '30 2 * * 1'
 


### PR DESCRIPTION
- CodeQL workflow filtered `push`/`pull_request` to `master`, a branch that does not exist; default branch is `main`
- effect: CodeQL ran only via weekly schedule, never on pushes or PRs
- point both triggers at `main`