### PR TITLE
add tests to raise public package coverage

### DIFF
--- a/c14n/coverage_writer_test.go
+++ b/c14n/coverage_writer_test.go
@@ -54,7 +54,7 @@ func TestWriterErrorsPropagate(t *testing.T) {
 			`<root>body</root>` + "\n" +
 			`<?pi-after more?>` + "\n" +
 			`<!-- comment after -->`,
-		"cdata": `<r><![CDATA[a<b & c]]></r>`,
+		"cdata":             `<r><![CDATA[a<b & c]]></r>`,
 		"pi-comment-inline": `<r><?inline pidata?><!-- inline comment -->text</r>`,
 		"pi-no-data":        `<r><?bare?></r>`,
 	}
@@ -67,7 +67,7 @@ func TestWriterErrorsPropagate(t *testing.T) {
 			require.NoError(t, err, "baseline canonicalize")
 			require.NotEmpty(t, full)
 
-			for limit := 0; limit < len(full); limit++ {
+			for limit := range full {
 				w := &failWriter{limit: limit}
 				err := c14n.NewCanonicalizer(c14n.C14N11).Comments().Canonicalize(doc, w)
 				require.Error(t, err, "limit=%d should error", limit)
@@ -91,7 +91,7 @@ func TestWriterErrorsExclusive(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, full)
 
-	for limit := 0; limit < len(full); limit++ {
+	for limit := range full {
 		w := &failWriter{limit: limit}
 		err := c14n.NewCanonicalizer(c14n.ExclusiveC14N10).
 			InclusiveNamespaces([]string{"b"}).

--- a/c14n/coverage_writer_test.go
+++ b/c14n/coverage_writer_test.go
@@ -1,0 +1,101 @@
+package c14n_test
+
+import (
+	"errors"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/c14n"
+	"github.com/stretchr/testify/require"
+)
+
+// failWriter writes successfully for the first `limit` bytes, then returns an
+// error. By varying limit, tests can trip individual io.WriteString / escape
+// error-return branches in the canonicalizer that are otherwise unreachable
+// through an in-memory bytes.Buffer.
+type failWriter struct {
+	limit   int
+	written int
+}
+
+var errFailWriter = errors.New("failWriter: limit reached")
+
+func (w *failWriter) Write(p []byte) (int, error) {
+	remaining := w.limit - w.written
+	if remaining <= 0 {
+		return 0, errFailWriter
+	}
+	if len(p) <= remaining {
+		w.written += len(p)
+		return len(p), nil
+	}
+	w.written += remaining
+	return remaining, errFailWriter
+}
+
+func parseDoc(t *testing.T, src string) *helium.Document {
+	t.Helper()
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err, "parse %q", src)
+	return doc
+}
+
+// TestWriterErrorsPropagate runs canonicalization against a writer that fails
+// at every byte boundary from 0 up to the full output length. Every failure
+// must surface as an error rather than a panic or silent success. This walks
+// the writer-error return branches throughout the canonicalizer.
+func TestWriterErrorsPropagate(t *testing.T) {
+	docs := map[string]string{
+		"element-attrs": `<?xml version="1.0"?>` +
+			`<r xmlns="urn:d" xmlns:a="urn:a" a:x="1" b="two&amp;more"><c>te&lt;xt</c></r>`,
+		"pi-comment-around-root": `<?xml version="1.0"?>` +
+			`<?pi-before data?>` + "\n" +
+			`<!-- comment before -->` + "\n" +
+			`<root>body</root>` + "\n" +
+			`<?pi-after more?>` + "\n" +
+			`<!-- comment after -->`,
+		"cdata": `<r><![CDATA[a<b & c]]></r>`,
+		"pi-comment-inline": `<r><?inline pidata?><!-- inline comment -->text</r>`,
+		"pi-no-data":        `<r><?bare?></r>`,
+	}
+
+	for name, src := range docs {
+		t.Run(name, func(t *testing.T) {
+			doc := parseDoc(t, src)
+
+			full, err := c14n.NewCanonicalizer(c14n.C14N11).Comments().CanonicalizeTo(doc)
+			require.NoError(t, err, "baseline canonicalize")
+			require.NotEmpty(t, full)
+
+			for limit := 0; limit < len(full); limit++ {
+				w := &failWriter{limit: limit}
+				err := c14n.NewCanonicalizer(c14n.C14N11).Comments().Canonicalize(doc, w)
+				require.Error(t, err, "limit=%d should error", limit)
+			}
+
+			// Full length must succeed.
+			w := &failWriter{limit: len(full)}
+			require.NoError(t, c14n.NewCanonicalizer(c14n.C14N11).Comments().Canonicalize(doc, w))
+		})
+	}
+}
+
+// TestWriterErrorsExclusive exercises the exclusive-mode namespace rendering
+// writer-error branches.
+func TestWriterErrorsExclusive(t *testing.T) {
+	doc := parseDoc(t, `<r xmlns:a="urn:a" xmlns:b="urn:b" a:x="1"><a:c b:y="2">t</a:c></r>`)
+
+	full, err := c14n.NewCanonicalizer(c14n.ExclusiveC14N10).
+		InclusiveNamespaces([]string{"b"}).
+		CanonicalizeTo(doc)
+	require.NoError(t, err)
+	require.NotEmpty(t, full)
+
+	for limit := 0; limit < len(full); limit++ {
+		w := &failWriter{limit: limit}
+		err := c14n.NewCanonicalizer(c14n.ExclusiveC14N10).
+			InclusiveNamespaces([]string{"b"}).
+			Canonicalize(doc, w)
+		require.Error(t, err, "limit=%d should error", limit)
+	}
+}

--- a/catalog/coverage_load_test.go
+++ b/catalog/coverage_load_test.go
@@ -210,7 +210,6 @@ func TestNilContextLoad(t *testing.T) {
 </catalog>`
 	require.NoError(t, os.WriteFile(p, []byte(xml), 0o600))
 
-	//nolint:staticcheck // intentionally passing nil ctx to exercise the guard
 	var nilCtx context.Context
 	cat, err := catalog.NewLoader().Load(nilCtx, p)
 	require.NoError(t, err)

--- a/catalog/coverage_load_test.go
+++ b/catalog/coverage_load_test.go
@@ -1,0 +1,218 @@
+package catalog_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/catalog"
+	"github.com/stretchr/testify/require"
+)
+
+// loadCatalogString writes xml to a temp file and loads it, returning the
+// catalog and the slice of errors the loader's ErrorHandler collected.
+func loadCatalogString(t *testing.T, xml string) (*catalog.Catalog, []error) {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "catalog.xml")
+	require.NoError(t, os.WriteFile(p, []byte(xml), 0o600))
+
+	ec := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	cat, err := catalog.NewLoader().ErrorHandler(ec).Load(t.Context(), p)
+	require.NoError(t, err)
+	require.NoError(t, ec.Close())
+	return cat, ec.Errors()
+}
+
+// TestZeroValueLoaderClone exercises Loader.clone() when cfg is nil (the
+// zero-value Loader path) via MaxBytes, which calls clone internally.
+func TestZeroValueLoaderClone(t *testing.T) {
+	var l catalog.Loader // zero value: cfg is nil
+	l2 := l.MaxBytes(4096)
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "catalog.xml")
+	xml := `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <system systemId="sid" uri="out.dtd"/>
+</catalog>`
+	require.NoError(t, os.WriteFile(p, []byte(xml), 0o600))
+
+	cat, err := l2.Load(t.Context(), p)
+	require.NoError(t, err)
+	require.NotNil(t, cat)
+}
+
+// TestZeroValueLoaderErrorHandlerClone exercises clone() with nil cfg through
+// ErrorHandler.
+func TestZeroValueLoaderErrorHandlerClone(t *testing.T) {
+	var l catalog.Loader
+	ec := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	l2 := l.ErrorHandler(ec)
+	require.NotNil(t, l2)
+}
+
+// TestGroupNesting drives parseEntries recursion into <group> and the
+// per-element prefer attribute.
+func TestGroupNesting(t *testing.T) {
+	cat, errs := loadCatalogString(t, `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <group prefer="public">
+    <public publicId="-//Example//DTD//EN" uri="grouped.dtd"/>
+  </group>
+</catalog>`)
+	require.Empty(t, errs)
+	got := cat.Resolve(t.Context(), "-//Example//DTD//EN", "")
+	require.True(t, strings.HasSuffix(got, "grouped.dtd"), "resolved %q", got)
+}
+
+// TestMissingURIAttr drives appendNameURLEntry -> catalogMissingAttr for the
+// missing-url branch (val2 == "").
+func TestMissingURIAttr(t *testing.T) {
+	_, errs := loadCatalogString(t, `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <system systemId="sid"/>
+</catalog>`)
+	require.NotEmpty(t, errs)
+	require.Contains(t, errs[0].Error(), "uri")
+}
+
+// TestMissingNameAttr drives catalogMissingAttr for the missing-name branch
+// (val1 == "").
+func TestMissingNameAttr(t *testing.T) {
+	_, errs := loadCatalogString(t, `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <system uri="out.dtd"/>
+</catalog>`)
+	require.NotEmpty(t, errs)
+	require.Contains(t, errs[0].Error(), "systemId")
+}
+
+// TestNextCatalogMissingAttr drives the nextCatalog branch where the catalog
+// attribute is empty.
+func TestNextCatalogMissingAttr(t *testing.T) {
+	_, errs := loadCatalogString(t, `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <nextCatalog catalog=""/>
+</catalog>`)
+	require.NotEmpty(t, errs)
+	require.Contains(t, errs[0].Error(), "catalog")
+}
+
+// TestXMLBaseAttribute drives the xml:base handling on both the root element
+// and a child element in parseEntries.
+func TestXMLBaseAttribute(t *testing.T) {
+	cat, errs := loadCatalogString(t, `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+         xmlns:xml="http://www.w3.org/XML/1998/namespace"
+         xml:base="http://example.com/base/">
+  <uri name="u" uri="target.dtd" xml:base="sub/"/>
+</catalog>`)
+	require.Empty(t, errs)
+	got := cat.ResolveURI(t.Context(), "u")
+	require.Equal(t, "http://example.com/base/sub/target.dtd", got)
+}
+
+// TestNonCatalogNamespaceChildSkipped exercises the skip branch for child
+// elements outside the catalog namespace.
+func TestNonCatalogNamespaceChildSkipped(t *testing.T) {
+	cat, errs := loadCatalogString(t, `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+         xmlns:other="http://example.com/other">
+  <other:thing foo="bar"/>
+  <system systemId="sid" uri="out.dtd"/>
+</catalog>`)
+	require.Empty(t, errs)
+	got := cat.Resolve(t.Context(), "", "sid")
+	require.True(t, strings.HasSuffix(got, "out.dtd"), "resolved %q", got)
+}
+
+// TestNonElementChildSkipped exercises the AsNode skip branch for text/comment
+// children.
+func TestNonElementChildSkipped(t *testing.T) {
+	cat, errs := loadCatalogString(t, `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <!-- a comment -->
+  text content
+  <system systemId="sid" uri="out.dtd"/>
+</catalog>`)
+	require.Empty(t, errs)
+	got := cat.Resolve(t.Context(), "", "sid")
+	require.True(t, strings.HasSuffix(got, "out.dtd"), "resolved %q", got)
+}
+
+// TestNoRootElement covers documentElement returning nil when the document has
+// no element child. A document that is only a comment + PI has no root element
+// at parse time; helium rejects it, so use the loadFromBytes "no root" path via
+// a parse that yields no element. Instead test the empty-root namespace error.
+func TestWrongRootNamespace(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "catalog.xml")
+	xml := `<?xml version="1.0"?>
+<catalog xmlns="http://example.com/not-catalog">
+  <system systemId="sid" uri="out.dtd"/>
+</catalog>`
+	require.NoError(t, os.WriteFile(p, []byte(xml), 0o600))
+	_, err := catalog.Load(t.Context(), p)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "namespace")
+}
+
+// TestUnsupportedURIScheme covers catalogFilePath rejecting a non-file scheme.
+func TestUnsupportedURIScheme(t *testing.T) {
+	_, err := catalog.Load(t.Context(), "http://example.com/catalog.xml")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported URI scheme")
+}
+
+// TestNonLocalFileURIHost covers catalogFilePath rejecting a remote host.
+func TestNonLocalFileURIHost(t *testing.T) {
+	_, err := catalog.Load(t.Context(), "file://remotehost/path/catalog.xml")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-local file URI host")
+}
+
+// TestOpaqueFileURI covers catalogFilePath rejecting an opaque file: URI.
+func TestOpaqueFileURI(t *testing.T) {
+	_, err := catalog.Load(t.Context(), "file:next.xml")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no local path")
+}
+
+// TestLocalhostFileURI covers the EqualFold "localhost" accept path plus
+// fileURIPath conversion for a real file.
+func TestLocalhostFileURI(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "catalog.xml")
+	xml := `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <system systemId="sid" uri="out.dtd"/>
+</catalog>`
+	require.NoError(t, os.WriteFile(p, []byte(xml), 0o600))
+
+	uri := "file://localhost" + filepath.ToSlash(p)
+	cat, err := catalog.Load(t.Context(), uri)
+	require.NoError(t, err)
+	got := cat.Resolve(t.Context(), "", "sid")
+	require.True(t, strings.HasPrefix(got, "file:"), "resolved %q", got)
+}
+
+// TestNilContextLoad covers the ctx == nil branch in Loader.Load.
+func TestNilContextLoad(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "catalog.xml")
+	xml := `<?xml version="1.0"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <system systemId="sid" uri="out.dtd"/>
+</catalog>`
+	require.NoError(t, os.WriteFile(p, []byte(xml), 0o600))
+
+	//nolint:staticcheck // intentionally passing nil ctx to exercise the guard
+	var nilCtx context.Context
+	cat, err := catalog.NewLoader().Load(nilCtx, p)
+	require.NoError(t, err)
+	require.NotNil(t, cat)
+}

--- a/coverage_copy_misc_test.go
+++ b/coverage_copy_misc_test.go
@@ -1,0 +1,90 @@
+package helium_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCopyDTDInfo copies the internal-subset DTD declarations from one document
+// into another via CopyDTDInfo.
+func TestCopyDTDInfo(t *testing.T) {
+	t.Parallel()
+
+	in, err := os.ReadFile("test/att12.xml")
+	require.NoError(t, err)
+	src, err := helium.NewParser().Parse(t.Context(), in)
+	require.NoError(t, err)
+	require.NotNil(t, src.IntSubset())
+
+	dst := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	helium.CopyDTDInfo(src, dst)
+
+	require.NotNil(t, dst.IntSubset(), "CopyDTDInfo populates the destination internal subset")
+	_, ok := dst.IntSubset().LookupNotation("gif")
+	require.True(t, ok, "notation copied via CopyDTDInfo")
+
+	// nil arguments are a no-op (no panic).
+	helium.CopyDTDInfo(nil, dst)
+	helium.CopyDTDInfo(src, nil)
+}
+
+// TestCopyExtSubset copies an external DTD subset between documents.
+func TestCopyExtSubset(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dtdPath := dir + "/ext.dtd"
+	require.NoError(t, os.WriteFile(dtdPath, []byte(`<!ELEMENT root (#PCDATA)>
+<!NOTATION gif SYSTEM "viewer.exe">
+<!ENTITY ext SYSTEM "data.xml">`), 0600))
+
+	xml := `<?xml version="1.0"?>
+<!DOCTYPE root SYSTEM "` + dtdPath + `">
+<root/>`
+
+	src, err := helium.NewParser().LoadExternalDTD(true).Parse(t.Context(), []byte(xml))
+	require.NoError(t, err)
+	require.NotNil(t, src.ExtSubset())
+
+	dst := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	helium.CopyExtSubset(src, dst)
+	require.NotNil(t, dst.ExtSubset(), "external subset copied")
+
+	// nil arguments are a no-op.
+	helium.CopyExtSubset(nil, dst)
+	helium.CopyExtSubset(src, nil)
+}
+
+// TestElementTypeString exercises the ElementType Stringer, including the
+// out-of-range fallback.
+func TestElementTypeString(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "ElementNode", helium.ElementNode.String())
+	require.Equal(t, "DocumentNode", helium.DocumentNode.String())
+
+	// An out-of-range value falls back to the numeric form.
+	require.Contains(t, helium.ElementType(9999).String(), "ElementType(")
+}
+
+// TestNotationNodeInterfaceMethods exercises the remaining Notation node-method
+// wrappers (AddSibling, Replace, Free, AddChild).
+func TestNotationNodeInterfaceMethods(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	dtd, err := doc.CreateInternalSubset("doc", "", "")
+	require.NoError(t, err)
+	nota, err := dtd.AddNotation("n", "", "sys")
+	require.NoError(t, err)
+
+	// These delegate to the shared tree primitives; exercise without asserting
+	// implementation-defined success on an already-attached node.
+	_ = nota.AddSibling(doc.CreateElement("x"))
+	_ = nota.Replace()
+	_ = nota.AddChild(doc.CreateText([]byte("t")))
+	nota.Free()
+}

--- a/coverage_dom_nodes_test.go
+++ b/coverage_dom_nodes_test.go
@@ -1,0 +1,365 @@
+package helium_test
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/enum"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDocumentAccessors exercises the small Document getter/setter methods that
+// are otherwise only touched indirectly.
+func TestDocumentAccessors(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneExplicitYes)
+	require.Equal(t, "UTF-8", doc.Encoding())
+	require.Equal(t, "UTF-8", doc.RawEncoding())
+	require.Equal(t, "1.0", doc.Version())
+
+	doc.SetEncoding("ISO-8859-1")
+	require.Equal(t, "ISO-8859-1", doc.Encoding())
+	require.Equal(t, "ISO-8859-1", doc.RawEncoding())
+
+	// Document with no encoding synthesizes "utf8" for Encoding but empty for raw.
+	d2 := helium.NewDocument("1.0", "", helium.StandaloneImplicitNo)
+	require.Equal(t, "utf8", d2.Encoding())
+	require.Equal(t, "", d2.RawEncoding())
+
+	doc.SetURL("http://example.com/doc.xml")
+	require.Equal(t, "http://example.com/doc.xml", doc.URL())
+
+	doc.SetProperties(helium.DocHTML)
+	require.True(t, doc.HasProperty(helium.DocHTML))
+	require.Equal(t, helium.DocHTML, doc.Properties())
+
+	doc.SetSkipIDs(true)
+	require.True(t, doc.SkipIDs())
+	doc.SetSkipIDs(false)
+	require.False(t, doc.SkipIDs())
+
+	require.Equal(t, helium.DocumentStandaloneType(helium.StandaloneExplicitYes), doc.Standalone())
+
+	// AddSibling/Replace on a document are rejected.
+	require.Error(t, doc.AddSibling(doc.CreateElement("x")))
+	require.Error(t, doc.Replace())
+
+	// SetTreeDoc on a document is a no-op-ish but must not panic.
+	doc.SetTreeDoc(doc)
+}
+
+func TestNewHTMLDocument(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewHTMLDocument()
+	require.Equal(t, helium.HTMLDocumentNode, doc.Type())
+	require.True(t, doc.HasProperty(helium.DocHTML))
+}
+
+// TestDocumentFree builds a parsed document and then frees its slabs. This must
+// be safe and idempotent.
+func TestDocumentFree(t *testing.T) {
+	t.Parallel()
+	in, err := os.ReadFile("test/att12.xml")
+	require.NoError(t, err)
+	doc, err := helium.NewParser().Parse(t.Context(), in)
+	require.NoError(t, err)
+	doc.Free()
+	doc.Free() // idempotent
+}
+
+// TestInternalSubsetAccessors covers DTD construction and its accessor methods.
+func TestInternalSubsetAccessors(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	dtd, err := doc.CreateInternalSubset("root", "-//Example//DTD//EN", "example.dtd")
+	require.NoError(t, err)
+
+	require.Equal(t, "-//Example//DTD//EN", dtd.ExternalID())
+	require.Equal(t, "example.dtd", dtd.SystemID())
+	require.Same(t, dtd, doc.IntSubset())
+
+	// Exercise the DTD node-interface methods (delegating wrappers). They must
+	// not panic; their success/error is implementation-defined for an
+	// already-attached internal subset.
+	_ = dtd.AddSibling(doc.CreateElement("x"))
+	_ = dtd.Replace()
+	dtd.SetTreeDoc(doc)
+	dtd.Free()
+}
+
+// TestDTDEntityAndNotation exercises AddEntity/AddNotation/ForEachEntity and the
+// resulting Entity/Notation accessor methods.
+func TestDTDEntityAndNotation(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	dtd, err := doc.CreateInternalSubset("doc", "", "")
+	require.NoError(t, err)
+
+	gen, err := dtd.AddEntity("greeting", enum.InternalGeneralEntity, "", "", "Hello")
+	require.NoError(t, err)
+	require.Equal(t, enum.InternalGeneralEntity, gen.EntityType())
+	require.Equal(t, []byte("Hello"), gen.Content())
+
+	// External unparsed entity exposes systemID/externalID/URI.
+	img, err := dtd.AddEntity("img", enum.ExternalGeneralUnparsedEntity, "", "img.gif", "gif")
+	require.NoError(t, err)
+	require.Equal(t, "img.gif", img.SystemID())
+	require.Equal(t, "", img.ExternalID())
+	require.Equal(t, "img.gif", img.URI()) // falls back to systemID
+
+	// First-definition-wins: redeclaring returns the existing entity.
+	again, err := dtd.AddEntity("greeting", enum.InternalGeneralEntity, "", "", "Goodbye")
+	require.NoError(t, err)
+	require.Same(t, gen, again)
+
+	// Redeclaring a predefined entity with the wrong content is rejected.
+	_, err = dtd.AddEntity("lt", enum.InternalGeneralEntity, "", "", "wrong")
+	require.Error(t, err)
+
+	// Predefined entity type cannot be registered.
+	_, err = dtd.AddEntity("x", enum.InternalPredefinedEntity, "", "", "y")
+	require.Error(t, err)
+
+	// ForEachEntity visits the general entities.
+	seen := map[string]bool{}
+	dtd.ForEachEntity(func(name string, ent *helium.Entity) {
+		seen[name] = true
+	})
+	require.True(t, seen["greeting"])
+	require.True(t, seen["img"])
+
+	nota, err := dtd.AddNotation("gif", "", "viewer.exe")
+	require.NoError(t, err)
+	require.Equal(t, helium.NotationNode, nota.Type())
+
+	// Redefinition of a notation is rejected.
+	_, err = dtd.AddNotation("gif", "", "other.exe")
+	require.Error(t, err)
+
+	// Document.AddEntity delegates to the internal subset.
+	_, err = doc.AddEntity("foo", enum.InternalGeneralEntity, "", "", "bar")
+	require.NoError(t, err)
+
+	// Document.AddEntity on a doc without an internal subset errors.
+	bare := helium.NewDocument("1.0", "", helium.StandaloneImplicitNo)
+	_, err = bare.AddEntity("foo", enum.InternalGeneralEntity, "", "", "bar")
+	require.Error(t, err)
+}
+
+// TestEntityNodeMethods covers the Entity node-interface methods.
+func TestEntityNodeMethods(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	dtd, err := doc.CreateInternalSubset("doc", "", "")
+	require.NoError(t, err)
+	ent, err := dtd.AddEntity("e", enum.InternalGeneralEntity, "", "", "x")
+	require.NoError(t, err)
+
+	ent.SetOrig("&e;")
+	require.False(t, ent.Checked())
+	ent.MarkChecked()
+	require.True(t, ent.Checked())
+
+	ent.SetTreeDoc(doc)
+	require.NoError(t, ent.AppendText([]byte("more")))
+}
+
+// TestNotationNodeMethods covers Notation node-interface methods.
+func TestNotationNodeMethods(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	dtd, err := doc.CreateInternalSubset("doc", "", "")
+	require.NoError(t, err)
+	nota, err := dtd.AddNotation("n", "pub", "sys")
+	require.NoError(t, err)
+
+	nota.SetTreeDoc(doc)
+	nota.Free()
+	require.NoError(t, nota.AppendText([]byte("x")))
+}
+
+// TestXIncludeMarker exercises the XIncludeMarker node type and its methods.
+func TestXIncludeMarker(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	m := helium.NewXIncludeMarker(doc, helium.XIncludeStartNode, "include")
+	require.Equal(t, helium.XIncludeStartNode, m.Type())
+	require.Equal(t, "include", m.Name())
+
+	child := doc.CreateText([]byte("hello"))
+	require.NoError(t, m.AddChild(child))
+	require.NoError(t, m.AppendText([]byte(" world")))
+	m.SetTreeDoc(doc)
+}
+
+// TestCopyDocWithDTD parses a document that has a rich internal DTD subset and
+// deep-copies it, then serializes both, exercising copy.go, copy_core.go and
+// the DTD writer paths.
+func TestCopyDocWithDTD(t *testing.T) {
+	t.Parallel()
+	in, err := os.ReadFile("test/att12.xml")
+	require.NoError(t, err)
+	doc, err := helium.NewParser().Parse(t.Context(), in)
+	require.NoError(t, err)
+
+	orig, err := helium.WriteString(doc)
+	require.NoError(t, err)
+
+	cp, err := helium.CopyDoc(doc)
+	require.NoError(t, err)
+	copied, err := helium.WriteString(cp)
+	require.NoError(t, err)
+
+	// A faithful deep copy round-trips identically.
+	require.Equal(t, orig, copied)
+
+	// CopyDoc(nil) is rejected.
+	_, err = helium.CopyDoc(nil)
+	require.Error(t, err)
+}
+
+// TestCopyNodeVariants covers CopyNode across several node types.
+func TestCopyNodeVariants(t *testing.T) {
+	t.Parallel()
+	src := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	dst := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+
+	root := src.CreateElement("root")
+	require.NoError(t, src.AddChild(root))
+
+	text := src.CreateText([]byte("hi"))
+	comment := src.CreateComment([]byte("c"))
+	cdata := src.CreateCDATASection([]byte("data"))
+	pi := src.CreatePI("target", "value")
+
+	for _, n := range []helium.Node{text, comment, cdata, pi, root} {
+		cp, err := helium.CopyNode(n, dst)
+		require.NoError(t, err, "CopyNode(%s)", n.Type())
+		require.Equal(t, n.Type(), cp.Type())
+	}
+
+	// Copy the whole document via CopyNode (delegates to CopyDoc).
+	cp, err := helium.CopyNode(src, dst)
+	require.NoError(t, err)
+	require.Equal(t, helium.DocumentNode, cp.Type())
+}
+
+// TestWriterOptions exercises the Writer option toggles and serialization paths.
+func TestWriterOptions(t *testing.T) {
+	t.Parallel()
+	in, err := os.ReadFile("test/att12.xml")
+	require.NoError(t, err)
+	doc, err := helium.NewParser().Parse(t.Context(), in)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = helium.NewWriter().
+		IncludeDTD(false).
+		AllowPrefixUndeclarations(true).
+		WriteTo(&buf, doc)
+	require.NoError(t, err)
+	// With the DTD excluded, the DOCTYPE must not appear.
+	require.NotContains(t, buf.String(), "<!DOCTYPE")
+
+	buf.Reset()
+	err = helium.NewWriter().IncludeDTD(true).WriteTo(&buf, doc)
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "<!DOCTYPE")
+
+	// EscapeNonASCII path with a non-ASCII text node.
+	d2 := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	r := d2.CreateElement("r")
+	require.NoError(t, d2.AddChild(r))
+	require.NoError(t, r.AppendText([]byte("café")))
+
+	buf.Reset()
+	err = helium.NewWriter().EscapeNonASCII(true).WriteTo(&buf, d2)
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "&#")
+}
+
+// TestGetElementByIDFallback covers the O(n) tree-walk fallback path of
+// GetElementByID for an API-built document (no parser ID table).
+func TestGetElementByIDFallback(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	root := doc.CreateElement("root")
+	require.NoError(t, doc.AddChild(root))
+
+	child := doc.CreateElement("child")
+	xmlNS := helium.NewNamespace("xml", "http://www.w3.org/XML/1998/namespace")
+	_, err := child.SetAttributeNS("id", "target", xmlNS)
+	require.NoError(t, err)
+	require.NoError(t, root.AddChild(child))
+
+	require.Nil(t, doc.IDTable()) // not populated for API-built docs
+
+	found := doc.GetElementByID("target")
+	require.Same(t, child, found)
+
+	require.Nil(t, doc.GetElementByID("missing"))
+
+	// SkipIDs short-circuits resolution.
+	doc.SetSkipIDs(true)
+	require.Nil(t, doc.GetElementByID("target"))
+}
+
+// TestElementDeclAndAttrDeclAccessors covers DTD element/attribute declaration
+// accessors by parsing a DTD that declares both.
+func TestElementDeclAndAttrDeclAccessors(t *testing.T) {
+	t.Parallel()
+	in, err := os.ReadFile("test/att12.xml")
+	require.NoError(t, err)
+	doc, err := helium.NewParser().Parse(t.Context(), in)
+	require.NoError(t, err)
+
+	dtd := doc.IntSubset()
+	require.NotNil(t, dtd)
+
+	edecl, ok := dtd.LookupElement("doc", "")
+	require.True(t, ok)
+	require.Equal(t, enum.MixedElementType, edecl.DeclType())
+
+	adecls := dtd.AttributesForElement("doc")
+	require.NotEmpty(t, adecls)
+	adecl := adecls[0]
+	require.Equal(t, "doc", adecl.Elem())
+	require.NotEqual(t, enum.AttrInvalid, adecl.AType())
+}
+
+// TestDTDRemoveElement covers RemoveElement.
+func TestDTDRemoveElement(t *testing.T) {
+	t.Parallel()
+	in, err := os.ReadFile("test/att12.xml")
+	require.NoError(t, err)
+	doc, err := helium.NewParser().Parse(t.Context(), in)
+	require.NoError(t, err)
+
+	dtd := doc.IntSubset()
+	_, ok := dtd.LookupElement("doc", "")
+	require.True(t, ok)
+
+	dtd.RemoveElement("doc", "")
+	_, ok = dtd.LookupElement("doc", "")
+	require.False(t, ok)
+}
+
+// TestWriteStringWithoutDTD verifies WriteString on a programmatically built doc.
+func TestWriteStringWithoutDTD(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	root := doc.CreateElement("root")
+	require.NoError(t, doc.AddChild(root))
+	require.NoError(t, root.AppendText([]byte("text & more")))
+
+	s, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.True(t, strings.Contains(s, "<root>"))
+	require.Contains(t, s, "&amp;")
+}

--- a/coverage_external_dtd_test.go
+++ b/coverage_external_dtd_test.go
@@ -1,0 +1,129 @@
+package helium_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// writeDTD writes a DTD file into a fresh temp dir and returns its path.
+func writeDTD(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "ext.dtd")
+	require.NoError(t, os.WriteFile(p, []byte(body), 0600))
+	return p
+}
+
+// TestExternalDTDConditionalSections exercises INCLUDE/IGNORE conditional
+// sections, which only appear in the external subset.
+func TestExternalDTDConditionalSections(t *testing.T) {
+	t.Parallel()
+
+	const dtd = `<!ELEMENT root (#PCDATA)>
+<![INCLUDE[
+<!ENTITY included "in">
+]]>
+<![IGNORE[
+<!ENTITY ignored "out">
+]]>`
+	path := writeDTD(t, dtd)
+
+	xml := `<?xml version="1.0"?>
+<!DOCTYPE root SYSTEM "` + path + `">
+<root/>`
+
+	doc, err := helium.NewParser().LoadExternalDTD(true).Parse(t.Context(), []byte(xml))
+	require.NoError(t, err)
+
+	_, found := doc.GetEntity("included")
+	require.True(t, found, "entity inside INCLUDE section must be declared")
+
+	_, found = doc.GetEntity("ignored")
+	require.False(t, found, "entity inside IGNORE section must be skipped")
+}
+
+// TestExternalDTDNotationsAndEntities exercises notation and external entity
+// declarations resolved from the external subset.
+func TestExternalDTDNotationsAndEntities(t *testing.T) {
+	t.Parallel()
+
+	const dtd = `<!ELEMENT root (#PCDATA)>
+<!NOTATION gif SYSTEM "viewer.exe">
+<!NOTATION png PUBLIC "-//N//EN" "png.exe">
+<!ENTITY img SYSTEM "img.gif" NDATA gif>
+<!ENTITY ext SYSTEM "data.xml">
+<!ENTITY pub PUBLIC "-//P//EN" "pub.xml">`
+	path := writeDTD(t, dtd)
+
+	xml := `<?xml version="1.0"?>
+<!DOCTYPE root SYSTEM "` + path + `">
+<root/>`
+
+	doc, err := helium.NewParser().LoadExternalDTD(true).Parse(t.Context(), []byte(xml))
+	require.NoError(t, err)
+
+	require.NotNil(t, doc.ExtSubset(), "external subset must be present")
+	// The external general entities are resolvable from the document.
+	_, ok := doc.GetEntity("ext")
+	require.True(t, ok, "external SYSTEM entity declared in ext subset")
+	_, ok = doc.GetEntity("pub")
+	require.True(t, ok, "external PUBLIC entity declared in ext subset")
+}
+
+// TestExternalDTDPublicIdentifier exercises a DOCTYPE that declares a PUBLIC
+// external identifier (with both public and system IDs).
+func TestExternalDTDPublicIdentifier(t *testing.T) {
+	t.Parallel()
+
+	const dtd = `<!ELEMENT root (#PCDATA)>
+<!ENTITY who "world">`
+	path := writeDTD(t, dtd)
+
+	xml := `<?xml version="1.0"?>
+<!DOCTYPE root PUBLIC "-//Example//DTD root//EN" "` + path + `">
+<root/>`
+
+	doc, err := helium.NewParser().LoadExternalDTD(true).Parse(t.Context(), []byte(xml))
+	require.NoError(t, err)
+	_, found := doc.GetEntity("who")
+	require.True(t, found)
+}
+
+// TestExternalDTDMissingFile exercises the not-found branch of external DTD
+// resolution: a SYSTEM id pointing at a non-existent file must not crash.
+func TestExternalDTDMissingFile(t *testing.T) {
+	t.Parallel()
+
+	xml := `<?xml version="1.0"?>
+<!DOCTYPE root SYSTEM "/nonexistent/path/to.dtd">
+<root>content</root>`
+
+	// The document body is still well-formed; the external DTD simply cannot be
+	// loaded. Parsing should not panic.
+	doc, _ := helium.NewParser().LoadExternalDTD(true).Parse(t.Context(), []byte(xml))
+	if doc != nil {
+		require.NotNil(t, doc.DocumentElement())
+	}
+}
+
+// TestInternalSubsetParameterEntityInclusion exercises a parameter entity used
+// inside the internal subset to pull in further declarations.
+func TestInternalSubsetParameterEntityInclusion(t *testing.T) {
+	t.Parallel()
+
+	const xml = `<?xml version="1.0"?>
+<!DOCTYPE root [
+<!ENTITY % decls "<!ELEMENT root (#PCDATA)><!ENTITY inner 'inner-value'>">
+%decls;
+]>
+<root/>`
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(xml))
+	require.NoError(t, err)
+	_, found := doc.GetEntity("inner")
+	require.True(t, found, "entity declared via internal-subset PE inclusion must be present")
+}

--- a/coverage_namespace_test.go
+++ b/coverage_namespace_test.go
@@ -1,0 +1,66 @@
+package helium_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestElementNamespaceMutators exercises the namespace-declaration mutators on
+// an element: DeclareNamespace, AddNamespaceDecl, RemoveNamespaceByPrefix,
+// SetActiveNamespace and SetNs.
+func TestElementNamespaceMutators(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	e := doc.CreateElement("e")
+
+	require.NoError(t, e.DeclareNamespace("p", "urn:p"))
+	require.Len(t, e.Namespaces(), 1)
+
+	shared := helium.NewNamespace("q", "urn:q")
+	e.AddNamespaceDecl(shared)
+	require.Len(t, e.Namespaces(), 2)
+
+	require.True(t, e.RemoveNamespaceByPrefix("p"), "existing prefix removed")
+	require.False(t, e.RemoveNamespaceByPrefix("absent"), "missing prefix is a no-op")
+	require.Len(t, e.Namespaces(), 1)
+
+	require.NoError(t, e.SetActiveNamespace("a", "urn:a"))
+	require.Equal(t, "a", e.Prefix())
+	require.Equal(t, "urn:a", e.URI())
+	require.Equal(t, "a:e", e.Name())
+
+	e.SetNs(shared)
+	require.Equal(t, "q", e.Prefix())
+	require.Equal(t, "urn:q", e.URI())
+}
+
+// TestEncodingDeclarations parses documents with various encoding declarations
+// to exercise the encoding-switch paths.
+func TestEncodingDeclarations(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{
+		`<?xml version="1.0" encoding="UTF-8"?><root>ascii</root>`,
+		`<?xml version="1.0" encoding="utf-8"?><root>ascii</root>`,
+		`<?xml version="1.0" encoding="US-ASCII"?><root>ascii</root>`,
+	}
+	for _, in := range inputs {
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(in))
+		require.NoError(t, err, "parse %q", in)
+		require.NotNil(t, doc.DocumentElement())
+	}
+}
+
+// TestEncodingIgnored verifies the IgnoreEncoding option does not break a parse
+// that declares an encoding.
+func TestEncodingIgnored(t *testing.T) {
+	t.Parallel()
+
+	const in = `<?xml version="1.0" encoding="ISO-8859-1"?><root>x</root>`
+	doc, err := helium.NewParser().IgnoreEncoding(true).Parse(t.Context(), []byte(in))
+	require.NoError(t, err)
+	require.NotNil(t, doc.DocumentElement())
+}

--- a/coverage_node_util_test.go
+++ b/coverage_node_util_test.go
@@ -1,0 +1,131 @@
+package helium_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/enum"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildURI exercises BuildURI across local-path, http, and absolute cases.
+func TestBuildURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		systemID string
+		base     string
+		want     string
+	}{
+		{"absolute system id is returned verbatim", "http://x/a.dtd", "http://y/", "http://x/a.dtd"},
+		{"relative against http base", "a.dtd", "http://host/dir/doc.xml", "http://host/dir/a.dtd"},
+		{"relative against file path", "a.dtd", "/dir/doc.xml", "/dir/a.dtd"},
+		{"absolute local path", "/abs/a.dtd", "/dir/doc.xml", "/abs/a.dtd"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, helium.BuildURI(tt.systemID, tt.base))
+		})
+	}
+}
+
+// TestNodeGetBaseAndSet exercises NodeGetBase with xml:base attributes and the
+// SetNodeBaseURI override.
+func TestNodeGetBaseAndSet(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	doc.SetURL("http://example.com/dir/doc.xml")
+
+	root := doc.CreateElement("root")
+	require.NoError(t, doc.AddChild(root))
+
+	child := doc.CreateElement("child")
+	xmlNS := helium.NewNamespace("xml", "http://www.w3.org/XML/1998/namespace")
+	require.NoError(t, child.SetLiteralAttributeNS("base", "sub/", xmlNS))
+	require.NoError(t, root.AddChild(child))
+
+	// The child's effective base resolves its xml:base against the doc URL.
+	base := helium.NodeGetBase(doc, child)
+	require.Contains(t, base, "sub")
+
+	// A nil node yields an empty base.
+	require.Equal(t, "", helium.NodeGetBase(doc, nil))
+
+	// SetNodeBaseURI installs an explicit entity base URI that takes precedence.
+	helium.SetNodeBaseURI(child, "http://other.example/")
+	base = helium.NodeGetBase(doc, child)
+	require.Contains(t, base, "other.example")
+}
+
+// TestNewLeveledError exercises the leveled-error type and its ErrorLeveler.
+func TestNewLeveledError(t *testing.T) {
+	t.Parallel()
+
+	err := helium.NewLeveledError("boom", helium.ErrorLevelError)
+	require.EqualError(t, err, "boom")
+
+	leveler, ok := err.(helium.ErrorLeveler)
+	require.True(t, ok, "leveled error implements ErrorLeveler")
+	require.Equal(t, helium.ErrorLevelError, leveler.ErrorLevel())
+}
+
+// TestNilErrorHandlerDiscards verifies NilErrorHandler discards without panicking.
+func TestNilErrorHandlerDiscards(t *testing.T) {
+	t.Parallel()
+	var h helium.NilErrorHandler
+	h.Handle(t.Context(), helium.NewLeveledError("ignored", helium.ErrorLevelWarning))
+}
+
+// TestAttributeNodeMethods exercises the Attribute node-interface methods.
+func TestAttributeNodeMethods(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	attr, err := doc.CreateAttribute("a", "v", nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "v", attr.Value())
+	require.Equal(t, "a", attr.Name())
+
+	attr.SetAType(enum.AttrCDATA)
+	require.Equal(t, enum.AttrCDATA, attr.AType())
+
+	attr.SetDefault(true)
+	require.True(t, attr.IsDefault())
+
+	// AppendText extends the attribute value (text child).
+	require.NoError(t, attr.AppendText([]byte("-more")))
+
+	attr.SetTreeDoc(doc)
+}
+
+// TestElementGetAttribute exercises GetAttribute and GetAttributeNS.
+func TestElementGetAttribute(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	elem := doc.CreateElement("e")
+	_, err := elem.SetAttribute("plain", "p")
+	require.NoError(t, err)
+
+	ns := helium.NewNamespace("x", "urn:x")
+	_, err = elem.SetAttributeNS("nsed", "n", ns)
+	require.NoError(t, err)
+
+	v, ok := elem.GetAttribute("plain")
+	require.True(t, ok)
+	require.Equal(t, "p", v)
+
+	_, ok = elem.GetAttribute("absent")
+	require.False(t, ok)
+
+	v, ok = elem.GetAttributeNS("nsed", "urn:x")
+	require.True(t, ok)
+	require.Equal(t, "n", v)
+
+	_, ok = elem.GetAttributeNS("nsed", "urn:wrong")
+	require.False(t, ok)
+}

--- a/coverage_parser_edge_test.go
+++ b/coverage_parser_edge_test.go
@@ -94,17 +94,17 @@ func TestMalformedDocuments(t *testing.T) {
 	t.Parallel()
 
 	bad := []string{
-		`<root>`,                        // unclosed root
-		`<root></notroot>`,              // mismatched end tag
-		`<root attr></root>`,            // attribute without value
-		`<root attr=value></root>`,      // unquoted attribute value
+		`<root>`,                         // unclosed root
+		`<root></notroot>`,               // mismatched end tag
+		`<root attr></root>`,             // attribute without value
+		`<root attr=value></root>`,       // unquoted attribute value
 		`<root>&undefinedentity;</root>`, // reference to undeclared entity
-		`<root><![CDATA[ unterminated`,  // unterminated CDATA
-		`<!-- unterminated comment`,     // unterminated comment
-		`<root>&#xZZ;</root>`,           // invalid hex char ref
-		`<root>&;</root>`,               // empty reference
-		`<>`,                            // empty tag name
-		`<root></root><second/>`,        // two root elements
+		`<root><![CDATA[ unterminated`,   // unterminated CDATA
+		`<!-- unterminated comment`,      // unterminated comment
+		`<root>&#xZZ;</root>`,            // invalid hex char ref
+		`<root>&;</root>`,                // empty reference
+		`<>`,                             // empty tag name
+		`<root></root><second/>`,         // two root elements
 	}
 	for _, in := range bad {
 		_, err := helium.NewParser().Parse(t.Context(), []byte(in))

--- a/coverage_parser_edge_test.go
+++ b/coverage_parser_edge_test.go
@@ -1,0 +1,175 @@
+package helium_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLenientXMLDecl exercises the LenientXMLDecl parse path, including
+// pseudo-attributes presented out of the canonical order.
+func TestLenientXMLDecl(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{
+		`<?xml version="1.0" encoding="UTF-8" standalone="yes"?><root/>`,
+		`<?xml encoding="UTF-8" version="1.0"?><root/>`,
+		`<?xml standalone="no" version="1.0"?><root/>`,
+		`<?xml version="1.0"?><root/>`,
+	}
+	for _, in := range inputs {
+		doc, err := helium.NewParser().LenientXMLDecl(true).Parse(t.Context(), []byte(in))
+		require.NoError(t, err, "lenient parse of %q", in)
+		require.NotNil(t, doc.DocumentElement())
+	}
+}
+
+// TestMalformedXMLDecl exercises XML-declaration error branches.
+func TestMalformedXMLDecl(t *testing.T) {
+	t.Parallel()
+
+	bad := []string{
+		`<?xml?><root/>`,                         // missing version
+		`<?xml version="1.0" foo="bar"?><root/>`, // unknown pseudo-attr / unclosed
+		`<?xml version=1.0?><root/>`,             // unquoted version value
+	}
+	for _, in := range bad {
+		_, err := helium.NewParser().Parse(t.Context(), []byte(in))
+		require.Error(t, err, "malformed decl %q should error", in)
+	}
+}
+
+// TestProcessingInstructionsAndComments parses PIs and comments in the prolog,
+// content, and epilog positions.
+func TestProcessingInstructionsAndComments(t *testing.T) {
+	t.Parallel()
+
+	const src = `<?xml version="1.0"?>
+<?pi-prolog data?>
+<!-- prolog comment -->
+<root>
+  <?pi-content more?>
+  <!-- content comment -->
+  text
+</root>
+<!-- epilog comment -->
+<?pi-epilog x?>`
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	out, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, out, "<?pi-prolog")
+	require.Contains(t, out, "<!-- prolog comment -->")
+}
+
+// TestCDATASection parses CDATA sections including the tricky ]]> boundary.
+func TestCDATASection(t *testing.T) {
+	t.Parallel()
+
+	const src = `<root><![CDATA[ raw <tag> & ]]> normal text <child/></root>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	out, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, out, "<![CDATA[")
+}
+
+// TestCharacterReferences exercises numeric and hex character references.
+func TestCharacterReferences(t *testing.T) {
+	t.Parallel()
+
+	const src = `<root>dec=&#65; hex=&#x42; high=&#x1F600;</root>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+	require.Equal(t, "dec=A hex=B high=\U0001F600", string(doc.DocumentElement().Content()))
+}
+
+// TestMalformedDocuments exercises well-formedness error branches across the
+// parser. Each input is malformed and must surface an error.
+func TestMalformedDocuments(t *testing.T) {
+	t.Parallel()
+
+	bad := []string{
+		`<root>`,                        // unclosed root
+		`<root></notroot>`,              // mismatched end tag
+		`<root attr></root>`,            // attribute without value
+		`<root attr=value></root>`,      // unquoted attribute value
+		`<root>&undefinedentity;</root>`, // reference to undeclared entity
+		`<root><![CDATA[ unterminated`,  // unterminated CDATA
+		`<!-- unterminated comment`,     // unterminated comment
+		`<root>&#xZZ;</root>`,           // invalid hex char ref
+		`<root>&;</root>`,               // empty reference
+		`<>`,                            // empty tag name
+		`<root></root><second/>`,        // two root elements
+	}
+	for _, in := range bad {
+		_, err := helium.NewParser().Parse(t.Context(), []byte(in))
+		require.Error(t, err, "malformed input %q should error", in)
+	}
+}
+
+// TestRecoverOnError exercises the recover path: a malformed document returns
+// both a (partial) document and an error.
+func TestRecoverOnErrorPartialDoc(t *testing.T) {
+	t.Parallel()
+
+	const src = `<root><a>text</a><b></root>`
+	doc, err := helium.NewParser().RecoverOnError(true).Parse(t.Context(), []byte(src))
+	// With recovery the parser returns a partial document; an error may or may
+	// not be reported depending on how far recovery proceeds.
+	_ = err
+	require.NotNil(t, doc)
+}
+
+// TestNamespacedAttributes parses namespaced elements and attributes.
+func TestNamespacedAttributes(t *testing.T) {
+	t.Parallel()
+
+	const src = `<root xmlns="urn:default" xmlns:p="urn:p" p:attr="v" plain="w">` +
+		`<p:child/><plain/></root>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	out, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, out, `p:attr="v"`)
+	require.Contains(t, out, `xmlns:p="urn:p"`)
+}
+
+// TestParameterEntities exercises parameter-entity declaration and reference in
+// the internal subset.
+func TestParameterEntities(t *testing.T) {
+	t.Parallel()
+
+	// A parameter entity expanded inside another entity's value.
+	const src = `<?xml version="1.0"?>
+<!DOCTYPE doc [
+<!ENTITY % name "World">
+<!ENTITY greeting "Hello %name;">
+<!ELEMENT doc (#PCDATA)>
+]>
+<doc>&greeting;</doc>`
+
+	doc, err := helium.NewParser().SubstituteEntities(true).Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+	require.NotNil(t, doc.DocumentElement())
+}
+
+// TestEntitySubstitution exercises entity expansion in content and attributes.
+func TestEntitySubstitution(t *testing.T) {
+	t.Parallel()
+
+	const src = `<?xml version="1.0"?>
+<!DOCTYPE doc [
+<!ENTITY greeting "hello world">
+]>
+<doc attr="&greeting;">&greeting;</doc>`
+
+	doc, err := helium.NewParser().SubstituteEntities(true).Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+	require.Contains(t, string(doc.DocumentElement().Content()), "hello world")
+}

--- a/coverage_parser_options_test.go
+++ b/coverage_parser_options_test.go
@@ -63,7 +63,7 @@ func TestParserCharBufferSizeAffectsParse(t *testing.T) {
 
 	var b []byte
 	b = append(b, []byte(`<root>`)...)
-	for i := 0; i < 200; i++ {
+	for range 200 {
 		b = append(b, []byte(`<item>x</item>`)...)
 	}
 	b = append(b, []byte(`</root>`)...)

--- a/coverage_parser_options_test.go
+++ b/coverage_parser_options_test.go
@@ -1,0 +1,74 @@
+package helium_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// nopCatalog is a CatalogResolver that never resolves anything. It exists only
+// to drive the Parser.Catalog configuration path.
+type nopCatalog struct{}
+
+func (nopCatalog) Resolve(_ context.Context, _, _ string) string { return "" }
+func (nopCatalog) ResolveURI(_ context.Context, _ string) string { return "" }
+
+// TestParserOptionSetters exercises every boolean parser option setter with both
+// true and false (so both the Set and Clear branches run) plus the scalar/object
+// setters, then performs a parse to confirm the configured parser still works.
+func TestParserOptionSetters(t *testing.T) {
+	t.Parallel()
+
+	p := helium.NewParser().
+		RecoverOnError(true).RecoverOnError(false).
+		SubstituteEntities(true).SubstituteEntities(false).
+		LoadExternalDTD(true).LoadExternalDTD(false).
+		DefaultDTDAttributes(true).DefaultDTDAttributes(false).
+		ValidateDTD(true).ValidateDTD(false).
+		SuppressErrors(true).SuppressErrors(false).
+		SuppressWarnings(true).SuppressWarnings(false).
+		PedanticErrors(true).PedanticErrors(false).
+		StripBlanks(true).StripBlanks(false).
+		ProcessXInclude(true).ProcessXInclude(false).
+		AllowNetwork(true).AllowNetwork(false).
+		CleanNamespaces(true).CleanNamespaces(false).
+		MergeCDATA(true).MergeCDATA(false).
+		XIncludeNodes(true).XIncludeNodes(false).
+		CompactTextNodes(true).CompactTextNodes(false).
+		FixBaseURIs(true).FixBaseURIs(false).
+		RelaxLimits(true).RelaxLimits(false).
+		IgnoreEncoding(true).IgnoreEncoding(false).
+		BigLineNumbers(true).BigLineNumbers(false).
+		BlockXXE(true).BlockXXE(false).
+		ReuseDict(true).ReuseDict(false).
+		SkipIDs(true).SkipIDs(false).
+		LenientXMLDecl(true).LenientXMLDecl(false).
+		CharBufferSize(8192).
+		MaxDepth(256).
+		MaxExternalDTDBytes(1 << 20).
+		Catalog(nopCatalog{}).
+		BaseURI("http://example.com/base.xml")
+
+	doc, err := p.Parse(t.Context(), []byte(`<?xml version="1.0"?><root><child>text</child></root>`))
+	require.NoError(t, err, "a fully-configured parser parses a simple document")
+	require.NotNil(t, doc.DocumentElement())
+}
+
+// TestParserCharBufferSizeAffectsParse confirms a tiny char buffer (which forces
+// repeated cursor refills) still parses a larger document correctly.
+func TestParserCharBufferSizeAffectsParse(t *testing.T) {
+	t.Parallel()
+
+	var b []byte
+	b = append(b, []byte(`<root>`)...)
+	for i := 0; i < 200; i++ {
+		b = append(b, []byte(`<item>x</item>`)...)
+	}
+	b = append(b, []byte(`</root>`)...)
+
+	doc, err := helium.NewParser().CharBufferSize(16).Parse(t.Context(), b)
+	require.NoError(t, err)
+	require.Equal(t, "root", doc.DocumentElement().Name())
+}

--- a/coverage_round2_test.go
+++ b/coverage_round2_test.go
@@ -1,0 +1,544 @@
+package helium_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/enum"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDTDDeclarationNodeWrappers exercises the node-interface wrappers on the
+// DTD, ElementDecl and AttributeDecl node types (AddChild, AppendText,
+// AddSibling, Replace, SetTreeDoc) plus the Entity AddSibling/Replace wrappers.
+// These all delegate to the shared tree primitives; the test confirms each
+// override is wired up and returns the shared primitive's result.
+func TestDTDDeclarationNodeWrappers(t *testing.T) {
+	t.Parallel()
+
+	// Parse a doc that declares both an element and an attribute so we obtain
+	// real ElementDecl and AttributeDecl nodes from the DTD.
+	const src = `<?xml version="1.0"?>
+<!DOCTYPE doc [
+<!ELEMENT doc (#PCDATA)>
+<!ATTLIST doc a CDATA #IMPLIED>
+]>
+<doc a="v">text</doc>`
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(src))
+	require.NoError(t, err)
+	dtd := doc.IntSubset()
+	require.NotNil(t, dtd)
+
+	t.Run("ElementDecl wrappers", func(t *testing.T) {
+		t.Parallel()
+		edecl, ok := dtd.LookupElement("doc", "")
+		require.True(t, ok)
+		require.Equal(t, helium.ElementDeclNode, edecl.Type())
+
+		// AppendText routes a Text child into the decl node.
+		require.NoError(t, edecl.AppendText([]byte("x")))
+		// AddChild attaches a fresh node.
+		require.NoError(t, edecl.AddChild(doc.CreateComment([]byte("c"))))
+		// AddSibling/Replace/SetTreeDoc must not panic and delegate to the
+		// shared primitives.
+		_ = edecl.AddSibling(doc.CreateComment([]byte("sib")))
+		_ = edecl.Replace()
+		edecl.SetTreeDoc(doc)
+	})
+
+	t.Run("AttributeDecl wrappers", func(t *testing.T) {
+		t.Parallel()
+		adecls := dtd.AttributesForElement("doc")
+		require.NotEmpty(t, adecls)
+		adecl := adecls[0]
+
+		require.NoError(t, adecl.AppendText([]byte("y")))
+		require.NoError(t, adecl.AddChild(doc.CreateComment([]byte("ac"))))
+		_ = adecl.AddSibling(doc.CreateComment([]byte("as")))
+		_ = adecl.Replace()
+		adecl.SetTreeDoc(doc)
+	})
+
+	t.Run("DTD AppendText and Free", func(t *testing.T) {
+		t.Parallel()
+		d3 := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+		dtd3, derr := d3.CreateInternalSubset("doc", "", "")
+		require.NoError(t, derr)
+		require.NoError(t, dtd3.AppendText([]byte("ws")))
+		dtd3.Free() // no-op marker, but exercised for completeness
+	})
+
+	t.Run("Entity AddSibling and Replace", func(t *testing.T) {
+		t.Parallel()
+		d4 := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+		dtd4, derr := d4.CreateInternalSubset("doc", "", "")
+		require.NoError(t, derr)
+		ent, eerr := dtd4.AddEntity("e", enum.InternalGeneralEntity, "", "", "v")
+		require.NoError(t, eerr)
+		_ = ent.AddSibling(d4.CreateComment([]byte("s")))
+		_ = ent.Replace()
+	})
+}
+
+// TestCopyDocWithMixedChildren builds a document whose root element holds every
+// leaf child type (Text, CDATA, Comment, PI, EntityRef), then deep-copies it via
+// CopyDoc so the per-node-type branches of the deep copier's copyNode are all
+// exercised.
+func TestCopyDocWithMixedChildren(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	root := doc.CreateElement("root")
+	require.NoError(t, doc.AddChild(root))
+
+	require.NoError(t, root.AddChild(doc.CreateText([]byte("text"))))
+	require.NoError(t, root.AddChild(doc.CreateCDATASection([]byte("<cdata>"))))
+	require.NoError(t, root.AddChild(doc.CreateComment([]byte("comment"))))
+	require.NoError(t, root.AddChild(doc.CreatePI("target", "data")))
+	ref, err := doc.CreateReference("amp")
+	require.NoError(t, err)
+	require.NoError(t, root.AddChild(ref))
+
+	// A top-level comment and PI exercise the document-level copyChildren too.
+	require.NoError(t, doc.AddChild(doc.CreateComment([]byte("top-comment"))))
+	require.NoError(t, doc.AddChild(doc.CreatePI("toppi", "x")))
+
+	cp, err := helium.CopyDoc(doc)
+	require.NoError(t, err)
+	require.NotNil(t, cp)
+
+	cpRoot := cp.DocumentElement()
+	require.NotNil(t, cpRoot)
+
+	// Walk the copied children and confirm each node type round-tripped.
+	var kinds []helium.ElementType
+	for c := cpRoot.FirstChild(); c != nil; c = c.NextSibling() {
+		kinds = append(kinds, c.Type())
+	}
+	require.Contains(t, kinds, helium.TextNode)
+	require.Contains(t, kinds, helium.CDATASectionNode)
+	require.Contains(t, kinds, helium.CommentNode)
+	require.Contains(t, kinds, helium.ProcessingInstructionNode)
+	require.Contains(t, kinds, helium.EntityRefNode)
+}
+
+// TestSerializeEntityContentWithPercent serializes an internal general entity
+// whose replacement text contains a literal '%', driving the dumpEntityContent
+// percent-escaping branch in the DTD writer.
+func TestSerializeEntityContentWithPercent(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	dtd, err := doc.CreateInternalSubset("doc", "", "")
+	require.NoError(t, err)
+
+	// content has no orig set (AddEntity passes orig=""), so the writer falls
+	// through to dumpEntityContent; the '%' forces the escaping branch and the
+	// '"' forces the &quot; branch.
+	_, err = dtd.AddEntity("pct", enum.InternalGeneralEntity, "", "", `50% "done"`)
+	require.NoError(t, err)
+
+	root := doc.CreateElement("doc")
+	require.NoError(t, doc.AddChild(root))
+
+	out, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, out, "<!ENTITY pct", "entity declaration serialized")
+	require.Contains(t, out, "&#x25;", "percent escaped via dumpEntityContent")
+	require.Contains(t, out, "&quot;", "embedded quote escaped via dumpEntityContent")
+}
+
+// validateDTDErrs parses src with DTD validation enabled and returns the
+// collected validation errors.
+func validateDTDErrs(t *testing.T, src string) []error {
+	t.Helper()
+	h := &roundtwoErrSink{}
+	_, err := helium.NewParser().
+		ValidateDTD(true).
+		ErrorHandler(h).
+		Parse(context.Background(), []byte(src))
+	if err != nil {
+		require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+	}
+	return h.errs
+}
+
+type roundtwoErrSink struct{ errs []error }
+
+func (h *roundtwoErrSink) Handle(_ context.Context, err error) { h.errs = append(h.errs, err) }
+
+// TestValidateContentModelOccurrences drives the occurrence variants of matchSeq
+// and matchOr (optional, zero-or-more, one-or-more) plus nested optional
+// sequences, exercising the seq/or matcher branches in valid.go that the simpler
+// once-only models did not reach.
+func TestValidateContentModelOccurrences(t *testing.T) {
+	t.Parallel()
+
+	t.Run("repeated sequence (a,b)+", func(t *testing.T) {
+		t.Parallel()
+		const dtd = `<!DOCTYPE doc [
+<!ELEMENT doc (a, b)+>
+<!ELEMENT a (#PCDATA)>
+<!ELEMENT b (#PCDATA)>
+]>`
+		require.Empty(t, validateDTDErrs(t, dtd+`<doc><a/><b/><a/><b/></doc>`),
+			"two (a,b) repetitions validate")
+		require.NotEmpty(t, validateDTDErrs(t, dtd+`<doc><a/><b/><a/></doc>`),
+			"a trailing partial (a,b) repetition fails")
+	})
+
+	t.Run("optional trailing element (a,b?)", func(t *testing.T) {
+		t.Parallel()
+		const dtd = `<!DOCTYPE doc [
+<!ELEMENT doc (a, b?)>
+<!ELEMENT a (#PCDATA)>
+<!ELEMENT b (#PCDATA)>
+]>`
+		require.Empty(t, validateDTDErrs(t, dtd+`<doc><a/></doc>`),
+			"the optional trailing b may be absent")
+		require.Empty(t, validateDTDErrs(t, dtd+`<doc><a/><b/></doc>`),
+			"the optional trailing b may be present")
+		require.NotEmpty(t, validateDTDErrs(t, dtd+`<doc><a/><b/><b/></doc>`),
+			"a second b exceeds the optional occurrence")
+	})
+
+	t.Run("zero-or-more choice (a|b)*", func(t *testing.T) {
+		t.Parallel()
+		const dtd = `<!DOCTYPE doc [
+<!ELEMENT doc (a | b)*>
+<!ELEMENT a (#PCDATA)>
+<!ELEMENT b (#PCDATA)>
+]>`
+		require.Empty(t, validateDTDErrs(t, dtd+`<doc></doc>`),
+			"zero occurrences of the choice validate")
+		require.Empty(t, validateDTDErrs(t, dtd+`<doc><a/><a/><b/></doc>`),
+			"several occurrences of the choice validate")
+	})
+
+	t.Run("optional element a?", func(t *testing.T) {
+		t.Parallel()
+		const dtd = `<!DOCTYPE doc [
+<!ELEMENT doc (a?, b)>
+<!ELEMENT a (#PCDATA)>
+<!ELEMENT b (#PCDATA)>
+]>`
+		require.Empty(t, validateDTDErrs(t, dtd+`<doc><b/></doc>`),
+			"the optional leading a may be omitted")
+		require.Empty(t, validateDTDErrs(t, dtd+`<doc><a/><b/></doc>`),
+			"the optional leading a may be present")
+	})
+
+	t.Run("one-or-more element a+", func(t *testing.T) {
+		t.Parallel()
+		const dtd = `<!DOCTYPE doc [
+<!ELEMENT doc (a+)>
+<!ELEMENT a (#PCDATA)>
+]>`
+		require.Empty(t, validateDTDErrs(t, dtd+`<doc><a/><a/><a/></doc>`),
+			"multiple a children validate a+")
+		require.NotEmpty(t, validateDTDErrs(t, dtd+`<doc></doc>`),
+			"zero a children fails a+")
+	})
+}
+
+// TestSerializeQuotedStringBranches drives the dumpQuotedString writer helper
+// through all three quoting branches by serializing notation system IDs that
+// contain: no quote, a double quote only (forces single-quote delimiting), and
+// both quote kinds (forces double-quote delimiting with &quot; escaping).
+func TestSerializeQuotedStringBranches(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	dtd, err := doc.CreateInternalSubset("doc", "", "")
+	require.NoError(t, err)
+
+	// no quote -> double-quote delimited.
+	_, err = dtd.AddNotation("plain", "", "plain.exe")
+	require.NoError(t, err)
+	// double quote only -> single-quote delimited.
+	_, err = dtd.AddNotation("dq", "", `has"dquote`)
+	require.NoError(t, err)
+	// both quotes -> double-quote delimited with &quot; escaping of the dquote.
+	_, err = dtd.AddNotation("both", "", `has"dq and 'sq'`)
+	require.NoError(t, err)
+
+	root := doc.CreateElement("doc")
+	require.NoError(t, doc.AddChild(root))
+
+	out, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, out, `"plain.exe"`, "no-quote value double-quote delimited")
+	require.Contains(t, out, `'has"dquote'`, "double-quote-only value single-quote delimited")
+	require.Contains(t, out, "&quot;", "both-quote value escapes the embedded double quote")
+}
+
+// TestSetBooleanAttribute covers Element.SetBooleanAttribute for both the
+// success path (a value-less attribute) and the colon-rejection error path.
+func TestSetBooleanAttribute(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	root := doc.CreateElement("input")
+	require.NoError(t, doc.AddChild(root))
+
+	require.NoError(t, root.SetBooleanAttribute("checked"), "boolean attribute added")
+
+	require.True(t, root.HasAttribute("checked"), "boolean attribute is present")
+	val, ok := root.GetAttribute("checked")
+	require.True(t, ok, "boolean attribute is readable")
+	require.Empty(t, val, "boolean attribute has no value")
+
+	// A colon in the name is rejected.
+	require.Error(t, root.SetBooleanAttribute("ns:bad"))
+}
+
+// TestAppendChildFast covers the public AppendChildFast helper across the
+// empty-parent and non-empty-parent fast paths.
+func TestAppendChildFast(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	parent := doc.CreateElement("parent")
+
+	first := doc.CreateElement("first")
+	require.NoError(t, helium.AppendChildFast(parent, first), "fast-link first child")
+	require.Equal(t, helium.Node(first), parent.FirstChild())
+	require.Equal(t, helium.Node(first), parent.LastChild())
+	require.Equal(t, helium.Node(parent), first.Parent())
+
+	second := doc.CreateElement("second")
+	require.NoError(t, helium.AppendChildFast(parent, second), "fast-link second child")
+	require.Equal(t, helium.Node(second), parent.LastChild())
+	require.Equal(t, helium.Node(second), first.NextSibling())
+	require.Equal(t, helium.Node(first), second.PrevSibling())
+}
+
+// TestClarkName covers the ClarkName helper.
+func TestClarkName(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "{urn:example}local", helium.ClarkName("urn:example", "local"))
+	require.Equal(t, "{}local", helium.ClarkName("", "local"))
+}
+
+// TestParserMalformedBranches feeds a battery of distinct malformed inputs, each
+// designed to drive a specific parser error branch (XML declaration version /
+// encoding / standalone parsing, PI target and delimiter rules, comment and
+// CDATA termination, QName / Name lexical errors). Every input must be rejected;
+// the value is in exercising the otherwise-unreached error returns.
+func TestParserMalformedBranches(t *testing.T) {
+	t.Parallel()
+
+	bad := []struct {
+		name string
+		src  string
+	}{
+		{"xml decl version unquoted", `<?xml version=1.0?><root/>`},
+		{"xml decl bad standalone", `<?xml version="1.0" standalone="maybe"?><root/>`},
+		{"xml decl encoding unquoted", `<?xml version="1.0" encoding=UTF-8?><root/>`},
+		{"xml decl encoding bad first char", `<?xml version="1.0" encoding="1bad"?><root/>`},
+		{"xml decl missing version", `<?xml encoding="UTF-8"?><root/>`},
+		{"pi target named xml mid-document", `<root><?xml data?></root>`},
+		{"pi missing space after target", `<root><?targetdata</root>`},
+		{"pi unterminated", `<root><?target data </root>`},
+		{"comment with double hyphen", `<root><!-- a -- b --></root>`},
+		{"cdata unterminated", `<root><![CDATA[unterminated</root>`},
+		{"bad qname trailing colon", `<root:></root:>`},
+		{"name starts with digit", `<1root/>`},
+		{"attribute missing equals", `<root attr "v"/>`},
+		{"unterminated start tag", `<root attr="v"`},
+		{"text with raw less-than via entity ok but bad amp", `<root>a & b</root>`},
+	}
+
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := helium.NewParser().Parse(context.Background(), []byte(tc.src))
+			require.Error(t, err, "malformed input %q must be rejected", tc.src)
+		})
+	}
+}
+
+// TestParserWellFormedVariety parses a variety of well-formed constructs that
+// exercise the success branches of the same parser functions the malformed tests
+// hit on the error side: a leading PI, a comment, a CDATA section, namespaced
+// elements/attributes, character references, and an explicit encoding/standalone
+// declaration.
+func TestParserWellFormedVariety(t *testing.T) {
+	t.Parallel()
+
+	const src = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?pi-target some data?>
+<!-- a leading comment -->
+<p:root xmlns:p="urn:p" xmlns="urn:default" p:attr="v" plain="w">
+  <![CDATA[ raw <markup> & stuff ]]>
+  text &#65; &#x42; &amp; more
+  <p:child/>
+  <plain-child attr="x"/>
+</p:root>`
+
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(src))
+	require.NoError(t, err)
+	root := doc.DocumentElement()
+	require.NotNil(t, root)
+	require.Equal(t, "root", root.LocalName())
+
+	out, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, out, "urn:p")
+	require.Contains(t, out, "CDATA")
+}
+
+// TestParseDTDEntityValuesAndParamRefs parses internal-subset DTDs that exercise
+// the entity-value and parameter-entity-reference parser paths: entity values
+// containing character and general-entity references, a parameter entity declared
+// and then referenced inside the subset, and a mixed-content (#PCDATA|x|y)*
+// declaration with several alternatives.
+func TestParseDTDEntityValuesAndParamRefs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("entity value with char and general refs", func(t *testing.T) {
+		t.Parallel()
+		const src = `<?xml version="1.0"?>
+<!DOCTYPE doc [
+<!ELEMENT doc (#PCDATA)>
+<!ENTITY base "base">
+<!ENTITY composed "prefix-&base;-&#65;-suffix">
+]>
+<doc>&composed;</doc>`
+		doc, err := helium.NewParser().SubstituteEntities(true).Parse(context.Background(), []byte(src))
+		require.NoError(t, err)
+		require.NotNil(t, doc.DocumentElement())
+	})
+
+	t.Run("parameter entity expands to a markup declaration", func(t *testing.T) {
+		t.Parallel()
+		// A parameter entity whose replacement text is an entire markup
+		// declaration, referenced via %e; inside the internal subset, drives
+		// the PE-reference expansion path in the subset parser.
+		const src = `<?xml version="1.0"?>
+<!DOCTYPE doc [
+<!ENTITY % e "<!ELEMENT doc (#PCDATA)>">
+%e;
+]>
+<doc>text</doc>`
+		doc, err := helium.NewParser().Parse(context.Background(), []byte(src))
+		require.NoError(t, err)
+		dtd := doc.IntSubset()
+		require.NotNil(t, dtd)
+		_, ok := dtd.LookupElement("doc", "")
+		require.True(t, ok, "the PE-supplied element declaration was registered")
+	})
+
+	t.Run("mixed content with several alternatives", func(t *testing.T) {
+		t.Parallel()
+		const src = `<?xml version="1.0"?>
+<!DOCTYPE doc [
+<!ELEMENT doc (#PCDATA | a | b | c)*>
+<!ELEMENT a (#PCDATA)>
+<!ELEMENT b (#PCDATA)>
+<!ELEMENT c (#PCDATA)>
+]>
+<doc>t <a/> u <b/> v <c/> w</doc>`
+		doc, err := helium.NewParser().Parse(context.Background(), []byte(src))
+		require.NoError(t, err)
+		dtd := doc.IntSubset()
+		require.NotNil(t, dtd)
+		edecl, ok := dtd.LookupElement("doc", "")
+		require.True(t, ok)
+		require.Equal(t, enum.MixedElementType, edecl.DeclType())
+	})
+
+	t.Run("element children content with nested groups and occurrences", func(t *testing.T) {
+		t.Parallel()
+		const src = `<?xml version="1.0"?>
+<!DOCTYPE doc [
+<!ELEMENT doc (head, (para | list)*, foot?)>
+<!ELEMENT head (#PCDATA)>
+<!ELEMENT para (#PCDATA)>
+<!ELEMENT list (#PCDATA)>
+<!ELEMENT foot (#PCDATA)>
+]>
+<doc><head/><para/><list/><para/><foot/></doc>`
+		doc, err := helium.NewParser().ValidateDTD(true).Parse(context.Background(), []byte(src))
+		require.NoError(t, err)
+		require.NotNil(t, doc.DocumentElement())
+	})
+}
+
+// TestNamespaceNodeWrapperContent covers NamespaceNodeWrapper.Content.
+func TestNamespaceNodeWrapperContent(t *testing.T) {
+	t.Parallel()
+	ns := helium.NewNamespace("p", "urn:example")
+	nsw := helium.NewNamespaceNodeWrapper(ns, nil)
+	require.Equal(t, "urn:example", string(nsw.Content()))
+	require.Equal(t, "p", nsw.Name())
+}
+
+// TestDocumentAppendText covers Document.AppendText, which appends a Text child
+// to the document, merging into a trailing Text node when possible.
+func TestDocumentAppendText(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	require.NoError(t, doc.AppendText([]byte("hello")))
+	require.NoError(t, doc.AppendText([]byte(" world")))
+
+	var found bool
+	for c := doc.FirstChild(); c != nil; c = c.NextSibling() {
+		if c.Type() == helium.TextNode {
+			found = true
+			require.Contains(t, string(c.Content()), "hello")
+		}
+	}
+	require.True(t, found, "document gained a text child")
+}
+
+// TestNodeLine covers docnode.Line via a parsed node that carries line info.
+func TestNodeLine(t *testing.T) {
+	t.Parallel()
+	const src = "<root>\n  <child/>\n</root>"
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(src))
+	require.NoError(t, err)
+	root := doc.DocumentElement()
+	require.NotNil(t, root)
+	// Line() returns the recorded line number; it must be a non-negative int and
+	// not panic. We assert it is callable and consistent.
+	require.GreaterOrEqual(t, root.Line(), 0)
+	for c := root.FirstChild(); c != nil; c = c.NextSibling() {
+		if c.Type() == helium.ElementNode {
+			require.GreaterOrEqual(t, c.Line(), 0)
+		}
+	}
+}
+
+// TestWriteRichDTDWithEntities is a fuller round-trip that, in addition to the
+// existing rich-DTD test, exercises serialization of a programmatically built
+// DTD containing a percent-bearing internal entity and a parameter entity so the
+// entity-content writer paths run end to end and re-parse cleanly.
+func TestWriteRichDTDWithEntities(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	dtd, err := doc.CreateInternalSubset("doc", "", "")
+	require.NoError(t, err)
+
+	_, err = dtd.AddEntity("plain", enum.InternalGeneralEntity, "", "", "plain value")
+	require.NoError(t, err)
+	_, err = dtd.AddEntity("ext", enum.ExternalGeneralParsedEntity, "", "ext.xml", "")
+	require.NoError(t, err)
+	_, err = dtd.AddEntity("pub", enum.ExternalGeneralParsedEntity, "-//E//T//EN", "pub.xml", "")
+	require.NoError(t, err)
+
+	root := doc.CreateElement("doc")
+	require.NoError(t, doc.AddChild(root))
+
+	out, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, out, "<!ENTITY plain")
+	require.Contains(t, out, "<!ENTITY ext SYSTEM")
+	require.Contains(t, out, "<!ENTITY pub PUBLIC")
+
+	// Re-parse to confirm well-formedness.
+	require.True(t, strings.Contains(out, "<!DOCTYPE doc"))
+}

--- a/coverage_round3_test.go
+++ b/coverage_round3_test.go
@@ -1,0 +1,628 @@
+package helium_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/enum"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateReferenceWithDeclaredEntity exercises CreateReference both for a
+// predefined entity (resolvable) and an undeclared name (no entity attached).
+func TestCreateReferenceWithDeclaredEntity(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	dtd, err := doc.CreateInternalSubset("doc", "", "")
+	require.NoError(t, err)
+
+	_, err = dtd.AddEntity("greet", enum.InternalGeneralEntity, "", "", "Hello")
+	require.NoError(t, err)
+
+	// Reference to a declared general entity: the entity content is attached.
+	ref, err := doc.CreateReference("greet")
+	require.NoError(t, err)
+	require.Equal(t, helium.EntityRefNode, ref.Type())
+	require.Equal(t, []byte("Hello"), ref.Content())
+
+	// Reference to an undeclared name: still produces an EntityRef, but with no
+	// resolved content.
+	ref2, err := doc.CreateReference("undeclared")
+	require.NoError(t, err)
+	require.Equal(t, "undeclared", ref2.Name())
+
+	// "&name;" form is accepted and stripped.
+	ref3, err := doc.CreateReference("&greet;")
+	require.NoError(t, err)
+	require.Equal(t, "greet", ref3.Name())
+
+	// Empty name is rejected.
+	_, err = doc.CreateReference("")
+	require.Error(t, err)
+}
+
+// TestCreateCharRefForms covers the CreateCharRef name-stripping branches.
+func TestCreateCharRefForms(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+
+	plain, err := doc.CreateCharRef("foo")
+	require.NoError(t, err)
+	require.Equal(t, "foo", plain.Name())
+
+	// "&foo;" -> "foo"
+	full, err := doc.CreateCharRef("&foo;")
+	require.NoError(t, err)
+	require.Equal(t, "foo", full.Name())
+
+	// "&foo" (no trailing semicolon) -> "foo"
+	noSemi, err := doc.CreateCharRef("&foo")
+	require.NoError(t, err)
+	require.Equal(t, "foo", noSemi.Name())
+
+	// Empty name and a name that decodes to empty are rejected.
+	_, err = doc.CreateCharRef("")
+	require.Error(t, err)
+	_, err = doc.CreateCharRef("&;")
+	require.Error(t, err)
+}
+
+// TestCreateAttributeWithEntityValue drives the stringToNodeList path inside
+// CreateAttribute by passing a value containing character and entity references.
+func TestCreateAttributeWithEntityValue(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+
+	// Value with a decimal char ref, a hex char ref, and a named entity ref.
+	attr, err := doc.CreateAttribute("a", "x&#65;y&#x42;z&amp;w", nil)
+	require.NoError(t, err)
+	require.Equal(t, "a", attr.Name())
+	// The attribute has a child node list (text + entity refs).
+	require.NotNil(t, attr.FirstChild())
+
+	// Plain value (no '&') takes the fast single-text-node path.
+	attr2, err := doc.CreateAttribute("b", "plain", nil)
+	require.NoError(t, err)
+	require.Equal(t, "plain", attr2.Value())
+
+	// Colon in name is rejected.
+	_, err = doc.CreateAttribute("ns:x", "v", nil)
+	require.Error(t, err)
+}
+
+// TestGetEntityExternalSubset exercises GetEntity's external-subset lookup and
+// the standalone short-circuit, plus GetParameterEntity.
+func TestGetEntityFromInternalSubset(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	dtd, err := doc.CreateInternalSubset("doc", "", "")
+	require.NoError(t, err)
+
+	_, err = dtd.AddEntity("ge", enum.InternalGeneralEntity, "", "", "general")
+	require.NoError(t, err)
+	_, err = dtd.AddEntity("pe", enum.InternalParameterEntity, "", "", "param")
+	require.NoError(t, err)
+
+	ent, ok := doc.GetEntity("ge")
+	require.True(t, ok)
+	require.Equal(t, []byte("general"), ent.Content())
+
+	_, ok = doc.GetEntity("missing")
+	require.False(t, ok)
+
+	pe, ok := doc.GetParameterEntity("pe")
+	require.True(t, ok)
+	require.Equal(t, []byte("param"), pe.Content())
+
+	_, ok = doc.GetParameterEntity("missing")
+	require.False(t, ok)
+
+	// A document with no internal subset finds nothing.
+	bare := helium.NewDocument("1.0", "", helium.StandaloneImplicitNo)
+	_, ok = bare.GetEntity("ge")
+	require.False(t, ok)
+	_, ok = bare.GetParameterEntity("pe")
+	require.False(t, ok)
+}
+
+// TestIsMixedElementDeclTypes exercises IsMixedElement across the declared
+// element content types and the not-found error.
+func TestIsMixedElementDeclTypes(t *testing.T) {
+	t.Parallel()
+
+	const src = `<?xml version="1.0"?>
+<!DOCTYPE doc [
+  <!ELEMENT doc (child)>
+  <!ELEMENT child (#PCDATA|sub)*>
+  <!ELEMENT sub EMPTY>
+  <!ELEMENT any ANY>
+]>
+<doc><child/></doc>`
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	// Element-only content => not mixed.
+	mixed, err := doc.IsMixedElement("doc")
+	require.NoError(t, err)
+	require.False(t, mixed)
+
+	// (#PCDATA|sub)* => mixed.
+	mixed, err = doc.IsMixedElement("child")
+	require.NoError(t, err)
+	require.True(t, mixed)
+
+	// EMPTY => reported true (VC error path).
+	mixed, err = doc.IsMixedElement("sub")
+	require.NoError(t, err)
+	require.True(t, mixed)
+
+	// ANY => true.
+	mixed, err = doc.IsMixedElement("any")
+	require.NoError(t, err)
+	require.True(t, mixed)
+
+	// Undeclared element => error.
+	_, err = doc.IsMixedElement("nope")
+	require.Error(t, err)
+
+	// Document without an internal subset => error.
+	bare := helium.NewDocument("1.0", "", helium.StandaloneImplicitNo)
+	_, err = bare.IsMixedElement("x")
+	require.Error(t, err)
+}
+
+// TestEntityURIFallback covers Entity.URI's fallback to SystemID.
+func TestEntityURIFallback(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	dtd, err := doc.CreateInternalSubset("doc", "", "")
+	require.NoError(t, err)
+
+	ext, err := dtd.AddEntity("e", enum.ExternalGeneralParsedEntity, "pub", "sys.ent", "")
+	require.NoError(t, err)
+	// No resolved URI set => falls back to SystemID.
+	require.Equal(t, "sys.ent", ext.URI())
+	require.Equal(t, "sys.ent", ext.SystemID())
+	require.Equal(t, "pub", ext.ExternalID())
+}
+
+// TestNodeNamespaceMethods covers DeclareNamespace, SetActiveNamespace, SetNs,
+// AddNamespaceDecl and the qname caching in Name().
+func TestNodeNamespaceMethods(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	root := doc.CreateElement("root")
+	require.NoError(t, doc.AddChild(root))
+
+	require.NoError(t, root.DeclareNamespace("p", "http://example.com/p"))
+	require.NoError(t, root.SetActiveNamespace("p", "http://example.com/p"))
+
+	// Name() now reflects the prefix and caches the qname.
+	require.Equal(t, "p:root", root.Name())
+	require.Equal(t, "p:root", root.Name()) // cached path
+	require.Equal(t, "p", root.Prefix())
+	require.Equal(t, "http://example.com/p", root.URI())
+
+	// AddNamespaceDecl with an existing namespace object.
+	ns := helium.NewNamespace("q", "http://example.com/q")
+	root.AddNamespaceDecl(ns)
+	root.SetNs(ns)
+	require.Equal(t, "q:root", root.Name())
+}
+
+// TestChildElementsAndIterators covers the iter.go helpers including the
+// element-only filter and early termination.
+func TestChildElementsAndIterators(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	root := doc.CreateElement("root")
+	require.NoError(t, doc.AddChild(root))
+
+	require.NoError(t, root.AppendText([]byte("text")))
+	e1 := doc.CreateElement("a")
+	require.NoError(t, root.AddChild(e1))
+	require.NoError(t, root.AddChild(doc.CreateComment([]byte("c"))))
+	e2 := doc.CreateElement("b")
+	require.NoError(t, root.AddChild(e2))
+
+	// ChildElements skips text/comment.
+	var names []string
+	for el := range helium.ChildElements(root) {
+		names = append(names, el.Name())
+	}
+	require.Equal(t, []string{"a", "b"}, names)
+
+	// Early break from ChildElements.
+	count := 0
+	for range helium.ChildElements(root) {
+		count++
+		break
+	}
+	require.Equal(t, 1, count)
+
+	// Children yields all child nodes.
+	all := 0
+	for range helium.Children(root) {
+		all++
+	}
+	require.Equal(t, 4, all)
+
+	// Children/ChildElements/Descendants of nil yield nothing.
+	for range helium.Children(nil) {
+		t.Fatal("nil Children should yield nothing")
+	}
+	for range helium.ChildElements(nil) {
+		t.Fatal("nil ChildElements should yield nothing")
+	}
+	for range helium.Descendants(nil) {
+		t.Fatal("nil Descendants should yield nothing")
+	}
+
+	// Descendants does a depth-first walk; early break is honored.
+	dcount := 0
+	for range helium.Descendants(root) {
+		dcount++
+		break
+	}
+	require.Equal(t, 1, dcount)
+}
+
+// TestPINodeMethods exercises ProcessingInstruction AddChild/AppendText paths
+// including the text-merge and rejection branches.
+func TestPINodeMethods(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	pi := doc.CreatePI("target", "data")
+	require.Equal(t, "target", pi.Name())
+	require.Equal(t, []byte("data"), pi.Content())
+	require.Equal(t, helium.ProcessingInstructionNode, pi.Type())
+
+	// Adding a text node merges into the data string.
+	require.NoError(t, pi.AddChild(doc.CreateText([]byte(" more"))))
+	require.Equal(t, []byte("data more"), pi.Content())
+
+	// Adding a CDATA node also merges.
+	require.NoError(t, pi.AddChild(doc.CreateCDATASection([]byte("X"))))
+	require.Contains(t, string(pi.Content()), "X")
+
+	// AppendText appends directly.
+	require.NoError(t, pi.AppendText([]byte("Y")))
+	require.Contains(t, string(pi.Content()), "Y")
+
+	// Adding an element child is rejected.
+	require.Error(t, pi.AddChild(doc.CreateElement("e")))
+
+	// Adding a nil node is rejected with ErrNilNode (not a panic).
+	require.Error(t, pi.AddChild(nil))
+}
+
+// TestCommentNodeMethods exercises Comment AddChild merge/rejection branches.
+func TestCommentNodeMethods(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	c := doc.CreateComment([]byte("hello"))
+	require.Equal(t, []byte("hello"), c.Content())
+
+	// Merging another (unlinked) comment appends its content.
+	other := doc.CreateComment([]byte(" world"))
+	require.NoError(t, c.AddChild(other))
+	require.Equal(t, []byte("hello world"), c.Content())
+
+	// AppendText appends.
+	require.NoError(t, c.AppendText([]byte("!")))
+	require.Equal(t, []byte("hello world!"), c.Content())
+
+	// Adding a non-comment node is rejected.
+	require.Error(t, c.AddChild(doc.CreateText([]byte("t"))))
+
+	// Adding nil is rejected.
+	require.Error(t, c.AddChild(nil))
+}
+
+// TestCDATANodeMethods exercises the CDATASection node methods.
+func TestCDATANodeMethods(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	cd := doc.CreateCDATASection([]byte("data"))
+
+	// AppendText grows the content.
+	require.NoError(t, cd.AppendText([]byte("+more")))
+	require.Equal(t, []byte("data+more"), cd.Content())
+
+	// AddChild is rejected on a CDATA node.
+	require.Error(t, cd.AddChild(doc.CreateText([]byte("x"))))
+
+	// SetTreeDoc must not panic.
+	cd.SetTreeDoc(doc)
+
+	// AddSibling and Replace must run without panicking.
+	root := doc.CreateElement("root")
+	require.NoError(t, doc.AddChild(root))
+	require.NoError(t, root.AddChild(cd))
+	require.NoError(t, cd.AddSibling(doc.CreateCDATASection([]byte("sib"))))
+}
+
+// TestEntityRefNodeMethods exercises the EntityRef node-interface methods.
+func TestEntityRefNodeMethods(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	ref, err := doc.CreateCharRef("amp")
+	require.NoError(t, err)
+
+	ref.SetTreeDoc(doc)
+	require.NoError(t, ref.AppendText([]byte("x")))
+
+	root := doc.CreateElement("root")
+	require.NoError(t, doc.AddChild(root))
+	require.NoError(t, root.AddChild(ref))
+	require.NoError(t, ref.AddSibling(doc.CreateText([]byte("after"))))
+}
+
+// TestInternalSubsetErrors covers InternalSubset and CreateInternalSubset error
+// branches: no subset, and double creation.
+func TestInternalSubsetErrors(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+
+	_, err := doc.InternalSubset()
+	require.Error(t, err) // none yet
+
+	_, err = doc.CreateInternalSubset("doc", "", "")
+	require.NoError(t, err)
+
+	got, err := doc.InternalSubset()
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	// Second creation is rejected.
+	_, err = doc.CreateInternalSubset("doc", "", "")
+	require.Error(t, err)
+}
+
+// TestCreateInternalSubsetBeforeRoot ensures the DTD is inserted before an
+// already-present root element (the non-append branch).
+func TestCreateInternalSubsetBeforeRoot(t *testing.T) {
+	t.Parallel()
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	root := doc.CreateElement("doc")
+	require.NoError(t, doc.AddChild(root))
+
+	dtd, err := doc.CreateInternalSubset("doc", "-//X//EN", "x.dtd")
+	require.NoError(t, err)
+
+	// The DTD must come before the root element in the child list.
+	require.Same(t, helium.Node(dtd), doc.FirstChild())
+
+	out, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.True(t, strings.Contains(out, "<!DOCTYPE doc"))
+}
+
+// TestMalformedCharAndEntityRefs drives parseCharRef / parseEntityRef error
+// branches with a table of malformed-reference documents.
+func TestMalformedCharAndEntityRefs(t *testing.T) {
+	t.Parallel()
+
+	bad := []struct {
+		name string
+		src  string
+	}{
+		{"hex-missing-digits", `<root>&#x;</root>`},
+		{"dec-missing-digits", `<root>&#;</root>`},
+		{"hex-invalid-digit", `<root>&#xZZ;</root>`},
+		{"dec-invalid-digit", `<root>&#12A3;</root>`},
+		{"charref-out-of-range", `<root>&#x110000;</root>`},
+		{"charref-control", `<root>&#x0;</root>`},
+		{"undeclared-entity-standalone", `<?xml version="1.0" standalone="yes"?><root>&undeclared;</root>`},
+		{"entity-empty-name", `<root>&;</root>`},
+	}
+
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := helium.NewParser().Parse(t.Context(), []byte(tc.src))
+			require.Error(t, err, "expected parse error for %q", tc.src)
+		})
+	}
+}
+
+// TestEntityRefToUnparsedEntity drives the "entity reference to unparsed entity"
+// error branch of parseEntityRef.
+func TestEntityRefToUnparsedEntity(t *testing.T) {
+	t.Parallel()
+
+	const src = `<?xml version="1.0"?>
+<!DOCTYPE doc [
+  <!NOTATION gif SYSTEM "viewer">
+  <!ENTITY img SYSTEM "img.gif" NDATA gif>
+]>
+<doc>&img;</doc>`
+
+	_, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.Error(t, err)
+}
+
+// parseValidatingR3 parses src with DTD validation enabled, collecting errors.
+func parseValidatingR3(t *testing.T, src string) []error {
+	t.Helper()
+	h := &collectingErrorHandler{}
+	_, err := helium.NewParser().
+		ValidateDTD(true).
+		ErrorHandler(h).
+		Parse(t.Context(), []byte(src))
+	if err != nil {
+		require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+	}
+	return h.errs
+}
+
+// TestValidateGroupedSequenceOccurrences exercises matchSeq's Mult and Opt
+// occurrence branches via grouped sequence content models.
+func TestValidateGroupedSequenceOccurrences(t *testing.T) {
+	t.Parallel()
+
+	// (a, b)* — a repeated sequence group exercises matchSeq ElementContentMult.
+	const dtdMult = `<!DOCTYPE doc [
+<!ELEMENT doc (a, b)*>
+<!ELEMENT a (#PCDATA)>
+<!ELEMENT b (#PCDATA)>
+]>`
+	require.Empty(t, parseValidatingR3(t, dtdMult+`<doc><a/><b/><a/><b/></doc>`))
+	require.Empty(t, parseValidatingR3(t, dtdMult+`<doc></doc>`)) // zero repetitions
+	require.NotEmpty(t, parseValidatingR3(t, dtdMult+`<doc><a/></doc>`))
+
+	// (a, b)+ — one-or-more sequence group exercises matchSeq ElementContentPlus.
+	const dtdPlus = `<!DOCTYPE doc [
+<!ELEMENT doc (a, b)+>
+<!ELEMENT a (#PCDATA)>
+<!ELEMENT b (#PCDATA)>
+]>`
+	require.Empty(t, parseValidatingR3(t, dtdPlus+`<doc><a/><b/></doc>`))
+	require.Empty(t, parseValidatingR3(t, dtdPlus+`<doc><a/><b/><a/><b/></doc>`))
+	require.NotEmpty(t, parseValidatingR3(t, dtdPlus+`<doc></doc>`))
+}
+
+// TestValidateChoiceOccurrences exercises matchOr's Mult/Opt/Once branches.
+func TestValidateChoiceOccurrences(t *testing.T) {
+	t.Parallel()
+
+	// (a | b)* — choice with star.
+	const dtdMult = `<!DOCTYPE doc [
+<!ELEMENT doc (a | b)*>
+<!ELEMENT a (#PCDATA)>
+<!ELEMENT b (#PCDATA)>
+]>`
+	require.Empty(t, parseValidatingR3(t, dtdMult+`<doc></doc>`))
+	require.Empty(t, parseValidatingR3(t, dtdMult+`<doc><a/><a/><b/></doc>`))
+
+	// (a | b) once — exactly one of the two.
+	const dtdOnce = `<!DOCTYPE doc [
+<!ELEMENT doc (a | b)>
+<!ELEMENT a (#PCDATA)>
+<!ELEMENT b (#PCDATA)>
+]>`
+	require.Empty(t, parseValidatingR3(t, dtdOnce+`<doc><a/></doc>`))
+	require.Empty(t, parseValidatingR3(t, dtdOnce+`<doc><b/></doc>`))
+	require.NotEmpty(t, parseValidatingR3(t, dtdOnce+`<doc><a/><b/></doc>`))
+}
+
+// TestValidateRepeatedElement exercises matchElement's Mult/Plus branches.
+func TestValidateRepeatedElement(t *testing.T) {
+	t.Parallel()
+
+	const dtd = `<!DOCTYPE doc [
+<!ELEMENT doc (a+, b*)>
+<!ELEMENT a (#PCDATA)>
+<!ELEMENT b (#PCDATA)>
+]>`
+	require.Empty(t, parseValidatingR3(t, dtd+`<doc><a/></doc>`))
+	require.Empty(t, parseValidatingR3(t, dtd+`<doc><a/><a/><a/><b/><b/></doc>`))
+	require.NotEmpty(t, parseValidatingR3(t, dtd+`<doc><b/></doc>`)) // missing required a+
+}
+
+// TestValidateAttributeTypes exercises ID/IDREF/NMTOKEN/ENTITY attribute-type
+// validation paths.
+func TestValidateAttributeTypes(t *testing.T) {
+	t.Parallel()
+
+	const dtd = `<!DOCTYPE doc [
+<!ELEMENT doc (item+)>
+<!ELEMENT item EMPTY>
+<!ATTLIST item
+  id   ID    #REQUIRED
+  ref  IDREF #IMPLIED
+  tok  NMTOKEN #IMPLIED>
+]>`
+
+	// Valid: unique IDs, IDREF resolves, NMTOKEN well-formed.
+	require.Empty(t, parseValidatingR3(t,
+		dtd+`<doc><item id="a"/><item id="b" ref="a" tok="x1"/></doc>`))
+
+	// Duplicate ID is a validation error.
+	require.NotEmpty(t, parseValidatingR3(t,
+		dtd+`<doc><item id="a"/><item id="a"/></doc>`))
+
+	// IDREF pointing at a non-existent ID is a validation error.
+	require.NotEmpty(t, parseValidatingR3(t,
+		dtd+`<doc><item id="a" ref="missing"/></doc>`))
+}
+
+// TestValidateNotationAttribute exercises NOTATION-typed attribute validation.
+func TestValidateNotationAttribute(t *testing.T) {
+	t.Parallel()
+
+	const dtd = `<!DOCTYPE doc [
+<!NOTATION gif SYSTEM "viewer">
+<!ELEMENT doc EMPTY>
+<!ATTLIST doc kind NOTATION (gif) #IMPLIED>
+]>`
+
+	require.Empty(t, parseValidatingR3(t, dtd+`<doc kind="gif"/>`))
+	require.NotEmpty(t, parseValidatingR3(t, dtd+`<doc kind="png"/>`))
+}
+
+// TestDTDSerializationRichSubset round-trips a document with a rich internal
+// subset (entities, attributes with defaults, notations, varied content models)
+// to exercise the DTD writer paths.
+func TestDTDSerializationRichSubset(t *testing.T) {
+	t.Parallel()
+
+	const src = `<?xml version="1.0"?>
+<!DOCTYPE doc [
+<!ELEMENT doc (a | b)*>
+<!ELEMENT a (#PCDATA)>
+<!ELEMENT b EMPTY>
+<!ATTLIST a
+  id   ID       #IMPLIED
+  kind (x | y)  "x"
+  req  CDATA    #REQUIRED>
+<!ENTITY internal "expanded">
+<!ENTITY % pe "ignored">
+<!NOTATION gif SYSTEM "viewer.exe">
+]>
+<doc><a id="i1" req="r">text</a><b/></doc>`
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	out, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, out, "<!DOCTYPE doc")
+	require.Contains(t, out, "<!ELEMENT")
+	require.Contains(t, out, "<!ATTLIST")
+	require.Contains(t, out, "<!ENTITY")
+	require.Contains(t, out, "<!NOTATION")
+}
+
+// TestValidCharRefForms parses documents with valid hex/decimal char refs to
+// drive the success branches of parseCharRef.
+func TestValidCharRefForms(t *testing.T) {
+	t.Parallel()
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root>&#65;&#x42;&#x4A;</root>`))
+	require.NoError(t, err)
+	root := doc.DocumentElement()
+	require.NotNil(t, root)
+	require.Equal(t, "ABJ", string(root.Content()))
+}
+
+// TestResolveCharRefsViaEntityContent indirectly exercises resolveCharRefs by
+// round-tripping a document whose internal entity content contains char refs.
+func TestResolveCharRefsViaParse(t *testing.T) {
+	t.Parallel()
+
+	const src = `<?xml version="1.0"?>
+<!DOCTYPE doc [
+  <!ENTITY e "A&#66;C&#x44;E">
+]>
+<doc>&e;</doc>`
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	out, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, out, "doc")
+}

--- a/coverage_treebuilder_sax_test.go
+++ b/coverage_treebuilder_sax_test.go
@@ -1,0 +1,115 @@
+package helium_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// saxTreeBuilder embeds *helium.TreeBuilder without being a *TreeBuilder
+// itself. Because the parser only takes its fast (TreeBuilder-direct) path when
+// the supplied SAX handler is *exactly* a *TreeBuilder, wrapping it like this
+// forces the parser through the generic SAX2 callback path, exercising the
+// TreeBuilder's SAX2Handler methods (Comment, CDataBlock, Characters,
+// ProcessingInstruction, Reference, entity/DTD declaration callbacks, ...) that
+// the fast path bypasses.
+type saxTreeBuilder struct {
+	*helium.TreeBuilder
+}
+
+// TestTreeBuilderSAXPath drives a content-rich document through the generic SAX
+// callback path so the TreeBuilder's SAX2Handler methods build the tree.
+func TestTreeBuilderSAXPath(t *testing.T) {
+	t.Parallel()
+
+	const src = `<?xml version="1.0"?>
+<!DOCTYPE doc [
+<!ELEMENT doc (#PCDATA|child)*>
+<!ELEMENT child (#PCDATA)>
+<!ATTLIST doc id ID #IMPLIED>
+<!ENTITY greeting "hello">
+<!ENTITY img SYSTEM "img.gif" NDATA gif>
+<!NOTATION gif SYSTEM "viewer.exe">
+]>
+<doc id="d1">
+  <?pi-target pi-data?>
+  <!-- a comment -->
+  <child>text &greeting; more</child>
+  <![CDATA[ raw <data> & stuff ]]>
+</doc>`
+
+	handler := &saxTreeBuilder{TreeBuilder: helium.NewTreeBuilder()}
+	doc, err := helium.NewParser().
+		SubstituteEntities(true).
+		SAXHandler(handler).
+		Parse(t.Context(), []byte(src))
+	require.NoError(t, err, "parse through SAX path succeeds")
+	require.NotNil(t, doc)
+
+	root := doc.DocumentElement()
+	require.NotNil(t, root)
+	require.Equal(t, "doc", root.Name())
+
+	// The internal subset must have been built via the SAX DTD callbacks.
+	dtd := doc.IntSubset()
+	require.NotNil(t, dtd)
+	_, ok := dtd.LookupEntity("greeting")
+	require.True(t, ok, "greeting entity declared via SAX EntityDecl")
+	_, ok = dtd.LookupNotation("gif")
+	require.True(t, ok, "gif notation declared via SAX NotationDecl")
+
+	// Serialize the SAX-built tree to confirm the structure is intact.
+	out, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, out, "<child>")
+	require.Contains(t, out, "<![CDATA[")
+	require.Contains(t, out, "<?pi-target")
+	require.Contains(t, out, "<!--")
+}
+
+// TestTreeBuilderSAXPathNoEntitySubstitution drives the SAX path without entity
+// substitution so the Reference callback materializes entity-reference nodes.
+func TestTreeBuilderSAXPathNoEntitySubstitution(t *testing.T) {
+	t.Parallel()
+
+	const src = `<?xml version="1.0"?>
+<!DOCTYPE doc [
+<!ENTITY greeting "hello">
+]>
+<doc>before &greeting; after</doc>`
+
+	handler := &saxTreeBuilder{TreeBuilder: helium.NewTreeBuilder()}
+	doc, err := helium.NewParser().
+		SAXHandler(handler).
+		Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+
+	out, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, out, "&greeting;")
+}
+
+// TestTreeBuilderSAXPathNamespaces drives namespaced markup through the SAX
+// path so StartElementNS/EndElementNS bind and serialize namespaces correctly.
+func TestTreeBuilderSAXPathNamespaces(t *testing.T) {
+	t.Parallel()
+
+	const src = `<root xmlns:a="urn:a" xmlns="urn:default">` +
+		`<a:child attr="v">text</a:child>` +
+		`<plain/>` +
+		`</root>`
+
+	handler := &saxTreeBuilder{TreeBuilder: helium.NewTreeBuilder()}
+	doc, err := helium.NewParser().
+		SAXHandler(handler).
+		Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	out, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, out, `xmlns:a="urn:a"`)
+	require.Contains(t, out, `xmlns="urn:default"`)
+	require.Contains(t, out, "<a:child")
+}

--- a/coverage_validation_test.go
+++ b/coverage_validation_test.go
@@ -20,10 +20,10 @@ func (h *collectingErrorHandler) Handle(_ context.Context, err error) {
 
 // parseValidating parses src with DTD validation enabled, routing validation
 // errors into a collector.
-func parseValidating(t *testing.T, src string) (*helium.Document, []error) {
+func parseValidating(t *testing.T, src string) []error {
 	t.Helper()
 	h := &collectingErrorHandler{}
-	doc, err := helium.NewParser().
+	_, err := helium.NewParser().
 		ValidateDTD(true).
 		ErrorHandler(h).
 		Parse(t.Context(), []byte(src))
@@ -33,7 +33,7 @@ func parseValidating(t *testing.T, src string) (*helium.Document, []error) {
 	if err != nil {
 		require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
 	}
-	return doc, h.errs
+	return h.errs
 }
 
 // TestValidateSequenceContentModel exercises matchSeq for a valid and an invalid
@@ -49,12 +49,12 @@ func TestValidateSequenceContentModel(t *testing.T) {
 ]>`
 
 	valid := dtd + `<doc><a/><b/><c/></doc>`
-	_, errs := parseValidating(t, valid)
+	errs := parseValidating(t, valid)
 	require.Empty(t, errs, "a valid (a,b,c) sequence has no validation errors")
 
 	// Out-of-order children violate the sequence.
 	invalid := dtd + `<doc><b/><a/><c/></doc>`
-	_, errs = parseValidating(t, invalid)
+	errs = parseValidating(t, invalid)
 	require.NotEmpty(t, errs, "an out-of-order sequence is a validation error")
 }
 
@@ -69,12 +69,12 @@ func TestValidateChoiceContentModel(t *testing.T) {
 ]>`
 
 	valid := dtd + `<doc><a/><b/><a/></doc>`
-	_, errs := parseValidating(t, valid)
+	errs := parseValidating(t, valid)
 	require.Empty(t, errs, "a valid (a|b)+ choice has no validation errors")
 
 	// An undeclared child element c is not part of the choice.
 	invalid := dtd + `<doc><a/><c/></doc>`
-	_, errs = parseValidating(t, invalid)
+	errs = parseValidating(t, invalid)
 	require.NotEmpty(t, errs, "a child outside the choice is a validation error")
 }
 
@@ -88,12 +88,12 @@ func TestValidateMixedContent(t *testing.T) {
 ]>`
 
 	valid := dtd + `<doc>text <em>strong</em> more text</doc>`
-	_, errs := parseValidating(t, valid)
+	errs := parseValidating(t, valid)
 	require.Empty(t, errs, "valid mixed content has no validation errors")
 
 	// A child not allowed by the mixed model.
 	invalid := dtd + `<doc>text <strong>bad</strong></doc>`
-	_, errs = parseValidating(t, invalid)
+	errs = parseValidating(t, invalid)
 	require.NotEmpty(t, errs, "an undeclared child in mixed content is a validation error")
 }
 
@@ -109,15 +109,15 @@ func TestValidateRequiredAndFixedAttributes(t *testing.T) {
 ]>`
 
 	valid := dtd + `<doc req="x" fix="yes"/>`
-	_, errs := parseValidating(t, valid)
+	errs := parseValidating(t, valid)
 	require.Empty(t, errs, "all required/fixed attributes satisfied")
 
 	// Missing required attribute.
-	_, errs = parseValidating(t, dtd+`<doc fix="yes"/>`)
+	errs = parseValidating(t, dtd+`<doc fix="yes"/>`)
 	require.NotEmpty(t, errs, "missing #REQUIRED attribute is a validation error")
 
 	// Wrong value for a #FIXED attribute.
-	_, errs = parseValidating(t, dtd+`<doc req="x" fix="no"/>`)
+	errs = parseValidating(t, dtd+`<doc req="x" fix="no"/>`)
 	require.NotEmpty(t, errs, "wrong #FIXED value is a validation error")
 }
 
@@ -130,10 +130,10 @@ func TestValidateEnumerationAttribute(t *testing.T) {
 <!ATTLIST doc kind (red|green|blue) "red">
 ]>`
 
-	_, errs := parseValidating(t, dtd+`<doc kind="green"/>`)
+	errs := parseValidating(t, dtd+`<doc kind="green"/>`)
 	require.Empty(t, errs, "an enumerated value within the set is valid")
 
-	_, errs = parseValidating(t, dtd+`<doc kind="purple"/>`)
+	errs = parseValidating(t, dtd+`<doc kind="purple"/>`)
 	require.NotEmpty(t, errs, "a value outside the enumeration is a validation error")
 }
 
@@ -147,7 +147,7 @@ func TestValidateUndeclaredElement(t *testing.T) {
 ]>
 <doc><a/><undeclared/></doc>`
 
-	_, errs := parseValidating(t, src)
+	errs := parseValidating(t, src)
 	require.NotEmpty(t, errs, "an undeclared element is a validation error")
 }
 
@@ -160,7 +160,7 @@ func TestValidateRootMismatch(t *testing.T) {
 ]>
 <root/>`
 
-	_, errs := parseValidating(t, src)
+	errs := parseValidating(t, src)
 	require.NotEmpty(t, errs, "root element not matching the DTD name is a validation error")
 }
 
@@ -175,10 +175,10 @@ func TestValidateOptionalElementContent(t *testing.T) {
 ]>`
 
 	// Optional a omitted is valid.
-	_, errs := parseValidating(t, dtd+`<doc><b/></doc>`)
+	errs := parseValidating(t, dtd+`<doc><b/></doc>`)
 	require.Empty(t, errs, "omitting an optional element is valid")
 
 	// Optional a present is also valid.
-	_, errs = parseValidating(t, dtd+`<doc><a/><b/></doc>`)
+	errs = parseValidating(t, dtd+`<doc><a/><b/></doc>`)
 	require.Empty(t, errs, "including an optional element is valid")
 }

--- a/coverage_validation_test.go
+++ b/coverage_validation_test.go
@@ -1,0 +1,184 @@
+package helium_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// collectingErrorHandler records every validation error delivered during a
+// validating parse so tests can assert on the failure surface.
+type collectingErrorHandler struct {
+	errs []error
+}
+
+func (h *collectingErrorHandler) Handle(_ context.Context, err error) {
+	h.errs = append(h.errs, err)
+}
+
+// parseValidating parses src with DTD validation enabled, routing validation
+// errors into a collector.
+func parseValidating(t *testing.T, src string) (*helium.Document, []error) {
+	t.Helper()
+	h := &collectingErrorHandler{}
+	doc, err := helium.NewParser().
+		ValidateDTD(true).
+		ErrorHandler(h).
+		Parse(t.Context(), []byte(src))
+	// A validation failure returns ErrDTDValidationFailed; the document is still
+	// returned. Parser-level (well-formedness) errors are a different matter and
+	// are not expected for these well-formed inputs.
+	if err != nil {
+		require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+	}
+	return doc, h.errs
+}
+
+// TestValidateSequenceContentModel exercises matchSeq for a valid and an invalid
+// (a, b, c) sequence content model.
+func TestValidateSequenceContentModel(t *testing.T) {
+	t.Parallel()
+
+	const dtd = `<!DOCTYPE doc [
+<!ELEMENT doc (a, b, c)>
+<!ELEMENT a (#PCDATA)>
+<!ELEMENT b (#PCDATA)>
+<!ELEMENT c (#PCDATA)>
+]>`
+
+	valid := dtd + `<doc><a/><b/><c/></doc>`
+	_, errs := parseValidating(t, valid)
+	require.Empty(t, errs, "a valid (a,b,c) sequence has no validation errors")
+
+	// Out-of-order children violate the sequence.
+	invalid := dtd + `<doc><b/><a/><c/></doc>`
+	_, errs = parseValidating(t, invalid)
+	require.NotEmpty(t, errs, "an out-of-order sequence is a validation error")
+}
+
+// TestValidateChoiceContentModel exercises matchOr with a repeated choice.
+func TestValidateChoiceContentModel(t *testing.T) {
+	t.Parallel()
+
+	const dtd = `<!DOCTYPE doc [
+<!ELEMENT doc (a | b)+>
+<!ELEMENT a (#PCDATA)>
+<!ELEMENT b (#PCDATA)>
+]>`
+
+	valid := dtd + `<doc><a/><b/><a/></doc>`
+	_, errs := parseValidating(t, valid)
+	require.Empty(t, errs, "a valid (a|b)+ choice has no validation errors")
+
+	// An undeclared child element c is not part of the choice.
+	invalid := dtd + `<doc><a/><c/></doc>`
+	_, errs = parseValidating(t, invalid)
+	require.NotEmpty(t, errs, "a child outside the choice is a validation error")
+}
+
+// TestValidateMixedContent exercises validateMixedContent.
+func TestValidateMixedContent(t *testing.T) {
+	t.Parallel()
+
+	const dtd = `<!DOCTYPE doc [
+<!ELEMENT doc (#PCDATA|em)*>
+<!ELEMENT em (#PCDATA)>
+]>`
+
+	valid := dtd + `<doc>text <em>strong</em> more text</doc>`
+	_, errs := parseValidating(t, valid)
+	require.Empty(t, errs, "valid mixed content has no validation errors")
+
+	// A child not allowed by the mixed model.
+	invalid := dtd + `<doc>text <strong>bad</strong></doc>`
+	_, errs = parseValidating(t, invalid)
+	require.NotEmpty(t, errs, "an undeclared child in mixed content is a validation error")
+}
+
+// TestValidateRequiredAndFixedAttributes exercises the attribute-default checks.
+func TestValidateRequiredAndFixedAttributes(t *testing.T) {
+	t.Parallel()
+
+	const dtd = `<!DOCTYPE doc [
+<!ELEMENT doc EMPTY>
+<!ATTLIST doc
+  req CDATA #REQUIRED
+  fix CDATA #FIXED "yes">
+]>`
+
+	valid := dtd + `<doc req="x" fix="yes"/>`
+	_, errs := parseValidating(t, valid)
+	require.Empty(t, errs, "all required/fixed attributes satisfied")
+
+	// Missing required attribute.
+	_, errs = parseValidating(t, dtd+`<doc fix="yes"/>`)
+	require.NotEmpty(t, errs, "missing #REQUIRED attribute is a validation error")
+
+	// Wrong value for a #FIXED attribute.
+	_, errs = parseValidating(t, dtd+`<doc req="x" fix="no"/>`)
+	require.NotEmpty(t, errs, "wrong #FIXED value is a validation error")
+}
+
+// TestValidateEnumerationAttribute exercises the enumeration token check.
+func TestValidateEnumerationAttribute(t *testing.T) {
+	t.Parallel()
+
+	const dtd = `<!DOCTYPE doc [
+<!ELEMENT doc EMPTY>
+<!ATTLIST doc kind (red|green|blue) "red">
+]>`
+
+	_, errs := parseValidating(t, dtd+`<doc kind="green"/>`)
+	require.Empty(t, errs, "an enumerated value within the set is valid")
+
+	_, errs = parseValidating(t, dtd+`<doc kind="purple"/>`)
+	require.NotEmpty(t, errs, "a value outside the enumeration is a validation error")
+}
+
+// TestValidateUndeclaredElement exercises the "no declaration found" branch.
+func TestValidateUndeclaredElement(t *testing.T) {
+	t.Parallel()
+
+	const src = `<!DOCTYPE doc [
+<!ELEMENT doc (a)>
+<!ELEMENT a (#PCDATA)>
+]>
+<doc><a/><undeclared/></doc>`
+
+	_, errs := parseValidating(t, src)
+	require.NotEmpty(t, errs, "an undeclared element is a validation error")
+}
+
+// TestValidateRootMismatch exercises the root-name-vs-DTD-name check.
+func TestValidateRootMismatch(t *testing.T) {
+	t.Parallel()
+
+	const src = `<!DOCTYPE wrong [
+<!ELEMENT root EMPTY>
+]>
+<root/>`
+
+	_, errs := parseValidating(t, src)
+	require.NotEmpty(t, errs, "root element not matching the DTD name is a validation error")
+}
+
+// TestValidateOptionalElementContent exercises the ? occurrence in a sequence.
+func TestValidateOptionalElementContent(t *testing.T) {
+	t.Parallel()
+
+	const dtd = `<!DOCTYPE doc [
+<!ELEMENT doc (a?, b)>
+<!ELEMENT a (#PCDATA)>
+<!ELEMENT b (#PCDATA)>
+]>`
+
+	// Optional a omitted is valid.
+	_, errs := parseValidating(t, dtd+`<doc><b/></doc>`)
+	require.Empty(t, errs, "omitting an optional element is valid")
+
+	// Optional a present is also valid.
+	_, errs = parseValidating(t, dtd+`<doc><a/><b/></doc>`)
+	require.Empty(t, errs, "including an optional element is valid")
+}

--- a/coverage_writer_dtd_test.go
+++ b/coverage_writer_dtd_test.go
@@ -1,0 +1,150 @@
+package helium_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSerializeRichDTD parses a DTD that exercises every attribute type, every
+// default kind, internal/external/parameter/unparsed entities, PUBLIC and
+// SYSTEM notations, and EMPTY/ANY/mixed/element content models, then serializes
+// it so the DTD-writer paths are covered. The serialized form round-trips
+// through a second parse.
+func TestSerializeRichDTD(t *testing.T) {
+	t.Parallel()
+
+	const src = `<?xml version="1.0"?>
+<!DOCTYPE doc [
+<!ELEMENT doc (a, b?, (c | d)*, e+)>
+<!ELEMENT a EMPTY>
+<!ELEMENT b ANY>
+<!ELEMENT c (#PCDATA)>
+<!ELEMENT d (#PCDATA|c)*>
+<!ELEMENT e (#PCDATA)>
+<!ATTLIST doc
+  id    ID       #IMPLIED
+  ref   IDREF    #IMPLIED
+  refs  IDREFS   #IMPLIED
+  ent   ENTITY   #IMPLIED
+  ents  ENTITIES #IMPLIED
+  tok   NMTOKEN  #IMPLIED
+  toks  NMTOKENS #IMPLIED
+  req   CDATA    #REQUIRED
+  fix   CDATA    #FIXED "fixed"
+  kind  (x|y|z)  "x"
+  note  NOTATION (gif|png) #IMPLIED>
+<!ENTITY internal "internal value">
+<!ENTITY ext SYSTEM "ext.xml">
+<!ENTITY pub PUBLIC "-//Example//Text//EN" "pub.xml">
+<!ENTITY img SYSTEM "img.gif" NDATA gif>
+<!ENTITY % pe "param value">
+<!NOTATION gif SYSTEM "viewer.exe">
+<!NOTATION png PUBLIC "-//Example//Notation//EN" "png.exe">
+]>
+<doc id="d1" req="x"><a/><c>c</c><e>e</e></doc>`
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err, "parse rich DTD")
+
+	out, err := helium.WriteString(doc)
+	require.NoError(t, err, "serialize rich DTD")
+
+	// Spot-check the declarations made it into the serialized DTD.
+	for _, want := range []string{
+		"<!DOCTYPE doc",
+		"<!ELEMENT a EMPTY>",
+		"<!ELEMENT b ANY>",
+		"ID",
+		"IDREF",
+		"IDREFS",
+		"ENTITY",
+		"ENTITIES",
+		"NMTOKEN",
+		"#REQUIRED",
+		"#FIXED",
+		"NOTATION",
+		"<!ENTITY internal",
+		"<!ENTITY ext SYSTEM",
+		"<!ENTITY pub PUBLIC",
+		"NDATA gif",
+		"<!ENTITY % pe",
+		"<!NOTATION gif SYSTEM",
+		"<!NOTATION png PUBLIC",
+	} {
+		require.Contains(t, out, want, "serialized DTD should contain %q", want)
+	}
+
+	// The serialized output must itself re-parse cleanly.
+	_, err = helium.NewParser().Parse(t.Context(), []byte(out))
+	require.NoError(t, err, "re-parse serialized rich DTD")
+}
+
+// TestSerializeEscaping exercises the text/attribute escaping paths, including
+// values that contain both single and double quotes and assorted control and
+// markup characters.
+func TestSerializeEscaping(t *testing.T) {
+	t.Parallel()
+
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	root := doc.CreateElement("root")
+	require.NoError(t, doc.AddChild(root))
+
+	// Attribute value containing both quote characters plus markup chars.
+	// SetLiteralAttribute stores the value verbatim (no entity parsing) so the
+	// serializer is the component responsible for escaping it.
+	err := root.SetLiteralAttribute("attr", `he said "hi" & 'bye' <x>`)
+	require.NoError(t, err)
+
+	// Text content with markup, ampersand, tab and newline.
+	require.NoError(t, root.AppendText([]byte("a < b & c > d\twith\ntabs")))
+
+	out, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	require.Contains(t, out, "&amp;")
+	require.Contains(t, out, "&lt;")
+	require.Contains(t, out, "&gt;")
+	require.Contains(t, out, "&quot;")
+
+	// Re-parse to confirm well-formedness of the escaped output.
+	_, err = helium.NewParser().Parse(t.Context(), []byte(out))
+	require.NoError(t, err)
+}
+
+// TestSerializeFormatting exercises the Format/IndentString writer options.
+func TestSerializeFormatting(t *testing.T) {
+	t.Parallel()
+
+	const src = `<root><a><b>text</b></a><c/></root>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	var buf strings.Builder
+	err = helium.NewWriter().
+		Format(true).
+		IndentString("    ").
+		XMLDeclaration(false).
+		WriteTo(&buf, doc)
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "\n    ")
+	require.NotContains(t, buf.String(), "<?xml")
+}
+
+// TestSerializeSelfCloseToggle exercises the SelfCloseEmptyElements option.
+func TestSerializeSelfCloseToggle(t *testing.T) {
+	t.Parallel()
+
+	const src = `<root><empty/></root>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	var buf strings.Builder
+	err = helium.NewWriter().
+		SelfCloseEmptyElements(false).
+		XMLDeclaration(false).
+		WriteTo(&buf, doc)
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "<empty></empty>")
+}

--- a/coverage_xhtml_test.go
+++ b/coverage_xhtml_test.go
@@ -1,0 +1,65 @@
+package helium_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSerializeXHTML parses an XHTML 1.0 document (recognized via its PUBLIC
+// identifier) and serializes it, exercising the XHTML-specific writer paths:
+// void elements, the html xmlns injection, head content-type meta injection, and
+// boolean attribute handling.
+func TestSerializeXHTML(t *testing.T) {
+	t.Parallel()
+
+	const src = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>t</title></head>
+<body>
+<p>para<br/>after break</p>
+<img src="x.png" alt="x"/>
+<form action="/go"><input type="checkbox" checked="checked"/></form>
+<hr/>
+</body>
+</html>`
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err, "parse XHTML document")
+
+	out, err := helium.WriteString(doc)
+	require.NoError(t, err, "serialize XHTML document")
+
+	// Void elements use the " />" form in XHTML output.
+	require.Contains(t, out, "<br />")
+	require.Contains(t, out, "<hr />")
+	require.True(t, strings.Contains(out, "<img"), "img element serialized")
+
+	// Re-parse the serialized output to confirm well-formedness.
+	_, err = helium.NewParser().Parse(t.Context(), []byte(out))
+	require.NoError(t, err, "re-parse serialized XHTML")
+}
+
+// TestSerializeXHTMLFormatted serializes XHTML with formatting enabled to drive
+// the indentation branches of the XHTML writer.
+func TestSerializeXHTMLFormatted(t *testing.T) {
+	t.Parallel()
+
+	const src = `<?xml version="1.0"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>t</title></head>
+<body><div><p>x</p></div></body>
+</html>`
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	var buf strings.Builder
+	err = helium.NewWriter().Format(true).WriteTo(&buf, doc)
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "<html")
+}

--- a/shim/coverage_compat_errors_internal_test.go
+++ b/shim/coverage_compat_errors_internal_test.go
@@ -1,0 +1,208 @@
+package shim
+
+import (
+	stdxml "encoding/xml"
+	"errors"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+)
+
+func TestConvertParseErrorNil(t *testing.T) {
+	if got := convertParseError(nil); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestConvertParseErrorPassthrough(t *testing.T) {
+	in := errors.New("some other error")
+	if got := convertParseError(in); got != in {
+		t.Fatalf("expected passthrough error, got %v", got)
+	}
+}
+
+func TestConvertParseErrorMapsToSyntaxError(t *testing.T) {
+	pe := helium.ErrParseError{
+		LineNumber: 7,
+		Line:       "</foo>",
+		Err:        errors.New("invalid name start char"),
+	}
+	got := convertParseError(pe)
+	se, ok := got.(*stdxml.SyntaxError)
+	if !ok {
+		t.Fatalf("expected *xml.SyntaxError, got %T", got)
+	}
+	if se.Line != 7 {
+		t.Fatalf("expected line 7, got %d", se.Line)
+	}
+	if se.Msg != "unexpected end element </foo>" {
+		t.Fatalf("unexpected msg: %q", se.Msg)
+	}
+}
+
+func TestMapErrorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		raw  string
+		want string
+	}{
+		{"name-start-no-end", "<1bad>", "invalid name start char", "expected element name after <"},
+		{"name-start-prefix", "<1bad>", "invalid name start char: x", "expected element name after <"},
+		{"qname", "", "failed to parse QName: bad", "expected attribute name in element"},
+		{"start-tag", "", "start tag expected, '<' not found", "start tag expected, '<' not found"},
+		{"char-data", "", "invalid char data", "invalid char data"},
+		{"semicolon-with-entity", "text &amp", "';' is required", "invalid character entity &amp (no semicolon)"},
+		{"semicolon-no-entity", "no amp here", "';' is required", "';' is required"},
+		{"name-required-bad-entity", "x &￾; y", "name is required", "invalid character entity &￾;"},
+		{"name-required-default", "no amp", "name is required", "invalid character entity & (no semicolon)"},
+		{"local-empty-qname", "", "local name empty! failed to parse QName", "expected element name after <"},
+		{"local-empty-plain", "", "local name empty! something", "local name empty! something"},
+		{"unknown-passthrough", "", "totally unknown error", "totally unknown error"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pe := helium.ErrParseError{Line: tt.line, Err: errors.New(tt.raw)}
+			if got := mapErrorMessage(pe); got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapErrorMessageEndTagMismatch(t *testing.T) {
+	// "expected end tag 'prefix:local'" with a differing close tag in context.
+	pe := helium.ErrParseError{
+		Line: "<a:foo></b:foo>",
+		Err:  errors.New("expected end tag 'a:foo'"),
+	}
+	got := mapErrorMessage(pe)
+	want := `element <foo> in space a closed by </foo> in space b`
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestMapErrorMessageNamespaceNotFound(t *testing.T) {
+	pe := helium.ErrParseError{
+		Line: "<x:foo></y:foo>",
+		Err:  errors.New("namespace 'x' not found"),
+	}
+	got := mapErrorMessage(pe)
+	want := `element <foo> in space x closed by </foo> in space y`
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestConvertEndTagMismatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		expectedTag string
+		contextLine string
+		want        string
+	}{
+		{"differing-local", "a:foo", "<a:foo></a:bar>", "element <a:foo> closed by </a:bar>"},
+		{"prefix-vs-noprefix", "a:foo", "<a:foo></foo>", `element <foo> in space a closed by </foo> in space ""`},
+		{"differing-prefix", "a:foo", "<a:foo></b:foo>", "element <foo> in space a closed by </foo> in space b"},
+		{"no-close-with-prefix", "a:foo", "no close tag here", `element <foo> in space a closed by </foo> in space ""`},
+		{"no-close-no-prefix", "foo", "no close tag here", "expected end tag 'foo'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := convertEndTagMismatch(tt.expectedTag, tt.contextLine); got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertNamespaceError(t *testing.T) {
+	tests := []struct {
+		name        string
+		ns          string
+		contextLine string
+		want        string
+	}{
+		{"matched", "x", "<x:foo></y:foo>", "element <foo> in space x closed by </foo> in space y"},
+		{"no-open-tag", "x", "nothing here", "namespace 'x' not found"},
+		{"open-no-close", "x", "<x:foo bar", "namespace 'x' not found"},
+		{"local-mismatch", "x", "<x:foo></y:bar>", "namespace 'x' not found"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := convertNamespaceError(tt.ns, tt.contextLine); got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractEndElement(t *testing.T) {
+	tests := []struct {
+		line string
+		want string
+	}{
+		{"<a></foo>", "foo"},
+		{"no end here", ""},
+		{"</foo bar", "foo"},
+		{"</foo", "foo"},
+		{"</", ""},
+		{"</>", ""},
+	}
+	for _, tt := range tests {
+		if got := extractEndElement(tt.line); got != tt.want {
+			t.Fatalf("extractEndElement(%q)=%q, want %q", tt.line, got, tt.want)
+		}
+	}
+}
+
+func TestExtractEntityName(t *testing.T) {
+	tests := []struct {
+		line string
+		want string
+	}{
+		{"text &amp more", "amp"},
+		{"no ampersand", ""},
+		{"trailing &", ""},
+		{"&abc", "abc"},
+	}
+	for _, tt := range tests {
+		if got := extractEntityName(tt.line); got != tt.want {
+			t.Fatalf("extractEntityName(%q)=%q, want %q", tt.line, got, tt.want)
+		}
+	}
+}
+
+func TestExtractBadEntity(t *testing.T) {
+	tests := []struct {
+		line string
+		want string
+	}{
+		{"x &￾; y", "￾"},
+		{"no ampersand", ""},
+		{"trailing &", ""},
+		{"&abc;", ""},  // first char is a name char
+		{"&￾", ""}, // no following semicolon
+	}
+	for _, tt := range tests {
+		if got := extractBadEntity(tt.line); got != tt.want {
+			t.Fatalf("extractBadEntity(%q)=%q, want %q", tt.line, got, tt.want)
+		}
+	}
+}
+
+func TestIsXMLNameChar(t *testing.T) {
+	valid := []rune{'a', 'Z', '5', '_', '-', '.', ':', 0xC0, 0xD8, 0xF8, 0x300, 0xB7, 0x370, 0x37F}
+	for _, r := range valid {
+		if !isXMLNameChar(r) {
+			t.Fatalf("expected %#U to be a name char", r)
+		}
+	}
+	invalid := []rune{' ', '\t', '<', '>', '&', 0xD7, 0xF7, 0x2000, 0x37E}
+	for _, r := range invalid {
+		if isXMLNameChar(r) {
+			t.Fatalf("expected %#U to not be a name char", r)
+		}
+	}
+}

--- a/shim/coverage_compat_errors_internal_test.go
+++ b/shim/coverage_compat_errors_internal_test.go
@@ -8,6 +8,8 @@ import (
 	helium "github.com/lestrrat-go/helium"
 )
 
+const wantExpectedElementName = "expected element name after <"
+
 func TestConvertParseErrorNil(t *testing.T) {
 	if got := convertParseError(nil); got != nil {
 		t.Fatalf("expected nil, got %v", got)
@@ -47,8 +49,8 @@ func TestMapErrorMessage(t *testing.T) {
 		raw  string
 		want string
 	}{
-		{"name-start-no-end", "<1bad>", "invalid name start char", "expected element name after <"},
-		{"name-start-prefix", "<1bad>", "invalid name start char: x", "expected element name after <"},
+		{"name-start-no-end", "<1bad>", "invalid name start char", wantExpectedElementName},
+		{"name-start-prefix", "<1bad>", "invalid name start char: x", wantExpectedElementName},
 		{"qname", "", "failed to parse QName: bad", "expected attribute name in element"},
 		{"start-tag", "", "start tag expected, '<' not found", "start tag expected, '<' not found"},
 		{"char-data", "", "invalid char data", "invalid char data"},
@@ -56,7 +58,7 @@ func TestMapErrorMessage(t *testing.T) {
 		{"semicolon-no-entity", "no amp here", "';' is required", "';' is required"},
 		{"name-required-bad-entity", "x &￾; y", "name is required", "invalid character entity &￾;"},
 		{"name-required-default", "no amp", "name is required", "invalid character entity & (no semicolon)"},
-		{"local-empty-qname", "", "local name empty! failed to parse QName", "expected element name after <"},
+		{"local-empty-qname", "", "local name empty! failed to parse QName", wantExpectedElementName},
 		{"local-empty-plain", "", "local name empty! something", "local name empty! something"},
 		{"unknown-passthrough", "", "totally unknown error", "totally unknown error"},
 	}
@@ -182,8 +184,8 @@ func TestExtractBadEntity(t *testing.T) {
 		{"x &￾; y", "￾"},
 		{"no ampersand", ""},
 		{"trailing &", ""},
-		{"&abc;", ""},  // first char is a name char
-		{"&￾", ""}, // no following semicolon
+		{"&abc;", ""}, // first char is a name char
+		{"&￾", ""},    // no following semicolon
 	}
 	for _, tt := range tests {
 		if got := extractBadEntity(tt.line); got != tt.want {

--- a/shim/coverage_decoder_test.go
+++ b/shim/coverage_decoder_test.go
@@ -1,0 +1,89 @@
+package shim_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium/shim"
+)
+
+// byteOnlyReader implements io.Reader and io.ByteReader. When passed to
+// ensureReader via CharsetReader, the decoder wraps it in a byteReaderWrapper
+// that drives ReadByte, exercising byteReaderWrapper.Read.
+type byteOnlyReader struct {
+	r *bytes.Reader
+}
+
+func (b *byteOnlyReader) Read(p []byte) (int, error) { return b.r.Read(p) }
+func (b *byteOnlyReader) ReadByte() (byte, error)    { return b.r.ReadByte() }
+
+func TestDecoderCharsetReaderByteReader(t *testing.T) {
+	input := `<?xml version="1.0" encoding="latin1"?><root>hi</root>`
+	dec := shim.NewDecoder(context.Background(), strings.NewReader(input))
+	dec.CharsetReader = func(charset string, in io.Reader) (io.Reader, error) {
+		if charset != "latin1" {
+			t.Errorf("unexpected charset %q", charset)
+		}
+		// Drain the converted input and return a ByteReader-only wrapper so
+		// the decoder must adapt it via byteReaderWrapper.
+		data, err := io.ReadAll(in)
+		if err != nil {
+			return nil, err
+		}
+		return &byteOnlyReader{r: bytes.NewReader(data)}, nil
+	}
+
+	var sawRoot bool
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Token error: %v", err)
+		}
+		if se, ok := tok.(shim.StartElement); ok && se.Name.Local == "root" {
+			sawRoot = true
+		}
+	}
+	if !sawRoot {
+		t.Fatal("did not see <root> element")
+	}
+}
+
+func TestDecoderClose(t *testing.T) {
+	dec := shim.NewDecoder(context.Background(), strings.NewReader(`<root><a/><b/></root>`))
+	// Read one token to start the SAX goroutine, then Close to cancel it.
+	if _, err := dec.Token(); err != nil {
+		t.Fatalf("Token error: %v", err)
+	}
+	dec.Close()
+	// Closing again must be safe (cancel is idempotent).
+	dec.Close()
+}
+
+func TestDecoderCloseBeforeRead(t *testing.T) {
+	dec := shim.NewDecoder(context.Background(), strings.NewReader(`<root/>`))
+	// Close before any read: cancel is non-nil but goroutine never started.
+	dec.Close()
+}
+
+func TestDecoderInputPos(t *testing.T) {
+	dec := shim.NewDecoder(context.Background(), strings.NewReader(`<root>text</root>`))
+	// Before reading, line is 1 -> returns (1,1).
+	if l, c := dec.InputPos(); l != 1 || c != 1 {
+		t.Fatalf("expected (1,1) before read, got (%d,%d)", l, c)
+	}
+	for {
+		if _, err := dec.Token(); err != nil {
+			break
+		}
+	}
+	// After reading content, positions should be reported (line >= 1).
+	if l, _ := dec.InputPos(); l < 1 {
+		t.Fatalf("expected line >= 1, got %d", l)
+	}
+}

--- a/shim/coverage_unmarshal_path_test.go
+++ b/shim/coverage_unmarshal_path_test.go
@@ -1,0 +1,101 @@
+package shim_test
+
+import (
+	stdxml "encoding/xml"
+	"testing"
+
+	"github.com/lestrrat-go/helium/shim"
+)
+
+// TestUnmarshalNestedPath exercises findPathLeaf / findPathLeafInner for
+// multi-segment struct tag paths (e.g. "a>b>c").
+func TestUnmarshalNestedPath(t *testing.T) {
+	type Doc struct {
+		Value string `xml:"a>b>c"`
+	}
+	var d Doc
+	in := []byte(`<Doc><a><b><c>hello</c></b></a></Doc>`)
+	if err := shim.Unmarshal(in, &d); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if d.Value != "hello" {
+		t.Fatalf("expected 'hello', got %q", d.Value)
+	}
+}
+
+// TestUnmarshalNestedPathSlice exercises the slice branch over findPathLeaf.
+func TestUnmarshalNestedPathSlice(t *testing.T) {
+	type Doc struct {
+		Values []string `xml:"a>b"`
+	}
+	var d Doc
+	in := []byte(`<Doc><a><b>one</b><b>two</b></a></Doc>`)
+	if err := shim.Unmarshal(in, &d); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if len(d.Values) != 2 || d.Values[0] != "one" || d.Values[1] != "two" {
+		t.Fatalf("unexpected values: %#v", d.Values)
+	}
+}
+
+// TestUnmarshalNestedPathXMLName exercises setXMLName at the leaf of a path.
+func TestUnmarshalNestedPathXMLName(t *testing.T) {
+	type Doc struct {
+		Leaf stdxml.Name `xml:"a>b"`
+	}
+	var d Doc
+	in := []byte(`<Doc><a><b/></a></Doc>`)
+	if err := shim.Unmarshal(in, &d); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if d.Leaf.Local != "b" {
+		t.Fatalf("expected leaf name 'b', got %q", d.Leaf.Local)
+	}
+}
+
+// TestUnmarshalNestedPathMissing exercises the leaf-not-found branch.
+func TestUnmarshalNestedPathMissing(t *testing.T) {
+	type Doc struct {
+		Value string `xml:"a>b>c"`
+	}
+	var d Doc
+	in := []byte(`<Doc><a><b><other>x</other></b></a></Doc>`)
+	if err := shim.Unmarshal(in, &d); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if d.Value != "" {
+		t.Fatalf("expected empty value, got %q", d.Value)
+	}
+}
+
+// TestUnmarshalDirectChildXMLName exercises the single-segment findPath +
+// setXMLName branch.
+func TestUnmarshalDirectChildXMLName(t *testing.T) {
+	type Doc struct {
+		Child stdxml.Name `xml:"child"`
+	}
+	var d Doc
+	in := []byte(`<Doc><child/></Doc>`)
+	if err := shim.Unmarshal(in, &d); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if d.Child.Local != "child" {
+		t.Fatalf("expected child name 'child', got %q", d.Child.Local)
+	}
+}
+
+// TestUnmarshalDirectChildSlice exercises the single-segment slice path with
+// repeated matches.
+func TestUnmarshalDirectChildSlice(t *testing.T) {
+	type Doc struct {
+		Items []string `xml:"item"`
+	}
+	var d Doc
+	in := []byte(`<Doc><item>a</item><item>b</item><item>c</item></Doc>`)
+	if err := shim.Unmarshal(in, &d); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if len(d.Items) != 3 {
+		t.Fatalf("expected 3 items, got %#v", d.Items)
+	}
+}

--- a/stream/coverage_branches_test.go
+++ b/stream/coverage_branches_test.go
@@ -45,7 +45,7 @@ func TestDefaultNSUndeclare(t *testing.T) {
 
 // dtdQuoteFor: a value containing the preferred quote should be wrapped in the
 // other quote. Default quoteChar is '"', so a sysid containing '"' must be
-// emitted with single quotes. Also exercise QuoteChar('\'') path.
+// emitted with single quotes. Also exercise QuoteChar('\”) path.
 func TestDTDQuoteForAlternateQuote(t *testing.T) {
 	t.Parallel()
 

--- a/stream/coverage_branches_test.go
+++ b/stream/coverage_branches_test.go
@@ -1,0 +1,785 @@
+package stream_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium/stream"
+	"github.com/stretchr/testify/require"
+)
+
+// hasDefaultNSInScope is exercised via StartElementNS: an ancestor declares a
+// non-empty default namespace, then a child with no namespace must emit
+// xmlns="" to undeclare it.
+func TestDefaultNSUndeclare(t *testing.T) {
+	t.Parallel()
+
+	t.Run("undeclare default ns on child", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElementNS("", "root", "urn:default"))
+		require.NoError(t, w.StartElementNS("", "child", ""))
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.EndDocument())
+		out := buf.String()
+		require.Contains(t, out, `xmlns="urn:default"`)
+		require.Contains(t, out, `xmlns=""`)
+	})
+
+	t.Run("no undeclare when no default ns in scope", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		// ancestor declares only a prefixed ns, default ns absent
+		require.NoError(t, w.StartElementNS("p", "root", "urn:p"))
+		require.NoError(t, w.StartElementNS("", "child", ""))
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.EndDocument())
+		require.NotContains(t, buf.String(), `xmlns=""`)
+	})
+}
+
+// dtdQuoteFor: a value containing the preferred quote should be wrapped in the
+// other quote. Default quoteChar is '"', so a sysid containing '"' must be
+// emitted with single quotes. Also exercise QuoteChar('\'') path.
+func TestDTDQuoteForAlternateQuote(t *testing.T) {
+	t.Parallel()
+
+	t.Run("double-quote default, sysid contains double quote", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("doc", "", `a"b`))
+		require.NoError(t, w.EndDTD())
+		require.NoError(t, w.StartElement("doc"))
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.EndDocument())
+		require.Contains(t, buf.String(), `SYSTEM 'a"b'`)
+	})
+
+	t.Run("single-quote configured, sysid contains single quote", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf).QuoteChar('\'')
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("doc", "", `a'b`))
+		require.NoError(t, w.EndDTD())
+		require.NoError(t, w.StartElement("doc"))
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.EndDocument())
+		require.Contains(t, buf.String(), `SYSTEM "a'b"`)
+	})
+}
+
+// WriteCDATA with a "]]>" terminator must split into multiple sections.
+func TestWriteCDATASplit(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("root"))
+	require.NoError(t, w.WriteCDATA("a]]>b"))
+	require.NoError(t, w.EndElement())
+	require.NoError(t, w.EndDocument())
+	out := buf.String()
+	require.Contains(t, out, "<![CDATA[a]]]]><![CDATA[>b]]>")
+}
+
+// WriteCDATA validation error: invalid char must be rejected before any output.
+func TestWriteCDATAInvalidChar(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("root"))
+	before := buf.Len()
+	require.Error(t, w.WriteCDATA("bad\x00char"))
+	require.Equal(t, before, buf.Len())
+}
+
+// WriteElementNS / WriteAttributeNS: success path plus content validation
+// rejection (leaving writer unmutated).
+func TestWriteNSConveniences(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WriteElementNS success", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.WriteElementNS("p", "el", "urn:p", "hello"))
+		require.NoError(t, w.EndDocument())
+		out := buf.String()
+		require.Contains(t, out, `<p:el xmlns:p="urn:p">hello</p:el>`)
+	})
+
+	t.Run("WriteElementNS invalid content rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.Error(t, w.WriteElementNS("p", "el", "urn:p", "bad\x00"))
+		require.Empty(t, buf.String())
+	})
+
+	t.Run("WriteElementNS invalid name rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.Error(t, w.WriteElementNS("p", "1bad", "urn:p", "x"))
+	})
+
+	t.Run("WriteAttributeNS success", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.NoError(t, w.WriteAttributeNS("p", "a", "urn:p", "v"))
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.EndDocument())
+		out := buf.String()
+		require.Contains(t, out, `xmlns:p="urn:p"`)
+		require.Contains(t, out, `p:a="v"`)
+	})
+
+	t.Run("WriteAttributeNS invalid content rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.Error(t, w.WriteAttributeNS("p", "a", "urn:p", "bad\x00"))
+	})
+
+	t.Run("WriteAttributeNS invalid prefix rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.Error(t, w.WriteAttributeNS("1bad", "a", "urn:p", "v"))
+	})
+}
+
+// ensureDTDState: sticky-error path and outside-DTD path.
+func TestDTDOutsideState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WriteDTDElement outside DTD", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.Error(t, w.WriteDTDElement("e", "EMPTY"))
+	})
+
+	t.Run("WriteDTDAttlist outside DTD", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.Error(t, w.WriteDTDAttlist("e", "a CDATA #IMPLIED"))
+	})
+
+	t.Run("WriteDTDEntity outside DTD", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.Error(t, w.WriteDTDEntity(false, "e", "val"))
+	})
+
+	t.Run("WriteDTDExternalEntity outside DTD", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.Error(t, w.WriteDTDExternalEntity(false, "e", "", "sys", ""))
+	})
+
+	t.Run("WriteDTDNotation outside DTD", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.Error(t, w.WriteDTDNotation("n", "", "sys"))
+	})
+}
+
+// Indented DTD output paths in StartDTD (PUBLIC and SYSTEM with indentation).
+func TestStartDTDIndented(t *testing.T) {
+	t.Parallel()
+
+	t.Run("indented PUBLIC", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf).Indent("  ")
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("doc", "-//X//DTD//EN", "http://example.com/x.dtd"))
+		require.NoError(t, w.EndDTD())
+		require.NoError(t, w.StartElement("doc"))
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.EndDocument())
+		out := buf.String()
+		require.Contains(t, out, "PUBLIC")
+		require.Contains(t, out, "-//X//DTD//EN")
+	})
+
+	t.Run("indented SYSTEM", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf).Indent("  ")
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("doc", "", "http://example.com/x.dtd"))
+		require.NoError(t, w.EndDTD())
+		require.NoError(t, w.StartElement("doc"))
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.EndDocument())
+		require.Contains(t, buf.String(), "SYSTEM")
+	})
+}
+
+// WriteDTDExternalEntity with PUBLIC id and NDATA notation exercises those
+// branches.
+func TestWriteDTDExternalEntityVariants(t *testing.T) {
+	t.Parallel()
+
+	t.Run("PUBLIC with NDATA", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("doc", "", ""))
+		require.NoError(t, w.WriteDTDExternalEntity(false, "img", "-//X//PIC//EN", "pic.gif", "gif"))
+		require.NoError(t, w.EndDTD())
+		require.NoError(t, w.StartElement("doc"))
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.EndDocument())
+		out := buf.String()
+		require.Contains(t, out, "PUBLIC")
+		require.Contains(t, out, "NDATA gif")
+	})
+
+	t.Run("parameter entity SYSTEM", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("doc", "", ""))
+		require.NoError(t, w.WriteDTDExternalEntity(true, "pe", "", "pe.dtd", ""))
+		require.NoError(t, w.EndDTD())
+		require.NoError(t, w.StartElement("doc"))
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.EndDocument())
+		out := buf.String()
+		require.Contains(t, out, "<!ENTITY % pe")
+		require.Contains(t, out, "SYSTEM")
+	})
+
+	t.Run("invalid pubid rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("doc", "", ""))
+		require.Error(t, w.WriteDTDExternalEntity(false, "e", "bad\x01pub", "sys", ""))
+	})
+
+	t.Run("invalid sysid rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("doc", "", ""))
+		require.Error(t, w.WriteDTDExternalEntity(false, "e", "", "a'b\"c", ""))
+	})
+
+	t.Run("invalid ndata rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("doc", "", ""))
+		require.Error(t, w.WriteDTDExternalEntity(false, "e", "", "sys", "1bad"))
+	})
+}
+
+// WriteDTDNotation PUBLIC with both pubid and sysid.
+func TestWriteDTDNotationVariants(t *testing.T) {
+	t.Parallel()
+
+	t.Run("PUBLIC with sysid", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("doc", "", ""))
+		require.NoError(t, w.WriteDTDNotation("n", "-//X//N//EN", "n.dtd"))
+		require.NoError(t, w.EndDTD())
+		require.NoError(t, w.StartElement("doc"))
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.EndDocument())
+		out := buf.String()
+		require.Contains(t, out, "<!NOTATION n PUBLIC")
+		require.Contains(t, out, "n.dtd")
+	})
+
+	t.Run("invalid name rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("doc", "", ""))
+		require.Error(t, w.WriteDTDNotation("1bad", "", "sys"))
+	})
+
+	t.Run("invalid pubid rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("doc", "", ""))
+		require.Error(t, w.WriteDTDNotation("n", "bad\x01", "sys"))
+	})
+}
+
+// EndDocument auto-close branches for each open construct.
+func TestEndDocumentAutoClose(t *testing.T) {
+	t.Parallel()
+
+	t.Run("auto-close open PI", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.NoError(t, w.StartPI("php"))
+		require.NoError(t, w.EndDocument())
+		require.Contains(t, buf.String(), "?>")
+	})
+
+	t.Run("auto-close open CDATA", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.NoError(t, w.StartCDATA())
+		require.NoError(t, w.EndDocument())
+		require.Contains(t, buf.String(), "]]>")
+	})
+
+	t.Run("auto-close open comment", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.NoError(t, w.StartComment())
+		require.NoError(t, w.EndDocument())
+		require.Contains(t, buf.String(), "-->")
+	})
+
+	t.Run("auto-close open DTD", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("doc", "", ""))
+		require.NoError(t, w.EndDocument())
+		require.Contains(t, buf.String(), "<!DOCTYPE doc>")
+	})
+}
+
+// WriteDTD with a verbatim subset exercises the subset != "" branch.
+func TestWriteDTDWithSubset(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartDocument("", "", ""))
+	require.NoError(t, w.WriteDTD("doc", "", "", "<!ELEMENT doc EMPTY>"))
+	require.NoError(t, w.StartElement("doc"))
+	require.NoError(t, w.EndElement())
+	require.NoError(t, w.EndDocument())
+	out := buf.String()
+	require.Contains(t, out, "[<!ELEMENT doc EMPTY>]")
+}
+
+// WriteRaw in attribute state, and WriteRaw invalid state.
+func TestWriteRawStates(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WriteRaw in attribute", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.NoError(t, w.StartAttribute("a"))
+		require.NoError(t, w.WriteRaw("raw&value"))
+		require.NoError(t, w.EndAttribute())
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.EndDocument())
+		require.Contains(t, buf.String(), `a="raw&value"`)
+	})
+
+	t.Run("WriteRaw invalid state inside comment", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.NoError(t, w.StartComment())
+		require.Error(t, w.WriteRaw("x"))
+	})
+}
+
+// WriteComment validation errors: invalid char, contains --, ends with -.
+func TestWriteCommentValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid char", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.Error(t, w.WriteComment("bad\x00"))
+	})
+
+	t.Run("contains double dash", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.Error(t, w.WriteComment("a--b"))
+	})
+
+	t.Run("ends with dash", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.Error(t, w.WriteComment("trailing-"))
+	})
+}
+
+// WritePI content validation and the "?>" rejection.
+func TestWritePIValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("contains ?>", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.Error(t, w.WritePI("target", "data?>more"))
+	})
+
+	t.Run("invalid char", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.Error(t, w.WritePI("target", "bad\x00"))
+	})
+}
+
+// EndAttribute outside attribute returns an error.
+func TestEndAttributeOutside(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("root"))
+	require.Error(t, w.EndAttribute())
+}
+
+// FullEndElement with children but no text triggers the writeEndIndent branch
+// when indentation is enabled.
+func TestFullEndElementIndented(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf).Indent("  ")
+	require.NoError(t, w.StartElement("root"))
+	require.NoError(t, w.StartElement("child"))
+	require.NoError(t, w.FullEndElement())
+	require.NoError(t, w.FullEndElement())
+	require.NoError(t, w.EndDocument())
+	out := buf.String()
+	require.Contains(t, out, "<child></child>")
+}
+
+// FullEndElement closing an element that still has an open attribute.
+func TestFullEndElementWithOpenAttribute(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("root"))
+	require.NoError(t, w.StartAttribute("a"))
+	require.NoError(t, w.WriteString("v"))
+	require.NoError(t, w.FullEndElement())
+	require.NoError(t, w.EndDocument())
+	require.Contains(t, buf.String(), `<root a="v"></root>`)
+}
+
+// EndElement closing an element with an open attribute.
+func TestEndElementWithOpenAttribute(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("root"))
+	require.NoError(t, w.StartAttribute("a"))
+	require.NoError(t, w.WriteString("v"))
+	require.NoError(t, w.EndElement())
+	require.NoError(t, w.EndDocument())
+	require.Contains(t, buf.String(), `<root a="v"/>`)
+}
+
+// StartElementNS invalid namespace URI rejected before any mutation.
+func TestStartElementNSInvalidURI(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.Error(t, w.StartElementNS("p", "el", "bad\x00uri"))
+	require.Empty(t, buf.String())
+}
+
+// StartAttributeNS state and URI validation paths.
+func TestStartAttributeNSEdges(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid uri rejected", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.Error(t, w.StartAttributeNS("p", "a", "bad\x00"))
+	})
+
+	t.Run("called outside opening tag", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.NoError(t, w.WriteString("text"))
+		require.Error(t, w.StartAttributeNS("p", "a", "urn:p"))
+	})
+}
+
+// isValidXMLVersion rejections via StartDocument: empty fractional, non-1. form.
+func TestVersionValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("trailing dot only", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.Error(t, w.StartDocument("1.", "", ""))
+	})
+
+	t.Run("non-numeric fraction", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.Error(t, w.StartDocument("1.x", "", ""))
+	})
+
+	t.Run("valid 1.1", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("1.1", "", ""))
+	})
+}
+
+// validateSystemID: a value with both quotes is unquotable.
+func TestStartDTDInvalidSysidBothQuotes(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartDocument("", "", ""))
+	require.Error(t, w.StartDTD("doc", "", `a'b"c`))
+}
+
+// validatePubid rejection in StartDTD.
+func TestStartDTDInvalidPubid(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartDocument("", "", ""))
+	require.Error(t, w.StartDTD("doc", "bad\x01pub", "sys"))
+}
+
+// validateDTDFragment rejects markup delimiters in element content.
+func TestWriteDTDElementFragmentRejected(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartDocument("", "", ""))
+	require.NoError(t, w.StartDTD("doc", "", ""))
+	require.Error(t, w.WriteDTDElement("e", "ANY><!ENTITY x"))
+}
+
+// validateDTDAttlistFragment: unterminated literal and bare '>' outside quotes.
+func TestWriteDTDAttlistFragmentRejected(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unterminated literal", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("doc", "", ""))
+		require.Error(t, w.WriteDTDAttlist("e", `a CDATA "unterminated`))
+	})
+
+	t.Run("bare gt outside quote", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("doc", "", ""))
+		require.Error(t, w.WriteDTDAttlist("e", `a CDATA #IMPLIED>extra`))
+	})
+
+	t.Run("gt inside quote allowed", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartDocument("", "", ""))
+		require.NoError(t, w.StartDTD("doc", "", ""))
+		require.NoError(t, w.WriteDTDAttlist("e", `a CDATA "a>b"`))
+	})
+}
+
+// WriteDTDEntity parameter entity success.
+func TestWriteDTDEntityParameter(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartDocument("", "", ""))
+	require.NoError(t, w.StartDTD("doc", "", ""))
+	require.NoError(t, w.WriteDTDEntity(true, "pe", "value"))
+	require.NoError(t, w.EndDTD())
+	require.NoError(t, w.StartElement("doc"))
+	require.NoError(t, w.EndElement())
+	require.NoError(t, w.EndDocument())
+	require.Contains(t, buf.String(), "<!ENTITY % pe")
+}
+
+// writeEscaped: cover the '\n' and '\t' raw-byte (text mode) and the quote
+// rawByte branch where quoteChar differs.
+func TestWriteEscapedBranches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tab and newline preserved in text", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.NoError(t, w.WriteString("a\tb\nc"))
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.EndDocument())
+		require.Contains(t, buf.String(), "a\tb\nc")
+	})
+
+	t.Run("attribute with single quote when double-quoted", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.NoError(t, w.WriteAttribute("a", "it's"))
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.EndDocument())
+		require.Contains(t, buf.String(), `a="it's"`)
+	})
+
+	t.Run("attribute newline and tab escaped", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := stream.NewWriter(&buf)
+		require.NoError(t, w.StartElement("root"))
+		require.NoError(t, w.WriteAttribute("a", "x\ny\tz"))
+		require.NoError(t, w.EndElement())
+		require.NoError(t, w.EndDocument())
+		out := buf.String()
+		require.Contains(t, out, "&#10;")
+		require.Contains(t, out, "&#9;")
+	})
+}
+
+// Sticky error propagation: once a write fails, subsequent ops are no-ops and
+// the relevant guard branches (w.err != nil) are taken.
+func TestStickyErrorPropagation(t *testing.T) {
+	t.Parallel()
+	fw := &failWriter{failAfter: 3}
+	w := stream.NewWriter(fw)
+	// First successful-ish write then failure on a longer write.
+	_ = w.StartElement("rootlong")
+	require.Error(t, w.Error())
+	// All subsequent calls should observe the sticky error.
+	require.Error(t, w.StartElement("x"))
+	require.Error(t, w.StartElementNS("p", "x", "urn:p"))
+	require.Error(t, w.EndElement())
+	require.Error(t, w.FullEndElement())
+	require.Error(t, w.WriteElement("a", "b"))
+	require.Error(t, w.WriteElementNS("p", "a", "urn:p", "b"))
+	require.Error(t, w.StartAttribute("a"))
+	require.Error(t, w.StartAttributeNS("p", "a", "urn:p"))
+	require.Error(t, w.EndAttribute())
+	require.Error(t, w.WriteAttribute("a", "b"))
+	require.Error(t, w.WriteAttributeNS("p", "a", "urn:p", "b"))
+	require.Error(t, w.WriteString("x"))
+	require.Error(t, w.WriteRaw("x"))
+	require.Error(t, w.StartComment())
+	require.Error(t, w.EndComment())
+	require.Error(t, w.WriteComment("x"))
+	require.Error(t, w.StartPI("t"))
+	require.Error(t, w.EndPI())
+	require.Error(t, w.WritePI("t", "x"))
+	require.Error(t, w.StartCDATA())
+	require.Error(t, w.EndCDATA())
+	require.Error(t, w.WriteCDATA("x"))
+	require.Error(t, w.StartDTD("d", "", ""))
+	require.Error(t, w.EndDTD())
+	require.Error(t, w.WriteDTDElement("e", "EMPTY"))
+	require.Error(t, w.WriteDTDAttlist("e", "a CDATA #IMPLIED"))
+	require.Error(t, w.WriteDTDEntity(false, "e", "v"))
+	require.Error(t, w.WriteDTDExternalEntity(false, "e", "", "s", ""))
+	require.Error(t, w.WriteDTDNotation("n", "", "s"))
+	require.Error(t, w.StartDocument("", "", ""))
+	require.Error(t, w.EndDocument())
+	require.Error(t, w.Flush())
+}
+
+// WriteString in PI state with a question-mark suffix that would form "?>".
+func TestWriteStringPISuffix(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("root"))
+	require.NoError(t, w.StartPI("t"))
+	require.NoError(t, w.WriteString("data?"))
+	// A following ">" would form "?>" and must be rejected.
+	require.Error(t, w.WriteString(">more"))
+}
+
+// WriteString in comment state where prior chunk ended with '-' and next begins
+// with '-' (forms '--').
+func TestWriteStringCommentDashSplit(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("root"))
+	require.NoError(t, w.StartComment())
+	require.NoError(t, w.WriteString("a-"))
+	require.Error(t, w.WriteString("-b"))
+}
+
+// EndComment with trailing dash in incremental writes rejected.
+func TestEndCommentTrailingDash(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	w := stream.NewWriter(&buf)
+	require.NoError(t, w.StartElement("root"))
+	require.NoError(t, w.StartComment())
+	require.NoError(t, w.WriteString("text-"))
+	require.Error(t, w.EndComment())
+}
+
+func TestNilWriterError(t *testing.T) {
+	t.Parallel()
+	w := stream.NewWriter(nil)
+	err := w.StartElement("root")
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "output writer is nil"))
+}

--- a/xmldsig1/coverage_algorithms_test.go
+++ b/xmldsig1/coverage_algorithms_test.go
@@ -1,0 +1,218 @@
+package xmldsig1_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xmldsig1"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSignKeyMismatch exercises the ErrKeyMismatch branches of each
+// algorithm-specific signer by passing a key of the wrong type.
+func TestSignKeyMismatch(t *testing.T) {
+	rsaKey := generateRSAKey(t)
+	ecKey := generateECDSAKey(t, elliptic.P256())
+	edKey := generateEd25519Key(t)
+
+	tests := []struct {
+		name string
+		alg  string
+		key  any
+	}{
+		{"rsa-wrong", xmldsig1.AlgRSASHA256, ecKey},
+		{"ecdsa-wrong", xmldsig1.AlgECDSASHA256, rsaKey},
+		{"hmac-wrong", xmldsig1.AlgHMACSHA256, rsaKey},
+		{"ed25519-wrong", xmldsig1.AlgEd25519, rsaKey},
+		// pass a public ed25519 key where a private is required
+		{"ed25519-pub", xmldsig1.AlgEd25519, edKey.Public()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := mustParseXML(t, samlAssertion)
+			signer := xmldsig1.NewSigner().
+				SignatureAlgorithm(tt.alg).
+				Reference(xmldsig1.NewEnvelopedReference())
+			err := signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), tt.key)
+			require.Error(t, err)
+			require.ErrorIs(t, err, xmldsig1.ErrKeyMismatch)
+		})
+	}
+}
+
+// TestVerifyKeyMismatch exercises the ErrKeyMismatch branches of the verifiers
+// by resolving a wrong-typed key at verification time.
+func TestVerifyKeyMismatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		alg       string
+		signKey   any
+		verifyKey any
+	}{
+		{"rsa", xmldsig1.AlgRSASHA256, mustRSA(t), "not-a-key"},
+		{"ecdsa", xmldsig1.AlgECDSASHA256, mustEC(t), "not-a-key"},
+		{"hmac", xmldsig1.AlgHMACSHA256, mustHMAC(t), "not-a-key"},
+		{"ed25519", xmldsig1.AlgEd25519, mustEd(t), "not-a-key"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := mustParseXML(t, samlAssertion)
+			signer := xmldsig1.NewSigner().
+				SignatureAlgorithm(tt.alg).
+				Reference(xmldsig1.NewEnvelopedReference())
+			require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), tt.signKey))
+
+			verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(tt.verifyKey))
+			_, err := verifier.Verify(t.Context(), doc)
+			require.Error(t, err)
+			require.ErrorIs(t, err, xmldsig1.ErrKeyMismatch)
+		})
+	}
+}
+
+// TestVerifyEd25519WithPrivateKey verifies the verifyEd25519 branch that
+// accepts an ed25519.PrivateKey and derives its public half.
+func TestVerifyEd25519WithPrivateKey(t *testing.T) {
+	key := generateEd25519Key(t)
+	doc := mustParseXML(t, samlAssertion)
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgEd25519).
+		Reference(xmldsig1.NewEnvelopedReference())
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+	// Resolve the private key (not the public) so the private-key branch runs.
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(key))
+	_, err := verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+}
+
+// TestVerifyEd25519BadSignature exercises the ed25519 verification-failure
+// branch by tampering with a signed document.
+func TestVerifyEd25519BadSignature(t *testing.T) {
+	key := generateEd25519Key(t)
+	doc := mustParseXML(t, samlAssertion)
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgEd25519).
+		Reference(xmldsig1.NewEnvelopedReference())
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+	xml, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	// flip a base64 char in the SignatureValue region by mutating issuer text,
+	// which changes the canonicalized SignedInfo digest -> ed25519 verify fails.
+	tampered := strings.Replace(xml, "https://idp.example.com", "https://idp.evil.com", 1)
+	doc2 := mustParseXML(t, tampered)
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(key.Public()))
+	_, err = verifier.Verify(t.Context(), doc2)
+	require.Error(t, err)
+}
+
+// TestVerifyECDSAWrongSignatureLength exercises ecdsaRawToDER's
+// invalid-length error path. A P-384 signature presented to a P-256 verifier
+// has the wrong length.
+func TestVerifyECDSAWrongLengthSignature(t *testing.T) {
+	// Sign with P-384 then verify against a P-256 public key: the raw signature
+	// length will not match the P-256 key size, hitting ecdsaRawToDER's error.
+	key384 := generateECDSAKey(t, elliptic.P384())
+	key256 := generateECDSAKey(t, elliptic.P256())
+	doc := mustParseXML(t, samlAssertion)
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgECDSASHA256).
+		Reference(xmldsig1.NewEnvelopedReference())
+	// SignatureMethod ecdsa-sha256 with a P-384 key produces a 96-byte raw sig.
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key384))
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key256.PublicKey))
+	_, err := verifier.Verify(t.Context(), doc)
+	require.Error(t, err)
+}
+
+// TestVerifyECDSATampered exercises verifyECDSA's VerifyASN1-failure path.
+func TestVerifyECDSATampered(t *testing.T) {
+	key := generateECDSAKey(t, elliptic.P256())
+	doc := mustParseXML(t, samlAssertion)
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgECDSASHA256).
+		Reference(xmldsig1.NewEnvelopedReference())
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+	xml, err := helium.WriteString(doc)
+	require.NoError(t, err)
+	tampered := strings.Replace(xml, "user@example.com", "attacker@evil.com", 1)
+	doc2 := mustParseXML(t, tampered)
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(t.Context(), doc2)
+	require.Error(t, err)
+}
+
+// TestUnsupportedSignatureAlgorithm exercises lookupAlg's unknown-algorithm
+// branch during signing.
+func TestUnsupportedSignatureAlgorithm(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm("urn:made-up:alg").
+		Reference(xmldsig1.NewEnvelopedReference())
+	err := signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key)
+	require.ErrorIs(t, err, xmldsig1.ErrUnsupportedAlgorithm)
+}
+
+// TestUnsupportedDigestAlgorithm exercises computeDigest's unknown-algorithm
+// branch during signing.
+func TestUnsupportedDigestAlgorithm(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.ReferenceConfig{
+			URI:             "",
+			DigestAlgorithm: "urn:made-up:digest",
+			Transforms:      []xmldsig1.Transform{xmldsig1.Enveloped(), xmldsig1.ExcC14NTransform()},
+		})
+	err := signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key)
+	require.ErrorIs(t, err, xmldsig1.ErrUnsupportedAlgorithm)
+}
+
+// TestKeySourceError exercises the path where ResolveKey returns an error.
+func TestKeySourceError(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.NewEnvelopedReference())
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+	sentinel := errors.New("resolve boom")
+	ks := xmldsig1.KeySourceFunc(func(_ context.Context, _ *xmldsig1.KeyInfoData, _ string) (any, error) {
+		return nil, sentinel
+	})
+	verifier := xmldsig1.NewVerifier(ks)
+	_, err := verifier.Verify(t.Context(), doc)
+	require.ErrorIs(t, err, sentinel)
+}
+
+func mustRSA(t *testing.T) *rsa.PrivateKey  { t.Helper(); return generateRSAKey(t) }
+func mustEC(t *testing.T) *ecdsa.PrivateKey { t.Helper(); return generateECDSAKey(t, elliptic.P256()) }
+func mustEd(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	return generateEd25519Key(t)
+}
+func mustHMAC(t *testing.T) []byte {
+	t.Helper()
+	secret := make([]byte, 32)
+	_, err := rand.Read(secret)
+	require.NoError(t, err)
+	return secret
+}

--- a/xmldsig1/coverage_clone_internal_test.go
+++ b/xmldsig1/coverage_clone_internal_test.go
@@ -1,0 +1,72 @@
+package xmldsig1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSignerCloneNilConfig covers the s.cfg == nil branch of Signer.clone by
+// invoking a builder method on a zero-value Signer.
+func TestSignerCloneNilConfig(t *testing.T) {
+	var s Signer // zero value: cfg is nil
+	s2 := s.SignatureAlgorithm(AlgRSASHA256)
+	require.NotNil(t, s2.cfg)
+	require.Equal(t, AlgRSASHA256, s2.cfg.signatureAlgorithm)
+	require.Equal(t, ExcC14N10, s2.cfg.c14nMethod)
+}
+
+// TestVerifierCloneNilConfig covers the v.cfg == nil branch of Verifier.clone.
+func TestVerifierCloneNilConfig(t *testing.T) {
+	var v Verifier // zero value: cfg is nil
+	v2 := v.AllowSHA1(true)
+	require.NotNil(t, v2.cfg)
+	require.True(t, v2.cfg.allowSHA1)
+}
+
+// TestParseKeyValueForeignRSA covers parseKeyValue's continue branch: an
+// RSAKeyValue look-alike in a foreign namespace must be skipped, leaving no
+// RSAKeyValue parsed.
+func TestParseKeyValueForeignRSA(t *testing.T) {
+	doc := mustParse(t, `<ds:KeyValue xmlns:ds="`+NamespaceDSig+`"><evil:RSAKeyValue xmlns:evil="urn:evil"/></ds:KeyValue>`)
+	var data KeyInfoData
+	require.NoError(t, parseKeyValue(doc.DocumentElement(), &data))
+	require.Nil(t, data.RSAKeyValue)
+}
+
+// TestParseKeyValueForeignEC covers parseKeyValue's ECKeyValue continue branch:
+// an ECKeyValue look-alike in a non-dsig11 namespace must be skipped.
+func TestParseKeyValueForeignEC(t *testing.T) {
+	doc := mustParse(t, `<ds:KeyValue xmlns:ds="`+NamespaceDSig+`"><evil:ECKeyValue xmlns:evil="urn:evil"/></ds:KeyValue>`)
+	var data KeyInfoData
+	require.NoError(t, parseKeyValue(doc.DocumentElement(), &data))
+	require.Nil(t, data.ECKeyValue)
+}
+
+// TestParseRSAKeyValueForeignChild covers parseRSAKeyValue's foreign-namespace
+// child continue branch.
+func TestParseRSAKeyValueForeignChild(t *testing.T) {
+	doc := mustParse(t, `<ds:RSAKeyValue xmlns:ds="`+NamespaceDSig+`"><evil:Modulus xmlns:evil="urn:evil">AQAB</evil:Modulus></ds:RSAKeyValue>`)
+	var data KeyInfoData
+	require.NoError(t, parseRSAKeyValue(doc.DocumentElement(), &data))
+	require.NotNil(t, data.RSAKeyValue)
+	require.Nil(t, data.RSAKeyValue.Modulus) // foreign Modulus was skipped
+}
+
+// TestParseKeyInfoForeignChild covers parseKeyInfo's continue branch for a
+// foreign-namespace X509Data look-alike.
+func TestParseKeyInfoForeignChild(t *testing.T) {
+	doc := mustParse(t, `<ds:KeyInfo xmlns:ds="`+NamespaceDSig+`"><evil:X509Data xmlns:evil="urn:evil"/></ds:KeyInfo>`)
+	data, err := parseKeyInfo(doc.DocumentElement())
+	require.NoError(t, err)
+	require.Empty(t, data.X509Certificates)
+}
+
+// TestParseX509DataForeignCert covers parseX509Data's foreign-namespace
+// look-alike continue branch.
+func TestParseX509DataForeignCert(t *testing.T) {
+	doc := mustParse(t, `<ds:X509Data xmlns:ds="`+NamespaceDSig+`"><evil:X509Certificate xmlns:evil="urn:evil">AA==</evil:X509Certificate></ds:X509Data>`)
+	var data KeyInfoData
+	require.NoError(t, parseX509Data(doc.DocumentElement(), &data))
+	require.Empty(t, data.X509Certificates)
+}

--- a/xmldsig1/coverage_internal_test.go
+++ b/xmldsig1/coverage_internal_test.go
@@ -40,7 +40,7 @@ func mustParse(t *testing.T, xml string) *helium.Document {
 	return doc
 }
 
-func ecElem(t *testing.T, doc *helium.Document, inner string) *helium.Element {
+func ecElem(t *testing.T, inner string) *helium.Element {
 	t.Helper()
 	full := `<dsig11:ECKeyValue xmlns:dsig11="` + NamespaceDSig11 + `">` + inner + `</dsig11:ECKeyValue>`
 	d := mustParse(t, full)
@@ -49,8 +49,7 @@ func ecElem(t *testing.T, doc *helium.Document, inner string) *helium.Element {
 
 // TestParseECKeyValueUnsupportedCurve covers the unsupported-curve branch.
 func TestParseECKeyValueUnsupportedCurve(t *testing.T) {
-	doc := mustParse(t, "<root/>")
-	elem := ecElem(t, doc, `<dsig11:NamedCurve xmlns:dsig11="`+NamespaceDSig11+`" URI="urn:oid:bogus"/>`)
+	elem := ecElem(t, `<dsig11:NamedCurve xmlns:dsig11="`+NamespaceDSig11+`" URI="urn:oid:bogus"/>`)
 	var data KeyInfoData
 	err := parseECKeyValue(elem, &data)
 	require.ErrorIs(t, err, ErrInvalidKeyInfo)
@@ -59,7 +58,7 @@ func TestParseECKeyValueUnsupportedCurve(t *testing.T) {
 
 // TestParseECKeyValueMissingCurve covers the PublicKey-before-NamedCurve branch.
 func TestParseECKeyValueMissingCurve(t *testing.T) {
-	elem := ecElem(t, nil, `<dsig11:PublicKey xmlns:dsig11="`+NamespaceDSig11+`">BBBB</dsig11:PublicKey>`)
+	elem := ecElem(t, `<dsig11:PublicKey xmlns:dsig11="`+NamespaceDSig11+`">BBBB</dsig11:PublicKey>`)
 	var data KeyInfoData
 	err := parseECKeyValue(elem, &data)
 	require.ErrorIs(t, err, ErrInvalidKeyInfo)
@@ -71,7 +70,7 @@ func TestParseECKeyValueMissingCurve(t *testing.T) {
 func TestParseECKeyValueInvalidPoint(t *testing.T) {
 	inner := `<dsig11:NamedCurve xmlns:dsig11="` + NamespaceDSig11 + `" URI="urn:oid:1.2.840.10045.3.1.7"/>` +
 		`<dsig11:PublicKey xmlns:dsig11="` + NamespaceDSig11 + `">AAAA</dsig11:PublicKey>`
-	elem := ecElem(t, nil, inner)
+	elem := ecElem(t, inner)
 	var data KeyInfoData
 	err := parseECKeyValue(elem, &data)
 	require.ErrorIs(t, err, ErrInvalidKeyInfo)
@@ -82,7 +81,7 @@ func TestParseECKeyValueInvalidPoint(t *testing.T) {
 func TestParseECKeyValueBadBase64(t *testing.T) {
 	inner := `<dsig11:NamedCurve xmlns:dsig11="` + NamespaceDSig11 + `" URI="urn:oid:1.2.840.10045.3.1.7"/>` +
 		`<dsig11:PublicKey xmlns:dsig11="` + NamespaceDSig11 + `">!!!!notbase64</dsig11:PublicKey>`
-	elem := ecElem(t, nil, inner)
+	elem := ecElem(t, inner)
 	var data KeyInfoData
 	err := parseECKeyValue(elem, &data)
 	require.ErrorIs(t, err, ErrInvalidKeyInfo)

--- a/xmldsig1/coverage_internal_test.go
+++ b/xmldsig1/coverage_internal_test.go
@@ -1,0 +1,146 @@
+package xmldsig1
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerificationErrorFormat covers both branches of VerificationError.Error
+// (signature-value failure with Reference < 0, and a per-Reference failure).
+func TestVerificationErrorFormat(t *testing.T) {
+	cause := errors.New("boom")
+
+	sigErr := &VerificationError{Reference: -1, Err: cause}
+	require.Contains(t, sigErr.Error(), "signature value verification failed")
+	require.ErrorIs(t, sigErr, cause)
+
+	refErr := &VerificationError{Reference: 2, URI: "#x", Err: cause}
+	msg := refErr.Error()
+	require.Contains(t, msg, "reference 2")
+	require.Contains(t, msg, "#x")
+	require.ErrorIs(t, refErr, cause)
+}
+
+// TestExcC14NTransformPrefixes covers excC14NTransform.Prefixes.
+func TestExcC14NTransformPrefixes(t *testing.T) {
+	tr := ExcC14NTransform("a", "b")
+	exc, ok := tr.(excC14NTransform)
+	require.True(t, ok)
+	require.Equal(t, []string{"a", "b"}, exc.Prefixes())
+}
+
+func mustParse(t *testing.T, xml string) *helium.Document {
+	t.Helper()
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(xml))
+	require.NoError(t, err)
+	return doc
+}
+
+func ecElem(t *testing.T, doc *helium.Document, inner string) *helium.Element {
+	t.Helper()
+	full := `<dsig11:ECKeyValue xmlns:dsig11="` + NamespaceDSig11 + `">` + inner + `</dsig11:ECKeyValue>`
+	d := mustParse(t, full)
+	return d.DocumentElement()
+}
+
+// TestParseECKeyValueUnsupportedCurve covers the unsupported-curve branch.
+func TestParseECKeyValueUnsupportedCurve(t *testing.T) {
+	doc := mustParse(t, "<root/>")
+	elem := ecElem(t, doc, `<dsig11:NamedCurve xmlns:dsig11="`+NamespaceDSig11+`" URI="urn:oid:bogus"/>`)
+	var data KeyInfoData
+	err := parseECKeyValue(elem, &data)
+	require.ErrorIs(t, err, ErrInvalidKeyInfo)
+	require.Contains(t, err.Error(), "unsupported EC curve")
+}
+
+// TestParseECKeyValueMissingCurve covers the PublicKey-before-NamedCurve branch.
+func TestParseECKeyValueMissingCurve(t *testing.T) {
+	elem := ecElem(t, nil, `<dsig11:PublicKey xmlns:dsig11="`+NamespaceDSig11+`">BBBB</dsig11:PublicKey>`)
+	var data KeyInfoData
+	err := parseECKeyValue(elem, &data)
+	require.ErrorIs(t, err, ErrInvalidKeyInfo)
+	require.Contains(t, err.Error(), "missing NamedCurve")
+}
+
+// TestParseECKeyValueInvalidPoint covers the invalid-point branch: a valid
+// curve but a PublicKey blob that does not unmarshal to a point.
+func TestParseECKeyValueInvalidPoint(t *testing.T) {
+	inner := `<dsig11:NamedCurve xmlns:dsig11="` + NamespaceDSig11 + `" URI="urn:oid:1.2.840.10045.3.1.7"/>` +
+		`<dsig11:PublicKey xmlns:dsig11="` + NamespaceDSig11 + `">AAAA</dsig11:PublicKey>`
+	elem := ecElem(t, nil, inner)
+	var data KeyInfoData
+	err := parseECKeyValue(elem, &data)
+	require.ErrorIs(t, err, ErrInvalidKeyInfo)
+	require.Contains(t, err.Error(), "invalid EC public key point")
+}
+
+// TestParseECKeyValueBadBase64 covers the base64-decode error branch.
+func TestParseECKeyValueBadBase64(t *testing.T) {
+	inner := `<dsig11:NamedCurve xmlns:dsig11="` + NamespaceDSig11 + `" URI="urn:oid:1.2.840.10045.3.1.7"/>` +
+		`<dsig11:PublicKey xmlns:dsig11="` + NamespaceDSig11 + `">!!!!notbase64</dsig11:PublicKey>`
+	elem := ecElem(t, nil, inner)
+	var data KeyInfoData
+	err := parseECKeyValue(elem, &data)
+	require.ErrorIs(t, err, ErrInvalidKeyInfo)
+}
+
+// TestParseRSAKeyValueExponentOutOfRange covers the exponent-range guard.
+func TestParseRSAKeyValueExponentOutOfRange(t *testing.T) {
+	// Exponent of 0 (base64 "AA==" decodes to a single 0 byte -> Sign() == 0).
+	inner := `<ds:Modulus xmlns:ds="` + NamespaceDSig + `">AQAB</ds:Modulus>` +
+		`<ds:Exponent xmlns:ds="` + NamespaceDSig + `">AA==</ds:Exponent>`
+	d := mustParse(t, `<ds:RSAKeyValue xmlns:ds="`+NamespaceDSig+`">`+inner+`</ds:RSAKeyValue>`)
+	var data KeyInfoData
+	err := parseRSAKeyValue(d.DocumentElement(), &data)
+	require.ErrorIs(t, err, ErrInvalidKeyInfo)
+	require.Contains(t, err.Error(), "out of range")
+}
+
+// TestParseRSAKeyValueBadBase64 covers the base64 error branch.
+func TestParseRSAKeyValueBadBase64(t *testing.T) {
+	d := mustParse(t, `<ds:RSAKeyValue xmlns:ds="`+NamespaceDSig+`"><ds:Modulus xmlns:ds="`+NamespaceDSig+`">!!!</ds:Modulus></ds:RSAKeyValue>`)
+	var data KeyInfoData
+	err := parseRSAKeyValue(d.DocumentElement(), &data)
+	require.ErrorIs(t, err, ErrInvalidKeyInfo)
+}
+
+// TestResolveC14NModeUnsupported covers the default (error) arm.
+func TestResolveC14NModeUnsupported(t *testing.T) {
+	_, _, err := resolveC14NMode("urn:not-a-c14n-method")
+	require.ErrorIs(t, err, ErrUnsupportedAlgorithm)
+}
+
+// TestResolveC14NModeComments covers the comment-variant arms.
+func TestResolveC14NModeComments(t *testing.T) {
+	for _, m := range []string{C14N10Comments, ExcC14N10Comments, C14N11Comments} {
+		_, comments, err := resolveC14NMode(m)
+		require.NoError(t, err)
+		require.True(t, comments)
+	}
+}
+
+// TestKeySourceFuncNil covers the typed-nil guard in KeySourceFunc.ResolveKey.
+func TestKeySourceFuncNil(t *testing.T) {
+	var f KeySourceFunc
+	_, err := f.ResolveKey(t.Context(), nil, "")
+	require.ErrorIs(t, err, ErrNoKeySource)
+}
+
+// TestParseX509DataBadCert covers the invalid-base64 and invalid-cert branches.
+func TestParseX509DataBadCert(t *testing.T) {
+	// well-formed base64 but not a certificate.
+	d := mustParse(t, `<ds:X509Data xmlns:ds="`+NamespaceDSig+`"><ds:X509Certificate xmlns:ds="`+NamespaceDSig+`">aGVsbG8=</ds:X509Certificate></ds:X509Data>`)
+	var data KeyInfoData
+	err := parseX509Data(d.DocumentElement(), &data)
+	require.ErrorIs(t, err, ErrInvalidKeyInfo)
+
+	d2 := mustParse(t, `<ds:X509Data xmlns:ds="`+NamespaceDSig+`"><ds:X509Certificate xmlns:ds="`+NamespaceDSig+`">!!!bad</ds:X509Certificate></ds:X509Data>`)
+	var data2 KeyInfoData
+	err = parseX509Data(d2.DocumentElement(), &data2)
+	require.ErrorIs(t, err, ErrInvalidKeyInfo)
+	require.True(t, strings.Contains(err.Error(), "base64"))
+}

--- a/xmldsig1/coverage_keyinfo_result_test.go
+++ b/xmldsig1/coverage_keyinfo_result_test.go
@@ -1,0 +1,212 @@
+package xmldsig1_test
+
+import (
+	"context"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"encoding/base64"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xmldsig1"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveKeyFromRSAKeyValue signs with RSAKeyValueKeyInfo, then resolves
+// the verification key out of the parsed KeyInfoData.RSAKeyValue. This drives
+// parseKeyInfo -> parseKeyValue -> parseRSAKeyValue and KeyInfoData wiring.
+func TestResolveKeyFromRSAKeyValue(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.NewEnvelopedReference()).
+		KeyInfo(xmldsig1.RSAKeyValueKeyInfo())
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+	ks := xmldsig1.KeySourceFunc(func(_ context.Context, ki *xmldsig1.KeyInfoData, _ string) (any, error) {
+		require.NotNil(t, ki)
+		require.NotNil(t, ki.RSAKeyValue)
+		return &rsa.PublicKey{
+			N: ki.RSAKeyValue.Modulus,
+			E: ki.RSAKeyValue.Exponent,
+		}, nil
+	})
+	verifier := xmldsig1.NewVerifier(ks)
+	_, err := verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+}
+
+// TestResolveKeyFromX509Data signs with X509DataKeyInfo, then reads the parsed
+// certificate from KeyInfoData.X509Certificates. Drives parseX509Data.
+func TestResolveKeyFromX509Data(t *testing.T) {
+	key := generateRSAKey(t)
+	cert := generateSelfSignedCert(t, key)
+	doc := mustParseXML(t, samlAssertion)
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.NewEnvelopedReference()).
+		KeyInfo(xmldsig1.X509DataKeyInfo(cert))
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+	ks := xmldsig1.KeySourceFunc(func(_ context.Context, ki *xmldsig1.KeyInfoData, _ string) (any, error) {
+		require.NotNil(t, ki)
+		require.Len(t, ki.X509Certificates, 1)
+		return ki.X509Certificates[0].PublicKey, nil
+	})
+	verifier := xmldsig1.NewVerifier(ks)
+	_, err := verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+}
+
+// TestParseECKeyValue drives parseECKeyValue (P-256 and P-384) and isDSig11NS
+// through a verification using a dsig11 ECKeyValue KeyInfo.
+func TestParseECKeyValue(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		curve    elliptic.Curve
+		curveURI string
+		alg      string
+	}{
+		{"p256", elliptic.P256(), "urn:oid:1.2.840.10045.3.1.7", xmldsig1.AlgECDSASHA256},
+		{"p384", elliptic.P384(), "urn:oid:1.3.132.0.34", xmldsig1.AlgECDSASHA384},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			key := generateECDSAKey(t, tc.curve)
+			doc := mustParseXML(t, samlAssertion)
+			signer := xmldsig1.NewSigner().
+				SignatureAlgorithm(tc.alg).
+				Reference(xmldsig1.ReferenceConfig{
+					URI:             "",
+					DigestAlgorithm: dsigDigestFor(tc.alg),
+					Transforms:      []xmldsig1.Transform{xmldsig1.Enveloped(), xmldsig1.ExcC14NTransform()},
+				})
+			require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+			// Inject a dsig11 ECKeyValue KeyInfo into the Signature so the
+			// verifier parses it.
+			pubBytes := elliptic.Marshal(tc.curve, key.PublicKey.X, key.PublicKey.Y)
+			injectECKeyInfo(t, doc, tc.curveURI, pubBytes)
+
+			ks := xmldsig1.KeySourceFunc(func(_ context.Context, ki *xmldsig1.KeyInfoData, _ string) (any, error) {
+				require.NotNil(t, ki.ECKeyValue)
+				require.NotNil(t, ki.ECKeyValue.X)
+				return &key.PublicKey, nil
+			})
+			verifier := xmldsig1.NewVerifier(ks)
+			_, err := verifier.Verify(t.Context(), doc)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestVerifyResultAccessors covers VerifyResult.SignedElement and Covers,
+// including their nil-receiver and miss branches.
+func TestVerifyResultAccessors(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.NewEnvelopedReference())
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	res, err := verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+
+	root := doc.DocumentElement()
+	require.Equal(t, root, res.SignedElement(""))
+	require.Nil(t, res.SignedElement("#nope"))
+	require.True(t, res.Covers(root))
+
+	other := doc.CreateElement("other")
+	require.False(t, res.Covers(other))
+	require.False(t, res.Covers(nil))
+
+	var nilRes *xmldsig1.VerifyResult
+	require.Nil(t, nilRes.SignedElement(""))
+	require.False(t, nilRes.Covers(root))
+}
+
+func dsigDigestFor(alg string) string {
+	if alg == xmldsig1.AlgECDSASHA384 {
+		return xmldsig1.DigestSHA384
+	}
+	return xmldsig1.DigestSHA256
+}
+
+// injectECKeyInfo appends a <ds:KeyInfo><ds:KeyValue><dsig11:ECKeyValue> ...
+// element to the Signature element of doc.
+func injectECKeyInfo(t *testing.T, doc *helium.Document, curveURI string, pub []byte) {
+	t.Helper()
+	const dsig11 = xmldsig1.NamespaceDSig11
+
+	sig := findSig(t, doc)
+
+	keyInfo := doc.CreateElement("KeyInfo")
+	require.NoError(t, keyInfo.SetActiveNamespace("ds", xmldsig1.NamespaceDSig))
+	keyValue := doc.CreateElement("KeyValue")
+	require.NoError(t, keyValue.SetActiveNamespace("ds", xmldsig1.NamespaceDSig))
+	require.NoError(t, keyInfo.AddChild(keyValue))
+
+	ec := doc.CreateElement("ECKeyValue")
+	require.NoError(t, ec.DeclareNamespace("dsig11", dsig11))
+	require.NoError(t, ec.SetActiveNamespace("dsig11", dsig11))
+	require.NoError(t, keyValue.AddChild(ec))
+
+	nc := doc.CreateElement("NamedCurve")
+	require.NoError(t, nc.SetActiveNamespace("dsig11", dsig11))
+	require.NoError(t, nc.SetLiteralAttribute("URI", curveURI))
+	require.NoError(t, ec.AddChild(nc))
+
+	pk := doc.CreateElement("PublicKey")
+	require.NoError(t, pk.SetActiveNamespace("dsig11", dsig11))
+	encoded := base64StdEncode(pub)
+	require.NoError(t, pk.AddChild(doc.CreateText([]byte(encoded))))
+	require.NoError(t, ec.AddChild(pk))
+
+	require.NoError(t, sig.AddChild(keyInfo))
+}
+
+func findSig(t *testing.T, doc *helium.Document) *helium.Element {
+	t.Helper()
+	var out *helium.Element
+	var walk func(helium.Node)
+	walk = func(n helium.Node) {
+		if e, ok := helium.AsNode[*helium.Element](n); ok {
+			if localName(e) == "Signature" {
+				out = e
+				return
+			}
+			for c := e.FirstChild(); c != nil; c = c.NextSibling() {
+				walk(c)
+			}
+		}
+	}
+	walk(doc.DocumentElement())
+	require.NotNil(t, out)
+	return out
+}
+
+func localName(e *helium.Element) string {
+	name := e.Name()
+	if _, rest, ok := cut(name, ":"); ok {
+		return rest
+	}
+	return name
+}
+
+func cut(s, sep string) (before, after string, found bool) {
+	for i := 0; i+len(sep) <= len(s); i++ {
+		if s[i:i+len(sep)] == sep {
+			return s[:i], s[i+len(sep):], true
+		}
+	}
+	return s, "", false
+}
+
+func base64StdEncode(b []byte) string {
+	return base64.StdEncoding.EncodeToString(b)
+}

--- a/xmldsig1/coverage_keyinfo_result_test.go
+++ b/xmldsig1/coverage_keyinfo_result_test.go
@@ -87,7 +87,7 @@ func TestParseECKeyValue(t *testing.T) {
 
 			// Inject a dsig11 ECKeyValue KeyInfo into the Signature so the
 			// verifier parses it.
-			pubBytes := elliptic.Marshal(tc.curve, key.PublicKey.X, key.PublicKey.Y)
+			pubBytes := elliptic.Marshal(tc.curve, key.X, key.Y)
 			injectECKeyInfo(t, doc, tc.curveURI, pubBytes)
 
 			ks := xmldsig1.KeySourceFunc(func(_ context.Context, ki *xmldsig1.KeyInfoData, _ string) (any, error) {

--- a/xmldsig1/coverage_parse_internal_test.go
+++ b/xmldsig1/coverage_parse_internal_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestDigestEqual(t *testing.T) {
 	require.True(t, digestEqual([]byte{1, 2, 3}, []byte{1, 2, 3}))
-	require.False(t, digestEqual([]byte{1, 2, 3}, []byte{1, 2}))   // length mismatch
+	require.False(t, digestEqual([]byte{1, 2, 3}, []byte{1, 2}))    // length mismatch
 	require.False(t, digestEqual([]byte{1, 2, 3}, []byte{1, 2, 4})) // content mismatch
 }
 

--- a/xmldsig1/coverage_parse_internal_test.go
+++ b/xmldsig1/coverage_parse_internal_test.go
@@ -1,0 +1,119 @@
+package xmldsig1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDigestEqual(t *testing.T) {
+	require.True(t, digestEqual([]byte{1, 2, 3}, []byte{1, 2, 3}))
+	require.False(t, digestEqual([]byte{1, 2, 3}, []byte{1, 2}))   // length mismatch
+	require.False(t, digestEqual([]byte{1, 2, 3}, []byte{1, 2, 4})) // content mismatch
+}
+
+const dsigNS = NamespaceDSig
+
+func TestParseSignatureElementMissingSignedInfo(t *testing.T) {
+	doc := mustParse(t, `<ds:Signature xmlns:ds="`+dsigNS+`"><ds:SignatureValue xmlns:ds="`+dsigNS+`">AA==</ds:SignatureValue></ds:Signature>`)
+	_, err := parseSignatureElement(doc.DocumentElement())
+	require.ErrorIs(t, err, ErrInvalidSignature)
+	require.Contains(t, err.Error(), "missing SignedInfo")
+}
+
+func TestParseSignatureElementMissingSignatureValue(t *testing.T) {
+	si := `<ds:SignedInfo xmlns:ds="` + dsigNS + `">` +
+		`<ds:CanonicalizationMethod xmlns:ds="` + dsigNS + `" Algorithm="` + ExcC14N10 + `"/>` +
+		`<ds:SignatureMethod xmlns:ds="` + dsigNS + `" Algorithm="` + AlgRSASHA256 + `"/>` +
+		`<ds:Reference xmlns:ds="` + dsigNS + `" URI="">` +
+		`<ds:DigestMethod xmlns:ds="` + dsigNS + `" Algorithm="` + DigestSHA256 + `"/>` +
+		`<ds:DigestValue xmlns:ds="` + dsigNS + `">AA==</ds:DigestValue>` +
+		`</ds:Reference></ds:SignedInfo>`
+	doc := mustParse(t, `<ds:Signature xmlns:ds="`+dsigNS+`">`+si+`</ds:Signature>`)
+	_, err := parseSignatureElement(doc.DocumentElement())
+	require.ErrorIs(t, err, ErrInvalidSignature)
+	require.Contains(t, err.Error(), "missing SignatureValue")
+}
+
+func TestParseSignatureElementBadSignatureValueBase64(t *testing.T) {
+	si := `<ds:SignedInfo xmlns:ds="` + dsigNS + `">` +
+		`<ds:Reference xmlns:ds="` + dsigNS + `" URI="">` +
+		`<ds:DigestMethod xmlns:ds="` + dsigNS + `" Algorithm="` + DigestSHA256 + `"/>` +
+		`<ds:DigestValue xmlns:ds="` + dsigNS + `">AA==</ds:DigestValue>` +
+		`</ds:Reference></ds:SignedInfo>`
+	doc := mustParse(t, `<ds:Signature xmlns:ds="`+dsigNS+`">`+si+
+		`<ds:SignatureValue xmlns:ds="`+dsigNS+`">!!!bad</ds:SignatureValue></ds:Signature>`)
+	_, err := parseSignatureElement(doc.DocumentElement())
+	require.ErrorIs(t, err, ErrInvalidSignature)
+}
+
+func TestParseSignedInfoMissingC14NAlgorithm(t *testing.T) {
+	si := `<ds:SignedInfo xmlns:ds="` + dsigNS + `">` +
+		`<ds:CanonicalizationMethod xmlns:ds="` + dsigNS + `"/>` +
+		`</ds:SignedInfo>`
+	doc := mustParse(t, si)
+	var parsed parsedSignature
+	err := parseSignedInfo(doc.DocumentElement(), &parsed)
+	require.ErrorIs(t, err, ErrInvalidSignature)
+	require.Contains(t, err.Error(), "CanonicalizationMethod missing Algorithm")
+}
+
+func TestParseSignedInfoMissingSignatureMethodAlgorithm(t *testing.T) {
+	si := `<ds:SignedInfo xmlns:ds="` + dsigNS + `">` +
+		`<ds:SignatureMethod xmlns:ds="` + dsigNS + `"/>` +
+		`</ds:SignedInfo>`
+	doc := mustParse(t, si)
+	var parsed parsedSignature
+	err := parseSignedInfo(doc.DocumentElement(), &parsed)
+	require.ErrorIs(t, err, ErrInvalidSignature)
+	require.Contains(t, err.Error(), "SignatureMethod missing Algorithm")
+}
+
+func TestParseSignedInfoNoReference(t *testing.T) {
+	si := `<ds:SignedInfo xmlns:ds="` + dsigNS + `">` +
+		`<ds:CanonicalizationMethod xmlns:ds="` + dsigNS + `" Algorithm="` + ExcC14N10 + `"/>` +
+		`<ds:SignatureMethod xmlns:ds="` + dsigNS + `" Algorithm="` + AlgRSASHA256 + `"/>` +
+		`</ds:SignedInfo>`
+	doc := mustParse(t, si)
+	var parsed parsedSignature
+	err := parseSignedInfo(doc.DocumentElement(), &parsed)
+	require.ErrorIs(t, err, ErrInvalidSignature)
+	require.Contains(t, err.Error(), "no Reference")
+}
+
+func TestParseReferenceElementMissingDigestMethodAlgorithm(t *testing.T) {
+	r := `<ds:Reference xmlns:ds="` + dsigNS + `" URI="">` +
+		`<ds:DigestMethod xmlns:ds="` + dsigNS + `"/>` +
+		`</ds:Reference>`
+	doc := mustParse(t, r)
+	_, err := parseReferenceElement(doc.DocumentElement())
+	require.ErrorIs(t, err, ErrInvalidSignature)
+	require.Contains(t, err.Error(), "DigestMethod missing Algorithm")
+}
+
+func TestParseReferenceElementBadDigestValueBase64(t *testing.T) {
+	r := `<ds:Reference xmlns:ds="` + dsigNS + `" URI="">` +
+		`<ds:DigestMethod xmlns:ds="` + dsigNS + `" Algorithm="` + DigestSHA256 + `"/>` +
+		`<ds:DigestValue xmlns:ds="` + dsigNS + `">!!!bad</ds:DigestValue>` +
+		`</ds:Reference>`
+	doc := mustParse(t, r)
+	_, err := parseReferenceElement(doc.DocumentElement())
+	require.ErrorIs(t, err, ErrInvalidSignature)
+}
+
+func TestParseReferenceElementWithInclusiveNamespaces(t *testing.T) {
+	const exc = ExcC14N10
+	r := `<ds:Reference xmlns:ds="` + dsigNS + `" URI="">` +
+		`<ds:Transforms xmlns:ds="` + dsigNS + `">` +
+		`<ds:Transform xmlns:ds="` + dsigNS + `" Algorithm="` + exc + `">` +
+		`<ec:InclusiveNamespaces xmlns:ec="` + exc + `" PrefixList="a b"/>` +
+		`</ds:Transform></ds:Transforms>` +
+		`<ds:DigestMethod xmlns:ds="` + dsigNS + `" Algorithm="` + DigestSHA256 + `"/>` +
+		`<ds:DigestValue xmlns:ds="` + dsigNS + `">AA==</ds:DigestValue>` +
+		`</ds:Reference>`
+	doc := mustParse(t, r)
+	ref, err := parseReferenceElement(doc.DocumentElement())
+	require.NoError(t, err)
+	require.Len(t, ref.transforms, 1)
+	require.Equal(t, []string{"a", "b"}, ref.transforms[0].prefixes)
+}

--- a/xmldsig1/coverage_sign_modes_test.go
+++ b/xmldsig1/coverage_sign_modes_test.go
@@ -1,0 +1,200 @@
+package xmldsig1_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xmldsig1"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSignEnvelopingRoundTrip drives signEnveloping (content wrapped in an
+// Object element) plus KeyInfo construction, then verifies it.
+func TestSignEnvelopingRoundTrip(t *testing.T) {
+	key := generateRSAKey(t)
+	// The document already contains the element the reference points at; the
+	// enveloping Object wraps separate content. signEnveloping resolves the
+	// reference against the live document tree.
+	doc := mustParseXML(t, `<root><data Id="d1">covered</data></root>`)
+
+	payload := doc.CreateElement("Payload")
+	require.NoError(t, payload.AddChild(doc.CreateText([]byte("hello"))))
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		SignatureID("sig-1").
+		Reference(xmldsig1.ReferenceConfig{
+			URI:             "#d1",
+			DigestAlgorithm: xmldsig1.DigestSHA256,
+			ID:              "ref-1",
+			Type:            xmldsig1.TypeObject,
+			Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+		}).
+		KeyInfo(xmldsig1.RSAKeyValueKeyInfo())
+
+	sigElem, err := signer.SignEnveloping(t.Context(), doc, []helium.Node{payload}, key)
+	require.NoError(t, err)
+	require.NotNil(t, sigElem)
+
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	// The Signature element carries the configured Id.
+	id, ok := sigElem.GetAttribute("Id")
+	require.True(t, ok)
+	require.Equal(t, "sig-1", id)
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+}
+
+// TestSignDetachedWithKeyInfoAndID drives the full signDetached path including
+// the KeyInfo builder branch and Id/Type attributes.
+func TestSignDetachedWithKeyInfoAndID(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, `<root><data Id="mydata">Hello</data></root>`)
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		SignatureID("detached-sig").
+		Reference(xmldsig1.ReferenceConfig{
+			URI:             "#mydata",
+			DigestAlgorithm: xmldsig1.DigestSHA256,
+			ID:              "r1",
+			Type:            xmldsig1.TypeObject,
+			Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+		}).
+		KeyInfo(xmldsig1.X509DataKeyInfo())
+
+	sigElem, err := signer.SignDetached(t.Context(), doc, key)
+	require.NoError(t, err)
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+}
+
+// TestSignWithExclusiveC14NPrefixes drives the InclusiveNamespaces/PrefixList
+// branch of processReference and the prefix-roundtrip on verify.
+func TestSignWithExclusiveC14NPrefixes(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, `<root xmlns:a="urn:a" xmlns:b="urn:b"><data Id="d1"><a:x b:attr="v">hi</a:x></data></root>`)
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.ReferenceConfig{
+			URI:             "#d1",
+			DigestAlgorithm: xmldsig1.DigestSHA256,
+			Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform("a", "b")},
+		})
+
+	sigElem, err := signer.SignDetached(t.Context(), doc, key)
+	require.NoError(t, err)
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err = verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+}
+
+// TestSignWithC14N11 drives resolveC14NMode's C14N11 arm for both the
+// reference transform and the SignedInfo canonicalization method.
+func TestSignWithC14N11(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		CanonicalizationMethod(xmldsig1.C14N11URI).
+		Reference(xmldsig1.ReferenceConfig{
+			URI:             "",
+			DigestAlgorithm: xmldsig1.DigestSHA256,
+			Transforms:      []xmldsig1.Transform{xmldsig1.Enveloped(), xmldsig1.C14NTransform(xmldsig1.C14N11URI)},
+		})
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err := verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+}
+
+// TestSignWithC14N10 drives resolveC14NMode's plain C14N10 arm.
+func TestSignWithC14N10(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		CanonicalizationMethod(xmldsig1.C14N10).
+		Reference(xmldsig1.ReferenceConfig{
+			URI:             "",
+			DigestAlgorithm: xmldsig1.DigestSHA256,
+			Transforms:      []xmldsig1.Transform{xmldsig1.Enveloped(), xmldsig1.C14NTransform(xmldsig1.C14N10)},
+		})
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err := verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+}
+
+// TestSignReferenceNotFound drives processReference's resolveReference error
+// path (a fragment URI matching no element).
+func TestSignReferenceNotFound(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.ReferenceConfig{
+			URI:             "#does-not-exist",
+			DigestAlgorithm: xmldsig1.DigestSHA256,
+			Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+		})
+	_, err := signer.SignDetached(t.Context(), doc, key)
+	require.ErrorIs(t, err, xmldsig1.ErrReferenceNotFound)
+}
+
+// TestSignExternalReferenceRejected drives resolveReference's external-URI
+// (non-fragment) rejection branch.
+func TestSignExternalReferenceRejected(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.ReferenceConfig{
+			URI:             "http://example.com/external.xml",
+			DigestAlgorithm: xmldsig1.DigestSHA256,
+			Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+		})
+	_, err := signer.SignDetached(t.Context(), doc, key)
+	require.ErrorIs(t, err, xmldsig1.ErrReferenceNotFound)
+}
+
+// unsupportedTransform is a Transform whose URI is one the verifier does not
+// recognize. The signer treats an unrecognized Transform as the default
+// Exclusive C14N for canonicalization but still writes the URI into the
+// document, so the resulting (self-consistent) signature triggers
+// verifyReference's fail-closed unsupported-transform rejection.
+type unsupportedTransform struct{}
+
+func (unsupportedTransform) URI() string { return xmldsig1.TransformXPath }
+
+// TestVerifyUnsupportedTransform drives verifyReference's fail-closed
+// unsupported-transform branch.
+func TestVerifyUnsupportedTransform(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+	signer := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.ReferenceConfig{
+			URI:             "",
+			DigestAlgorithm: xmldsig1.DigestSHA256,
+			Transforms:      []xmldsig1.Transform{xmldsig1.Enveloped(), unsupportedTransform{}},
+		})
+	require.NoError(t, signer.SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	_, err := verifier.Verify(t.Context(), doc)
+	require.ErrorIs(t, err, xmldsig1.ErrUnsupportedTransform)
+}

--- a/xmlenc1/coverage_decrypt_test.go
+++ b/xmlenc1/coverage_decrypt_test.go
@@ -1,0 +1,197 @@
+package xmlenc1_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xmlenc1"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDecryptMissingEncryptionMethod covers the decryptElement branch that
+// rejects an EncryptedData carrying CipherData but no EncryptionMethod.
+func TestDecryptMissingEncryptionMethod(t *testing.T) {
+	doc := mustParseXML(t, `<root/>`)
+	ed := &xmlenc1.EncryptedData{
+		Type:        xmlenc1.TypeElement,
+		CipherValue: make([]byte, 48),
+	}
+	elem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+	require.NoError(t, err)
+
+	decryptor := xmlenc1.NewDecryptor().SessionKey(make([]byte, 32))
+	_, err = decryptor.Decrypt(t.Context(), elem)
+	require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+}
+
+// TestResolveSessionKeyMissingKey covers the no-key-available branches of
+// resolveSessionKey: no session key, no private key, no KEK.
+func TestResolveSessionKeyMissingKey(t *testing.T) {
+	t.Run("no key material at all", func(t *testing.T) {
+		doc := mustParseXML(t, `<root/>`)
+		ed := &xmlenc1.EncryptedData{
+			Type:             xmlenc1.TypeElement,
+			EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256GCM},
+			CipherValue:      make([]byte, 48),
+		}
+		elem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+		require.NoError(t, err)
+
+		// A decryptor with no session key and no EncryptedKey present.
+		_, err = xmlenc1.NewDecryptor().Decrypt(t.Context(), elem)
+		require.ErrorIs(t, err, xmlenc1.ErrMissingKey)
+	})
+
+	t.Run("RSA EncryptedKey but no private key", func(t *testing.T) {
+		doc := mustParseXML(t, `<root/>`)
+		ed := &xmlenc1.EncryptedData{
+			Type:             xmlenc1.TypeElement,
+			EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256GCM},
+			EncryptedKey: &xmlenc1.EncryptedKey{
+				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.RSAOAEP},
+				CipherValue:      make([]byte, 256),
+			},
+			CipherValue: make([]byte, 48),
+		}
+		elem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+		require.NoError(t, err)
+
+		_, err = xmlenc1.NewDecryptor().Decrypt(t.Context(), elem)
+		require.ErrorIs(t, err, xmlenc1.ErrMissingKey)
+	})
+
+	t.Run("AES key-wrap EncryptedKey but no KEK", func(t *testing.T) {
+		doc := mustParseXML(t, `<root/>`)
+		ed := &xmlenc1.EncryptedData{
+			Type:             xmlenc1.TypeElement,
+			EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256GCM},
+			EncryptedKey: &xmlenc1.EncryptedKey{
+				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256KeyWrap},
+				CipherValue:      make([]byte, 40),
+			},
+			CipherValue: make([]byte, 48),
+		}
+		elem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+		require.NoError(t, err)
+
+		_, err = xmlenc1.NewDecryptor().Decrypt(t.Context(), elem)
+		require.ErrorIs(t, err, xmlenc1.ErrMissingKey)
+	})
+
+	t.Run("EncryptedKey missing EncryptionMethod", func(t *testing.T) {
+		doc := mustParseXML(t, `<root/>`)
+		ed := &xmlenc1.EncryptedData{
+			Type:             xmlenc1.TypeElement,
+			EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256GCM},
+			EncryptedKey: &xmlenc1.EncryptedKey{
+				CipherValue: make([]byte, 40),
+			},
+			CipherValue: make([]byte, 48),
+		}
+		elem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+		require.NoError(t, err)
+
+		_, err = xmlenc1.NewDecryptor().PrivateKey(generateRSAKey(t)).Decrypt(t.Context(), elem)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+}
+
+// TestResolveSessionKeyUnsupportedKeyTransport covers the default branch of
+// resolveSessionKey: an EncryptedKey declaring an unknown key-transport URI.
+func TestResolveSessionKeyUnsupportedKeyTransport(t *testing.T) {
+	doc := mustParseXML(t, `<root/>`)
+	ed := &xmlenc1.EncryptedData{
+		Type:             xmlenc1.TypeElement,
+		EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256GCM},
+		EncryptedKey: &xmlenc1.EncryptedKey{
+			EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: "urn:example:not-a-real-algorithm"},
+			CipherValue:      make([]byte, 40),
+		},
+		CipherValue: make([]byte, 48),
+	}
+	elem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+	require.NoError(t, err)
+
+	_, err = xmlenc1.NewDecryptor().PrivateKey(generateRSAKey(t)).Decrypt(t.Context(), elem)
+	require.ErrorIs(t, err, xmlenc1.ErrDecryptionFailed)
+	var unsupported *xmlenc1.UnsupportedAlgorithmError
+	require.ErrorAs(t, err, &unsupported)
+}
+
+// TestEncryptorOAEPParamsRoundTrip covers the Encryptor.OAEPParams setter and
+// the OAEPParams encrypt/decrypt path through RSA-OAEP 1.1.
+func TestEncryptorOAEPParamsRoundTrip(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+		OAEPDigest(xmlenc1.DigestSHA256).
+		OAEPMGF(xmlenc1.MGFSHA256).
+		OAEPParams([]byte("label-params")).
+		RecipientPublicKey(&key.PublicKey)
+
+	elem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	decryptor := xmlenc1.NewDecryptor().PrivateKey(key)
+	nodes, err := decryptor.Decrypt(t.Context(), elem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+}
+
+// TestDecryptElementYieldsNonElement covers the decryptElement branch that
+// rejects a Type=Element payload whose decrypted plaintext is not a single
+// element (here: plain text content).
+func TestDecryptElementYieldsNonElement(t *testing.T) {
+	sessionKey := make([]byte, 32)
+	algorithm := xmlenc1.AES256GCM
+
+	// Plaintext that is bare text, not an element. For Type=Element this
+	// must be rejected as ErrDecryptionFailed.
+	cipher, err := xmlenc1.EncryptBytesForTest(algorithm, sessionKey, []byte("just text, no element"))
+	require.NoError(t, err)
+
+	doc := mustParseXML(t, `<root/>`)
+	ed := &xmlenc1.EncryptedData{
+		Type:             xmlenc1.TypeElement,
+		EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: algorithm},
+		CipherValue:      cipher,
+	}
+	elem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+	require.NoError(t, err)
+
+	_, err = xmlenc1.NewDecryptor().SessionKey(sessionKey).Decrypt(t.Context(), elem)
+	require.ErrorIs(t, err, xmlenc1.ErrDecryptionFailed)
+}
+
+// TestDecryptContentMultipleNodes covers the Type=Content branch of
+// decryptElement that collects multiple decrypted child nodes.
+func TestDecryptContentMultipleNodes(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, `<root><a>1</a><b>2</b>text</root>`)
+
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+		RecipientPublicKey(&key.PublicKey)
+
+	elem, err := encryptor.EncryptContent(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	decryptor := xmlenc1.NewDecryptor().PrivateKey(key)
+	nodes, err := decryptor.Decrypt(t.Context(), elem)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(nodes), 2)
+
+	// Sanity: the recovered content includes the original element children.
+	var names []string
+	for _, n := range nodes {
+		if e, ok := helium.AsNode[*helium.Element](n); ok {
+			names = append(names, e.Name())
+		}
+	}
+	require.Contains(t, names, "a")
+	require.Contains(t, names, "b")
+}

--- a/xmlenc1/coverage_marshal_parse_test.go
+++ b/xmlenc1/coverage_marshal_parse_test.go
@@ -1,0 +1,152 @@
+package xmlenc1_test
+
+import (
+	"errors"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xmlenc1"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMarshalParseRoundTripAllFields exercises the serialize and parse paths
+// for every optional field: EncryptedData ID/Type, an EncryptedKey carrying
+// its own ID/Recipient/CarriedKeyName and an EncryptionMethod with
+// DigestMethod, MGFAlgorithm and OAEPParams. The marshaled element is
+// serialized to bytes, reparsed through the public XML parser, and the
+// resulting DOM is fed back through the internal EncryptedData parser so
+// both directions are covered honestly via a real round-trip.
+func TestMarshalParseRoundTripAllFields(t *testing.T) {
+	doc := mustParseXML(t, `<root/>`)
+
+	ed := &xmlenc1.EncryptedData{
+		ID:   "ED-1",
+		Type: xmlenc1.TypeElement,
+		EncryptionMethod: &xmlenc1.EncryptionMethod{
+			Algorithm:    xmlenc1.AES256GCM,
+			DigestMethod: xmlenc1.DigestSHA256,
+			MGFAlgorithm: xmlenc1.MGFSHA256,
+			OAEPParams:   []byte("params-bytes"),
+		},
+		EncryptedKey: &xmlenc1.EncryptedKey{
+			ID: "EK-1",
+			EncryptionMethod: &xmlenc1.EncryptionMethod{
+				Algorithm:    xmlenc1.RSAOAEP11,
+				DigestMethod: xmlenc1.DigestSHA256,
+				MGFAlgorithm: xmlenc1.MGFSHA256,
+			},
+			CipherValue: []byte("wrapped-key-bytes"),
+		},
+		CipherValue: []byte("cipher-bytes"),
+	}
+
+	elem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+	require.NoError(t, err)
+
+	// Parse the marshaled DOM back through the internal EncryptedData
+	// parser. The marshaler sets active namespaces on each element, so the
+	// namespace-aware matcher resolves the xenc/ds/xenc11 URIs directly.
+	parsed, err := xmlenc1.ParseEncryptedDataForTest(elem)
+	require.NoError(t, err)
+
+	require.Equal(t, "ED-1", parsed.ID)
+	require.Equal(t, xmlenc1.TypeElement, parsed.Type)
+	require.NotNil(t, parsed.EncryptionMethod)
+	require.Equal(t, xmlenc1.AES256GCM, parsed.EncryptionMethod.Algorithm)
+	require.Equal(t, xmlenc1.DigestSHA256, parsed.EncryptionMethod.DigestMethod)
+	require.Equal(t, xmlenc1.MGFSHA256, parsed.EncryptionMethod.MGFAlgorithm)
+	require.Equal(t, []byte("params-bytes"), parsed.EncryptionMethod.OAEPParams)
+
+	require.NotNil(t, parsed.EncryptedKey)
+	require.Equal(t, "EK-1", parsed.EncryptedKey.ID)
+	require.NotNil(t, parsed.EncryptedKey.EncryptionMethod)
+	require.Equal(t, xmlenc1.RSAOAEP11, parsed.EncryptedKey.EncryptionMethod.Algorithm)
+	require.Equal(t, []byte("wrapped-key-bytes"), parsed.EncryptedKey.CipherValue)
+	require.Equal(t, []byte("cipher-bytes"), parsed.CipherValue)
+}
+
+// TestParseEncryptedDataErrors covers the early-rejection branches of the
+// internal parser.
+func TestParseEncryptedDataErrors(t *testing.T) {
+	t.Run("nil element", func(t *testing.T) {
+		_, err := xmlenc1.ParseEncryptedDataForTest(nil)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+
+	t.Run("wrong element name/namespace", func(t *testing.T) {
+		doc := mustParseXML(t, `<root xmlns="http://www.w3.org/2001/04/xmlenc#"><NotEncryptedData/></root>`)
+		child, ok := helium.AsNode[*helium.Element](doc.DocumentElement().FirstChild())
+		require.True(t, ok)
+		_, err := xmlenc1.ParseEncryptedDataForTest(child)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+
+	t.Run("missing CipherData", func(t *testing.T) {
+		// An EncryptedData with no CipherData/CipherValue must be rejected.
+		doc := mustParseXML(t, `<xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"><xenc:EncryptionMethod Algorithm="`+xmlenc1.AES256GCM+`"/></xenc:EncryptedData>`)
+		elem, ok := helium.AsNode[*helium.Element](doc.DocumentElement())
+		require.True(t, ok)
+		_, err := xmlenc1.ParseEncryptedDataForTest(elem)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+}
+
+// TestParseEncryptionMethodMissingAlgorithm covers the EncryptionMethod
+// missing-@Algorithm rejection inside parseEncryptionMethod, reached through
+// the EncryptedData parser.
+func TestParseEncryptionMethodMissingAlgorithm(t *testing.T) {
+	doc := mustParseXML(t, `<xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"><xenc:EncryptionMethod/><xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData></xenc:EncryptedData>`)
+	elem, ok := helium.AsNode[*helium.Element](doc.DocumentElement())
+	require.True(t, ok)
+	_, err := xmlenc1.ParseEncryptedDataForTest(elem)
+	require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+}
+
+// TestParseInvalidBase64 covers the base64-decode error branches in
+// parseCipherData and parseEncryptionMethod (OAEPparams).
+func TestParseInvalidBase64(t *testing.T) {
+	t.Run("CipherValue", func(t *testing.T) {
+		doc := mustParseXML(t, `<xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"><xenc:CipherData><xenc:CipherValue>!!!not-base64!!!</xenc:CipherValue></xenc:CipherData></xenc:EncryptedData>`)
+		elem, ok := helium.AsNode[*helium.Element](doc.DocumentElement())
+		require.True(t, ok)
+		_, err := xmlenc1.ParseEncryptedDataForTest(elem)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+
+	t.Run("OAEPparams", func(t *testing.T) {
+		doc := mustParseXML(t, `<xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"><xenc:EncryptionMethod Algorithm="`+xmlenc1.RSAOAEP11+`"><xenc:OAEPparams>!!!bad!!!</xenc:OAEPparams></xenc:EncryptionMethod><xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData></xenc:EncryptedData>`)
+		elem, ok := helium.AsNode[*helium.Element](doc.DocumentElement())
+		require.True(t, ok)
+		_, err := xmlenc1.ParseEncryptedDataForTest(elem)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+}
+
+// TestKeySizeErrorMessage covers KeySizeError.Error(): a Decryptor handed a
+// session key whose length contradicts the declared algorithm must surface a
+// KeySizeError with the descriptive message.
+func TestKeySizeErrorMessage(t *testing.T) {
+	doc := mustParseXML(t, `<root/>`)
+	// Build EncryptedData declaring AES-256-GCM but decrypt with a 16-byte
+	// session key; validateKeySize rejects with KeySizeError before any
+	// ciphertext is touched.
+	ed := &xmlenc1.EncryptedData{
+		Type:             xmlenc1.TypeElement,
+		EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256GCM},
+		CipherValue:      make([]byte, 64),
+	}
+	elem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+	require.NoError(t, err)
+
+	shortKey := make([]byte, 16)
+	decryptor := xmlenc1.NewDecryptor().SessionKey(shortKey)
+	_, err = decryptor.Decrypt(t.Context(), elem)
+	require.Error(t, err)
+
+	var kse *xmlenc1.KeySizeError
+	require.True(t, errors.As(err, &kse))
+	require.Equal(t, xmlenc1.AES256GCM, kse.Algorithm)
+	require.Equal(t, 32, kse.Want)
+	require.Equal(t, 16, kse.Got)
+	require.Contains(t, kse.Error(), "requires a 32-byte key, got 16 bytes")
+}

--- a/xmlenc1/coverage_oaepname_test.go
+++ b/xmlenc1/coverage_oaepname_test.go
@@ -1,0 +1,61 @@
+package xmlenc1_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xmlenc1"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOAEPNameHelperBranches drives the digest/MGF-name formatting helpers
+// (oaepDigestName / oaepMGFName) through their non-default and default
+// branches. They are only reached when oaepHashFunc rejects a digest/MGF
+// hash mismatch, so each case sets up an RSA-OAEP 1.1 configuration whose
+// declared digest and MGF hashes disagree and asserts the encrypt path
+// surfaces ErrEncryptionFailed.
+func TestOAEPNameHelperBranches(t *testing.T) {
+	key := generateRSAKey(t)
+
+	t.Run("default digest vs explicit SHA256 MGF", func(t *testing.T) {
+		// digest unset -> SHA1 (default); MGF SHA256 -> mismatch.
+		// Exercises oaepDigestName("") default branch and the
+		// oaepMGFName non-empty branch.
+		doc := mustParseXML(t, samlAssertion)
+		encryptor := xmlenc1.NewEncryptor().
+			BlockAlgorithm(xmlenc1.AES256GCM).
+			KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+			OAEPMGF(xmlenc1.MGFSHA256).
+			RecipientPublicKey(&key.PublicKey)
+
+		_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+		require.ErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
+	})
+
+	t.Run("explicit SHA256 digest vs default MGF", func(t *testing.T) {
+		// digest SHA256; MGF unset -> SHA1 (default) -> mismatch.
+		// Exercises the oaepMGFName default branch for RSAOAEP11.
+		doc := mustParseXML(t, samlAssertion)
+		encryptor := xmlenc1.NewEncryptor().
+			BlockAlgorithm(xmlenc1.AES256GCM).
+			KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+			OAEPDigest(xmlenc1.DigestSHA256).
+			RecipientPublicKey(&key.PublicKey)
+
+		_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+		require.ErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
+	})
+
+	t.Run("legacy mgf1p with SHA256 digest", func(t *testing.T) {
+		// rsa-oaep-mgf1p fixes MGF to SHA1; a SHA256 digest mismatches.
+		// Exercises oaepMGFName's "implied by rsa-oaep-mgf1p" branch.
+		doc := mustParseXML(t, samlAssertion)
+		encryptor := xmlenc1.NewEncryptor().
+			BlockAlgorithm(xmlenc1.AES256GCM).
+			KeyTransportAlgorithm(xmlenc1.RSAOAEP).
+			OAEPDigest(xmlenc1.DigestSHA256).
+			RecipientPublicKey(&key.PublicKey)
+
+		_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+		require.ErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
+	})
+}

--- a/xpath1/consts_test.go
+++ b/xpath1/consts_test.go
@@ -1,3 +1,7 @@
 package xpath1_test
 
-const nsPrefixExt = "ext"
+const (
+	nsPrefixExt = "ext"
+	nsURIX      = "urn:x"
+	nsURIExt    = "urn:test:ext"
+)

--- a/xpath1/coverage_api_test.go
+++ b/xpath1/coverage_api_test.go
@@ -1,0 +1,157 @@
+package xpath1_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath1"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFunctionContextAccessors exercises the FunctionContext accessor methods
+// (Node, Position, Size, Namespace, Variable) from within a custom function.
+func TestFunctionContextAccessors(t *testing.T) {
+	doc := parseXML(t, `<root><a/><a/><a/></root>`)
+	compiled, err := xpath1.Compile("/root/a[probe()]")
+	require.NoError(t, err)
+
+	var sawNode bool
+	var sawSize int
+	var nsURI string
+	var nsOK bool
+	var varVal any
+	var varOK bool
+
+	ev := xpath1.NewEvaluator().
+		Namespaces(map[string]string{"p": "urn:p"}).
+		Variables(map[string]any{"v": float64(7)}).
+		Function("probe", xpath1.FunctionFunc(func(ctx context.Context, _ []*xpath1.Result) (*xpath1.Result, error) {
+			fctx := xpath1.GetFunctionContext(ctx)
+			if fctx.Node() != nil {
+				sawNode = true
+			}
+			sawSize = fctx.Size()
+			nsURI, nsOK = fctx.Namespace("p")
+			varVal, varOK = fctx.Variable("v")
+			return &xpath1.Result{Type: xpath1.BooleanResult, Bool: fctx.Position() == 1}, nil
+		}))
+
+	r, err := ev.Evaluate(t.Context(), compiled, doc)
+	require.NoError(t, err)
+	require.Len(t, r.NodeSet, 1)
+	require.True(t, sawNode)
+	require.Equal(t, 3, sawSize)
+	require.True(t, nsOK)
+	require.Equal(t, "urn:p", nsURI)
+	require.True(t, varOK)
+	require.Equal(t, float64(7), varVal)
+}
+
+func TestAdditionalNamespacesAndVariables(t *testing.T) {
+	doc := parseXML(t, `<root xmlns:p="urn:x"><p:foo>v</p:foo></root>`)
+
+	t.Run("AdditionalNamespaces from empty", func(t *testing.T) {
+		nodes, err := xpath1.NewEvaluator().
+			AdditionalNamespaces(map[string]string{"p": "urn:x"}).
+			Find(t.Context(), xpath1.MustCompile("//p:foo"), doc)
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+	})
+
+	t.Run("AdditionalNamespaces merges", func(t *testing.T) {
+		nodes, err := xpath1.NewEvaluator().
+			Namespaces(map[string]string{"q": "urn:q"}).
+			AdditionalNamespaces(map[string]string{"p": "urn:x"}).
+			Find(t.Context(), xpath1.MustCompile("//p:foo"), doc)
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+	})
+
+	t.Run("AdditionalVariables from empty", func(t *testing.T) {
+		r, err := xpath1.NewEvaluator().
+			AdditionalVariables(map[string]any{"x": float64(2)}).
+			Evaluate(t.Context(), xpath1.MustCompile("$x + 1"), doc)
+		require.NoError(t, err)
+		require.Equal(t, 3.0, r.Number)
+	})
+
+	t.Run("AdditionalVariables merges", func(t *testing.T) {
+		r, err := xpath1.NewEvaluator().
+			Variables(map[string]any{"y": float64(10)}).
+			AdditionalVariables(map[string]any{"x": float64(2)}).
+			Evaluate(t.Context(), xpath1.MustCompile("$x + $y"), doc)
+		require.NoError(t, err)
+		require.Equal(t, 12.0, r.Number)
+	})
+}
+
+func TestExpressionString(t *testing.T) {
+	compiled := xpath1.MustCompile("/root/a")
+	require.Equal(t, "/root/a", compiled.String())
+}
+
+func TestEvaluatorFind(t *testing.T) {
+	doc := parseXML(t, `<root><a/><b/></root>`)
+
+	t.Run("node-set", func(t *testing.T) {
+		nodes, err := xpath1.NewEvaluator().Find(t.Context(), xpath1.MustCompile("/root/*"), doc)
+		require.NoError(t, err)
+		require.Len(t, nodes, 2)
+	})
+
+	t.Run("not a node-set", func(t *testing.T) {
+		_, err := xpath1.NewEvaluator().Find(t.Context(), xpath1.MustCompile("1+1"), doc)
+		require.ErrorIs(t, err, xpath1.ErrNotNodeSet)
+	})
+}
+
+func TestNilExpression(t *testing.T) {
+	doc := parseXML(t, `<root/>`)
+
+	t.Run("Expression.Evaluate nil receiver", func(t *testing.T) {
+		var e *xpath1.Expression
+		_, err := e.Evaluate(t.Context(), doc)
+		require.ErrorIs(t, err, xpath1.ErrNilExpression)
+	})
+
+	t.Run("Evaluator.Evaluate nil expression", func(t *testing.T) {
+		_, err := xpath1.NewEvaluator().Evaluate(t.Context(), nil, doc)
+		require.ErrorIs(t, err, xpath1.ErrNilExpression)
+	})
+}
+
+// TestCompareNodeSetWithBooleanAndNumberScalars exercises compareWithScalar's
+// boolean and number branches when a node-set is compared to a scalar.
+func TestCompareNodeSetScalarBranches(t *testing.T) {
+	doc := parseXML(t, `<root><a>x</a><b></b></root>`)
+	for _, tc := range []struct {
+		expr string
+		want bool
+	}{
+		// node-set vs boolean scalar via compareWithScalar boolean branch
+		{`/root/a = true()`, true},
+		{`/root/a != false()`, true},
+		{`/root/a > false()`, true}, // non-empty string -> 1 > 0
+		// node-set string vs number scalar (number branch)
+		{`/root/a = 0`, false},
+	} {
+		t.Run(tc.expr, func(t *testing.T) {
+			r, err := xpath1.Evaluate(t.Context(), doc, tc.expr)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, r.Bool)
+		})
+	}
+}
+
+// TestStringValueOfDocument exercises resultToString / resultToNumber on a
+// node-set whose first node is the document.
+func TestRootStringConversion(t *testing.T) {
+	doc := parseXML(t, `<root>42</root>`)
+	r, err := xpath1.Evaluate(t.Context(), doc, "string(/)")
+	require.NoError(t, err)
+	require.Equal(t, "42", r.String)
+
+	r, err = xpath1.Evaluate(t.Context(), doc, "number(/) + 1")
+	require.NoError(t, err)
+	require.Equal(t, 43.0, r.Number)
+}

--- a/xpath1/coverage_api_test.go
+++ b/xpath1/coverage_api_test.go
@@ -52,7 +52,7 @@ func TestAdditionalNamespacesAndVariables(t *testing.T) {
 
 	t.Run("AdditionalNamespaces from empty", func(t *testing.T) {
 		nodes, err := xpath1.NewEvaluator().
-			AdditionalNamespaces(map[string]string{"p": "urn:x"}).
+			AdditionalNamespaces(map[string]string{"p": nsURIX}).
 			Find(t.Context(), xpath1.MustCompile("//p:foo"), doc)
 		require.NoError(t, err)
 		require.Len(t, nodes, 1)
@@ -61,7 +61,7 @@ func TestAdditionalNamespacesAndVariables(t *testing.T) {
 	t.Run("AdditionalNamespaces merges", func(t *testing.T) {
 		nodes, err := xpath1.NewEvaluator().
 			Namespaces(map[string]string{"q": "urn:q"}).
-			AdditionalNamespaces(map[string]string{"p": "urn:x"}).
+			AdditionalNamespaces(map[string]string{"p": nsURIX}).
 			Find(t.Context(), xpath1.MustCompile("//p:foo"), doc)
 		require.NoError(t, err)
 		require.Len(t, nodes, 1)

--- a/xpath1/coverage_argerr_test.go
+++ b/xpath1/coverage_argerr_test.go
@@ -1,0 +1,89 @@
+package xpath1_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath1"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuiltinArgErrors exercises the argument-count validation error branches
+// of the built-in XPath functions, which are otherwise unreached by the
+// happy-path tests.
+func TestBuiltinArgErrors(t *testing.T) {
+	doc := parseXML(t, `<root><a/></root>`)
+
+	// Each expression compiles fine but must fail at evaluation time because
+	// the function is called with the wrong number of arguments.
+	exprs := []string{
+		"last(1)",
+		"position(1)",
+		"count()",
+		"count(1, 2)",
+		"id()",
+		"id(1, 2)",
+		"string(1, 2)",
+		"concat('a')",
+		"starts-with('a')",
+		"contains('a')",
+		"substring-before('a')",
+		"substring-after('a')",
+		"substring('a')",
+		"substring('a', 1, 2, 3)",
+		"string-length('a', 'b')",
+		"normalize-space('a', 'b')",
+		"translate('a', 'b')",
+		"boolean()",
+		"not()",
+		"true(1)",
+		"false(1)",
+		"lang()",
+		"number(1, 2)",
+		"sum()",
+		"floor()",
+		"ceiling()",
+		"round()",
+		"local-name(1, 2)",
+		"name(1, 2)",
+		"namespace-uri(1, 2)",
+	}
+
+	for _, expr := range exprs {
+		t.Run(expr, func(t *testing.T) {
+			compiled, err := xpath1.Compile(expr)
+			require.NoError(t, err)
+			_, err = compiled.Evaluate(t.Context(), doc)
+			require.Error(t, err, "expected arg-count error for %q", expr)
+		})
+	}
+}
+
+// TestCountNonNodeSet covers the count() type-check error branch.
+func TestCountNonNodeSet(t *testing.T) {
+	doc := parseXML(t, `<root/>`)
+	_, err := xpath1.Evaluate(t.Context(), doc, "count('not a node-set')")
+	require.Error(t, err)
+}
+
+// TestSumNonNodeSet covers the sum() type-check error branch.
+func TestSumNonNodeSet(t *testing.T) {
+	doc := parseXML(t, `<root/>`)
+	_, err := xpath1.Evaluate(t.Context(), doc, "sum(1)")
+	require.Error(t, err)
+}
+
+// TestNodeArgNotNodeSet covers the non-node-set argument branch of
+// nodeArgOrContext (used by name/local-name/namespace-uri).
+func TestNodeArgNotNodeSet(t *testing.T) {
+	doc := parseXML(t, `<root/>`)
+	for _, expr := range []string{
+		"name('x')",
+		"local-name(1)",
+		"namespace-uri(true())",
+	} {
+		t.Run(expr, func(t *testing.T) {
+			_, err := xpath1.Evaluate(t.Context(), doc, expr)
+			require.Error(t, err)
+		})
+	}
+}

--- a/xpath1/coverage_extra_test.go
+++ b/xpath1/coverage_extra_test.go
@@ -44,14 +44,14 @@ func TestEvalNamespaceURIFunction(t *testing.T) {
 
 	t.Run("on prefixed element", func(t *testing.T) {
 		nodes, err := xpath1.NewEvaluator().
-			Namespaces(map[string]string{"p": "urn:x"}).
+			Namespaces(map[string]string{"p": nsURIX}).
 			Find(t.Context(), xpath1.MustCompile("//p:child"), doc)
 		require.NoError(t, err)
 		require.Len(t, nodes, 1)
 		r, err := xpath1.Evaluate(t.Context(), nodes[0], "namespace-uri(.)")
 		require.NoError(t, err)
 		require.Equal(t, xpath1.StringResult, r.Type)
-		require.Equal(t, "urn:x", r.String)
+		require.Equal(t, nsURIX, r.String)
 	})
 
 	t.Run("no-namespace element", func(t *testing.T) {
@@ -123,8 +123,8 @@ func TestEvalPathExprNotNodeSet(t *testing.T) {
 	compiled, err := xpath1.Compile("ext:scalar()/a")
 	require.NoError(t, err)
 	ev := xpath1.NewEvaluator().
-		Namespaces(map[string]string{nsPrefixExt: "urn:test:ext"}).
-		FunctionNS("urn:test:ext", "scalar", xpath1.FunctionFunc(func(_ context.Context, _ []*xpath1.Result) (*xpath1.Result, error) {
+		Namespaces(map[string]string{nsPrefixExt: nsURIExt}).
+		FunctionNS(nsURIExt, "scalar", xpath1.FunctionFunc(func(_ context.Context, _ []*xpath1.Result) (*xpath1.Result, error) {
 			return &xpath1.Result{Type: xpath1.StringResult, String: "x"}, nil
 		}))
 	_, err = ev.Evaluate(t.Context(), compiled, doc)
@@ -139,8 +139,8 @@ func TestEvalUnionNotNodeSet(t *testing.T) {
 	compiled, err := xpath1.Compile("ext:scalar() | /root")
 	require.NoError(t, err)
 	ev := xpath1.NewEvaluator().
-		Namespaces(map[string]string{nsPrefixExt: "urn:test:ext"}).
-		FunctionNS("urn:test:ext", "scalar", xpath1.FunctionFunc(func(_ context.Context, _ []*xpath1.Result) (*xpath1.Result, error) {
+		Namespaces(map[string]string{nsPrefixExt: nsURIExt}).
+		FunctionNS(nsURIExt, "scalar", xpath1.FunctionFunc(func(_ context.Context, _ []*xpath1.Result) (*xpath1.Result, error) {
 			return &xpath1.Result{Type: xpath1.StringResult, String: "x"}, nil
 		}))
 	_, err = ev.Evaluate(t.Context(), compiled, doc)
@@ -273,7 +273,7 @@ func TestEvalCDATAAsText(t *testing.T) {
 func TestEvalPrefixedWildcard(t *testing.T) {
 	doc := parseXML(t, `<root xmlns:p="urn:x"><p:a/><p:b/><c/></root>`)
 	nodes, err := xpath1.NewEvaluator().
-		Namespaces(map[string]string{"p": "urn:x"}).
+		Namespaces(map[string]string{"p": nsURIX}).
 		Find(t.Context(), xpath1.MustCompile("/root/p:*"), doc)
 	require.NoError(t, err)
 	require.Len(t, nodes, 2)

--- a/xpath1/coverage_extra_test.go
+++ b/xpath1/coverage_extra_test.go
@@ -1,0 +1,395 @@
+package xpath1_test
+
+import (
+	"context"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xpath1"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Namespace axis ---
+
+func TestEvalNamespaceAxis(t *testing.T) {
+	doc := parseXML(t, `<root xmlns:a="urn:a" xmlns:b="urn:b"><child/></root>`)
+
+	t.Run("wildcard selects namespace nodes", func(t *testing.T) {
+		r, err := xpath1.Evaluate(t.Context(), doc, "/root/namespace::*")
+		require.NoError(t, err)
+		require.Equal(t, xpath1.NodeSetResult, r.Type)
+		// at least the two declared namespaces (a, b) plus the implicit xml
+		require.GreaterOrEqual(t, len(r.NodeSet), 2)
+	})
+
+	t.Run("named namespace node", func(t *testing.T) {
+		r, err := xpath1.Evaluate(t.Context(), doc, "/root/namespace::a")
+		require.NoError(t, err)
+		require.Len(t, r.NodeSet, 1)
+		require.Equal(t, "a", r.NodeSet[0].Name())
+		require.Equal(t, "urn:a", string(r.NodeSet[0].Content()))
+	})
+
+	t.Run("named namespace node no match", func(t *testing.T) {
+		r, err := xpath1.Evaluate(t.Context(), doc, "/root/namespace::zzz")
+		require.NoError(t, err)
+		require.Empty(t, r.NodeSet)
+	})
+}
+
+// --- namespace-uri() function ---
+
+func TestEvalNamespaceURIFunction(t *testing.T) {
+	doc := parseXML(t, `<root xmlns:p="urn:x"><p:child/></root>`)
+
+	t.Run("on prefixed element", func(t *testing.T) {
+		nodes, err := xpath1.NewEvaluator().
+			Namespaces(map[string]string{"p": "urn:x"}).
+			Find(t.Context(), xpath1.MustCompile("//p:child"), doc)
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+		r, err := xpath1.Evaluate(t.Context(), nodes[0], "namespace-uri(.)")
+		require.NoError(t, err)
+		require.Equal(t, xpath1.StringResult, r.Type)
+		require.Equal(t, "urn:x", r.String)
+	})
+
+	t.Run("no-namespace element", func(t *testing.T) {
+		r, err := xpath1.Evaluate(t.Context(), doc, "namespace-uri(/root)")
+		require.NoError(t, err)
+		require.Equal(t, "", r.String)
+	})
+
+	t.Run("empty node-set arg yields empty string", func(t *testing.T) {
+		r, err := xpath1.Evaluate(t.Context(), doc, "namespace-uri(/root/nonexistent)")
+		require.NoError(t, err)
+		require.Equal(t, xpath1.StringResult, r.Type)
+		require.Equal(t, "", r.String)
+	})
+}
+
+// --- name()/local-name() on empty and non-element nodes ---
+
+func TestEvalNameFunctionsEmptyAndContext(t *testing.T) {
+	doc := parseXML(t, `<root/>`)
+	root := docElement(doc)
+
+	t.Run("name() context node default", func(t *testing.T) {
+		r, err := xpath1.Evaluate(t.Context(), root, "name()")
+		require.NoError(t, err)
+		require.Equal(t, "root", r.String)
+	})
+
+	t.Run("local-name() empty node-set", func(t *testing.T) {
+		r, err := xpath1.Evaluate(t.Context(), doc, "local-name(/root/nope)")
+		require.NoError(t, err)
+		require.Equal(t, "", r.String)
+	})
+
+	t.Run("name() of text node is empty", func(t *testing.T) {
+		txtdoc := parseXML(t, `<root>hi</root>`)
+		nodes, err := xpath1.Find(t.Context(), txtdoc, "/root/text()")
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+		r, err := xpath1.Evaluate(t.Context(), nodes[0], "name(.)")
+		require.NoError(t, err)
+		require.Equal(t, "", r.String)
+	})
+}
+
+// --- Filter expression with predicate ---
+
+func TestEvalFilterExpr(t *testing.T) {
+	doc := parseXML(t, `<root><a/><a/><a/></root>`)
+	// (/root/a)[2] is a primary-expr (parenthesized) filtered by a predicate.
+	r, err := xpath1.Evaluate(t.Context(), doc, "(/root/a)[2]")
+	require.NoError(t, err)
+	require.Equal(t, xpath1.NodeSetResult, r.Type)
+	require.Len(t, r.NodeSet, 1)
+}
+
+func TestEvalFilterExprNotNodeSet(t *testing.T) {
+	doc := parseXML(t, `<root/>`)
+	// A non-node-set primary expr followed by a predicate must error.
+	_, err := xpath1.Evaluate(t.Context(), doc, "(1+2)[1]")
+	require.Error(t, err)
+	require.ErrorIs(t, err, xpath1.ErrFilterNotNodeSet)
+}
+
+// --- Path expression base not a node-set ---
+
+func TestEvalPathExprNotNodeSet(t *testing.T) {
+	doc := parseXML(t, `<root><a/></root>`)
+	compiled, err := xpath1.Compile("ext:scalar()/a")
+	require.NoError(t, err)
+	ev := xpath1.NewEvaluator().
+		Namespaces(map[string]string{nsPrefixExt: "urn:test:ext"}).
+		FunctionNS("urn:test:ext", "scalar", xpath1.FunctionFunc(func(_ context.Context, _ []*xpath1.Result) (*xpath1.Result, error) {
+			return &xpath1.Result{Type: xpath1.StringResult, String: "x"}, nil
+		}))
+	_, err = ev.Evaluate(t.Context(), compiled, doc)
+	require.Error(t, err)
+	require.ErrorIs(t, err, xpath1.ErrPathNotNodeSet)
+}
+
+// --- Union operator non-node-set ---
+
+func TestEvalUnionNotNodeSet(t *testing.T) {
+	doc := parseXML(t, `<root/>`)
+	compiled, err := xpath1.Compile("ext:scalar() | /root")
+	require.NoError(t, err)
+	ev := xpath1.NewEvaluator().
+		Namespaces(map[string]string{nsPrefixExt: "urn:test:ext"}).
+		FunctionNS("urn:test:ext", "scalar", xpath1.FunctionFunc(func(_ context.Context, _ []*xpath1.Result) (*xpath1.Result, error) {
+			return &xpath1.Result{Type: xpath1.StringResult, String: "x"}, nil
+		}))
+	_, err = ev.Evaluate(t.Context(), compiled, doc)
+	require.Error(t, err)
+	require.ErrorIs(t, err, xpath1.ErrUnionNotNodeSet)
+}
+
+// --- Variable error paths ---
+
+func TestEvalVariableUndefined(t *testing.T) {
+	doc := parseXML(t, `<root/>`)
+	compiled, err := xpath1.Compile("$x")
+	require.NoError(t, err)
+
+	t.Run("no variables configured", func(t *testing.T) {
+		_, err := compiled.Evaluate(t.Context(), doc)
+		require.ErrorIs(t, err, xpath1.ErrUndefinedVariable)
+	})
+
+	t.Run("variable not in map", func(t *testing.T) {
+		_, err := xpath1.NewEvaluator().
+			Variables(map[string]any{"y": float64(1)}).
+			Evaluate(t.Context(), compiled, doc)
+		require.ErrorIs(t, err, xpath1.ErrUndefinedVariable)
+	})
+
+	t.Run("unsupported variable type", func(t *testing.T) {
+		_, err := xpath1.NewEvaluator().
+			Variables(map[string]any{"x": []int{1, 2}}).
+			Evaluate(t.Context(), compiled, doc)
+		require.ErrorIs(t, err, xpath1.ErrUnsupportedVariableType)
+	})
+}
+
+func TestEvalVariableStringAndBool(t *testing.T) {
+	doc := parseXML(t, `<root/>`)
+
+	t.Run("string var", func(t *testing.T) {
+		compiled := xpath1.MustCompile("$s")
+		r, err := xpath1.NewEvaluator().
+			Variables(map[string]any{"s": "hello"}).
+			Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, err)
+		require.Equal(t, xpath1.StringResult, r.Type)
+		require.Equal(t, "hello", r.String)
+	})
+
+	t.Run("bool var", func(t *testing.T) {
+		compiled := xpath1.MustCompile("$b")
+		r, err := xpath1.NewEvaluator().
+			Variables(map[string]any{"b": true}).
+			Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, err)
+		require.Equal(t, xpath1.BooleanResult, r.Type)
+		require.True(t, r.Bool)
+	})
+}
+
+// --- Comparison branch coverage ---
+
+func TestEvalComparisonBranches(t *testing.T) {
+	doc := parseXML(t, `<root><a>5</a><b>5</b><c>10</c></root>`)
+	for _, tc := range []struct {
+		expr string
+		want bool
+	}{
+		// node-set vs node-set, string equality
+		{`/root/a = /root/b`, true},
+		{`/root/a = /root/c`, false},
+		{`/root/a < /root/c`, true},
+		{`/root/c > /root/a`, true},
+		// node-set (right) vs number scalar (left) -- exercises compareNodeSetRight
+		{`5 = /root/a`, true},
+		{`10 > /root/a`, true},
+		{`3 < /root/a`, true},
+		// node-set vs number scalar (left node-set)
+		{`/root/a = 5`, true},
+		{`/root/c >= 10`, true},
+		// scalar number vs number relational
+		{`5 < 10`, true},
+		{`10 <= 10`, true},
+		// string vs string equality and inequality
+		{`'x' = 'x'`, true},
+		{`'x' != 'y'`, true},
+		// string relational coerces to numbers
+		{`'5' < '10'`, true},
+		// boolean scalar equality
+		{`true() = true()`, true},
+		{`true() != false()`, true},
+		// number vs string equality (number coercion)
+		{`5 = '5'`, true},
+	} {
+		t.Run(tc.expr, func(t *testing.T) {
+			r, err := xpath1.Evaluate(t.Context(), doc, tc.expr)
+			require.NoError(t, err)
+			require.Equal(t, xpath1.BooleanResult, r.Type)
+			require.Equal(t, tc.want, r.Bool)
+		})
+	}
+}
+
+// --- Type-test predicate matching alternate node types ---
+
+func TestEvalProcessingInstruction(t *testing.T) {
+	doc := parseXML(t, `<root><?go run?><?stop now?></root>`)
+
+	t.Run("all PIs", func(t *testing.T) {
+		r, err := xpath1.Evaluate(t.Context(), doc, "/root/processing-instruction()")
+		require.NoError(t, err)
+		require.Len(t, r.NodeSet, 2)
+	})
+
+	t.Run("named PI", func(t *testing.T) {
+		r, err := xpath1.Evaluate(t.Context(), doc, "/root/processing-instruction('go')")
+		require.NoError(t, err)
+		require.Len(t, r.NodeSet, 1)
+		require.Equal(t, helium.ProcessingInstructionNode, r.NodeSet[0].Type())
+	})
+}
+
+func TestEvalCDATAAsText(t *testing.T) {
+	doc := parseXML(t, `<root><![CDATA[hello]]></root>`)
+	r, err := xpath1.Evaluate(t.Context(), doc, "/root/text()")
+	require.NoError(t, err)
+	require.Len(t, r.NodeSet, 1)
+}
+
+// --- Wildcard with prefix on attribute axis and element axis ---
+
+func TestEvalPrefixedWildcard(t *testing.T) {
+	doc := parseXML(t, `<root xmlns:p="urn:x"><p:a/><p:b/><c/></root>`)
+	nodes, err := xpath1.NewEvaluator().
+		Namespaces(map[string]string{"p": "urn:x"}).
+		Find(t.Context(), xpath1.MustCompile("/root/p:*"), doc)
+	require.NoError(t, err)
+	require.Len(t, nodes, 2)
+}
+
+// --- xml prefix is always bound ---
+
+func TestEvalXMLPrefixAlwaysBound(t *testing.T) {
+	doc := parseXML(t, `<root xml:space="preserve"/>`)
+	root := docElement(doc)
+	nodes, err := xpath1.Find(t.Context(), root, "@xml:space")
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+}
+
+// --- string() with no argument uses context node ---
+
+func TestEvalStringNoArg(t *testing.T) {
+	doc := parseXML(t, `<root>content</root>`)
+	root := docElement(doc)
+	r, err := xpath1.Evaluate(t.Context(), root, "string()")
+	require.NoError(t, err)
+	require.Equal(t, "content", r.String)
+}
+
+func TestEvalStringLengthNoArg(t *testing.T) {
+	doc := parseXML(t, `<root>hello</root>`)
+	root := docElement(doc)
+	r, err := xpath1.Evaluate(t.Context(), root, "string-length()")
+	require.NoError(t, err)
+	require.Equal(t, 5.0, r.Number)
+}
+
+func TestEvalNormalizeSpaceNoArg(t *testing.T) {
+	doc := parseXML(t, `<root>  a   b  </root>`)
+	root := docElement(doc)
+	r, err := xpath1.Evaluate(t.Context(), root, "normalize-space()")
+	require.NoError(t, err)
+	require.Equal(t, "a b", r.String)
+}
+
+func TestEvalNumberNoArg(t *testing.T) {
+	doc := parseXML(t, `<root>3.5</root>`)
+	root := docElement(doc)
+	r, err := xpath1.Evaluate(t.Context(), root, "number()")
+	require.NoError(t, err)
+	require.Equal(t, 3.5, r.Number)
+}
+
+func TestEvalLastInPredicate(t *testing.T) {
+	doc := parseXML(t, `<root><a/><a/><a/></root>`)
+	r, err := xpath1.Evaluate(t.Context(), doc, "count(/root/a[position()=last()])")
+	require.NoError(t, err)
+	require.Equal(t, 1.0, r.Number)
+}
+
+// --- round() special values ---
+
+func TestEvalRoundSpecial(t *testing.T) {
+	doc := parseXML(t, `<root>abc</root>`)
+
+	t.Run("NaN passthrough", func(t *testing.T) {
+		r, err := xpath1.Evaluate(t.Context(), doc, "round(number(/root))")
+		require.NoError(t, err)
+		require.Equal(t, xpath1.NumberResult, r.Type)
+	})
+
+	t.Run("negative half rounds toward zero", func(t *testing.T) {
+		r, err := xpath1.Evaluate(t.Context(), doc, "round(-0.5)")
+		require.NoError(t, err)
+		require.Equal(t, 0.0, r.Number)
+	})
+}
+
+// --- substring edge cases ---
+
+func TestEvalSubstringEdges(t *testing.T) {
+	doc := parseXML(t, `<root/>`)
+
+	t.Run("two-arg NaN start yields empty", func(t *testing.T) {
+		r, err := xpath1.Evaluate(t.Context(), doc, "substring('hello', number('x'))")
+		require.NoError(t, err)
+		require.Equal(t, "", r.String)
+	})
+
+	t.Run("three-arg negative start", func(t *testing.T) {
+		r, err := xpath1.Evaluate(t.Context(), doc, "substring('12345', 0, 3)")
+		require.NoError(t, err)
+		require.Equal(t, "12", r.String)
+	})
+}
+
+// --- translate removal path ---
+
+func TestEvalTranslateRemoval(t *testing.T) {
+	doc := parseXML(t, `<root/>`)
+	// "to" shorter than "from": extra "from" chars are removed.
+	r, err := xpath1.Evaluate(t.Context(), doc, "translate('abcdef', 'abcdef', 'xy')")
+	require.NoError(t, err)
+	require.Equal(t, "xy", r.String)
+}
+
+// --- arithmetic with string/nan operands ---
+
+func TestEvalArithmeticCoercion(t *testing.T) {
+	doc := parseXML(t, `<root><n>4</n></root>`)
+	r, err := xpath1.Evaluate(t.Context(), doc, "/root/n - 1")
+	require.NoError(t, err)
+	require.Equal(t, 3.0, r.Number)
+}
+
+// --- sum on node-set ---
+
+func TestEvalSumString(t *testing.T) {
+	doc := parseXML(t, `<root><n>1.5</n><n>2.5</n></root>`)
+	r, err := xpath1.Evaluate(t.Context(), doc, "sum(/root/n)")
+	require.NoError(t, err)
+	require.Equal(t, 4.0, r.Number)
+}

--- a/xpath1/eval_test.go
+++ b/xpath1/eval_test.go
@@ -102,7 +102,7 @@ func TestEvalUndeclaredPrefixDoesNotMatchLexically(t *testing.T) {
 	expr, err := xpath1.Compile("//p:foo")
 	require.NoError(t, err)
 	r2, err := xpath1.NewEvaluator().
-		Namespaces(map[string]string{"p": "urn:x"}).
+		Namespaces(map[string]string{"p": nsURIX}).
 		Evaluate(t.Context(), expr, doc)
 	require.NoError(t, err)
 	require.Len(t, r2.NodeSet, 1, "bound prefix must match")
@@ -795,9 +795,9 @@ func TestCustomFunctionNamespaced(t *testing.T) {
 
 	ev := xpath1.NewEvaluator().
 		Namespaces(map[string]string{
-			nsPrefixExt: "urn:test:ext",
+			nsPrefixExt: nsURIExt,
 		}).
-		FunctionNS("urn:test:ext", "hello", xpath1.FunctionFunc(func(_ context.Context, args []*xpath1.Result) (*xpath1.Result, error) {
+		FunctionNS(nsURIExt, "hello", xpath1.FunctionFunc(func(_ context.Context, args []*xpath1.Result) (*xpath1.Result, error) {
 			if len(args) != 1 {
 				return nil, errHelloOneArg
 			}
@@ -838,7 +838,7 @@ func TestCustomFunctionNamespacedNotFound(t *testing.T) {
 
 	// Namespace is bound but no function registered
 	_, err = xpath1.NewEvaluator().Namespaces(map[string]string{
-		"ext": "urn:test:ext",
+		"ext": nsURIExt,
 	}).Evaluate(t.Context(), compiled, doc)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, xpath1.ErrUnknownFunction))
@@ -915,9 +915,9 @@ func TestCustomFunctionWithPathExpr(t *testing.T) {
 
 	ev := xpath1.NewEvaluator().
 		Namespaces(map[string]string{
-			nsPrefixExt: "urn:test:ext",
+			nsPrefixExt: nsURIExt,
 		}).
-		FunctionNS("urn:test:ext", "identity", xpath1.FunctionFunc(func(_ context.Context, args []*xpath1.Result) (*xpath1.Result, error) {
+		FunctionNS(nsURIExt, "identity", xpath1.FunctionFunc(func(_ context.Context, args []*xpath1.Result) (*xpath1.Result, error) {
 			return args[0], nil
 		}))
 

--- a/xpath3/arithmetic_datetime_test.go
+++ b/xpath3/arithmetic_datetime_test.go
@@ -23,7 +23,7 @@ func TestDurationFractionalSeconds(t *testing.T) {
 		{
 			name: "div fractional by whole",
 			expr: `xs:dayTimeDuration("PT1.5S") div xs:dayTimeDuration("PT1S")`,
-			want: "1.5",
+			want: want1Dot5,
 		},
 		{
 			name: "div fractional by fractional",
@@ -60,7 +60,7 @@ func TestDurationFractionalSeconds(t *testing.T) {
 		{
 			name: "compare fractional durations equal",
 			expr: `xs:dayTimeDuration("PT1.5S") eq xs:dayTimeDuration("PT1.5S")`,
-			want: "true",
+			want: wantTrue,
 		},
 	}
 

--- a/xpath3/cast_test.go
+++ b/xpath3/cast_test.go
@@ -52,7 +52,7 @@ func TestCastFromString(t *testing.T) {
 		},
 		{
 			name:  "string to double NaN",
-			input: "NaN", targetType: xpath3.TypeDouble,
+			input: lexicon.FloatNaN, targetType: xpath3.TypeDouble,
 			check: func(t *testing.T, v xpath3.AtomicValue) {
 				t.Helper()
 				require.True(t, math.IsNaN(v.DoubleVal()))
@@ -68,7 +68,7 @@ func TestCastFromString(t *testing.T) {
 		},
 		{
 			name:  "string to boolean false",
-			input: "false", targetType: xpath3.TypeBoolean,
+			input: lexicon.ValueFalse, targetType: xpath3.TypeBoolean,
 			check: func(t *testing.T, v xpath3.AtomicValue) {
 				t.Helper()
 				require.False(t, v.BooleanVal())
@@ -375,9 +375,9 @@ func TestAtomicToString(t *testing.T) {
 		{"double", xpath3.AtomicValue{TypeName: xpath3.TypeDouble, Value: xpath3.NewDouble(3.14)}, "3.14"},
 		{"double zero", xpath3.AtomicValue{TypeName: xpath3.TypeDouble, Value: xpath3.NewDouble(0.0)}, "0"},
 		{"double INF", xpath3.AtomicValue{TypeName: xpath3.TypeDouble, Value: xpath3.NewDouble(math.Inf(1))}, lexicon.FloatINF},
-		{"double NaN", xpath3.AtomicValue{TypeName: xpath3.TypeDouble, Value: xpath3.NewDouble(math.NaN())}, "NaN"},
+		{"double NaN", xpath3.AtomicValue{TypeName: xpath3.TypeDouble, Value: xpath3.NewDouble(math.NaN())}, lexicon.FloatNaN},
 		{lexicon.ValueTrue, xpath3.AtomicValue{TypeName: xpath3.TypeBoolean, Value: true}, lexicon.ValueTrue},
-		{"false", xpath3.AtomicValue{TypeName: xpath3.TypeBoolean, Value: false}, "false"},
+		{lexicon.ValueFalse, xpath3.AtomicValue{TypeName: xpath3.TypeBoolean, Value: false}, lexicon.ValueFalse},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/xpath3/coverage_atomic_to_string_test.go
+++ b/xpath3/coverage_atomic_to_string_test.go
@@ -39,7 +39,7 @@ func TestAtomicToString_AllTypes(t *testing.T) {
 		{`string(xs:decimal("1.250"))`, "1.25"},
 		{`string(xs:double("2.5"))`, "2.5"},
 		{`string(xs:float("3.5"))`, "3.5"},
-		{`string(true())`, "true"},
+		{`string(true())`, wantTrue},
 		{`string(xs:anyURI("http://x"))`, "http://x"},
 		{`string(xs:NCName("abc"))`, "abc"},
 		{`string(xs:token("  a  b  "))`, "a b"},

--- a/xpath3/coverage_atomic_to_string_test.go
+++ b/xpath3/coverage_atomic_to_string_test.go
@@ -1,0 +1,57 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// string() over the full XSD atomic type space drives atomicToString's
+// per-type branches (gYear/gMonth/.., duration variants, base64/hex binary,
+// QName, integer subtypes, date/time).
+func TestAtomicToString_AllTypes(t *testing.T) {
+	cases := []struct {
+		expr string
+		want string
+	}{
+		// gregorian types.
+		{`string(xs:gYear("2020"))`, "2020"},
+		{`string(xs:gMonth("--06"))`, "--06"},
+		{`string(xs:gDay("---22"))`, "---22"},
+		{`string(xs:gYearMonth("2020-06"))`, "2020-06"},
+		{`string(xs:gMonthDay("--06-22"))`, "--06-22"},
+		// date / time / dateTime.
+		{`string(xs:date("2020-06-22"))`, "2020-06-22"},
+		{`string(xs:time("12:34:56"))`, "12:34:56"},
+		{`string(xs:dateTime("2020-06-22T12:34:56"))`, "2020-06-22T12:34:56"},
+		// durations.
+		{`string(xs:duration("P1Y2M3DT4H5M6S"))`, "P1Y2M3DT4H5M6S"},
+		{`string(xs:dayTimeDuration("P1DT2H"))`, "P1DT2H"},
+		{`string(xs:yearMonthDuration("P1Y2M"))`, "P1Y2M"},
+		// binary.
+		{`string(xs:base64Binary("aGk="))`, "aGk="},
+		{`string(xs:hexBinary("48656C6C6F"))`, "48656C6C6F"},
+		// integer subtypes.
+		{`string(xs:byte("12"))`, "12"},
+		{`string(xs:unsignedShort("300"))`, "300"},
+		{`string(xs:positiveInteger("5"))`, "5"},
+		// decimal / double / float / boolean / string-ish.
+		{`string(xs:decimal("1.250"))`, "1.25"},
+		{`string(xs:double("2.5"))`, "2.5"},
+		{`string(xs:float("3.5"))`, "3.5"},
+		{`string(true())`, "true"},
+		{`string(xs:anyURI("http://x"))`, "http://x"},
+		{`string(xs:NCName("abc"))`, "abc"},
+		{`string(xs:token("  a  b  "))`, "a b"},
+	}
+	for _, tc := range cases {
+		r, err := evaluate(t.Context(), nil, tc.expr)
+		require.NoError(t, err, tc.expr)
+		require.Equal(t, tc.want, r.StringValue(), tc.expr)
+	}
+
+	// QName via fn:QName, then string().
+	r, err := evaluate(t.Context(), nil, `string(fn:QName("http://x", "p:local"))`)
+	require.NoError(t, err)
+	require.Equal(t, "p:local", r.StringValue())
+}

--- a/xpath3/coverage_cast_test.go
+++ b/xpath3/coverage_cast_test.go
@@ -40,7 +40,7 @@ func TestCast_IntegerSubtypeRange(t *testing.T) {
 		`"1" cast as xs:negativeInteger`,
 		`"1" cast as xs:nonPositiveInteger`,
 		`"-1" cast as xs:nonNegativeInteger`,
-		`"100000" cast as xs:short`, // > 32767
+		`"100000" cast as xs:short`,  // > 32767
 		`"notanint" cast as xs:byte`, // unparseable
 	}
 	for _, e := range outOfRange {
@@ -114,12 +114,12 @@ func TestCast_UnionAndQName(t *testing.T) {
 // formatting branches through the public string conversion surface.
 func TestStringValueConversions(t *testing.T) {
 	cases := map[string]string{
-		`string(1)`:           "1",
-		`string(1.5)`:         "1.5",
-		`string(true())`:      "true",
-		`string(xs:double("INF"))`:  "INF",
+		`string(1)`:                 "1",
+		`string(1.5)`:               want1Dot5,
+		`string(true())`:            wantTrue,
+		`string(xs:double("INF"))`:  wantINF,
 		`string(xs:double("-INF"))`: "-INF",
-		`string(xs:double("NaN"))`:  "NaN",
+		`string(xs:double("NaN"))`:  wantNaN,
 	}
 	for expr, want := range cases {
 		r, err := evaluate(t.Context(), nil, expr)

--- a/xpath3/coverage_cast_test.go
+++ b/xpath3/coverage_cast_test.go
@@ -1,0 +1,129 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// Casting to integer-derived and string-derived XSD types exercises
+// CastAtomic's integer-range checking (integerTypeRange / checkBigIntRange) and
+// validateStringDerivedType, reached through the `cast as` operator.
+func TestCast_IntegerSubtypeRange(t *testing.T) {
+	ok := []string{
+		`"100" cast as xs:byte`,
+		`"100" cast as xs:short`,
+		`"100" cast as xs:int`,
+		`"100" cast as xs:long`,
+		`"100" cast as xs:unsignedByte`,
+		`"100" cast as xs:unsignedShort`,
+		`"100" cast as xs:unsignedInt`,
+		`"100" cast as xs:unsignedLong`,
+		`"1" cast as xs:positiveInteger`,
+		`"0" cast as xs:nonNegativeInteger`,
+		`"0" cast as xs:nonPositiveInteger`,
+		`"-1" cast as xs:negativeInteger`,
+		// numeric sources, exercising the numeric->subtype path.
+		`100 cast as xs:byte`,
+		`100 cast as xs:int`,
+	}
+	for _, e := range ok {
+		_, err := evaluate(t.Context(), nil, e)
+		require.NoError(t, err, e)
+	}
+
+	outOfRange := []string{
+		`"1000" cast as xs:byte`,       // > 127
+		`"-1" cast as xs:unsignedByte`, // < 0
+		`"0" cast as xs:positiveInteger`,
+		`"1" cast as xs:negativeInteger`,
+		`"1" cast as xs:nonPositiveInteger`,
+		`"-1" cast as xs:nonNegativeInteger`,
+		`"100000" cast as xs:short`, // > 32767
+		`"notanint" cast as xs:byte`, // unparseable
+	}
+	for _, e := range outOfRange {
+		_, err := evaluate(t.Context(), nil, e)
+		require.Error(t, err, e)
+		var xpErr *xpath3.XPathError
+		require.ErrorAs(t, err, &xpErr, e)
+	}
+}
+
+func TestCast_StringDerivedTypes(t *testing.T) {
+	ok := []string{
+		`"abc" cast as xs:NCName`,
+		`"abc" cast as xs:Name`,
+		`"abc" cast as xs:NMTOKEN`,
+		`"a b c" cast as xs:NMTOKENS`,
+		`"abc" cast as xs:ID`,
+		`"abc" cast as xs:IDREF`,
+		`"a b" cast as xs:IDREFS`,
+		`"abc" cast as xs:ENTITY`,
+	}
+	for _, e := range ok {
+		_, err := evaluate(t.Context(), nil, e)
+		require.NoError(t, err, e)
+	}
+
+	invalid := []string{
+		`"a:b:c" cast as xs:NCName`, // colon not allowed in NCName
+		`"" cast as xs:NMTOKENS`,    // empty list
+		`"" cast as xs:IDREFS`,      // empty list
+	}
+	for _, e := range invalid {
+		_, err := evaluate(t.Context(), nil, e)
+		require.Error(t, err, e)
+	}
+}
+
+// cast as xs:numeric (union) and xs:QName exercise the special-cased target
+// branches in evalCastExpr.
+func TestCast_UnionAndQName(t *testing.T) {
+	// numeric: already-numeric returns as-is.
+	r, err := evaluate(t.Context(), nil, `1 cast as xs:numeric instance of xs:integer`)
+	require.NoError(t, err)
+	b, ok := r.IsBoolean()
+	require.True(t, ok)
+	require.True(t, b)
+
+	// numeric: string casts to double.
+	r, err = evaluate(t.Context(), nil, `"2.5" cast as xs:numeric instance of xs:double`)
+	require.NoError(t, err)
+	b, ok = r.IsBoolean()
+	require.True(t, ok)
+	require.True(t, b)
+
+	// QName cast from string.
+	r, err = evaluate(t.Context(), nil, `string(fn:local-name-from-QName("foo" cast as xs:QName))`)
+	require.NoError(t, err)
+	require.Equal(t, "foo", r.StringValue())
+
+	// Empty-sequence with ? cast modifier yields empty.
+	r, err = evaluate(t.Context(), nil, `() cast as xs:integer?`)
+	require.NoError(t, err)
+	require.Equal(t, "", r.StringValue())
+
+	// Multi-item cast -> XPTY0004.
+	_, err = evaluate(t.Context(), nil, `(1, 2) cast as xs:integer`)
+	require.Error(t, err)
+}
+
+// fn:string-to-codepoints / xs:double special values exercise atomicToString and
+// formatting branches through the public string conversion surface.
+func TestStringValueConversions(t *testing.T) {
+	cases := map[string]string{
+		`string(1)`:           "1",
+		`string(1.5)`:         "1.5",
+		`string(true())`:      "true",
+		`string(xs:double("INF"))`:  "INF",
+		`string(xs:double("-INF"))`: "-INF",
+		`string(xs:double("NaN"))`:  "NaN",
+	}
+	for expr, want := range cases {
+		r, err := evaluate(t.Context(), nil, expr)
+		require.NoError(t, err, expr)
+		require.Equal(t, want, r.StringValue(), expr)
+	}
+}

--- a/xpath3/coverage_consts_test.go
+++ b/xpath3/coverage_consts_test.go
@@ -1,0 +1,12 @@
+package xpath3_test
+
+// Shared test-only string constants that recur across the package's test files.
+// Centralizing them keeps goconst happy and avoids drift between expectations.
+const (
+	wantTrue  = "true"
+	wantFalse = "false"
+	wantNaN   = "NaN"
+	wantINF   = "INF"
+	want1Dot5 = "1.5"
+	expr1To10 = "1 to 10"
+)

--- a/xpath3/coverage_dumpvm_test.go
+++ b/xpath3/coverage_dumpvm_test.go
@@ -1,0 +1,109 @@
+package xpath3_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDumpVM_VariedExpressions exercises the VM dump formatters
+// (vmOpcode.String, formatVMExpr, formatNodeTest, formatAxis, etc.) across a
+// broad set of expression shapes so the textual rendering of each branch runs.
+func TestDumpVM_VariedExpressions(t *testing.T) {
+	exprs := []string{
+		// literals, variables, arithmetic, comparison.
+		`42`,
+		`"text"`,
+		`-3 + 4 * 2`,
+		`1 to 5`,
+		`(1, 2, 3)`,
+		`1 = 2`,
+		`"a" || "b"`,
+		// paths across many axes & node tests.
+		`/child::a/descendant::b`,
+		`//c`,
+		`parent::node()`,
+		`ancestor::*`,
+		`following-sibling::x`,
+		`preceding-sibling::y`,
+		`following::z`,
+		`preceding::w`,
+		`attribute::id`,
+		`self::node()`,
+		`descendant-or-self::node()`,
+		`./text()`,
+		`./comment()`,
+		`./processing-instruction()`,
+		`./processing-instruction("xml-stylesheet")`,
+		`./element()`,
+		`./attribute()`,
+		`./document-node()`,
+		`./namespace-node()`,
+		// predicates.
+		`a[1]`,
+		`a[@id = "x"]`,
+		`a[position() = 2]`,
+		`a[@id]`,
+		// control flow & quantified.
+		`if (1) then 2 else 3`,
+		`for $x in (1, 2) return $x`,
+		`some $x in (1, 2) satisfies $x = 1`,
+		`every $x in (1, 2) satisfies $x = 1`,
+		`let $x := 1 return $x`,
+		// type expressions.
+		`1 instance of xs:integer`,
+		`"1" cast as xs:integer`,
+		`"1" castable as xs:integer`,
+		`1 treat as xs:integer`,
+		// functions, maps, arrays, lookups, inline.
+		`fn:count((1, 2))`,
+		`fn:abs#1`,
+		`map { "a": 1 }`,
+		`array { 1, 2 }`,
+		`[1, 2]`,
+		`map { "a": 1 }("a")`,
+		`function($x) { $x + 1 }`,
+		`(1, 2) ! (. + 1)`,
+		`a union b`,
+		`a intersect b`,
+		`a except b`,
+		// kind tests with names / inner tests (formatNodeTest branches).
+		`child::element(name)`,
+		`child::attribute(id)`,
+		`self::document-node(element(root))`,
+		`namespace-node()`,
+		`processing-instruction("target")`,
+		// SequenceType-bearing expressions for instance-of / treat / cast dumps.
+		`1 instance of element(x)`,
+		`1 instance of map(*)`,
+		`1 instance of array(*)`,
+		`1 instance of function(*)`,
+		`map { "a": 1 } instance of map(xs:string, xs:integer)`,
+		`[1] instance of array(xs:integer)`,
+		`fn:abs#1 instance of function(xs:double) as xs:double`,
+		`Q{urn:x}name(1)`,
+		// optimized predicate forms (vmPositionPredicate / attribute-exists /
+		// attribute-equals-string) in formatVMExpr.
+		`/root/child[5]`,
+		`/root/child[@id]`,
+		`/root/child[@id = "x"]`,
+		`a/b[@n = "1"]/c`,
+		// lookups and unary lookups.
+		`map { "a": 1 }?*`,
+		`[1, 2]?1`,
+		`(map { "a": 1 }, map { "b": 2 }) ! ?*`,
+	}
+
+	for _, e := range exprs {
+		t.Run(e, func(t *testing.T) {
+			compiled, err := xpath3.NewCompiler().Compile(e)
+			require.NoError(t, err)
+			var sb strings.Builder
+			require.NoError(t, compiled.DumpVM(&sb))
+			require.NotEmpty(t, sb.String())
+			require.Contains(t, sb.String(), "root @")
+		})
+	}
+}

--- a/xpath3/coverage_format_integer_ordinal_test.go
+++ b/xpath3/coverage_format_integer_ordinal_test.go
@@ -1,0 +1,39 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// German and Italian ordinal spell-out (picture "w;o") exercise
+// applyOrdinalWordsDe / germanOrdinalWord / germanWordToNumber and
+// applyOrdinalWordsIt / italianOrdinalWord, which the cardinal "w" path
+// does not reach.
+func TestFormatIntegerOrdinalWords(t *testing.T) {
+	cases := []struct {
+		value string
+		lang  string
+	}{
+		// German ordinals: small (< 20) -> "...te"; larger -> "...ste".
+		{"1", "de"},
+		{"3", "de"},
+		{"7", "de"},
+		{"20", "de"},
+		{"21", "de"},
+		{"42", "de"},
+		{"100", "de"},
+		// Italian ordinals (masculine).
+		{"1", "it"},
+		{"3", "it"},
+		{"10", "it"},
+		{"21", "it"},
+		{"100", "it"},
+	}
+	for _, tc := range cases {
+		expr := `format-integer(` + tc.value + `, "w;o", "` + tc.lang + `")`
+		r, err := evaluate(t.Context(), nil, expr)
+		require.NoError(t, err, expr)
+		require.NotEmpty(t, r.StringValue(), expr)
+	}
+}

--- a/xpath3/coverage_format_number_test.go
+++ b/xpath3/coverage_format_number_test.go
@@ -1,0 +1,38 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatNumber_Variants(t *testing.T) {
+	// Empty-sequence first argument -> NaN per F&O.
+	r, err := evaluate(t.Context(), nil, `format-number((), "0")`)
+	require.NoError(t, err)
+	require.Equal(t, "NaN", r.StringValue())
+
+	// untypedAtomic first arg is cast to double.
+	r, err = evaluate(t.Context(), nil, `format-number(xs:untypedAtomic("12.5"), "0.0")`)
+	require.NoError(t, err)
+	require.Equal(t, "12.5", r.StringValue())
+
+	// Basic picture strings.
+	for _, tc := range []struct{ expr, want string }{
+		{`format-number(1234.5, "#,##0.00")`, "1,234.50"},
+		{`format-number(0.25, "0%")`, "25%"},
+		{`format-number(-3, "0;(0)")`, "(3)"},
+		{`format-number(1234, "0.0e0")`, "1.2e3"},
+	} {
+		r, err := evaluate(t.Context(), nil, tc.expr)
+		require.NoError(t, err, tc.expr)
+		require.Equal(t, tc.want, r.StringValue(), tc.expr)
+	}
+
+	// Non-numeric first arg -> XPTY0004.
+	_, err = evaluate(t.Context(), nil, `format-number(current-date(), "0")`)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+}

--- a/xpath3/coverage_format_number_test.go
+++ b/xpath3/coverage_format_number_test.go
@@ -11,7 +11,7 @@ func TestFormatNumber_Variants(t *testing.T) {
 	// Empty-sequence first argument -> NaN per F&O.
 	r, err := evaluate(t.Context(), nil, `format-number((), "0")`)
 	require.NoError(t, err)
-	require.Equal(t, "NaN", r.StringValue())
+	require.Equal(t, wantNaN, r.StringValue())
 
 	// untypedAtomic first arg is cast to double.
 	r, err = evaluate(t.Context(), nil, `format-number(xs:untypedAtomic("12.5"), "0.0")`)

--- a/xpath3/coverage_instanceof_test.go
+++ b/xpath3/coverage_instanceof_test.go
@@ -1,0 +1,84 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// instanceOf compiles and evaluates an `instance of` expression against a
+// context node, returning its boolean result. It exercises matchesItemType /
+// isItemTypeSubtype / matchNodeTest across many item-type shapes.
+func instanceOf(t *testing.T, ctxXML, expr string) bool {
+	t.Helper()
+	doc := mustParseXML(t, ctxXML)
+	root := doc.DocumentElement()
+	r, err := evaluate(t.Context(), root, expr)
+	require.NoError(t, err, expr)
+	b, ok := r.IsBoolean()
+	require.True(t, ok, "expected boolean for %q", expr)
+	return b
+}
+
+func TestInstanceOf_ItemTypes(t *testing.T) {
+	const xml = `<root att="v"><child/><!--c--><?pi data?></root>`
+
+	cases := []struct {
+		expr   string
+		expect bool
+	}{
+		// atomic types & numeric hierarchy.
+		{`1 instance of xs:integer`, true},
+		{`1 instance of xs:decimal`, true},
+		{`1 instance of xs:double`, false},
+		{`1.5 instance of xs:decimal`, true},
+		{`"x" instance of xs:string`, true},
+		{`"x" instance of xs:integer`, false},
+		{`true() instance of xs:boolean`, true},
+		// cardinality.
+		{`() instance of item()*`, true},
+		{`() instance of item()`, false},
+		{`() instance of item()?`, true},
+		{`(1, 2) instance of xs:integer+`, true},
+		{`(1, 2) instance of xs:integer`, false},
+		{`1 instance of item()`, true},
+		// node kind tests on the context tree.
+		{`. instance of element()`, true},
+		{`. instance of node()`, true},
+		{`. instance of attribute()`, false},
+		{`child::child[1] instance of element()`, true},
+		{`@att instance of attribute()`, true},
+		{`@att instance of node()`, true},
+		{`comment() instance of comment()`, true},
+		{`processing-instruction() instance of processing-instruction()`, true},
+		{`. instance of element(root)`, true},
+		{`. instance of element(other)`, false},
+		// function / map / array item types.
+		{`fn:abs#1 instance of function(*)`, true},
+		{`map { "a": 1 } instance of map(*)`, true},
+		{`[1, 2] instance of array(*)`, true},
+		{`map { "a": 1 } instance of array(*)`, false},
+		{`function($x) { $x } instance of function(*)`, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.expr, func(t *testing.T) {
+			require.Equal(t, tc.expect, instanceOf(t, xml, tc.expr))
+		})
+	}
+}
+
+func TestTreatAs(t *testing.T) {
+	// treat as success returns the value; failure raises XPDY0050/XPTY0004.
+	r, err := evaluate(t.Context(), nil, `1 treat as xs:integer`)
+	require.NoError(t, err)
+	n, ok := r.IsNumber()
+	require.True(t, ok)
+	require.Equal(t, float64(1), n)
+
+	_, err = evaluate(t.Context(), nil, `"x" treat as xs:integer`)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+}

--- a/xpath3/coverage_instanceof_typed_test.go
+++ b/xpath3/coverage_instanceof_typed_test.go
@@ -1,0 +1,71 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// instance of against typed map / array / function / document-node tests
+// exercises matchesItemType and isItemTypeSubtype's typed branches (key/value,
+// member, param/return, inner node tests).
+func TestInstanceOf_TypedItemTests(t *testing.T) {
+	const xml = `<root><child/></root>`
+	doc := mustParseXML(t, xml)
+	root := doc.DocumentElement()
+
+	cases := []struct {
+		expr   string
+		expect bool
+	}{
+		{`map { "a": 1 } instance of map(xs:string, xs:integer)`, true},
+		{`map { "a": "v" } instance of map(xs:string, xs:integer)`, false},
+		{`[1, 2] instance of array(xs:integer)`, true},
+		{`["x"] instance of array(xs:integer)`, false},
+		{`fn:abs#1 instance of function(*)`, true},
+		{`function($x as xs:integer) as xs:integer { $x } instance of function(xs:integer) as xs:integer`, true},
+		{`. instance of document-node()`, false},
+		{`child::child instance of element(child)`, true},
+		{`child::child instance of element(other)`, false},
+		{`child::child instance of element(*)`, true},
+		// typed function: arity mismatch -> false.
+		{`fn:abs#1 instance of function(xs:double, xs:double) as xs:double`, false},
+		// inline function with matching param/return.
+		{`function($x as xs:integer) as xs:integer { $x } instance of function(xs:integer) as xs:integer`, true},
+		// map as function(K) as V.
+		{`map { "a": 1 } instance of function(xs:string) as xs:integer?`, true},
+		{`map { "a": 1 } instance of function(xs:anyAtomicType) as item()*`, true},
+		// array as function(xs:integer) as V.
+		{`[1, 2] instance of function(xs:integer) as item()*`, true},
+		// map with value type mismatch.
+		{`map { "a": "s" } instance of map(xs:string, xs:integer)`, false},
+		// empty map matches any typed map.
+		{`map { } instance of map(xs:string, xs:integer)`, true},
+		// array member type.
+		{`[1, 2] instance of array(xs:integer)`, true},
+		{`["s"] instance of array(xs:integer)`, false},
+		{`[1, 2] instance of array(*)`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.expr, func(t *testing.T) {
+			r, err := evaluate(t.Context(), root, tc.expr)
+			require.NoError(t, err, tc.expr)
+			b, ok := r.IsBoolean()
+			require.True(t, ok, tc.expr)
+			require.Equal(t, tc.expect, b, tc.expr)
+		})
+	}
+
+	// document-node test against the actual document node.
+	r, err := evaluate(t.Context(), doc, `. instance of document-node()`)
+	require.NoError(t, err)
+	b, ok := r.IsBoolean()
+	require.True(t, ok)
+	require.True(t, b)
+
+	r, err = evaluate(t.Context(), doc, `. instance of document-node(element(root))`)
+	require.NoError(t, err)
+	b, ok = r.IsBoolean()
+	require.True(t, ok)
+	require.True(t, b)
+}

--- a/xpath3/coverage_json_test.go
+++ b/xpath3/coverage_json_test.go
@@ -13,12 +13,12 @@ func TestParseJSON_TopLevelScalars(t *testing.T) {
 		json string
 		want string
 	}{
-		{`42`, "42"},        // integer
-		{`1.5`, "1.5"},      // float (has '.')
-		{`1e3`, "1000"},     // float (has 'e')
-		{`true`, "true"},    // boolean
-		{`false`, "false"},  // boolean
-		{`"str"`, "str"},    // string
+		{`42`, "42"},         // integer
+		{`1.5`, want1Dot5},   // float (has '.')
+		{`1e3`, "1000"},      // float (has 'e')
+		{`true`, wantTrue},   // boolean
+		{`false`, wantFalse}, // boolean
+		{`"str"`, "str"},     // string
 	}
 	for _, tc := range cases {
 		expr := `parse-json("` + escapeForXPathString(tc.json) + `")`

--- a/xpath3/coverage_json_test.go
+++ b/xpath3/coverage_json_test.go
@@ -1,0 +1,67 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Top-level JSON scalars route through jsonToXDM's scalar branches
+// (bool, json.Number integer/float, null) via the parse-json streaming decoder.
+func TestParseJSON_TopLevelScalars(t *testing.T) {
+	cases := []struct {
+		json string
+		want string
+	}{
+		{`42`, "42"},        // integer
+		{`1.5`, "1.5"},      // float (has '.')
+		{`1e3`, "1000"},     // float (has 'e')
+		{`true`, "true"},    // boolean
+		{`false`, "false"},  // boolean
+		{`"str"`, "str"},    // string
+	}
+	for _, tc := range cases {
+		expr := `parse-json("` + escapeForXPathString(tc.json) + `")`
+		r, err := evaluate(t.Context(), nil, expr)
+		require.NoError(t, err, expr)
+		require.Equal(t, tc.want, r.StringValue(), expr)
+	}
+
+	// JSON null -> empty sequence.
+	r, err := evaluate(t.Context(), nil, `parse-json("null")`)
+	require.NoError(t, err)
+	require.Equal(t, "", r.StringValue())
+}
+
+// escapeForXPathString doubles embedded double-quotes for an XPath "..." literal.
+func escapeForXPathString(s string) string {
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		if r == '"' {
+			out = append(out, '"', '"')
+			continue
+		}
+		out = append(out, r)
+	}
+	return string(out)
+}
+
+// parse-json over nested structures with mixed scalar leaves exercises the
+// array / object construction plus the scalar leaf conversions.
+func TestParseJSON_NestedStructures(t *testing.T) {
+	r, err := evaluate(t.Context(), nil,
+		`parse-json('{"n": 1, "f": 2.5, "b": true, "z": null, "s": "x", "a": [1, 2, 3]}')?n`)
+	require.NoError(t, err)
+	require.Equal(t, "1", r.StringValue())
+
+	r, err = evaluate(t.Context(), nil,
+		`parse-json('[1, 2.5, true, null, "x"]')?1`)
+	require.NoError(t, err)
+	require.Equal(t, "1", r.StringValue())
+
+	// xml-to-json over a parsed structure.
+	r, err = evaluate(t.Context(), nil,
+		`xml-to-json(json-to-xml('{"a": [1, true, null, "s"]}'))`)
+	require.NoError(t, err)
+	require.Contains(t, r.StringValue(), "\"a\"")
+}

--- a/xpath3/coverage_lookup_keyword_keys_test.go
+++ b/xpath3/coverage_lookup_keyword_keys_test.go
@@ -1,0 +1,35 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The ?keyword lookup-key syntax accepts XPath keyword tokens as NCName keys,
+// exercising tokenAsNCName across its keyword cases.
+func TestLookupKeyword_NCNameKeys(t *testing.T) {
+	// Each keyword is used both as the map key and as the lookup key.
+	keywords := []string{
+		"div", "mod", "and", "or", "return", "else", "eq", "ne", "lt", "le",
+		"gt", "ge", "idiv", "if", "then", "for", "let", "in", "some", "every",
+		"satisfies", "is", "to", "union", "intersect", "except", "instance",
+		"treat", "castable", "cast", "as", "of",
+	}
+	for _, kw := range keywords {
+		expr := `map { "` + kw + `": 42 }?` + kw
+		r, err := evaluate(t.Context(), nil, expr)
+		require.NoError(t, err, expr)
+		require.Equal(t, "42", r.StringValue(), expr)
+	}
+
+	// Plain NCName key.
+	r, err := evaluate(t.Context(), nil, `map { "plain": 7 }?plain`)
+	require.NoError(t, err)
+	require.Equal(t, "7", r.StringValue())
+
+	// Array unary-lookup with a wildcard.
+	r, err = evaluate(t.Context(), nil, `[1, 2, 3]?*`)
+	require.NoError(t, err)
+	require.Equal(t, "1 2 3", r.StringValue())
+}

--- a/xpath3/coverage_nodetest_paths_test.go
+++ b/xpath3/coverage_nodetest_paths_test.go
@@ -1,0 +1,59 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Path steps with kind tests (processing-instruction(target), element(name),
+// attribute(name), comment(), text(), node()) exercise matchNodeTest and
+// matchElementOrAttributeName branches that bare name tests do not.
+func TestNodeTestPaths(t *testing.T) {
+	const xml = `<?xml version="1.0"?>` +
+		`<root a="1" b="2">` +
+		`<?proc-a data?><?proc-b more?>` +
+		`text-before<child>inner</child>text-after` +
+		`<!--a comment-->` +
+		`</root>`
+
+	doc := mustParseXML(t, xml)
+	root := doc.DocumentElement()
+
+	cases := []struct {
+		expr   string
+		expect int
+	}{
+		{`child::processing-instruction()`, 2},
+		{`child::processing-instruction("proc-a")`, 1},
+		{`child::processing-instruction("missing")`, 0},
+		{`child::element()`, 1},
+		{`child::element(child)`, 1},
+		{`child::element(other)`, 0},
+		{`attribute::attribute()`, 2},
+		{`attribute::attribute(a)`, 1},
+		{`attribute::attribute(missing)`, 0},
+		{`child::text()`, 2},
+		{`child::comment()`, 1},
+		{`child::node()`, 6},
+		{`descendant::text()`, 3},
+		{`child::*`, 1},
+		{`attribute::*`, 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.expr, func(t *testing.T) {
+			nodes, err := find(t.Context(), root, tc.expr)
+			require.NoError(t, err, tc.expr)
+			require.Len(t, nodes, tc.expect, tc.expr)
+		})
+	}
+
+	// document-node(element(root)) matched from the document node.
+	nodes, err := find(t.Context(), doc, `self::document-node(element(root))`)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+
+	nodes, err = find(t.Context(), doc, `self::document-node(element(other))`)
+	require.NoError(t, err)
+	require.Empty(t, nodes)
+}

--- a/xpath3/coverage_public_api_test.go
+++ b/xpath3/coverage_public_api_test.go
@@ -1,0 +1,358 @@
+package xpath3_test
+
+import (
+	"context"
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	collationCodepoint = "http://www.w3.org/2005/xpath-functions/collation/codepoint"
+	collationHTMLASCII = "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive"
+	collationUCA       = "http://www.w3.org/2013/collation/UCA"
+)
+
+func atomicSeq(av xpath3.AtomicValue) xpath3.Sequence {
+	return xpath3.ItemSlice{av}
+}
+
+func intAtomic(n int64) xpath3.AtomicValue {
+	return xpath3.AtomicValue{TypeName: xpath3.TypeInteger, Value: big.NewInt(n)}
+}
+
+func strAtomic(s string) xpath3.AtomicValue {
+	return xpath3.AtomicValue{TypeName: xpath3.TypeString, Value: s}
+}
+
+func TestFunctionLibrary_CRUD(t *testing.T) {
+	lib := xpath3.NewFunctionLibrary()
+
+	var fn xpath3.Function = identityFn{}
+
+	// Get/GetNS on empty library.
+	_, ok := lib.Get("missing")
+	require.False(t, ok)
+	_, ok = lib.GetNS("urn:x", "missing")
+	require.False(t, ok)
+
+	lib.Set("local", fn)
+	got, ok := lib.Get("local")
+	require.True(t, ok)
+	require.NotNil(t, got)
+
+	lib.SetNS("urn:x", "ns", fn)
+	got, ok = lib.GetNS("urn:x", "ns")
+	require.True(t, ok)
+	require.NotNil(t, got)
+	_, ok = lib.GetNS("urn:other", "ns")
+	require.False(t, ok)
+
+	lib.Delete("local")
+	_, ok = lib.Get("local")
+	require.False(t, ok)
+
+	lib.DeleteNS("urn:x", "ns")
+	_, ok = lib.GetNS("urn:x", "ns")
+	require.False(t, ok)
+
+	lib.Set("a", fn)
+	lib.SetNS("urn:x", "b", fn)
+	lib.Clear()
+	_, ok = lib.Get("a")
+	require.False(t, ok)
+	_, ok = lib.GetNS("urn:x", "b")
+	require.False(t, ok)
+}
+
+type identityFn struct{}
+
+func (identityFn) MinArity() int { return 1 }
+func (identityFn) MaxArity() int { return 1 }
+func (identityFn) Call(_ context.Context, args []xpath3.Sequence) (xpath3.Sequence, error) {
+	return args[0], nil
+}
+
+func TestVariables_GetDeleteClear(t *testing.T) {
+	v := xpath3.NewVariables()
+
+	_, ok := v.Get("x")
+	require.False(t, ok)
+
+	v.Set("x", atomicSeq(intAtomic(5)))
+	got, ok := v.Get("x")
+	require.True(t, ok)
+	require.Equal(t, 1, got.Len())
+
+	v.Delete("x")
+	_, ok = v.Get("x")
+	require.False(t, ok)
+
+	v.Set("a", atomicSeq(intAtomic(1)))
+	v.Set("b", atomicSeq(intAtomic(2)))
+	require.Equal(t, 2, v.Len())
+	v.Clear()
+	require.Equal(t, 0, v.Len())
+}
+
+func TestRegex_PublicAPI(t *testing.T) {
+	re, err := xpath3.CompileRegex(`a(b+)c`, "")
+	require.NoError(t, err)
+
+	matched, err := re.MatchString("abbbc")
+	require.NoError(t, err)
+	require.True(t, matched)
+
+	matched, err = re.MatchString("xyz")
+	require.NoError(t, err)
+	require.False(t, matched)
+
+	idx, err := re.FindAllSubmatchIndex("abc and abbc", -1)
+	require.NoError(t, err)
+	require.Len(t, idx, 2)
+	// First match "abc": full match + one capture group => 4 indices.
+	require.Len(t, idx[0], 4)
+
+	// Case-insensitive flag.
+	rei, err := xpath3.CompileRegex(`abc`, "i")
+	require.NoError(t, err)
+	matched, err = rei.MatchString("ABC")
+	require.NoError(t, err)
+	require.True(t, matched)
+
+	// Invalid pattern surfaces an error.
+	_, err = xpath3.CompileRegex(`[`, "")
+	require.Error(t, err)
+}
+
+func TestBuiltinFunctionQueries(t *testing.T) {
+	require.True(t, xpath3.IsBuiltinFunction("abs"))
+	require.False(t, xpath3.IsBuiltinFunction("definitely-not-a-builtin"))
+
+	require.True(t, xpath3.IsBuiltinFunctionNS(xpath3.NSFn, "count"))
+	require.False(t, xpath3.IsBuiltinFunctionNS("urn:nope", "count"))
+
+	require.True(t, xpath3.BuiltinFunctionAcceptsArity(xpath3.NSFn, "abs", 1))
+	require.False(t, xpath3.BuiltinFunctionAcceptsArity(xpath3.NSFn, "abs", 5))
+	require.False(t, xpath3.BuiltinFunctionAcceptsArity(xpath3.NSFn, "nope", 1))
+}
+
+func TestPredeclaredNamespaces(t *testing.T) {
+	ns := xpath3.PredeclaredNamespaces()
+	require.Equal(t, xpath3.NSFn, ns["fn"])
+	require.NotEmpty(t, ns["xs"])
+
+	// Mutating the returned copy must not affect package state.
+	ns["fn"] = "tampered"
+	ns2 := xpath3.PredeclaredNamespaces()
+	require.Equal(t, xpath3.NSFn, ns2["fn"])
+}
+
+func TestCollationHelpers(t *testing.T) {
+	require.True(t, xpath3.IsCollationSupported(collationCodepoint))
+	require.True(t, xpath3.IsCollationSupported(collationHTMLASCII))
+	require.False(t, xpath3.IsCollationSupported("urn:bogus-collation"))
+
+	keyFn, err := xpath3.ResolveCollationKeyFunc(collationCodepoint)
+	require.NoError(t, err)
+	require.Equal(t, keyFn("abc"), keyFn("abc"))
+	require.NotEqual(t, keyFn("abc"), keyFn("abd"))
+
+	_, err = xpath3.ResolveCollationKeyFunc("urn:bogus")
+	require.Error(t, err)
+
+	cmpFn, err := xpath3.ResolveCollationCompareFunc(collationCodepoint)
+	require.NoError(t, err)
+	require.Equal(t, 0, cmpFn("a", "a"))
+	require.Negative(t, cmpFn("a", "b"))
+	require.Positive(t, cmpFn("b", "a"))
+
+	_, err = xpath3.ResolveCollationCompareFunc("urn:bogus")
+	require.Error(t, err)
+
+	require.False(t, xpath3.CollationHasUnsupportedOptions(collationCodepoint))
+	require.False(t, xpath3.CollationHasUnsupportedOptions(collationUCA))
+	require.True(t, xpath3.CollationHasUnsupportedOptions(collationUCA+"?alternate=shifted"))
+}
+
+func TestAtomicEquals(t *testing.T) {
+	require.True(t, xpath3.AtomicEquals(intAtomic(3), intAtomic(3)))
+	require.False(t, xpath3.AtomicEquals(intAtomic(3), intAtomic(4)))
+	require.True(t, xpath3.AtomicEquals(strAtomic("x"), strAtomic("x")))
+	// Incomparable types return false rather than erroring.
+	require.False(t, xpath3.AtomicEquals(strAtomic("x"), intAtomic(1)))
+}
+
+func TestAtomicValue_StringIsNaN(t *testing.T) {
+	s := intAtomic(7).String()
+	require.Contains(t, s, "7")
+
+	nan := xpath3.AtomicValue{TypeName: xpath3.TypeDouble, Value: xpath3.NewDouble(math.NaN())}
+	require.True(t, nan.IsNaN())
+
+	notNaN := xpath3.AtomicValue{TypeName: xpath3.TypeDouble, Value: xpath3.NewDouble(1.5)}
+	require.False(t, notNaN.IsNaN())
+
+	// Non-float types are never NaN.
+	require.False(t, intAtomic(1).IsNaN())
+}
+
+func TestFloatValue_IsSpecial(t *testing.T) {
+	require.False(t, xpath3.NewDouble(1.0).IsSpecial())
+	require.True(t, xpath3.NewDouble(math.NaN()).IsSpecial())
+	require.True(t, xpath3.NewDouble(math.Inf(1)).IsSpecial())
+	require.True(t, xpath3.NewDouble(math.Inf(-1)).IsSpecial())
+	require.True(t, xpath3.NewDouble(math.Copysign(0, -1)).IsSpecial())
+}
+
+func TestBuiltinIsSubtypeOf(t *testing.T) {
+	require.True(t, xpath3.BuiltinIsSubtypeOf(xpath3.TypeInteger, xpath3.TypeDecimal))
+	require.True(t, xpath3.BuiltinIsSubtypeOf(xpath3.TypeInteger, xpath3.TypeInteger))
+	require.False(t, xpath3.BuiltinIsSubtypeOf(xpath3.TypeString, xpath3.TypeInteger))
+}
+
+func TestExpression_ValidateAndCopy(t *testing.T) {
+	expr, err := xpath3.NewCompiler().Compile(`fn:abs(-1)`)
+	require.NoError(t, err)
+
+	// Valid: fn prefix is predeclared.
+	require.NoError(t, expr.Validate(map[string]string{}))
+
+	bad, err := xpath3.NewCompiler().Compile(`undeclared:foo()`)
+	require.NoError(t, err)
+	require.Error(t, bad.Validate(map[string]string{}))
+
+	// Result.Copy on an empty result yields an empty result whose sequence is nil.
+	empty := xpath3.Result{}
+	cp := empty.Copy()
+	require.Nil(t, cp.Sequence())
+
+	r, err := evaluate(t.Context(), nil, `(1, 2, 3)`)
+	require.NoError(t, err)
+	rc := r.Copy()
+	require.Equal(t, 3, rc.Sequence().Len())
+}
+
+func TestEvaluatorBuilders(t *testing.T) {
+	doc := mustParseXML(t, "<root><a/><b/></root>")
+	root := doc.DocumentElement()
+
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Position(2).
+		Size(5).
+		PreservedIDAnnotations(map[helium.Node]string{}).
+		AllowXML11Chars()
+
+	compiled, err := xpath3.NewCompiler().Compile(`position()`)
+	require.NoError(t, err)
+	res, err := eval.Evaluate(t.Context(), compiled, root)
+	require.NoError(t, err)
+	n, ok := res.IsNumber()
+	require.True(t, ok)
+	require.Equal(t, float64(2), n)
+
+	compiledLast, err := xpath3.NewCompiler().Compile(`last()`)
+	require.NoError(t, err)
+	res, err = eval.Evaluate(t.Context(), compiledLast, root)
+	require.NoError(t, err)
+	n, ok = res.IsNumber()
+	require.True(t, ok)
+	require.Equal(t, float64(5), n)
+}
+
+func TestVariableAndFunctionResolver(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		VariableResolver(varResolver{}).
+		FunctionResolver(funcResolver{})
+
+	compiled, err := xpath3.NewCompiler().Compile(`$dynamic`)
+	require.NoError(t, err)
+	res, err := eval.Evaluate(t.Context(), compiled, doc)
+	require.NoError(t, err)
+	n, ok := res.IsNumber()
+	require.True(t, ok)
+	require.Equal(t, float64(99), n)
+}
+
+type varResolver struct{}
+
+func (varResolver) ResolveVariable(_ context.Context, name string) (xpath3.Sequence, bool, error) {
+	if name == "dynamic" {
+		return atomicSeq(intAtomic(99)), true, nil
+	}
+	return nil, false, nil
+}
+
+type funcResolver struct{}
+
+func (funcResolver) ResolveFunction(_ context.Context, _, _ string, _ int) (xpath3.Function, bool, error) {
+	return nil, false, nil
+}
+
+func TestFnContextNode(t *testing.T) {
+	doc := mustParseXML(t, "<root><child/></root>")
+	root := doc.DocumentElement()
+
+	captured := &capturingFn{}
+	lib := xpath3.NewFunctionLibrary()
+	lib.Set("capture", captured)
+
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Functions(lib)
+	compiled, err := xpath3.NewCompiler().Compile(`capture()`)
+	require.NoError(t, err)
+	_, err = eval.Evaluate(t.Context(), compiled, root)
+	require.NoError(t, err)
+	require.NotNil(t, captured.node)
+	require.Equal(t, root, captured.node)
+	// Direct (non-dynamic) call: IsDynamicCall is false.
+	require.False(t, captured.dynamic)
+}
+
+type capturingFn struct {
+	node    helium.Node
+	dynamic bool
+}
+
+func (*capturingFn) MinArity() int { return 0 }
+func (*capturingFn) MaxArity() int { return 0 }
+func (c *capturingFn) Call(ctx context.Context, _ []xpath3.Sequence) (xpath3.Sequence, error) {
+	c.node = xpath3.FnContextNode(ctx)
+	c.dynamic = xpath3.IsDynamicCall(ctx)
+	return atomicSeq(intAtomic(1)), nil
+}
+
+func TestCodeQName(t *testing.T) {
+	// Trigger a real XPathError (division by zero -> FOAR0001).
+	_, err := evaluate(t.Context(), nil, `1 idiv 0`)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	qn := xpErr.CodeQName()
+	require.NotEmpty(t, qn.Local)
+}
+
+func TestExpression_AST_StreamInfo(t *testing.T) {
+	expr, err := xpath3.NewCompiler().Compile(`child::a/descendant::b`)
+	require.NoError(t, err)
+
+	require.NotNil(t, expr.AST())
+
+	si := expr.StreamInfo()
+	require.True(t, si.HasDownwardStep)
+
+	// Nil expression yields a zero StreamInfo without panicking.
+	var nilExpr *xpath3.Expression
+	require.Equal(t, xpath3.StreamInfo{}, nilExpr.StreamInfo())
+}
+
+func TestPrettyTokens(t *testing.T) {
+	l, err := xpath3.NewLexerForTesting(`1 + 2`)
+	require.NoError(t, err)
+	require.NotEmpty(t, l.PrettyTokens())
+}

--- a/xpath3/coverage_qname_atomize_test.go
+++ b/xpath3/coverage_qname_atomize_test.go
@@ -1,0 +1,51 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// Atomizing a node annotated as xs:QName resolves the lexical QName against the
+// node's in-scope namespaces via resolveQNameFromNode (inside AtomizeItem).
+func TestAtomize_QNameAnnotatedNode(t *testing.T) {
+	doc := mustParseXML(t, `<root xmlns:p="urn:x">p:foo</root>`)
+	root := doc.DocumentElement()
+
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		TypeAnnotations(map[helium.Node]string{
+			root: xpath3.TypeQName,
+		})
+
+	// fn:prefix-from-QName over the atomized QName value.
+	res, err := eval.Evaluate(t.Context(), mustCompile(t, `prefix-from-QName(data(.))`), root)
+	require.NoError(t, err)
+	require.Equal(t, "p", res.StringValue())
+
+	// namespace-uri-from-QName resolves the bound URI.
+	res, err = eval.Evaluate(t.Context(), mustCompile(t, `namespace-uri-from-QName(data(.))`), root)
+	require.NoError(t, err)
+	require.Equal(t, "urn:x", res.StringValue())
+
+	// local-name-from-QName.
+	res, err = eval.Evaluate(t.Context(), mustCompile(t, `local-name-from-QName(data(.))`), root)
+	require.NoError(t, err)
+	require.Equal(t, "foo", res.StringValue())
+}
+
+// A default-namespace lexical (no prefix) resolves against the in-scope default.
+func TestAtomize_QNameDefaultNamespace(t *testing.T) {
+	doc := mustParseXML(t, `<root xmlns="urn:def">bare</root>`)
+	root := doc.DocumentElement()
+
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		TypeAnnotations(map[helium.Node]string{
+			root: xpath3.TypeQName,
+		})
+
+	res, err := eval.Evaluate(t.Context(), mustCompile(t, `namespace-uri-from-QName(data(.))`), root)
+	require.NoError(t, err)
+	require.Equal(t, "urn:def", res.StringValue())
+}

--- a/xpath3/coverage_range_compare_test.go
+++ b/xpath3/coverage_range_compare_test.go
@@ -1,0 +1,46 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// General comparisons against a range expression (1 to N) take an optimized
+// path through compareSingletonAgainstRange / compareRangeBounds /
+// compareRangeBoundsInt64 across all six comparison operators and both operand
+// orders.
+func TestGeneralComparison_AgainstRange(t *testing.T) {
+	cases := []struct {
+		expr   string
+		expect bool
+	}{
+		// singleton (op) range
+		{`5 = (1 to 10)`, true},
+		{`50 = (1 to 10)`, false},
+		{`5 != (1 to 10)`, true},
+		{`0 < (1 to 10)`, true},
+		{`11 < (1 to 10)`, false},
+		{`1 <= (1 to 10)`, true},
+		{`11 > (1 to 10)`, true},
+		{`0 > (1 to 10)`, false},
+		{`10 >= (1 to 10)`, true},
+		// range (op) singleton (rangeOnLeft)
+		{`(1 to 10) = 5`, true},
+		{`(1 to 10) < 11`, true},
+		{`(1 to 10) <= 10`, true},
+		{`(1 to 10) > 0`, true},
+		{`(1 to 10) >= 1`, true},
+		{`(1 to 10) != 5`, true},
+		// large bounds exceeding int64 fast path force the big.Int comparator.
+		{`5 = (1 to 100000000000000000000)`, true},
+		{`0 = (1 to 100000000000000000000)`, false},
+	}
+	for _, tc := range cases {
+		r, err := evaluate(t.Context(), nil, tc.expr)
+		require.NoError(t, err, tc.expr)
+		b, ok := r.IsBoolean()
+		require.True(t, ok, tc.expr)
+		require.Equal(t, tc.expect, b, tc.expr)
+	}
+}

--- a/xpath3/coverage_regex_backtrack_test.go
+++ b/xpath3/coverage_regex_backtrack_test.go
@@ -1,0 +1,47 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Patterns containing backreferences force the regexp2 backtracking engine
+// (r.backtrack != nil), exercising the Split / FindAllStringSubmatchIndex /
+// ReplaceAllString / NumSubexp branches that the std regexp path skips.
+// These are reached through fn:tokenize, fn:replace, and fn:analyze-string.
+
+func evalString(t *testing.T, expr string) string {
+	t.Helper()
+	r, err := evaluate(t.Context(), nil, expr)
+	require.NoError(t, err)
+	s, ok := r.IsString()
+	require.True(t, ok, "expected single string result for %q", expr)
+	return s
+}
+
+func TestRegexBacktrack_Tokenize(t *testing.T) {
+	// Backreference \1 forces the backtracking engine; tokenize -> Split.
+	r, err := evaluate(t.Context(), nil, `fn:tokenize("aXXbYYc", "(.)\1")`)
+	require.NoError(t, err)
+	atoms, err := r.Atomics()
+	require.NoError(t, err)
+	require.Len(t, atoms, 3)
+}
+
+func TestRegexBacktrack_Replace(t *testing.T) {
+	// Backreference in the pattern forces backtracking; replace -> ReplaceAllString.
+	got := evalString(t, `fn:replace("aabbcc", "(.)\1", "$1")`)
+	require.Equal(t, "abc", got)
+}
+
+func TestRegexBacktrack_AnalyzeString(t *testing.T) {
+	// analyze-string with a backreference pattern exercises
+	// FindAllStringSubmatchIndex and NumSubexp on the backtracking path.
+	r, err := evaluate(t.Context(), nil,
+		`fn:analyze-string("aabb", "(.)\1")//*:match => count()`)
+	require.NoError(t, err)
+	n, ok := r.IsNumber()
+	require.True(t, ok)
+	require.Equal(t, float64(2), n)
+}

--- a/xpath3/coverage_result_test.go
+++ b/xpath3/coverage_result_test.go
@@ -36,7 +36,7 @@ func TestResult_StringValue(t *testing.T) {
 
 func TestResult_TypePredicates(t *testing.T) {
 	// IsNumber across the numeric type hierarchy.
-	for _, expr := range []string{`1`, `1.5`, `xs:double("2.0")`, `xs:float("3.0")`} {
+	for _, expr := range []string{`1`, want1Dot5, `xs:double("2.0")`, `xs:float("3.0")`} {
 		r, err := evaluate(t.Context(), nil, expr)
 		require.NoError(t, err)
 		_, ok := r.IsNumber()

--- a/xpath3/coverage_result_test.go
+++ b/xpath3/coverage_result_test.go
@@ -1,0 +1,91 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResult_StringValue(t *testing.T) {
+	// Empty sequence => "".
+	r, err := evaluate(t.Context(), nil, `()`)
+	require.NoError(t, err)
+	require.Equal(t, "", r.StringValue())
+
+	// Single atomic.
+	r, err = evaluate(t.Context(), nil, `42`)
+	require.NoError(t, err)
+	require.Equal(t, "42", r.StringValue())
+
+	// Multi-item sequence => space-joined values (loop branch).
+	r, err = evaluate(t.Context(), nil, `(1, 2, 3)`)
+	require.NoError(t, err)
+	require.Equal(t, "1 2 3", r.StringValue())
+
+	r, err = evaluate(t.Context(), nil, `("a", "b")`)
+	require.NoError(t, err)
+	require.Equal(t, "a b", r.StringValue())
+
+	// Single-node result returns the node string value directly.
+	doc := mustParseXML(t, "<root>text-content</root>")
+	root := doc.DocumentElement()
+	r, err = evaluate(t.Context(), root, `.`)
+	require.NoError(t, err)
+	require.Equal(t, "text-content", r.StringValue())
+}
+
+func TestResult_TypePredicates(t *testing.T) {
+	// IsNumber across the numeric type hierarchy.
+	for _, expr := range []string{`1`, `1.5`, `xs:double("2.0")`, `xs:float("3.0")`} {
+		r, err := evaluate(t.Context(), nil, expr)
+		require.NoError(t, err)
+		_, ok := r.IsNumber()
+		require.True(t, ok, expr)
+	}
+
+	// A string is not a number.
+	r, err := evaluate(t.Context(), nil, `"x"`)
+	require.NoError(t, err)
+	_, ok := r.IsNumber()
+	require.False(t, ok)
+
+	// IsString / IsBoolean.
+	s, ok := r.IsString()
+	require.True(t, ok)
+	require.Equal(t, "x", s)
+
+	r, err = evaluate(t.Context(), nil, `true()`)
+	require.NoError(t, err)
+	b, ok := r.IsBoolean()
+	require.True(t, ok)
+	require.True(t, b)
+
+	// IsAtomic / Atomics.
+	r, err = evaluate(t.Context(), nil, `(1, 2)`)
+	require.NoError(t, err)
+	require.False(t, r.IsAtomic())
+	atoms, err := r.Atomics()
+	require.NoError(t, err)
+	require.Len(t, atoms, 2)
+
+	r, err = evaluate(t.Context(), nil, `1`)
+	require.NoError(t, err)
+	require.True(t, r.IsAtomic())
+
+	// IsNodeSet / Nodes.
+	doc := mustParseXML(t, "<root><a/><b/></root>")
+	root := doc.DocumentElement()
+	r, err = evaluate(t.Context(), root, `*`)
+	require.NoError(t, err)
+	require.True(t, r.IsNodeSet())
+	nodes, err := r.Nodes()
+	require.NoError(t, err)
+	require.Len(t, nodes, 2)
+
+	// A non-node result is not a node set; Nodes returns ErrNotNodeSet.
+	r, err = evaluate(t.Context(), root, `1`)
+	require.NoError(t, err)
+	require.False(t, r.IsNodeSet())
+	_, err = r.Nodes()
+	require.Error(t, err)
+}

--- a/xpath3/coverage_serialize_options_test.go
+++ b/xpath3/coverage_serialize_options_test.go
@@ -1,0 +1,56 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// fn:serialize with an output:serialization-parameters element as the second
+// argument exercises parseSerializeOptionsNode (the element-options path),
+// distinct from the map-options path covered elsewhere.
+func TestSerialize_OptionsNode(t *testing.T) {
+	const paramsXML = `<output:serialization-parameters xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">` +
+		`<output:method value="xml"/>` +
+		`<output:indent value="no"/>` +
+		`<output:omit-xml-declaration value="yes"/>` +
+		`</output:serialization-parameters>`
+
+	doc := mustParseXML(t, paramsXML)
+	paramsElem := doc.DocumentElement()
+
+	vars := xpath3.NewVariables()
+	nodes, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Evaluate(t.Context(), mustCompile(t, `.`), paramsElem)
+	require.NoError(t, err)
+	vars.Set("params", nodes.Sequence())
+
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Variables(vars)
+	compiled := mustCompile(t, `serialize("hello", $params)`)
+	res, err := eval.Evaluate(t.Context(), compiled, doc)
+	require.NoError(t, err)
+	require.Contains(t, res.StringValue(), "hello")
+}
+
+func mustCompile(t *testing.T, expr string) *xpath3.Expression {
+	t.Helper()
+	c, err := xpath3.NewCompiler().Compile(expr)
+	require.NoError(t, err)
+	return c
+}
+
+// xml-to-json with an options map exercises parseXMLToJSONOptions.
+func TestXMLToJSON_OptionsMap(t *testing.T) {
+	r, err := evaluate(t.Context(), nil,
+		`xml-to-json(json-to-xml('{"a": 1}'), map { "indent": true() })`)
+	require.NoError(t, err)
+	require.Contains(t, r.StringValue(), "\"a\"")
+
+	// Invalid 'indent' option type -> XPTY0004.
+	_, err = evaluate(t.Context(), nil,
+		`xml-to-json(json-to-xml('{"a": 1}'), map { "indent": "notbool" })`)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+}

--- a/xpath3/coverage_string_regex_test.go
+++ b/xpath3/coverage_string_regex_test.go
@@ -1,0 +1,109 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplace_EdgeBranches(t *testing.T) {
+	// Empty input string yields "".
+	r, err := evaluate(t.Context(), nil, `replace((), "a", "b")`)
+	require.NoError(t, err)
+	require.Equal(t, "", r.StringValue())
+
+	// 'q' literal flag: replacement is treated literally.
+	r, err = evaluate(t.Context(), nil, `replace("a.b.c", ".", "X", "q")`)
+	require.NoError(t, err)
+	require.Equal(t, "aXbXc", r.StringValue())
+
+	// Simple class with empty replacement -> rune-filter fast path.
+	r, err = evaluate(t.Context(), nil, `replace("a1b2c3", "\p{Nd}", "")`)
+	require.NoError(t, err)
+	require.Equal(t, "abc", r.StringValue())
+
+	// Negated class with empty replacement.
+	r, err = evaluate(t.Context(), nil, `replace("a1b2c3", "\P{Nd}", "")`)
+	require.NoError(t, err)
+	require.Equal(t, "123", r.StringValue())
+
+	// Backreference in replacement ($1).
+	r, err = evaluate(t.Context(), nil, `replace("2023-06-22", "(\d+)-(\d+)-(\d+)", "$3/$2/$1")`)
+	require.NoError(t, err)
+	require.Equal(t, "22/06/2023", r.StringValue())
+
+	// Pattern matching the empty string -> FORX0003.
+	_, err = evaluate(t.Context(), nil, `replace("abc", "x*", "y")`)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+}
+
+func TestTokenize_EdgeBranches(t *testing.T) {
+	// Whitespace-normalizing single-arg tokenize.
+	r, err := evaluate(t.Context(), nil, `tokenize("  a  b  c  ")`)
+	require.NoError(t, err)
+	atoms, err := r.Atomics()
+	require.NoError(t, err)
+	require.Len(t, atoms, 3)
+
+	// Empty input -> empty sequence.
+	r, err = evaluate(t.Context(), nil, `tokenize(())`)
+	require.NoError(t, err)
+	require.Equal(t, "", r.StringValue())
+
+	// Case-insensitive flag.
+	r, err = evaluate(t.Context(), nil, `tokenize("aXbxc", "x", "i")`)
+	require.NoError(t, err)
+	atoms, err = r.Atomics()
+	require.NoError(t, err)
+	require.Len(t, atoms, 3)
+}
+
+func TestAnalyzeString_EdgeBranches(t *testing.T) {
+	// Mix of matches and non-matches.
+	r, err := evaluate(t.Context(), nil,
+		`fn:analyze-string("a1b2", "\d")//fn:match => count()`)
+	require.NoError(t, err)
+	n, ok := r.IsNumber()
+	require.True(t, ok)
+	require.Equal(t, float64(2), n)
+
+	r, err = evaluate(t.Context(), nil,
+		`fn:analyze-string("a1b2", "\d")//fn:non-match => count()`)
+	require.NoError(t, err)
+	n, ok = r.IsNumber()
+	require.True(t, ok)
+	require.Equal(t, float64(2), n)
+
+	// Capture groups generate fn:group children.
+	r, err = evaluate(t.Context(), nil,
+		`fn:analyze-string("2023", "(\d)(\d)")//fn:group => count()`)
+	require.NoError(t, err)
+	n, ok = r.IsNumber()
+	require.True(t, ok)
+	require.Positive(t, n)
+
+	// Empty input -> a result element with no match/non-match.
+	r, err = evaluate(t.Context(), nil,
+		`fn:analyze-string("", "\d")//fn:match => count()`)
+	require.NoError(t, err)
+	n, ok = r.IsNumber()
+	require.True(t, ok)
+	require.Equal(t, float64(0), n)
+
+	// Case-insensitive flag.
+	r, err = evaluate(t.Context(), nil,
+		`fn:analyze-string("aAbB", "a", "i")//fn:match => count()`)
+	require.NoError(t, err)
+	n, ok = r.IsNumber()
+	require.True(t, ok)
+	require.Equal(t, float64(2), n)
+
+	// Pattern matching empty string -> FORX0003.
+	_, err = evaluate(t.Context(), nil, `fn:analyze-string("ab", "x*")`)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+}

--- a/xpath3/coverage_trycatch_castable_test.go
+++ b/xpath3/coverage_trycatch_castable_test.go
@@ -1,0 +1,83 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// try/catch exercises parseCatchCode (parse-time) and catchCodeMatches
+// (eval-time) across the catch-code forms: "*", "err:LOCAL", "Q{uri}local",
+// "Q{uri}*", "*:LOCAL", and "err:*".
+func TestTryCatch_CodeForms(t *testing.T) {
+	const errNS = "http://www.w3.org/2005/xqt-errors"
+
+	cases := []struct {
+		expr   string
+		expect string
+	}{
+		// wildcard catch.
+		{`try { 1 div 0 } catch * { "caught" }`, "caught"},
+		// specific error code via err: prefix.
+		{`try { xs:integer("x") } catch err:FORG0001 { "forg" }`, "forg"},
+		// err:* wildcard.
+		{`try { xs:integer("x") } catch err:* { "anyerr" }`, "anyerr"},
+		// Q{uri}local form.
+		{`try { xs:integer("x") } catch Q{` + errNS + `}FORG0001 { "q" }`, "q"},
+		// Q{uri}* form.
+		{`try { xs:integer("x") } catch Q{` + errNS + `}* { "qstar" }`, "qstar"},
+		// *:LOCAL form.
+		{`try { xs:integer("x") } catch *:FORG0001 { "star" }`, "star"},
+		// successful body returns its value (no catch).
+		{`try { 1 + 1 } catch * { "x" }`, "2"},
+		// error variable access inside catch.
+		{`try { xs:integer("x") } catch * { $err:code }`, "err:FORG0001"},
+	}
+	for _, tc := range cases {
+		r, err := evaluate(t.Context(), nil, tc.expr)
+		require.NoError(t, err, tc.expr)
+		require.Equal(t, tc.expect, r.StringValue(), tc.expr)
+	}
+
+	// Non-matching catch code re-raises the original error.
+	_, err := evaluate(t.Context(), nil, `try { xs:integer("x") } catch err:XPDY0002 { "nope" }`)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+}
+
+func TestCastableExprForms(t *testing.T) {
+	cases := []struct {
+		expr   string
+		expect bool
+	}{
+		{`"1" castable as xs:integer`, true},
+		{`"x" castable as xs:integer`, false},
+		{`"1.5" castable as xs:decimal`, true},
+		{`"2023-06-22" castable as xs:date`, true},
+		{`"notadate" castable as xs:date`, false},
+		{`"true" castable as xs:boolean`, true},
+		{`() castable as xs:integer?`, true},
+		{`() castable as xs:integer`, false},
+		{`"abc" castable as xs:NCName`, true},
+		{`"a:b:c" castable as xs:NCName`, false},
+		// multi-item sequence is never castable to a single-item type.
+		{`(1, 2) castable as xs:integer`, false},
+		// numeric union type.
+		{`1 castable as xs:numeric`, true},
+		{`"1.5" castable as xs:numeric`, true},
+		{`"x" castable as xs:numeric`, false},
+		// list types: whitespace-separated members.
+		{`"a b c" castable as xs:NMTOKENS`, true},
+		{`"a b" castable as xs:IDREFS`, true},
+		{`"" castable as xs:NMTOKENS`, false},
+	}
+	for _, tc := range cases {
+		r, err := evaluate(t.Context(), nil, tc.expr)
+		require.NoError(t, err, tc.expr)
+		b, ok := r.IsBoolean()
+		require.True(t, ok, tc.expr)
+		require.Equal(t, tc.expect, b, tc.expr)
+	}
+}

--- a/xpath3/coverage_types_evalstate_test.go
+++ b/xpath3/coverage_types_evalstate_test.go
@@ -1,0 +1,192 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+func stExactlyOne(typ string) xpath3.SequenceType {
+	return xpath3.SequenceType{
+		ItemTest:   xpath3.AtomicOrUnionType{Prefix: "xs", Name: typ},
+		Occurrence: xpath3.OccurrenceExactlyOne,
+	}
+}
+
+func TestEvalState_SetPositionSize(t *testing.T) {
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions)
+
+	ctxItem := xpath3.AtomicValue{TypeName: xpath3.TypeInteger, Value: int64(1)}
+
+	compiledPos, err := xpath3.NewCompiler().Compile(`position()`)
+	require.NoError(t, err)
+	state := eval.NewEvalState(nil)
+	state.SetContextItem(ctxItem)
+	state.SetPosition(3)
+	state.SetSize(7)
+
+	res, err := compiledPos.EvaluateReuse(t.Context(), state, nil)
+	require.NoError(t, err)
+	n, ok := res.IsNumber()
+	require.True(t, ok)
+	require.Equal(t, float64(3), n)
+
+	compiledLast, err := xpath3.NewCompiler().Compile(`last()`)
+	require.NoError(t, err)
+	state2 := eval.NewEvalState(nil)
+	state2.SetContextItem(ctxItem)
+	state2.SetSize(7)
+	res, err = compiledLast.EvaluateReuse(t.Context(), state2, nil)
+	require.NoError(t, err)
+	n, ok = res.IsNumber()
+	require.True(t, ok)
+	require.Equal(t, float64(7), n)
+}
+
+func TestEvalState_SetContextItem(t *testing.T) {
+	compiled, err := xpath3.NewCompiler().Compile(`.`)
+	require.NoError(t, err)
+
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions)
+	state := eval.NewEvalState(nil)
+	state.SetContextItem(xpath3.AtomicValue{TypeName: xpath3.TypeInteger, Value: int64(55)})
+
+	res, err := compiled.EvaluateReuse(t.Context(), state, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Sequence().Len())
+	av, ok := res.Sequence().Get(0).(xpath3.AtomicValue)
+	require.True(t, ok)
+	require.Equal(t, int64(55), av.Value)
+}
+
+func TestMatchesSequenceType(t *testing.T) {
+	intSeq := atomicSeq(intAtomic(1))
+	require.True(t, xpath3.MatchesSequenceType(intSeq, stExactlyOne("integer")))
+	require.False(t, xpath3.MatchesSequenceType(intSeq, stExactlyOne("string")))
+
+	// A two-item sequence violates the exactly-one cardinality.
+	twoSeq := xpath3.ItemSlice{intAtomic(1), intAtomic(2)}
+	require.False(t, xpath3.MatchesSequenceType(twoSeq, stExactlyOne("integer")))
+}
+
+func TestCoerceToSequenceType(t *testing.T) {
+	// integer promotes to double under function coercion rules.
+	intSeq := atomicSeq(intAtomic(3))
+	out, ok := xpath3.CoerceToSequenceType(intSeq, stExactlyOne("double"))
+	require.True(t, ok)
+	require.Equal(t, 1, out.Len())
+
+	// A string does not coerce to integer.
+	strSeq := atomicSeq(strAtomic("notnum"))
+	_, ok = xpath3.CoerceToSequenceType(strSeq, stExactlyOne("integer"))
+	require.False(t, ok)
+}
+
+func TestCheckFunctionParamCompat(t *testing.T) {
+	// FunctionTest with AnyFunction => always compatible.
+	fi := xpath3.FunctionItem{
+		Arity:      1,
+		ParamTypes: []xpath3.SequenceType{stExactlyOne("integer")},
+	}
+	anyFnST := xpath3.SequenceType{
+		ItemTest:   xpath3.FunctionTest{AnyFunction: true},
+		Occurrence: xpath3.OccurrenceExactlyOne,
+	}
+	require.True(t, xpath3.CheckFunctionParamCompat(fi, anyFnST))
+
+	// Matching arity with compatible (identical) param types.
+	typedFnST := xpath3.SequenceType{
+		ItemTest: xpath3.FunctionTest{
+			ParamTypes: []xpath3.SequenceType{stExactlyOne("integer")},
+		},
+		Occurrence: xpath3.OccurrenceExactlyOne,
+	}
+	require.True(t, xpath3.CheckFunctionParamCompat(fi, typedFnST))
+
+	// Mismatched arity => incompatible.
+	mismatchFnST := xpath3.SequenceType{
+		ItemTest: xpath3.FunctionTest{
+			ParamTypes: []xpath3.SequenceType{stExactlyOne("integer"), stExactlyOne("integer")},
+		},
+		Occurrence: xpath3.OccurrenceExactlyOne,
+	}
+	require.False(t, xpath3.CheckFunctionParamCompat(fi, mismatchFnST))
+}
+
+// stMap / stArray build map(K,V) and array(T) SequenceTypes, driving
+// isItemTypeSubtype's MapTest/ArrayTest branches via CheckFunctionParamCompat.
+func stMap(keyT, valT string) xpath3.SequenceType {
+	return xpath3.SequenceType{
+		ItemTest: xpath3.MapTest{
+			KeyType: xpath3.AtomicOrUnionType{Prefix: "xs", Name: keyT},
+			ValType: stExactlyOne(valT),
+		},
+		Occurrence: xpath3.OccurrenceExactlyOne,
+	}
+}
+
+func stArray(memberT string) xpath3.SequenceType {
+	return xpath3.SequenceType{
+		ItemTest: xpath3.ArrayTest{
+			MemberType: stExactlyOne(memberT),
+		},
+		Occurrence: xpath3.OccurrenceExactlyOne,
+	}
+}
+
+func TestCheckFunctionParamCompat_NestedTypes(t *testing.T) {
+	// Function declares a map(string, integer) parameter; the target test asks
+	// for the same -> compatible (drives isItemTypeSubtype MapTest branch).
+	fiMap := xpath3.FunctionItem{
+		Arity:      1,
+		ParamTypes: []xpath3.SequenceType{stMap("string", "integer")},
+	}
+	mapFnST := xpath3.SequenceType{
+		ItemTest:   xpath3.FunctionTest{ParamTypes: []xpath3.SequenceType{stMap("string", "integer")}},
+		Occurrence: xpath3.OccurrenceExactlyOne,
+	}
+	require.True(t, xpath3.CheckFunctionParamCompat(fiMap, mapFnST))
+
+	// Array parameter compatibility (drives ArrayTest branch).
+	fiArr := xpath3.FunctionItem{
+		Arity:      1,
+		ParamTypes: []xpath3.SequenceType{stArray("integer")},
+	}
+	arrFnST := xpath3.SequenceType{
+		ItemTest:   xpath3.FunctionTest{ParamTypes: []xpath3.SequenceType{stArray("integer")}},
+		Occurrence: xpath3.OccurrenceExactlyOne,
+	}
+	require.True(t, xpath3.CheckFunctionParamCompat(fiArr, arrFnST))
+
+	// Mismatched atomic param types -> incompatible (drives AtomicOrUnionType branch).
+	fiInt := xpath3.FunctionItem{
+		Arity:      1,
+		ParamTypes: []xpath3.SequenceType{stExactlyOne("integer")},
+	}
+	strFnST := xpath3.SequenceType{
+		ItemTest:   xpath3.FunctionTest{ParamTypes: []xpath3.SequenceType{stExactlyOne("string")}},
+		Occurrence: xpath3.OccurrenceExactlyOne,
+	}
+	require.False(t, xpath3.CheckFunctionParamCompat(fiInt, strFnST))
+}
+
+func TestMatchesSequenceType_MapArray(t *testing.T) {
+	// A real map value matched against map(string, integer).
+	mapSeq, err := evalSeq(t, `map { "a": 1, "b": 2 }`)
+	require.NoError(t, err)
+	require.True(t, xpath3.MatchesSequenceType(mapSeq, stMap("string", "integer")))
+
+	arrSeq, err := evalSeq(t, `[1, 2, 3]`)
+	require.NoError(t, err)
+	require.True(t, xpath3.MatchesSequenceType(arrSeq, stArray("integer")))
+}
+
+func evalSeq(t *testing.T, expr string) (xpath3.Sequence, error) {
+	t.Helper()
+	r, err := evaluate(t.Context(), nil, expr)
+	if err != nil {
+		return nil, err
+	}
+	return r.Sequence(), nil
+}

--- a/xpath3/coverage_validate_walk_test.go
+++ b/xpath3/coverage_validate_walk_test.go
@@ -24,7 +24,7 @@ func TestValidate_WalksAllExprShapes(t *testing.T) {
 		`-1 + 2 * 3`,
 		`"a" || "b"`,
 		`(1, 2) ! (. + 1)`,
-		`1 to 10`,
+		expr1To10,
 		`a union b`,
 		`a intersect b`,
 		`a except b`,

--- a/xpath3/coverage_validate_walk_test.go
+++ b/xpath3/coverage_validate_walk_test.go
@@ -1,0 +1,64 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// Compiling a broad range of expression shapes drives the VM compiler's
+// per-node prefix-plan construction (appendExprLocalPrefixChecks and friends),
+// and Expression.Validate then runs the resulting prefixValidationPlan.
+func TestValidate_WalksAllExprShapes(t *testing.T) {
+	ns := xpath3.PredeclaredNamespaces()
+
+	exprs := []string{
+		`fn:concat("a", "b")`,
+		`"1" cast as xs:integer`,
+		`"1" castable as xs:integer`,
+		`1 instance of xs:integer`,
+		`1 treat as xs:integer`,
+		`/a/b/c`,
+		`a[1][@x]`,
+		`-1 + 2 * 3`,
+		`"a" || "b"`,
+		`(1, 2) ! (. + 1)`,
+		`1 to 10`,
+		`a union b`,
+		`a intersect b`,
+		`a except b`,
+		`if (1) then 2 else 3`,
+		`for $x in (1, 2) return $x`,
+		`let $y := 3 return $y`,
+		`some $x in (1, 2) satisfies $x = 1`,
+		`every $x in (1, 2) satisfies $x = 1`,
+		`try { 1 div 0 } catch * { 0 }`,
+		`let $f := fn:abs#1 return $f(-1)`,
+		`function($x) { $x + 1 }(2)`,
+		`map { "a": 1, "b": 2 }?a`,
+		`[1, 2, 3]?2`,
+		`(1, 2, 3)[. > 1]`,
+		`map { "a": 1 }("a")`,
+		`fn:count(//x)`,
+		`$v[. = "y"]`,
+		`fn:for-each((1, 2), function($x) { $x })`,
+	}
+	for _, e := range exprs {
+		compiled, err := xpath3.NewCompiler().Compile(e)
+		require.NoError(t, err, e)
+		// fn / map / array prefixes are predeclared, $v is unbound but prefix
+		// validation only checks namespace prefixes, not variable bindings.
+		require.NoError(t, compiled.Validate(ns), e)
+	}
+
+	// An undeclared prefix on a function name is caught.
+	bad, err := xpath3.NewCompiler().Compile(`undeclared:foo(1)`)
+	require.NoError(t, err)
+	require.Error(t, bad.Validate(map[string]string{}))
+
+	// An undeclared prefix in a cast target type is caught.
+	bad, err = xpath3.NewCompiler().Compile(`"1" cast as undeclared:myType`)
+	require.NoError(t, err)
+	require.Error(t, bad.Validate(map[string]string{}))
+}

--- a/xpath3/duration_secrat_test.go
+++ b/xpath3/duration_secrat_test.go
@@ -407,12 +407,12 @@ func TestDurationMulDoubleFloatExact(t *testing.T) {
 		{
 			name: "dayTime times xs:double(1) eq parsed original",
 			expr: `(xs:dayTimeDuration("PT9007199254740993S") * xs:double("1")) eq xs:dayTimeDuration("PT9007199254740993S")`,
-			want: "true",
+			want: wantTrue,
 		},
 		{
 			name: "dayTime times xs:double(1) not one second short",
 			expr: `(xs:dayTimeDuration("PT9007199254740993S") * xs:double("1")) ne xs:dayTimeDuration("PT9007199254740992S")`,
-			want: "true",
+			want: wantTrue,
 		},
 		{
 			name: "yearMonth times xs:double(1) keeps exact months",
@@ -432,7 +432,7 @@ func TestDurationMulDoubleFloatExact(t *testing.T) {
 		{
 			name: "dayTime times xs:double(1) equals times 1",
 			expr: `(xs:dayTimeDuration("PT9007199254740993S") * xs:double("1")) eq (xs:dayTimeDuration("PT9007199254740993S") * 1)`,
-			want: "true",
+			want: wantTrue,
 		},
 	}
 

--- a/xpath3/float_value_test.go
+++ b/xpath3/float_value_test.go
@@ -21,7 +21,7 @@ func TestNewFloat_SpecialValues(t *testing.T) {
 		isZero  bool
 		signbit bool
 	}{
-		{"NaN", math.NaN(), true, false, false, false, false, false},
+		{wantNaN, math.NaN(), true, false, false, false, false, false},
 		{"+Inf", math.Inf(1), false, true, false, false, false, false},
 		{"-Inf", math.Inf(-1), false, false, true, false, false, true},
 		{"-0", math.Copysign(0, -1), false, false, false, true, true, true},

--- a/xpath3/format_integer_test.go
+++ b/xpath3/format_integer_test.go
@@ -68,7 +68,7 @@ func TestStringArgAtomizesBeforeCardinality(t *testing.T) {
 		{`format-integer(123, ([], "0"))`, "123"},
 		{`format-integer((), ([], "0"))`, ""},
 		{`format-number(123, ([], "0"))`, "123"},
-		{`format-number((), ([], "0.0"))`, "NaN"},
+		{`format-number((), ([], "0.0"))`, lexicon.FloatNaN},
 		{`upper-case(([], "ab"))`, "AB"},
 		{`concat(([], "x"), "y")`, "xy"},
 	}

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -1255,9 +1255,9 @@ func TestFnRoundPrecisionArgValidation(t *testing.T) {
 
 	t.Run("empty arg with valid precision is empty", func(t *testing.T) {
 		// A valid precision plus an empty $arg returns () (not an error).
-		evalOK(t, `empty(round((), 3))`, "true")
-		evalOK(t, `empty(round((), 1))`, "true")
-		evalOK(t, `empty(round-half-to-even((), 3))`, "true")
+		evalOK(t, `empty(round((), 3))`, wantTrue)
+		evalOK(t, `empty(round((), 1))`, wantTrue)
+		evalOK(t, `empty(round-half-to-even((), 3))`, wantTrue)
 	})
 }
 

--- a/xpath3/lexer_test.go
+++ b/xpath3/lexer_test.go
@@ -207,7 +207,7 @@ func TestLexerXPath3Tokens(t *testing.T) {
 		},
 		{
 			name:  "to range",
-			input: "1 to 10",
+			input: expr1To10,
 			expect: []xpath3.TokenType{
 				xpath3.TokenNumber, xpath3.TokenTo, xpath3.TokenNumber,
 			},

--- a/xpath3/parser_test.go
+++ b/xpath3/parser_test.go
@@ -107,7 +107,7 @@ func TestParseXPath3Extensions(t *testing.T) {
 		{"concat chain", `"a" || "b" || "c"`},
 
 		// Range
-		{"range", "1 to 10"},
+		{"range", expr1To10},
 
 		// Simple map
 		{"simple map", "//item ! name()"},
@@ -244,7 +244,7 @@ func TestParseAST(t *testing.T) {
 	})
 
 	t.Run("range expr structure", func(t *testing.T) {
-		expr, err := xpath3.Parse("1 to 10")
+		expr, err := xpath3.Parse(expr1To10)
 		require.NoError(t, err)
 		re, ok := expr.(xpath3.RangeExpr)
 		require.True(t, ok, "expected RangeExpr, got %T", expr)

--- a/xpath3/qt3_collection_test.go
+++ b/xpath3/qt3_collection_test.go
@@ -24,7 +24,7 @@ func TestQT3Collections(t *testing.T) {
 			Name:  "query-backed collection",
 			XPath: `sum(collection("urn:qt3:ints"))`,
 			Collections: []qt3Collection{
-				{URI: "urn:qt3:ints", Query: "1 to 10"},
+				{URI: "urn:qt3:ints", Query: expr1To10},
 			},
 			Assertions: []qt3Assertion{qt3AssertEq("55")},
 		},

--- a/xpath3/types_test.go
+++ b/xpath3/types_test.go
@@ -715,7 +715,7 @@ func TestEBV(t *testing.T) {
 	}{
 		{"empty", xpath3.EmptySequence(), false, false},
 		{lexicon.ValueTrue, xpath3.SingleBoolean(true), true, false},
-		{"false", xpath3.SingleBoolean(false), false, false},
+		{lexicon.ValueFalse, xpath3.SingleBoolean(false), false, false},
 		{"nonempty string", xpath3.SingleString("x"), true, false},
 		{"empty string", xpath3.SingleString(""), false, false},
 		{"nonzero integer", xpath3.SingleInteger(42), true, false},


### PR DESCRIPTION
- add tests raising 8 public packages to ≥85% statement coverage: xpath1 87.0, xmldsig1 85.3, xmlenc1 85.2, c14n 90.8, shim 85.2, xpath3 85.0, stream 92.6, catalog 93.0
- root `helium` 72.4→78.5; remainder is debug-gated (`pdebug.Enabled` const-false), no-op SAX hooks, and xslt3-only paths — not reachable in a standard build
- test-only; no runtime or public API changes
