### PR TITLE
harden CI: matrix, govulncheck, pinned tooling

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -16,7 +16,7 @@ xsd            → helium, xpath1, internal/lexicon, internal/xsd/value, interna
 relaxng        → helium, internal/lexicon, internal/iofs, internal/xsd/value, internal/xmlchar
 schematron     → helium, xpath1
 xpointer       → helium, xpath1, internal/xmlchar
-c14n           → helium, internal/lexicon, internal/domutil
+c14n           → helium, internal/lexicon, internal/domutil, internal/uripath
 xmldsig1       → helium, c14n, internal/lexicon, internal/domutil
 xmlenc1        → helium, internal/domutil
 html           → helium, sax, push, internal/xmlchar

--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -4,16 +4,16 @@ Arrows show "imports" direction. Indented items are transitive.
 
 ```
 cmd/helium     → internal/cli/heliumcmd
-internal/cli/heliumcmd → helium, c14n, relaxng, schematron, xsd, xinclude, xpath1, xpath3, catalog, internal/cliutil
+internal/cli/heliumcmd → helium, c14n, relaxng, schematron, xsd, xinclude, xpath1, xpath3, catalog, internal/cliutil, internal/uripath
 shim           → helium, stream, enum, internal/encoding, internal/xmlchar
-xinclude       → helium, xpointer, internal/encoding, internal/iofs, internal/lexicon
+xinclude       → helium, xpointer, internal/encoding, internal/iofs, internal/lexicon, internal/uripath
                   → xpath1 (via xpointer)
                   → internal/xmlchar (via xpointer)
 xpath1         → helium, internal/lexicon, internal/domutil
 xpath3         → helium, internal/xpath, internal/lexicon, internal/icu, internal/unparsedtext, internal/strcursor, internal/sequence, internal/xsdregex, internal/xmlchar, internal/domutil
 xslt3          → helium, xpath3, xsd, html, internal/iofs, internal/lexicon, internal/sequence, internal/uripath, internal/xpathstream, internal/domutil, xslt3/internal/elements
-xsd            → helium, xpath1, internal/lexicon, internal/xsd/value, internal/xsdregex
-relaxng        → helium, internal/lexicon, internal/iofs, internal/xsd/value, internal/xmlchar
+xsd            → helium, xpath1, internal/lexicon, internal/xsd/value, internal/xsdregex, internal/uripath
+relaxng        → helium, internal/lexicon, internal/iofs, internal/xsd/value, internal/xmlchar, internal/uripath
 schematron     → helium, xpath1
 xpointer       → helium, xpath1, internal/xmlchar
 c14n           → helium, internal/lexicon, internal/domutil, internal/uripath
@@ -23,7 +23,7 @@ html           → helium, sax, push, internal/xmlchar
 catalog        → helium, internal/catalog, internal/lexicon, internal/xmlchar
 stream         → internal/encoding, internal/xmlchar
 sax            → helium, enum
-helium (root)  → sax, enum, internal/encoding, internal/bitset, internal/parser, push, internal/stack
+helium (root)  → sax, enum, internal/encoding, internal/bitset, internal/parser, push, internal/stack, internal/uripath
 sink           → (none)
 enum           → (none)
 internal/lexicon → (none)

--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -32,7 +32,9 @@ push → (none)
 internal/heliumtest → (none)
 internal/sequence → (none)
 internal/strcursor → (none)
-internal/unparsedtext → internal/xmlchar
+internal/unparsedtext → internal/xmlchar, internal/uripath
+internal/catalog → internal/uripath
+internal/uripath → (none)
 internal/xsdregex → (none)
 internal/xsd/value → internal/lexicon
 internal/domutil → helium, internal/lexicon, internal/xmlchar
@@ -41,7 +43,7 @@ test           → helium
 ```
 
 ## Leaf packages (no helium deps)
-sink, enum, internal/bitset, internal/heliumtest, internal/parser, push, internal/stack, internal/cliutil, internal/catalog, internal/encoding, internal/lexicon, internal/icu, internal/sequence, internal/strcursor, internal/unparsedtext, internal/xsdregex
+sink, enum, internal/bitset, internal/heliumtest, internal/parser, push, internal/stack, internal/cliutil, internal/encoding, internal/lexicon, internal/icu, internal/sequence, internal/strcursor, internal/xsdregex, internal/uripath
 
 ## Core layer
 helium (root) → sax, enum, internal/*

--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -11,7 +11,7 @@ xinclude       → helium, xpointer, internal/encoding, internal/iofs, internal/
                   → internal/xmlchar (via xpointer)
 xpath1         → helium, internal/lexicon, internal/domutil
 xpath3         → helium, internal/xpath, internal/lexicon, internal/icu, internal/unparsedtext, internal/strcursor, internal/sequence, internal/xsdregex, internal/xmlchar, internal/domutil
-xslt3          → helium, xpath3, xsd, html, internal/lexicon, internal/sequence, internal/xpathstream, internal/domutil, xslt3/internal/elements
+xslt3          → helium, xpath3, xsd, html, internal/iofs, internal/lexicon, internal/sequence, internal/uripath, internal/xpathstream, internal/domutil, xslt3/internal/elements
 xsd            → helium, xpath1, internal/lexicon, internal/xsd/value, internal/xsdregex
 relaxng        → helium, internal/lexicon, internal/iofs, internal/xsd/value, internal/xmlchar
 schematron     → helium, xpath1

--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -4,7 +4,7 @@ Arrows show "imports" direction. Indented items are transitive.
 
 ```
 cmd/helium     → internal/cli/heliumcmd
-internal/cli/heliumcmd → helium, c14n, relaxng, schematron, xsd, xinclude, xpath1, xpath3, catalog, internal/cliutil, internal/uripath
+internal/cli/heliumcmd → helium, c14n, relaxng, schematron, xsd, xinclude, xpath1, xpath3, catalog, internal/cliutil, internal/uripath, internal/iofs
 shim           → helium, stream, enum, internal/encoding, internal/xmlchar
 xinclude       → helium, xpointer, internal/encoding, internal/iofs, internal/lexicon, internal/uripath
                   → xpath1 (via xpointer)
@@ -12,7 +12,7 @@ xinclude       → helium, xpointer, internal/encoding, internal/iofs, internal/
 xpath1         → helium, internal/lexicon, internal/domutil
 xpath3         → helium, internal/xpath, internal/lexicon, internal/icu, internal/unparsedtext, internal/strcursor, internal/sequence, internal/xsdregex, internal/xmlchar, internal/domutil
 xslt3          → helium, xpath3, xsd, html, internal/iofs, internal/lexicon, internal/sequence, internal/uripath, internal/xpathstream, internal/domutil, xslt3/internal/elements
-xsd            → helium, xpath1, internal/lexicon, internal/xsd/value, internal/xsdregex, internal/uripath
+xsd            → helium, xpath1, internal/lexicon, internal/xsd/value, internal/xsdregex, internal/uripath, internal/iofs
 relaxng        → helium, internal/lexicon, internal/iofs, internal/xsd/value, internal/xmlchar, internal/uripath
 schematron     → helium, xpath1
 xpointer       → helium, xpath1, internal/xmlchar
@@ -23,7 +23,7 @@ html           → helium, sax, push, internal/xmlchar
 catalog        → helium, internal/catalog, internal/lexicon, internal/xmlchar
 stream         → internal/encoding, internal/xmlchar
 sax            → helium, enum
-helium (root)  → sax, enum, internal/encoding, internal/bitset, internal/parser, push, internal/stack, internal/uripath
+helium (root)  → sax, enum, internal/encoding, internal/bitset, internal/parser, push, internal/stack, internal/uripath, internal/iofs
 sink           → (none)
 enum           → (none)
 internal/lexicon → (none)
@@ -32,7 +32,7 @@ push → (none)
 internal/heliumtest → (none)
 internal/sequence → (none)
 internal/strcursor → (none)
-internal/unparsedtext → internal/xmlchar, internal/uripath
+internal/unparsedtext → internal/xmlchar, internal/uripath, internal/iofs
 internal/catalog → internal/uripath
 internal/uripath → (none)
 internal/xsdregex → (none)

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,24 @@
-# Preserve exact bytes in QT3 fixtures (BOM, CR/LF/NEL/LS, encodings).
+# Golden / expected-output fixtures are compared byte-for-byte against
+# library output. Some legitimately contain embedded CR (\r) bytes as part of
+# the captured data (e.g. SAX entity-content events), so we must preserve the
+# committed bytes EXACTLY rather than normalize line endings. "-text" disables
+# all EOL conversion, so a Windows checkout (autocrlf=true) cannot rewrite a
+# golden's LF terminators to CRLF and break the comparison, and cannot mangle
+# the intentional embedded CRs either.
+*.expected -text
+*.golden   -text
+*.sax2     -text
+*.sax      -text
+*.dump     -text
+*.lint     -text
+
+# Result-directory goldens for the validation suites (relaxng / xsd /
+# schematron use "*.err" under result/; c14n uses extension-less files under
+# result/). Pin the whole result/ subtree byte-for-byte.
+testdata/libxml2-compat/**/result/** -text
+
+# Preserve exact bytes in the W3C conformance fixture trees (BOM, CR/LF/NEL/LS,
+# encodings, and .out goldens with embedded CR). The harnesses normalize line
+# endings themselves, so these must be checked out verbatim on every platform.
 testdata/qt3ts/testdata/** -text
+testdata/xslt30/testdata/** -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,24 +1,28 @@
-# Golden / expected-output fixtures are compared byte-for-byte against
-# library output. Some legitimately contain embedded CR (\r) bytes as part of
-# the captured data (e.g. SAX entity-content events), so we must preserve the
-# committed bytes EXACTLY rather than normalize line endings. "-text" disables
-# all EOL conversion, so a Windows checkout (autocrlf=true) cannot rewrite a
-# golden's LF terminators to CRLF and break the comparison, and cannot mangle
-# the intentional embedded CRs either.
+# Test fixtures — INPUTS and OUTPUTS — are read and compared byte-for-byte by
+# the test harnesses (golden comparisons, SAX-event captures, byte counts,
+# checksum-sensitive parsing). Git's autocrlf on the Windows CI runner would
+# otherwise rewrite the LF-committed majority to CRLF on checkout, so an input
+# .xml gains stray \r bytes (shifting byte counts and SAX offsets) and an output
+# golden no longer matches the library's LF output.
+#
+# "-text" disables ALL end-of-line conversion, so every checkout reproduces the
+# committed blob EXACTLY on every platform. Unlike "eol=lf" it does NOT rewrite
+# files, so a fixture that genuinely contains intentional CR/CRLF bytes (e.g. a
+# SAX entity-content capture, or a deliberate line-ending test input) is
+# preserved verbatim rather than normalized. Pinning the WHOLE fixture trees —
+# inputs and outputs alike — is the robust form: it cannot be defeated by a new
+# input extension the per-extension rules below do not enumerate.
+testdata/**            -text
+test/**                -text
+relaxng/testdata/**    -text
+xslt3/testdata/**      -text
+
+# Belt-and-suspenders: pin the known golden/expected-output extensions byte-exact
+# regardless of where they live, in case a future fixture lands outside the trees
+# pinned above. (Redundant with the tree rules for current paths.)
 *.expected -text
 *.golden   -text
 *.sax2     -text
 *.sax      -text
 *.dump     -text
 *.lint     -text
-
-# Result-directory goldens for the validation suites (relaxng / xsd /
-# schematron use "*.err" under result/; c14n uses extension-less files under
-# result/). Pin the whole result/ subtree byte-for-byte.
-testdata/libxml2-compat/**/result/** -text
-
-# Preserve exact bytes in the W3C conformance fixture trees (BOM, CR/LF/NEL/LS,
-# encodings, and .out goldens with embedded CR). The harnesses normalize line
-# endings themselves, so these must be checked out verbatim on every platform.
-testdata/qt3ts/testdata/** -text
-testdata/xslt30/testdata/** -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,27 @@ permissions:
 
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -race -timeout 20m ./...
+
+  verify:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -33,7 +54,7 @@ jobs:
         run: go mod download
 
       - name: Install stringer
-        run: go install golang.org/x/tools/cmd/stringer@latest
+        run: go install golang.org/x/tools/cmd/stringer@v0.46.0
 
       - name: Check generated parser state file
         run: |
@@ -44,10 +65,6 @@ jobs:
         run: |
           go mod tidy
           git diff --exit-code go.mod go.sum
-
-      - name: Run tests
-        run: |
-          go test -race -timeout 20m ./...
 
       - name: Build helium command
         run: |
@@ -61,3 +78,17 @@ jobs:
             git status --porcelain
             exit 1
           fi
+
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.4.0 ./...

--- a/c14n/canonicalizer.go
+++ b/c14n/canonicalizer.go
@@ -876,9 +876,14 @@ func (c *canonicalizer) documentBaseURI() string {
 		return uripath.WindowsToFileURI(c.baseURI)
 	}
 
-	// A POSIX-absolute base is already anchored; just normalize separators and
-	// attach the file scheme. A relative base is anchored against the working
-	// directory with filepath.Abs first (POSIX result is a "/..."-rooted path).
+	// A POSIX-absolute base is already anchored; normalize separators, remove
+	// dot-segments, and attach the file scheme. A relative base is anchored
+	// against the working directory with filepath.Abs first (POSIX result is a
+	// "/..."-rooted path). SlashClean (not ToSlash) preserves the historical
+	// behavior of the old unconditional filepath.Abs, which collapsed "." / ".."
+	// / "//" in the base; this matters because the base feeds relativizeURI and
+	// the C14N 1.1 xml:base fixup, so a non-canonical base would change canonical
+	// output bytes (which are XML-signature input).
 	abs := c.baseURI
 	if !uripath.IsPOSIXAbsolute(abs) {
 		anchored, err := filepath.Abs(c.baseURI)
@@ -892,7 +897,7 @@ func (c *canonicalizer) documentBaseURI() string {
 		}
 		abs = anchored
 	}
-	return "file://" + uripath.ToSlash(abs)
+	return "file://" + uripath.SlashClean(abs)
 }
 
 // xmlBaseLocalName is the local name of the xml:base attribute.

--- a/c14n/canonicalizer.go
+++ b/c14n/canonicalizer.go
@@ -11,6 +11,7 @@ import (
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/domutil"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/uripath"
 )
 
 type canonicalizer struct {
@@ -861,12 +862,37 @@ func (c *canonicalizer) documentBaseURI() string {
 	if u, err := url.Parse(c.baseURI); err == nil && u.IsAbs() && len(u.Scheme) > 1 {
 		return c.baseURI
 	}
-	// Convert file path to URL for proper URI resolution.
-	absPath, err := filepath.Abs(c.baseURI)
-	if err != nil {
-		return c.baseURI
+	// A Windows-absolute base ("D:\dir\doc.xml", "D:/dir/doc.xml", or a UNC path)
+	// is already absolute, so it is converted to a forward-slash "file:" URI
+	// directly — WITHOUT filepath.Abs. This is detected from the string shape
+	// (uripath), so it is handled identically on POSIX and Windows: on a POSIX
+	// host filepath.Abs would misread "D:\..." as a relative path and prepend the
+	// working directory, corrupting the base. On Windows, prepending a bare
+	// "file://" to the native backslash path ("file://D:\dir\doc.xml") yields a
+	// value url.Parse cannot navigate, collapsing the downstream ".." in
+	// relativizeURI into output like "..//x"; WindowsToFileURI rewrites it to the
+	// proper "file:///D:/dir/doc.xml".
+	if uripath.IsWindowsAbsolute(c.baseURI) {
+		return uripath.WindowsToFileURI(c.baseURI)
 	}
-	return "file://" + absPath
+
+	// A POSIX-absolute base is already anchored; just normalize separators and
+	// attach the file scheme. A relative base is anchored against the working
+	// directory with filepath.Abs first (POSIX result is a "/..."-rooted path).
+	abs := c.baseURI
+	if !uripath.IsPOSIXAbsolute(abs) {
+		anchored, err := filepath.Abs(c.baseURI)
+		if err != nil {
+			return c.baseURI
+		}
+		// On Windows filepath.Abs may produce a drive-letter path; route it
+		// through the Windows converter for a correct "file:///C:/..." URI.
+		if uripath.IsWindowsAbsolute(anchored) {
+			return uripath.WindowsToFileURI(anchored)
+		}
+		abs = anchored
+	}
+	return "file://" + uripath.ToSlash(abs)
 }
 
 // xmlBaseLocalName is the local name of the xml:base attribute.

--- a/c14n/canonicalizer_internal_test.go
+++ b/c14n/canonicalizer_internal_test.go
@@ -1,0 +1,55 @@
+package c14n
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDocumentBaseURIWindowsDrive is the string-shaped (GOOS-independent)
+// regression for the Windows C14N 1.1 xml:base fixup failure: a Windows-drive
+// base URI must be turned into a proper forward-slash "file:" URI so the
+// downstream RFC 3986 ".." relativization in relativizeURI counts segments
+// correctly. Before the fix, "file://" was prepended to a backslash path
+// ("file://D:\dir\doc.xml"), which url.Parse could not navigate, collapsing
+// "../../x" into "..//x". A Windows-absolute base is a plain string, so the
+// Windows branch is exercised on any OS; the POSIX cases confirm no regression.
+func TestDocumentBaseURIWindowsDrive(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		baseURI string
+		want    string
+	}{
+		{"windows drive backslash", `D:\dir\sub\doc.xml`, "file:///D:/dir/sub/doc.xml"},
+		{"windows drive forward slash", "D:/dir/sub/doc.xml", "file:///D:/dir/sub/doc.xml"},
+		{"unc path", `\\host\share\doc.xml`, "file://host/share/doc.xml"},
+		// An already-absolute URI is preserved untouched.
+		{"absolute http uri", "http://example.com/dir/doc.xml", "http://example.com/dir/doc.xml"},
+		{"empty base", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := &canonicalizer{baseURI: tc.baseURI}
+			require.Equal(t, tc.want, c.documentBaseURI())
+		})
+	}
+}
+
+// TestRelativizeURIDotDotForwardSlash verifies that relativizeURI emits a
+// correct "../../" relative reference from forward-slash "file:" URIs — the
+// value that must be byte-identical on POSIX and Windows. The Windows path
+// failure ("..//x") only arose because documentBaseURI fed it a backslash base;
+// given a proper forward-slash file URI, the relativization itself is platform
+// independent.
+func TestRelativizeURIDotDotForwardSlash(t *testing.T) {
+	t.Parallel()
+
+	// base of element <d>: foo/bar resolved twice up then x — see the
+	// xmlbase-c14n11spec3-102 golden.
+	base := "file:///work/dir/test/foo/bar"
+	target := "file:///work/dir/x"
+	require.Equal(t, "../../x", relativizeURI(base, target))
+}

--- a/c14n/canonicalizer_internal_test.go
+++ b/c14n/canonicalizer_internal_test.go
@@ -28,6 +28,13 @@ func TestDocumentBaseURIWindowsDrive(t *testing.T) {
 		// An already-absolute URI is preserved untouched.
 		{"absolute http uri", "http://example.com/dir/doc.xml", "http://example.com/dir/doc.xml"},
 		{"empty base", "", ""},
+		// POSIX-absolute bases must be dot-segment-cleaned (matching the old
+		// unconditional filepath.Abs), since a non-canonical base would change
+		// canonical (signature) output. SlashClean, not a raw separator swap.
+		{"posix clean", "/work/dir/doc.xml", "file:///work/dir/doc.xml"},
+		{"posix dotdot", "/work/dir/../doc.xml", "file:///work/doc.xml"},
+		{"posix double slash", "/work//dir/doc.xml", "file:///work/dir/doc.xml"},
+		{"posix dot", "/work/./dir/doc.xml", "file:///work/dir/doc.xml"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/catalog/coverage_load_test.go
+++ b/catalog/coverage_load_test.go
@@ -193,7 +193,14 @@ func TestLocalhostFileURI(t *testing.T) {
 </catalog>`
 	require.NoError(t, os.WriteFile(p, []byte(xml), 0o600))
 
-	uri := "file://localhost" + filepath.ToSlash(p)
+	// Build "file://localhost/<path>". On Windows the slashed path is
+	// "C:/..." (no leading slash), so prepend one to avoid producing
+	// "file://localhostC:/..." where "localhostC:" is read as the host.
+	slashed := filepath.ToSlash(p)
+	if !strings.HasPrefix(slashed, "/") {
+		slashed = "/" + slashed
+	}
+	uri := "file://localhost" + slashed
 	cat, err := catalog.Load(t.Context(), uri)
 	require.NoError(t, err)
 	got := cat.Resolve(t.Context(), "", "sid")

--- a/catalog/integration_test.go
+++ b/catalog/integration_test.go
@@ -4,12 +4,26 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/catalog"
 	"github.com/stretchr/testify/require"
 )
+
+// nativePathToFileURI builds a "file:///" URI from a native absolute path on any
+// OS. On POSIX the path begins with "/", so "file://" + "/tmp/x" already yields
+// the correct "file:///tmp/x". On Windows the slashed path is "C:/..." (no
+// leading slash), so a leading slash is prepended to avoid "file://C:/..."
+// where "C:" is mis-read as the URI host.
+func nativePathToFileURI(p string) string {
+	slashed := filepath.ToSlash(p)
+	if !strings.HasPrefix(slashed, "/") {
+		slashed = "/" + slashed
+	}
+	return "file://" + slashed
+}
 
 func TestCatalogExternalSubset(t *testing.T) {
 	t.Parallel()
@@ -70,7 +84,7 @@ func TestCatalogExternalSubsetFileURI(t *testing.T) {
 	// Catalog mapping the system ID to a "file:" URI rather than a bare path.
 	// The resolved value reaches the parser as "file:///...", which must be
 	// converted to a local path before being opened (CAT-001).
-	fileURI := "file://" + filepath.ToSlash(dtdPath)
+	fileURI := nativePathToFileURI(dtdPath)
 	catContent := `<?xml version="1.0"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
   <system systemId="http://example.com/test.dtd" uri="` + fileURI + `"/>
@@ -114,7 +128,7 @@ func TestCatalogResolveEntityFileURI(t *testing.T) {
 	entPath := filepath.Join(dir, "ext.ent")
 	require.NoError(t, os.WriteFile(entPath, []byte(entContent), 0644))
 
-	fileURI := "file://" + filepath.ToSlash(entPath)
+	fileURI := nativePathToFileURI(entPath)
 	catContent := `<?xml version="1.0"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
   <system systemId="http://example.com/ext.ent" uri="` + fileURI + `"/>

--- a/catalog/load.go
+++ b/catalog/load.go
@@ -198,10 +198,18 @@ func catalogFilePath(ref string) (string, bool, error) {
 // space rather than as bare filesystem paths.
 //
 // (&url.URL{Scheme: "file", Path: ...}).String() percent-encodes as needed and,
-// on Windows, converts the OS separator to "/" via filepath.ToSlash, yielding
-// "file:///C:/tmp/catalog.xml". On POSIX the absolute path already uses "/".
+// on Windows, converts the OS separator to "/" via filepath.ToSlash. A Windows
+// drive-letter absolute path slashes to "C:/tmp/catalog.xml" — with NO leading
+// slash — which url.URL.String() would render as "file://C:/tmp/catalog.xml",
+// reading "C:" as the authority/host. Prepend the missing leading slash so the
+// result is the correct "file:///C:/tmp/catalog.xml". On POSIX the absolute
+// path already begins with "/", so this is a no-op there.
 func localPathToFileURI(absPath string) string {
-	u := url.URL{Scheme: "file", Path: filepath.ToSlash(absPath)}
+	slashed := filepath.ToSlash(absPath)
+	if !strings.HasPrefix(slashed, "/") {
+		slashed = "/" + slashed
+	}
+	u := url.URL{Scheme: "file", Path: slashed}
 	return u.String()
 }
 

--- a/coverage_external_dtd_test.go
+++ b/coverage_external_dtd_test.go
@@ -9,6 +9,7 @@ import (
 	"testing/fstest"
 
 	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/iofs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -119,7 +120,11 @@ func TestExternalDTDMissingFile(t *testing.T) {
 type trimSlashFS struct{ inner fs.FS }
 
 func (f trimSlashFS) Open(name string) (fs.File, error) {
-	return f.inner.Open(strings.TrimPrefix(name, "/")) //nolint:wrapcheck // test helper
+	// Normalize to forward slashes (the native open name is backslash-separated
+	// on Windows: "C:\\win\\dir\\ext.dtd") and drop the leading slash the POSIX
+	// "/C:/..." form carries, so fstest.MapFS (keyed "C:/win/dir/ext.dtd")
+	// serves it on every OS.
+	return f.inner.Open(strings.TrimPrefix(filepath.ToSlash(name), "/")) //nolint:wrapcheck // test helper
 }
 
 // TestExternalSubsetResolvesAgainstWindowsDriveFileURIBase is the string-shaped
@@ -130,18 +135,18 @@ func (f trimSlashFS) Open(name string) (fs.File, error) {
 // BuildURI) and convert it to a local path before Open, NOT mangle it with
 // filepath.Dir/Join — on Windows that cleared the directory and dropped the DTD.
 // The base is a plain string, so this exercises the Windows branch on every OS.
-// FileURIToPath of "file:///C:/win/dir/ext.dtd" keeps the leading slash on a
-// POSIX host ("/C:/win/dir/ext.dtd"), so the FS is keyed on that.
+// The resolved open name is whatever FileURIToPath yields for the combined
+// "file:///C:/win/dir/ext.dtd": "/C:/win/dir/ext.dtd" on a POSIX host,
+// "C:\\win\\dir\\ext.dtd" on Windows. Derive it the same way so the assertion
+// is correct on both, and let trimSlashFS normalize either form to the MapFS key.
 func TestExternalSubsetResolvesAgainstWindowsDriveFileURIBase(t *testing.T) {
 	t.Parallel()
 
 	const dtd = `<!ELEMENT chapter (#PCDATA)>
 <!ENTITY greet "hello from nested dtd">`
 
-	const openName = "/C:/win/dir/ext.dtd"
-	// The resolved open name is an absolute "/C:/..." path (FileURIToPath of the
-	// drive-rooted file URI on a POSIX host), which is not an fs.ValidPath; trim
-	// the leading slash so fstest.MapFS can serve it.
+	openName, err := iofs.FileURIToPath("file:///C:/win/dir/ext.dtd")
+	require.NoError(t, err)
 	fsys := &recordingFS{inner: trimSlashFS{fstest.MapFS{"C:/win/dir/ext.dtd": {Data: []byte(dtd)}}}}
 
 	xml := `<?xml version="1.0"?>` +

--- a/coverage_external_dtd_test.go
+++ b/coverage_external_dtd_test.go
@@ -1,9 +1,12 @@
 package helium_test
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/stretchr/testify/require"
@@ -108,6 +111,57 @@ func TestExternalDTDMissingFile(t *testing.T) {
 	if doc != nil {
 		require.NotNil(t, doc.DocumentElement())
 	}
+}
+
+// trimSlashFS adapts an fs.FS so a leading-slash absolute name (such as the
+// "/C:/..." path FileURIToPath yields on a POSIX host) is accepted by an
+// fs.ValidPath-enforcing FS like fstest.MapFS.
+type trimSlashFS struct{ inner fs.FS }
+
+func (f trimSlashFS) Open(name string) (fs.File, error) {
+	return f.inner.Open(strings.TrimPrefix(name, "/")) //nolint:wrapcheck // test helper
+}
+
+// TestExternalSubsetResolvesAgainstWindowsDriveFileURIBase is the string-shaped
+// (GOOS-independent) regression for the Windows nested-external-DTD failure: a
+// document parsed with a Windows-drive "file:" base URI
+// ("file:///C:/win/dir/doc.xml") that declares a RELATIVE external DTD
+// ("ext.dtd"). The resolver must combine them into a proper "file:" URI (via
+// BuildURI) and convert it to a local path before Open, NOT mangle it with
+// filepath.Dir/Join — on Windows that cleared the directory and dropped the DTD.
+// The base is a plain string, so this exercises the Windows branch on every OS.
+// FileURIToPath of "file:///C:/win/dir/ext.dtd" keeps the leading slash on a
+// POSIX host ("/C:/win/dir/ext.dtd"), so the FS is keyed on that.
+func TestExternalSubsetResolvesAgainstWindowsDriveFileURIBase(t *testing.T) {
+	t.Parallel()
+
+	const dtd = `<!ELEMENT chapter (#PCDATA)>
+<!ENTITY greet "hello from nested dtd">`
+
+	const openName = "/C:/win/dir/ext.dtd"
+	// The resolved open name is an absolute "/C:/..." path (FileURIToPath of the
+	// drive-rooted file URI on a POSIX host), which is not an fs.ValidPath; trim
+	// the leading slash so fstest.MapFS can serve it.
+	fsys := &recordingFS{inner: trimSlashFS{fstest.MapFS{"C:/win/dir/ext.dtd": {Data: []byte(dtd)}}}}
+
+	xml := `<?xml version="1.0"?>` +
+		`<!DOCTYPE chapter SYSTEM "ext.dtd">` +
+		`<chapter>text</chapter>`
+
+	doc, err := helium.NewParser().
+		LoadExternalDTD(true).
+		BaseURI("file:///C:/win/dir/doc.xml").
+		FS(fsys).
+		Parse(t.Context(), []byte(xml))
+	require.NoError(t, err)
+
+	// The relative SYSTEM id resolved into the base directory (never dropped to a
+	// bare "ext.dtd", the Windows filepath.Join failure mode), so the DTD was
+	// found and its general entity declared.
+	require.True(t, fsys.wasOpened(openName),
+		"relative SYSTEM id must resolve against the windows-drive file: base")
+	_, found := doc.GetEntity("greet")
+	require.True(t, found, "entity from external DTD must be declared, proving the file: DTD URI was resolved")
 }
 
 // TestInternalSubsetParameterEntityInclusion exercises a parameter entity used

--- a/coverage_node_util_test.go
+++ b/coverage_node_util_test.go
@@ -38,6 +38,17 @@ func TestBuildURI(t *testing.T) {
 		{"absolute http system id against windows drive base", "http://example.com/a/b", `D:\dir\doc.xsl`, "http://example.com/a/b"},
 		{"absolute http system id against windows slash base", "http://example.com/a/b", "D:/dir/doc.xsl", "http://example.com/a/b"},
 		{"absolute file system id against windows base", "file:///x/y", `C:\dir\doc.xsl`, "file:///x/y"},
+		// A RELATIVE Windows base (backslashes, no drive — what filepath.Join
+		// yields on Windows for a relative test path) must keep its directory so a
+		// sibling entity resolves inside it. Without backslash-aware handling this
+		// dropped to a bare "world.txt" and the external entity could not be found.
+		{"sibling against relative windows base", "world.txt", `..\d\e\example.xml`, "../d/e/world.txt"},
+		// A file: base with a Windows drive letter must yield a proper file: URI
+		// (not the drive-rooted "/D:/..." path url.Parse exposes), so file-URI-aware
+		// loaders convert it back to a native path. The POSIX file: base below
+		// keeps returning a plain path, proving POSIX is unaffected.
+		{"sibling against windows drive file uri", "inc.dtd", "file:///D:/tmp/t/inc.xml", "file:///D:/tmp/t/inc.dtd"},
+		{"sibling against posix file uri", "inc.dtd", "file:///tmp/t/inc.xml", "/tmp/t/inc.dtd"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/coverage_node_util_test.go
+++ b/coverage_node_util_test.go
@@ -47,8 +47,8 @@ func TestBuildURI(t *testing.T) {
 		// (not the drive-rooted "/D:/..." path url.Parse exposes), so file-URI-aware
 		// loaders convert it back to a native path. The POSIX file: base below
 		// keeps returning a plain path, proving POSIX is unaffected.
-		{"sibling against windows drive file uri", "inc.dtd", "file:///D:/tmp/t/inc.xml", "file:///D:/tmp/t/inc.dtd"},
-		{"sibling against posix file uri", "inc.dtd", "file:///tmp/t/inc.xml", "/tmp/t/inc.dtd"},
+		{"sibling against windows drive file uri", "nested.dtd", "file:///D:/tmp/t/inc.xml", "file:///D:/tmp/t/nested.dtd"},
+		{"sibling against posix file uri", "nested.dtd", "file:///tmp/t/inc.xml", "/tmp/t/nested.dtd"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/coverage_node_util_test.go
+++ b/coverage_node_util_test.go
@@ -31,6 +31,13 @@ func TestBuildURI(t *testing.T) {
 		{"windows-absolute system id returned verbatim", `C:\abs\a.dtd`, `D:\dir\doc.xml`, `C:\abs\a.dtd`},
 		{"interior dot-dot against windows base", "../sib/child.xml", `C:\a\b\main.xml`, "C:/a/sib/child.xml"},
 		{"unc base resolves relative ref", "child.xml", `\\host\share\main.xml`, "//host/share/child.xml"},
+		// An absolute-URI systemID stands on its own even when the base is a
+		// native Windows path. Without the scheme check this collapsed "http://"
+		// to "http:/" and joined it onto the drive-letter base (Windows-only
+		// regression that broke the W3C resolve-uri/base-uri cluster).
+		{"absolute http system id against windows drive base", "http://example.com/a/b", `D:\dir\doc.xsl`, "http://example.com/a/b"},
+		{"absolute http system id against windows slash base", "http://example.com/a/b", "D:/dir/doc.xsl", "http://example.com/a/b"},
+		{"absolute file system id against windows base", "file:///x/y", `C:\dir\doc.xsl`, "file:///x/y"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/coverage_node_util_test.go
+++ b/coverage_node_util_test.go
@@ -22,6 +22,15 @@ func TestBuildURI(t *testing.T) {
 		{"relative against http base", "a.dtd", "http://host/dir/doc.xml", "http://host/dir/a.dtd"},
 		{"relative against file path", "a.dtd", "/dir/doc.xml", "/dir/a.dtd"},
 		{"absolute local path", "/abs/a.dtd", "/dir/doc.xml", "/abs/a.dtd"},
+		// Windows shapes are plain strings, so the Windows behavior below is
+		// exercised on any GOOS. A native Windows base must NOT route the drive
+		// letter through url.Parse (which would emit "c:///a.dtd"); it resolves
+		// with local-path (forward-slash) semantics.
+		{"relative against windows backslash base", "child.xml", `C:\dir\main.xml`, "C:/dir/child.xml"},
+		{"relative against windows forward-slash base", "a.dtd", "D:/dir/doc.xml", "D:/dir/a.dtd"},
+		{"windows-absolute system id returned verbatim", `C:\abs\a.dtd`, `D:\dir\doc.xml`, `C:\abs\a.dtd`},
+		{"interior dot-dot against windows base", "../sib/child.xml", `C:\a\b\main.xml`, "C:/a/sib/child.xml"},
+		{"unc base resolves relative ref", "child.xml", `\\host\share\main.xml`, "//host/share/child.xml"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/lestrrat-go/helium
 
 go 1.26.1
 
+toolchain go1.26.4
+
 require (
 	github.com/dlclark/regexp2 v1.12.0
 	github.com/stretchr/testify v1.11.1

--- a/internal/catalog/uri.go
+++ b/internal/catalog/uri.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+
+	"github.com/lestrrat-go/helium/internal/uripath"
 )
 
 // ResolveURI resolves value against base. If value already has a scheme, or
@@ -56,7 +58,10 @@ func ResolveURI(base, value string) (string, error) {
 
 	// Non-URI local-path base: apply OS-path semantics. An absolute value is
 	// returned unchanged; a relative one is joined against the base directory.
-	if filepath.IsAbs(value) {
+	// uripath.IsAbsolutePath recognizes both POSIX- and Windows-absolute shapes
+	// regardless of the host OS, so a "/abs/x" reference is not mis-joined
+	// against the base dir on Windows (where filepath.IsAbs("/abs/x") is false).
+	if uripath.IsAbsolutePath(value) || filepath.IsAbs(value) {
 		return value, nil
 	}
 
@@ -64,7 +69,14 @@ func ResolveURI(base, value string) (string, error) {
 }
 
 // HasScheme checks if s looks like a URI with a scheme (e.g., "http://...").
+// A single-letter "scheme" that is actually a Windows drive-letter prefix
+// (e.g. "C:\\path" or "D:/path") is NOT treated as a URI scheme, so a native
+// catalog base path is resolved with OS-path semantics rather than leaking the
+// drive letter into URI space.
 func HasScheme(s string) bool {
+	if uripath.HasWindowsDrivePrefix(s) {
+		return false
+	}
 	colon := strings.IndexByte(s, ':')
 	if colon < 1 {
 		return false

--- a/internal/catalog/uri_test.go
+++ b/internal/catalog/uri_test.go
@@ -121,3 +121,58 @@ func TestResolveURI(t *testing.T) {
 		})
 	}
 }
+
+// HasScheme must not misread a single-letter Windows drive (e.g. "D:") as a URI
+// scheme. These string inputs are GOOS-independent so the Windows behavior is
+// covered on Linux CI.
+func TestHasScheme(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"http://example.com/x", true},
+		{"file:///tmp/x", true},
+		{"urn:isbn:0", true},
+		{`C:\catalog.xml`, false},       // Windows drive, not a scheme
+		{`D:/share/catalog.xml`, false}, // Windows drive, forward slash
+		{"C:", false},
+		{"/tmp/catalog.xml", false},
+		{"relative.xml", false},
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, catalog.HasScheme(tc.in), "in=%q", tc.in)
+	}
+}
+
+// ResolveURI with a Windows drive-letter base must treat the base as a local
+// path (not a URI), and a Windows-absolute value must be returned unchanged.
+// These string inputs exercise the Windows path on any GOOS.
+func TestResolveURIWindowsShapes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("windows-drive base resolves relative ref as local path", func(t *testing.T) {
+		got, err := catalog.ResolveURI(`C:\dir\catalog.xml`, "asset.xml")
+		require.NoError(t, err)
+		// filepath.Join/Dir use the host separator; on POSIX this is
+		// "C:\\dir/asset.xml". The key property is that the drive letter is
+		// NOT leaked into URI space ("c:///...").
+		require.NotContains(t, got, "c://")
+		require.NotContains(t, got, "C://")
+		require.Contains(t, got, "asset.xml")
+	})
+
+	t.Run("windows-absolute value returned unchanged", func(t *testing.T) {
+		got, err := catalog.ResolveURI("/tmp/catalog.xml", `C:\abs\asset.xml`)
+		require.NoError(t, err)
+		require.Equal(t, `C:\abs\asset.xml`, got)
+	})
+
+	t.Run("posix-absolute value against local base returned unchanged on any OS", func(t *testing.T) {
+		// On Windows filepath.IsAbs("/abs/x") is false; uripath.IsAbsolutePath
+		// keeps it absolute so it is not mis-joined against the base dir.
+		got, err := catalog.ResolveURI(`C:\dir\catalog.xml`, "/abs/asset.xml")
+		require.NoError(t, err)
+		require.Equal(t, "/abs/asset.xml", got)
+	})
+}

--- a/internal/cli/heliumcmd/lint.go
+++ b/internal/cli/heliumcmd/lint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lestrrat-go/helium/c14n"
 	"github.com/lestrrat-go/helium/catalog"
 	henc "github.com/lestrrat-go/helium/internal/encoding"
+	"github.com/lestrrat-go/helium/internal/uripath"
 	"github.com/lestrrat-go/helium/xinclude"
 	"github.com/lestrrat-go/helium/xpath1"
 	"github.com/lestrrat-go/helium/xsd"
@@ -501,12 +502,46 @@ func (c *command) pathDirs(cfg *config) []string {
 		return nil
 	}
 	var dirs []string
-	for d := range strings.SplitSeq(cfg.pathDirs, ":") {
+	for _, d := range splitSearchPath(cfg.pathDirs) {
 		if d != "" {
 			dirs = append(dirs, d)
 		}
 	}
 	return dirs
+}
+
+// splitSearchPath splits a colon-separated DTD/entity search path (xmllint
+// style) while keeping a Windows drive-letter prefix ("D:\\dtd", "C:/x")
+// attached to its directory. A naive strings.Split on ':' would shatter
+// "D:\\dtd" into "D" and "\\dtd", corrupting the search path on Windows and
+// making a DTD resolved via --path unfindable (validation then spuriously
+// fails). A colon is treated as a drive separator — and NOT a list separator —
+// only when it is the SECOND character of a segment, follows a single ASCII
+// letter, and is itself followed by a path separator ('/' or '\\') or the end
+// of the segment. This is GOOS-independent (string-shape based), so the
+// behavior is exercised on POSIX too; a genuine POSIX list like
+// "/a/b:/c/d" still splits normally because "/a/b" does not match the
+// drive-prefix shape.
+func splitSearchPath(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] != ':' {
+			continue
+		}
+		// A "X:" at the very start of the current segment, where X is a single
+		// ASCII letter and the next char is a separator (or segment end), is a
+		// Windows drive prefix, not a list separator.
+		if i == start+1 && uripath.IsWindowsDriveLetter(s[start]) {
+			if i+1 >= len(s) || s[i+1] == '/' || s[i+1] == '\\' {
+				continue
+			}
+		}
+		out = append(out, s[start:i])
+		start = i + 1
+	}
+	out = append(out, s[start:])
+	return out
 }
 
 func (c *command) compileSchema(ctx context.Context, cfg *config) (*xsd.Schema, error) {

--- a/internal/cli/heliumcmd/lint.go
+++ b/internal/cli/heliumcmd/lint.go
@@ -525,7 +525,7 @@ func (c *command) pathDirs(cfg *config) []string {
 func splitSearchPath(s string) []string {
 	var out []string
 	start := 0
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		if s[i] != ':' {
 			continue
 		}

--- a/internal/cli/heliumcmd/safety_internal_test.go
+++ b/internal/cli/heliumcmd/safety_internal_test.go
@@ -2,6 +2,7 @@ package heliumcmd
 
 import (
 	"math"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -20,25 +21,29 @@ func TestLocalFilePath(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "sub/mod.xsl", got)
 	})
+	// A "file:" URI is decoded into a NATIVE local path, so the expected value
+	// is wrapped in filepath.FromSlash (POSIX "/tmp/mod.xsl", Windows
+	// "\\tmp\\mod.xsl"). The plain-path subtests above pass the string through
+	// unchanged, so they are not wrapped.
 	t.Run("file URI empty host", func(t *testing.T) {
 		got, err := localFilePath("file:///tmp/mod.xsl")
 		require.NoError(t, err)
-		require.Equal(t, "/tmp/mod.xsl", got)
+		require.Equal(t, filepath.FromSlash("/tmp/mod.xsl"), got)
 	})
 	t.Run("file URI localhost host", func(t *testing.T) {
 		got, err := localFilePath("file://localhost/tmp/mod.xsl")
 		require.NoError(t, err)
-		require.Equal(t, "/tmp/mod.xsl", got)
+		require.Equal(t, filepath.FromSlash("/tmp/mod.xsl"), got)
 	})
 	t.Run("file URI uppercase localhost host", func(t *testing.T) {
 		got, err := localFilePath("file://LOCALHOST/tmp/mod.xsl")
 		require.NoError(t, err)
-		require.Equal(t, "/tmp/mod.xsl", got)
+		require.Equal(t, filepath.FromSlash("/tmp/mod.xsl"), got)
 	})
 	t.Run("file URI percent-decoded", func(t *testing.T) {
 		got, err := localFilePath("file:///tmp/a%20b/mod.xsl")
 		require.NoError(t, err)
-		require.Equal(t, "/tmp/a b/mod.xsl", got)
+		require.Equal(t, filepath.FromSlash("/tmp/a b/mod.xsl"), got)
 	})
 	t.Run("remote host rejected", func(t *testing.T) {
 		_, err := localFilePath("file://example.com/mod.xsl")

--- a/internal/cli/heliumcmd/split_search_path_internal_test.go
+++ b/internal/cli/heliumcmd/split_search_path_internal_test.go
@@ -1,0 +1,35 @@
+package heliumcmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSplitSearchPath verifies the --path (DTD/entity search path) splitter
+// keeps a Windows drive-letter prefix attached to its directory while still
+// splitting a genuine colon-separated list. A naive strings.Split(':') would
+// shatter "D:\\dtd" into "D" and "\\dtd", so a DTD resolved via --path becomes
+// unfindable on Windows and validation spuriously fails (TestLintOutput
+// OverLaterReadDTDSucceeds, exit 3). The shapes are plain strings, so the
+// Windows behavior is exercised on Linux.
+func TestSplitSearchPath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{`D:\a\helium\dtd`, []string{`D:\a\helium\dtd`}},
+		{"C:/x/dtd", []string{"C:/x/dtd"}},
+		{`D:\a:E:\b`, []string{`D:\a`, `E:\b`}}, // two drive paths, colon-joined
+		{"/a/b:/c/d", []string{"/a/b", "/c/d"}}, // POSIX list still splits
+		{"single", []string{"single"}},
+		{"", []string{""}},
+		{"D:", []string{"D:"}},                // bare drive
+		{"a:b", []string{"a", "b"}},           // single-letter but no separator after -> list
+		{"/x:D:\\y", []string{"/x", "D:\\y"}}, // mixed POSIX + drive
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, splitSearchPath(tc.in), "in=%q", tc.in)
+	}
+}

--- a/internal/iofs/iofs_test.go
+++ b/internal/iofs/iofs_test.go
@@ -1,6 +1,7 @@
 package iofs_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/lestrrat-go/helium/internal/iofs"
@@ -10,25 +11,28 @@ import (
 func TestFileURIToPath(t *testing.T) {
 	t.Parallel()
 
+	// FileURIToPath returns a NATIVE path (via filepath.FromSlash), so the
+	// expected value is wrapped in filepath.FromSlash: "/tmp/inc.xml" on POSIX,
+	// "\\tmp\\inc.xml" on Windows.
 	t.Run("absolute file URI", func(t *testing.T) {
 		t.Parallel()
 		p, err := iofs.FileURIToPath("file:///tmp/inc.xml")
 		require.NoError(t, err)
-		require.Equal(t, "/tmp/inc.xml", p)
+		require.Equal(t, filepath.FromSlash("/tmp/inc.xml"), p)
 	})
 
 	t.Run("localhost host", func(t *testing.T) {
 		t.Parallel()
 		p, err := iofs.FileURIToPath("file://localhost/tmp/inc.xml")
 		require.NoError(t, err)
-		require.Equal(t, "/tmp/inc.xml", p)
+		require.Equal(t, filepath.FromSlash("/tmp/inc.xml"), p)
 	})
 
 	t.Run("percent-decoded path", func(t *testing.T) {
 		t.Parallel()
 		p, err := iofs.FileURIToPath("file:///tmp/a%20b.xml")
 		require.NoError(t, err)
-		require.Equal(t, "/tmp/a b.xml", p)
+		require.Equal(t, filepath.FromSlash("/tmp/a b.xml"), p)
 	})
 
 	t.Run("non-local host rejected", func(t *testing.T) {

--- a/internal/unparsedtext/unparsedtext.go
+++ b/internal/unparsedtext/unparsedtext.go
@@ -32,6 +32,7 @@ import (
 
 	iencoding "github.com/lestrrat-go/helium/internal/encoding"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/uripath"
 	"github.com/lestrrat-go/helium/internal/xmlchar"
 )
 
@@ -534,11 +535,16 @@ func (r *FileURIResolver) ResolveURI(uri string) (io.ReadCloser, error) {
 	}
 
 	var target string
-	switch parsed.Scheme {
-	case lexicon.SchemeFile:
+	switch {
+	case parsed.Scheme == lexicon.SchemeFile:
 		target = parsed.Path
-	case "":
-		if filepath.IsAbs(uri) {
+	// A bare Windows absolute path ("C:\\dir\\data.txt") is mis-parsed by
+	// url.Parse as scheme "c"; treat it as a local absolute path, not a URI.
+	case parsed.Scheme == "" || isWindowsDriveScheme(parsed):
+		// uripath.IsAbsolutePath recognizes both POSIX- and Windows-absolute
+		// shapes regardless of GOOS, so a "/abs" or "C:\\abs" reference is kept
+		// absolute rather than joined against BaseDir.
+		if filepath.IsAbs(uri) || uripath.IsAbsolutePath(uri) {
 			target = uri
 		} else {
 			target = filepath.Join(r.BaseDir, uri)

--- a/internal/unparsedtext/unparsedtext.go
+++ b/internal/unparsedtext/unparsedtext.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/text/transform"
 
 	iencoding "github.com/lestrrat-go/helium/internal/encoding"
+	"github.com/lestrrat-go/helium/internal/iofs"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/uripath"
 	"github.com/lestrrat-go/helium/internal/xmlchar"
@@ -537,7 +538,19 @@ func (r *FileURIResolver) ResolveURI(uri string) (io.ReadCloser, error) {
 	var target string
 	switch {
 	case parsed.Scheme == lexicon.SchemeFile:
-		target = parsed.Path
+		// Convert the "file:" URI to a native filesystem path. On Windows a
+		// drive-letter URI ("file:///C:/dir/x.txt") yields a native path
+		// ("C:\\dir\\x.txt") rather than the spurious leading-slash, forward-slash
+		// form ("/C:/dir/x.txt") that parsed.Path holds; otherwise the
+		// containedRel check below compares it against a native BaseDir and
+		// wrongly reports the target as outside the base. iofs.FileURIToPath is
+		// GOOS-parameterized, so POSIX behavior ("file:///a/b" -> "/a/b") is
+		// unchanged.
+		p, ferr := iofs.FileURIToPath(uri)
+		if ferr != nil {
+			return nil, ferr
+		}
+		target = p
 	// A bare Windows absolute path ("C:\\dir\\data.txt") is mis-parsed by
 	// url.Parse as scheme "c"; treat it as a local absolute path, not a URI.
 	case parsed.Scheme == "" || isWindowsDriveScheme(parsed):

--- a/internal/unparsedtext/unparsedtext_test.go
+++ b/internal/unparsedtext/unparsedtext_test.go
@@ -18,6 +18,20 @@ import (
 
 const encUTF8 = "utf-8"
 
+// fileURI builds a proper "file:///" URI from a native absolute path on any OS.
+// Naively concatenating fileURI(path) is correct on POSIX (the path begins
+// with "/", giving "file:///tmp/x"), but on Windows the path is "C:\\..." so
+// the result is "file://C:\\..." where "C:" is mis-parsed as the URI host.
+// Normalizing backslashes to slashes and ensuring a single leading slash before
+// the path yields "file:///C:/..." (and keeps "file:///tmp/x" on POSIX).
+func fileURI(path string) string {
+	p := filepath.ToSlash(path)
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return "file://" + p
+}
+
 func TestSplitLines(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -289,7 +303,7 @@ func TestReadURI(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte("file-uri"), 0644))
 
 		cfg := &unparsedtext.Config{URIResolver: &unparsedtext.FileURIResolver{BaseDir: dir}}
-		data, err := unparsedtext.ReadURI(t.Context(), cfg, "file://"+path)
+		data, err := unparsedtext.ReadURI(t.Context(), cfg, fileURI(path))
 		require.NoError(t, err)
 		require.Equal(t, "file-uri", string(data))
 	})
@@ -344,7 +358,7 @@ func TestMaxBytes(t *testing.T) {
 			URIResolver: &unparsedtext.FileURIResolver{BaseDir: dir},
 			MaxBytes:    10,
 		}
-		_, err := unparsedtext.LoadText(t.Context(), cfg, "file://"+path, "")
+		_, err := unparsedtext.LoadText(t.Context(), cfg, fileURI(path), "")
 		require.Error(t, err)
 		var ue *unparsedtext.Error
 		require.ErrorAs(t, err, &ue)
@@ -360,7 +374,7 @@ func TestMaxBytes(t *testing.T) {
 			URIResolver: &unparsedtext.FileURIResolver{BaseDir: dir},
 			MaxBytes:    10,
 		}
-		text, err := unparsedtext.LoadText(t.Context(), cfg, "file://"+path, "")
+		text, err := unparsedtext.LoadText(t.Context(), cfg, fileURI(path), "")
 		require.NoError(t, err)
 		require.Equal(t, strings.Repeat("a", 10), text)
 	})
@@ -374,7 +388,7 @@ func TestMaxBytes(t *testing.T) {
 			URIResolver: &unparsedtext.FileURIResolver{BaseDir: dir},
 			MaxBytes:    10,
 		}
-		_, err := unparsedtext.ReadURI(t.Context(), cfg, "file://"+path)
+		_, err := unparsedtext.ReadURI(t.Context(), cfg, fileURI(path))
 		require.Error(t, err)
 		var ue *unparsedtext.Error
 		require.ErrorAs(t, err, &ue)
@@ -401,7 +415,7 @@ func TestMaxBytes(t *testing.T) {
 			URIResolver: &unparsedtext.FileURIResolver{BaseDir: dir},
 			MaxBytes:    -1,
 		}
-		text, err := unparsedtext.LoadText(t.Context(), cfg, "file://"+path, "")
+		text, err := unparsedtext.LoadText(t.Context(), cfg, fileURI(path), "")
 		require.NoError(t, err)
 		require.Len(t, text, 100)
 	})
@@ -413,7 +427,7 @@ func TestLoadText(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "test.txt"), []byte("hello world"), 0644))
 
 		cfg := &unparsedtext.Config{
-			BaseURI:     "file://" + dir + "/",
+			BaseURI:     fileURI(dir) + "/",
 			URIResolver: &unparsedtext.FileURIResolver{BaseDir: dir},
 		}
 		text, err := unparsedtext.LoadText(t.Context(), cfg, "test.txt", "")
@@ -427,7 +441,7 @@ func TestLoadText(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte("hello\x00world"), 0644))
 
 		cfg := &unparsedtext.Config{URIResolver: &unparsedtext.FileURIResolver{BaseDir: dir}}
-		text, err := unparsedtext.LoadText(t.Context(), cfg, "file://"+path, "")
+		text, err := unparsedtext.LoadText(t.Context(), cfg, fileURI(path), "")
 		require.Error(t, err)
 		require.Empty(t, text)
 		var ue *unparsedtext.Error
@@ -452,7 +466,7 @@ func TestLoadTextLines(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte("line1\r\nline2\nline3"), 0644))
 
 	cfg := &unparsedtext.Config{URIResolver: &unparsedtext.FileURIResolver{BaseDir: dir}}
-	lines, err := unparsedtext.LoadTextLines(t.Context(), cfg, "file://"+path, "")
+	lines, err := unparsedtext.LoadTextLines(t.Context(), cfg, fileURI(path), "")
 	require.NoError(t, err)
 	require.Equal(t, []string{"line1", "line2", "line3"}, lines)
 }
@@ -463,8 +477,8 @@ func TestIsAvailable(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte("ok"), 0644))
 
 	cfg := &unparsedtext.Config{URIResolver: &unparsedtext.FileURIResolver{BaseDir: dir}}
-	require.True(t, unparsedtext.IsAvailable(t.Context(), cfg, "file://"+path, ""))
-	require.False(t, unparsedtext.IsAvailable(t.Context(), cfg, "file://"+filepath.Join(dir, "nope.txt"), ""))
+	require.True(t, unparsedtext.IsAvailable(t.Context(), cfg, fileURI(path), ""))
+	require.False(t, unparsedtext.IsAvailable(t.Context(), cfg, fileURI(filepath.Join(dir, "nope.txt")), ""))
 }
 
 func TestFileURIResolver(t *testing.T) {
@@ -541,7 +555,7 @@ func TestReadURINoFileReadByDefault(t *testing.T) {
 	require.Equal(t, unparsedtext.ErrCodeRetrieval, ue.Code)
 
 	// nil config — file:// URI
-	_, err = unparsedtext.ReadURI(t.Context(), nil, "file://"+path)
+	_, err = unparsedtext.ReadURI(t.Context(), nil, fileURI(path))
 	require.Error(t, err)
 	require.ErrorAs(t, err, &ue)
 	require.Equal(t, unparsedtext.ErrCodeRetrieval, ue.Code)
@@ -568,7 +582,7 @@ func TestLoadTextNoFileReadByDefault(t *testing.T) {
 	path := filepath.Join(dir, "secret.txt")
 	require.NoError(t, os.WriteFile(path, []byte("secret"), 0644))
 
-	_, err := unparsedtext.LoadText(t.Context(), nil, "file://"+path, "")
+	_, err := unparsedtext.LoadText(t.Context(), nil, fileURI(path), "")
 	require.Error(t, err)
 	var ue *unparsedtext.Error
 	require.ErrorAs(t, err, &ue)
@@ -594,7 +608,7 @@ func TestFileURIResolverRejectsTraversal(t *testing.T) {
 	})
 
 	t.Run("file URI with absolute path refused", func(t *testing.T) {
-		_, err := r.ResolveURI("file://" + outside)
+		_, err := r.ResolveURI(fileURI(outside))
 		require.Error(t, err)
 	})
 }

--- a/internal/unparsedtext/unparsedtext_test.go
+++ b/internal/unparsedtext/unparsedtext_test.go
@@ -496,6 +496,18 @@ func TestFileURIResolver(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unsupported URI scheme")
 	})
+
+	// A bare Windows absolute path is mis-parsed by url.Parse as scheme "c",
+	// but must NOT be rejected as an unsupported URI scheme: the resolver has
+	// to treat it as a local path. This string is exercised on every OS, so the
+	// classification fix is covered on Linux CI. On Linux the path is not a real
+	// file, so the resolver fails later at the filesystem layer — the assertion
+	// is only that it does NOT fail with "unsupported URI scheme: c".
+	t.Run("bare windows path not treated as scheme c", func(t *testing.T) {
+		_, err := r.ResolveURI(`C:\does\not\exist.txt`)
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "unsupported URI scheme")
+	})
 }
 
 func TestReadURINoNetworkByDefault(t *testing.T) {

--- a/internal/uripath/uripath.go
+++ b/internal/uripath/uripath.go
@@ -10,6 +10,8 @@
 // that the Windows-specific behavior is exercised by the Linux test suite.
 package uripath
 
+import "path"
+
 // IsWindowsDriveLetter reports whether b is an ASCII letter usable as a Windows
 // drive letter ([A-Za-z]).
 func IsWindowsDriveLetter(b byte) bool {
@@ -85,4 +87,60 @@ func ToSlash(s string) string {
 		}
 	}
 	return string(b)
+}
+
+// JoinLocalBaseDir resolves a relative local-filesystem ref against the
+// directory of a local-filesystem base path, returning a FORWARD-SLASH result
+// on every OS. Both inputs are normalized with [ToSlash] first, then joined
+// with path.Join (slash semantics), so the resolution never depends on
+// runtime.GOOS or filepath.Separator. This keeps the documented forward-slash
+// contract of helium's URI-style resolvers on Windows, where filepath.Join
+// would otherwise emit backslashes and corrupt a POSIX-shaped base.
+//
+// The base may be a full file path ("/a/b/style.xsl") or a directory-like path
+// ("/a/b"); the caller is responsible for choosing baseDir accordingly (see the
+// resolvers that pass a directory derived from the base). ref must already be
+// known not to be absolute under either OS convention; an absolute ref should
+// be returned verbatim by the caller before reaching here.
+func JoinLocalBaseDir(baseDir, ref string) string {
+	return path.Join(ToSlash(baseDir), ToSlash(ref))
+}
+
+// LocalBaseDir derives the containing directory of a local-filesystem base
+// path, in FORWARD-SLASH form. If the base already names a directory (it ends
+// in a separator) the trailing separator is trimmed; if the base's last segment
+// carries no '.', the whole base is treated as a directory; otherwise the last
+// segment is dropped (path.Dir). The result is always slash-separated so it is
+// stable across OSes.
+func LocalBaseDir(base string) string {
+	slashed := ToSlash(base)
+	if len(slashed) > 0 && slashed[len(slashed)-1] == '/' {
+		trimmed := slashed
+		for len(trimmed) > 1 && trimmed[len(trimmed)-1] == '/' {
+			trimmed = trimmed[:len(trimmed)-1]
+		}
+		return trimmed
+	}
+	last := path.Base(slashed)
+	if !containsDot(last) {
+		return slashed
+	}
+	return path.Dir(slashed)
+}
+
+// SlashDir returns the directory portion of a forward-slash path, equivalent to
+// path.Dir but provided here so callers that already work in slash space (e.g.
+// keys into an fs.FS) can derive a parent directory without reaching for the
+// OS-dependent filepath.Dir, which would reintroduce backslashes on Windows.
+func SlashDir(p string) string {
+	return path.Dir(ToSlash(p))
+}
+
+func containsDot(s string) bool {
+	for i := range len(s) {
+		if s[i] == '.' {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/uripath/uripath.go
+++ b/internal/uripath/uripath.go
@@ -64,7 +64,7 @@ func IsAbsolutePath(s string) bool {
 // path ("\\\\server\\share" -> "file://server/share"). s MUST be a Windows
 // absolute path (see IsWindowsAbsolute); callers gate on that first.
 func WindowsToFileURI(s string) string {
-	slashed := toSlash(s)
+	slashed := ToSlash(s)
 	if HasWindowsDrivePrefix(s) {
 		return "file:///" + slashed
 	}
@@ -73,10 +73,11 @@ func WindowsToFileURI(s string) string {
 	return "file:" + slashed
 }
 
-// toSlash replaces every backslash with a forward slash. It is the
-// OS-independent equivalent of filepath.ToSlash on Windows, applied
-// unconditionally so the conversion is testable on POSIX.
-func toSlash(s string) string {
+// ToSlash replaces every backslash with a forward slash. Unlike
+// filepath.ToSlash, the replacement is unconditional (not gated on
+// runtime.GOOS), so a Windows path is normalized — and the normalization is
+// testable — on POSIX as well.
+func ToSlash(s string) string {
 	b := []byte(s)
 	for i := range b {
 		if b[i] == '\\' {

--- a/internal/uripath/uripath.go
+++ b/internal/uripath/uripath.go
@@ -1,0 +1,87 @@
+// Package uripath provides small, OS-independent helpers for distinguishing
+// native filesystem paths from URI references, and for converting native
+// Windows/POSIX absolute paths into "file:" URIs.
+//
+// Every helper here decides purely from the STRING shape of its input — it
+// never consults runtime.GOOS or filepath separators. This is deliberate: the
+// helium URI/path resolution code must behave the same way on every platform
+// (so that, e.g., a Windows drive-letter path embedded in a catalog or a
+// stylesheet base URI is recognized even when helium runs on POSIX), and so
+// that the Windows-specific behavior is exercised by the Linux test suite.
+package uripath
+
+// IsWindowsDriveLetter reports whether b is an ASCII letter usable as a Windows
+// drive letter ([A-Za-z]).
+func IsWindowsDriveLetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+// HasWindowsDrivePrefix reports whether s begins with a Windows drive-letter
+// specifier: an ASCII letter, a colon, and then either a path separator
+// ('/' or '\\') or the end of the string. Examples that match: "C:\\x",
+// "c:/x", "D:". A lone "C:foo" (drive-relative, no separator) does NOT match,
+// matching the conservative shape used elsewhere in the tree.
+func HasWindowsDrivePrefix(s string) bool {
+	if len(s) < 2 {
+		return false
+	}
+	if !IsWindowsDriveLetter(s[0]) || s[1] != ':' {
+		return false
+	}
+	if len(s) == 2 {
+		return true
+	}
+	return s[2] == '/' || s[2] == '\\'
+}
+
+// IsWindowsAbsolute reports whether s is a Windows-style absolute path: a
+// drive-letter path ("C:\\x", "C:/x", "C:") or a UNC / rooted path beginning
+// with a backslash ("\\\\server\\share", "\\x").
+func IsWindowsAbsolute(s string) bool {
+	if HasWindowsDrivePrefix(s) {
+		return true
+	}
+	return len(s) > 0 && s[0] == '\\'
+}
+
+// IsPOSIXAbsolute reports whether s is a POSIX-style absolute path: it begins
+// with a single forward slash. This is GOOS-independent on purpose so a
+// "/etc/passwd"-shaped reference is recognized as absolute even on Windows.
+func IsPOSIXAbsolute(s string) bool {
+	return len(s) > 0 && s[0] == '/'
+}
+
+// IsAbsolutePath reports whether s is absolute under EITHER POSIX or Windows
+// conventions, independent of the host OS. Use this in security/containment
+// guards so a path that is absolute on the "other" OS is still rejected.
+func IsAbsolutePath(s string) bool {
+	return IsPOSIXAbsolute(s) || IsWindowsAbsolute(s)
+}
+
+// WindowsToFileURI converts a Windows absolute path into a "file:" URI. It
+// normalizes backslashes to forward slashes and prefixes "file:///" for a
+// drive-letter path ("C:\\a\\b" -> "file:///C:/a/b") or "file://" for a UNC
+// path ("\\\\server\\share" -> "file://server/share"). s MUST be a Windows
+// absolute path (see IsWindowsAbsolute); callers gate on that first.
+func WindowsToFileURI(s string) string {
+	slashed := toSlash(s)
+	if HasWindowsDrivePrefix(s) {
+		return "file:///" + slashed
+	}
+	// UNC: "//server/share" already begins with the two slashes after
+	// normalization, so "file:" + slashed yields "file://server/share".
+	return "file:" + slashed
+}
+
+// toSlash replaces every backslash with a forward slash. It is the
+// OS-independent equivalent of filepath.ToSlash on Windows, applied
+// unconditionally so the conversion is testable on POSIX.
+func toSlash(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] == '\\' {
+			b[i] = '/'
+		}
+	}
+	return string(b)
+}

--- a/internal/uripath/uripath.go
+++ b/internal/uripath/uripath.go
@@ -10,7 +10,10 @@
 // that the Windows-specific behavior is exercised by the Linux test suite.
 package uripath
 
-import "path"
+import (
+	"path"
+	"strings"
+)
 
 // IsWindowsDriveLetter reports whether b is an ASCII letter usable as a Windows
 // drive letter ([A-Za-z]).
@@ -164,6 +167,137 @@ func LocalBaseDir(base string) string {
 // OS-dependent filepath.Dir, which would reintroduce backslashes on Windows.
 func SlashDir(p string) string {
 	return path.Dir(ToSlash(p))
+}
+
+// SlashClean is path.Clean over a backslash-normalized input, so a Windows path
+// (or a path with mixed separators, as produced when a forward-slash URI ref is
+// joined with a backslash OS base) is collapsed using forward-slash dot-segment
+// semantics on every OS. Unlike filepath.Clean it never emits '\' and never
+// applies Windows volume/UNC handling, so the result is byte-identical across
+// platforms.
+func SlashClean(p string) string {
+	return path.Clean(ToSlash(p))
+}
+
+// SlashRel computes the relative reference from the directory tree rooted at
+// baseDir to target, using pure forward-slash (RFC 3986 dot-segment) semantics
+// — the slash-space analogue of filepath.Rel. Both inputs are normalized with
+// [ToSlash] and [path.Clean] first, so the computation never depends on
+// runtime.GOOS or filepath.Separator (filepath.Rel diverges on Windows: it
+// splits on '\', mishandles a path that already uses '/', and applies
+// drive-letter rules). baseDir and target must agree on rootedness (both
+// absolute or both relative); when they don't, target is returned cleaned and
+// unchanged, mirroring filepath.Rel's error path where the caller falls back to
+// the absolute target.
+//
+// The result is the minimal sequence of ".." and forward path segments that,
+// resolved against baseDir, yields target. It is the value used verbatim as an
+// xml:base relative reference, so it MUST be byte-identical on POSIX and
+// Windows.
+func SlashRel(baseDir, target string) string {
+	base := SlashClean(baseDir)
+	targ := SlashClean(target)
+	if base == targ {
+		return "."
+	}
+
+	baseAbs := IsPOSIXAbsolute(base)
+	targAbs := IsPOSIXAbsolute(targ)
+	if baseAbs != targAbs {
+		// Cannot relativize across rootedness; caller treats this like
+		// filepath.Rel's error and keeps the (cleaned) target.
+		return targ
+	}
+
+	baseSeg := splitSlash(base)
+	targSeg := splitSlash(targ)
+
+	// Drop the longest common prefix of segments.
+	i := 0
+	for i < len(baseSeg) && i < len(targSeg) && baseSeg[i] == targSeg[i] {
+		i++
+	}
+
+	var out []string
+	for j := i; j < len(baseSeg); j++ {
+		// A ".." in the remaining base means base escaped above a point that
+		// target shares, which filepath.Rel reports as impossible; fall back.
+		if baseSeg[j] == ".." {
+			return targ
+		}
+		out = append(out, "..")
+	}
+	out = append(out, targSeg[i:]...)
+	if len(out) == 0 {
+		return "."
+	}
+	return path.Join(out...)
+}
+
+// SlashCommonDir returns the longest common directory prefix of the directories
+// of a and b, in forward-slash form — the slash-space analogue of the previous
+// filepath-based commonAncestorDir. Inputs are normalized with [ToSlash] and
+// [path.Clean]; the directory of each (its last segment dropped) is compared
+// segment by segment. Returns "." when there is no shared directory prefix.
+func SlashCommonDir(a, b string) string {
+	aDir := SlashDir(SlashClean(a))
+	bDir := SlashDir(SlashClean(b))
+	aParts := splitSlash(aDir)
+	bParts := splitSlash(bDir)
+
+	n := min(len(aParts), len(bParts))
+	common := 0
+	for i := range n {
+		if aParts[i] != bParts[i] {
+			break
+		}
+		common = i + 1
+	}
+	if common == 0 {
+		return "."
+	}
+	return joinSlashSegments(aParts[:common])
+}
+
+// joinSlashSegments rejoins segments produced by splitSlash, preserving the
+// leading-slash root marker. path.Join would silently drop a leading "" segment
+// (and with it the absolute-path root), so reconstruct it explicitly: an empty
+// first segment means the path was rooted ("/"+rest), otherwise it is relative.
+func joinSlashSegments(segs []string) string {
+	if len(segs) == 0 {
+		return "."
+	}
+	if segs[0] == "" {
+		if len(segs) == 1 {
+			return "/"
+		}
+		return "/" + path.Join(segs[1:]...)
+	}
+	return path.Join(segs...)
+}
+
+// splitSlash splits a cleaned forward-slash path into its non-empty segments,
+// preserving a leading-slash marker as an empty first segment so an absolute
+// path keeps its root during segment comparison.
+func splitSlash(p string) []string {
+	if p == "" || p == "." {
+		return nil
+	}
+	rooted := p[0] == '/'
+	trimmed := p
+	for len(trimmed) > 0 && trimmed[0] == '/' {
+		trimmed = trimmed[1:]
+	}
+	var segs []string
+	for s := range strings.SplitSeq(trimmed, "/") {
+		if s != "" {
+			segs = append(segs, s)
+		}
+	}
+	if rooted {
+		return append([]string{""}, segs...)
+	}
+	return segs
 }
 
 func containsDot(s string) bool {

--- a/internal/uripath/uripath.go
+++ b/internal/uripath/uripath.go
@@ -36,6 +36,36 @@ func HasWindowsDrivePrefix(s string) bool {
 	return s[2] == '/' || s[2] == '\\'
 }
 
+// HasURIScheme reports whether s begins with an absolute-URI scheme followed by
+// a colon, e.g. "http://host/p", "file:///x", "urn:isbn:0". The scheme syntax
+// is RFC 3986's ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ), but a SINGLE-letter
+// scheme is deliberately NOT recognized so that a Windows drive-letter prefix
+// ("C:\\x", "D:/x") is never mistaken for a URI scheme. Callers that need to
+// treat a drive letter as a path must gate on HasWindowsDrivePrefix first; this
+// helper exists so an absolute URI can be distinguished from a relative
+// reference independent of runtime.GOOS.
+func HasURIScheme(s string) bool {
+	if len(s) < 2 || !IsWindowsDriveLetter(s[0]) {
+		return false
+	}
+	i := 1
+	for i < len(s) {
+		c := s[i]
+		switch {
+		case (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') || c == '+' || c == '-' || c == '.':
+			i++
+		case c == ':':
+			// A single-character scheme ("C:") is a Windows drive letter, not a
+			// URI scheme. Require at least two scheme characters.
+			return i >= 2
+		default:
+			return false
+		}
+	}
+	return false
+}
+
 // IsWindowsAbsolute reports whether s is a Windows-style absolute path: a
 // drive-letter path ("C:\\x", "C:/x", "C:") or a UNC / rooted path beginning
 // with a backslash ("\\\\server\\share", "\\x").

--- a/internal/uripath/uripath_test.go
+++ b/internal/uripath/uripath_test.go
@@ -85,6 +85,58 @@ func TestIsAbsolutePath(t *testing.T) {
 	}
 }
 
+// JoinLocalBaseDir must always emit forward slashes, normalizing a Windows
+// (backslash) base or ref so the result is identical on every OS. This is what
+// keeps helium's URI-style resolvers from leaking '\' into their documented
+// forward-slash output on Windows.
+func TestJoinLocalBaseDir(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		baseDir string
+		ref     string
+		want    string
+	}{
+		{"/dir", "a.dtd", "/dir/a.dtd"},
+		{"/dir/", "a.dtd", "/dir/a.dtd"},
+		{`C:\dir`, "child.xml", "C:/dir/child.xml"},
+		{`C:/dir`, `sub\child.xml`, "C:/dir/sub/child.xml"},
+		{"/a/b", "../c/x", "/a/c/x"},
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, uripath.JoinLocalBaseDir(tc.baseDir, tc.ref),
+			"baseDir=%q ref=%q", tc.baseDir, tc.ref)
+	}
+}
+
+// LocalBaseDir distinguishes a file base (drop the last segment) from a
+// directory base (keep it), always in forward-slash form.
+func TestLocalBaseDir(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"/work/main.xsl", "/work"},
+		{"/work/schemas", "/work/schemas"}, // extensionless last segment = directory
+		{"/work/schemas/", "/work/schemas"},
+		{`C:\work\main.xsl`, "C:/work"},
+		{`C:\work\schemas`, "C:/work/schemas"},
+		{`C:\work\schemas\`, "C:/work/schemas"},
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, uripath.LocalBaseDir(tc.in), "in=%q", tc.in)
+	}
+}
+
+// SlashDir is path.Dir over a backslash-normalized input, so a Windows path
+// yields a forward-slash parent on any OS.
+func TestSlashDir(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "/a/b", uripath.SlashDir("/a/b/c.xml"))
+	require.Equal(t, "schemas", uripath.SlashDir(`schemas\x.rng`))
+	require.Equal(t, "C:/a", uripath.SlashDir(`C:\a\b.xsl`))
+}
+
 func TestWindowsToFileURI(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/internal/uripath/uripath_test.go
+++ b/internal/uripath/uripath_test.go
@@ -1,0 +1,102 @@
+package uripath_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/internal/uripath"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasWindowsDrivePrefix(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{`C:\x`, true},
+		{`c:/x`, true},
+		{`D:`, true},
+		{`Z:\a\b\c`, true},
+		{`C:foo`, false}, // drive-relative, no separator
+		{`/usr/x`, false},
+		{`\\server\share`, false},
+		{`http://x`, false}, // multi-letter scheme
+		{`1:\x`, false},     // non-alpha drive
+		{``, false},
+		{`C`, false},
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, uripath.HasWindowsDrivePrefix(tc.in), "in=%q", tc.in)
+	}
+}
+
+func TestIsWindowsAbsolute(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{`C:\x`, true},
+		{`C:/x`, true},
+		{`D:`, true},
+		{`\\server\share`, true},
+		{`\rooted`, true},
+		{`/usr/x`, false},
+		{`relative\path`, false},
+		{`C:foo`, false},
+		{``, false},
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, uripath.IsWindowsAbsolute(tc.in), "in=%q", tc.in)
+	}
+}
+
+func TestIsPOSIXAbsolute(t *testing.T) {
+	t.Parallel()
+	require.True(t, uripath.IsPOSIXAbsolute("/usr/x"))
+	require.True(t, uripath.IsPOSIXAbsolute("/"))
+	require.False(t, uripath.IsPOSIXAbsolute("usr/x"))
+	require.False(t, uripath.IsPOSIXAbsolute(`C:\x`))
+	require.False(t, uripath.IsPOSIXAbsolute(""))
+}
+
+// IsAbsolutePath must be true for an absolute path under EITHER convention,
+// regardless of the host OS. This is what makes a containment guard reject a
+// POSIX "/etc/passwd" on Windows and a Windows "C:\..." on POSIX.
+func TestIsAbsolutePath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{`/etc/passwd`, true},  // POSIX-absolute
+		{`C:\windows`, true},   // Windows drive-absolute
+		{`D:/data`, true},      // Windows drive-absolute, forward slash
+		{`E:`, true},           // bare drive
+		{`\\host\share`, true}, // UNC
+		{`\abs`, true},         // backslash-rooted
+		{`relative/x`, false},
+		{`a.dtd`, false},
+		{`C:foo`, false},
+		{``, false},
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, uripath.IsAbsolutePath(tc.in), "in=%q", tc.in)
+	}
+}
+
+func TestWindowsToFileURI(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{`C:\a\b`, "file:///C:/a/b"},
+		{`D:/ents/x.xml`, "file:///D:/ents/x.xml"},
+		{`c:\x`, "file:///c:/x"},
+		{`\\server\share\f.xml`, "file://server/share/f.xml"},
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, uripath.WindowsToFileURI(tc.in), "in=%q", tc.in)
+	}
+}

--- a/internal/uripath/uripath_test.go
+++ b/internal/uripath/uripath_test.go
@@ -163,6 +163,67 @@ func TestSlashDir(t *testing.T) {
 	require.Equal(t, "C:/a", uripath.SlashDir(`C:\a\b.xsl`))
 }
 
+// SlashRel must compute a forward-slash relative reference (RFC 3986
+// dot-segment semantics) identically on POSIX and Windows, NEVER using
+// filepath.Rel. Windows drive-rooted and mixed-separator inputs are plain
+// strings, so the Windows behavior is exercised on any GOOS.
+func TestSlashRel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		baseDir string
+		target  string
+		want    string
+	}{
+		// xml:base relativization cases mirrored from the XInclude base.xml golden.
+		{"docs/one", "docs/one/two/three/four", "two/three/four"},
+		{"docs/one", "ents/one/two2", "../../ents/one/two2"},
+		{"docs/one", "ents/one2/two", "../../ents/one2/two"},
+		// Absolute POSIX inputs keep their root through segment comparison.
+		{"/a/b/docs/one", "/a/b/ents/one/two2", "../../ents/one/two2"},
+		// Mixed separators (forward-slash URI ref joined against a backslash OS
+		// base, as happens on Windows) must still relativize correctly.
+		{`docs\one`, "docs/one/two/three/four", "two/three/four"},
+		{`D:/a/b/docs/one`, `D:\a\b\ents\one\two2`, "../../ents/one/two2"},
+		// Identical paths collapse to ".".
+		{"a/b", "a/b", "."},
+		// Rootedness mismatch falls back to the cleaned target (filepath.Rel error path).
+		{"/a/b", "c/d", "c/d"},
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, uripath.SlashRel(tc.baseDir, tc.target),
+			"baseDir=%q target=%q", tc.baseDir, tc.target)
+	}
+}
+
+// SlashCommonDir must find the longest common directory prefix in forward-slash
+// form, preserving the leading-slash root (path.Join would otherwise drop it).
+func TestSlashCommonDir(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		a    string
+		b    string
+		want string
+	}{
+		{"/x/y/ents/inc.xml", "/x/y/docs/doc.xml", "/x/y"},
+		{"x/y/ents/inc.xml", "x/y/docs/doc.xml", "x/y"},
+		// Windows drive paths share the drive segment; backslashes are normalized.
+		{`D:\x\y\ents\inc.xml`, "D:/x/y/docs/doc.xml", "D:/x/y"},
+		// No shared directory prefix.
+		{"/a/x.xml", "/b/y.xml", "/"},
+		{"a/x.xml", "b/y.xml", "."},
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, uripath.SlashCommonDir(tc.a, tc.b), "a=%q b=%q", tc.a, tc.b)
+	}
+}
+
+func TestSlashClean(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "/a/c", uripath.SlashClean("/a/b/../c"))
+	require.Equal(t, "a/b", uripath.SlashClean(`a\b`))
+	require.Equal(t, "C:/a/b", uripath.SlashClean(`C:\a\.\b`))
+}
+
 func TestWindowsToFileURI(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/internal/uripath/uripath_test.go
+++ b/internal/uripath/uripath_test.go
@@ -30,6 +30,32 @@ func TestHasWindowsDrivePrefix(t *testing.T) {
 	}
 }
 
+func TestHasURIScheme(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"http://host/p", true},
+		{"https://host/p", true},
+		{"file:///x", true},
+		{"urn:isbn:0", true},
+		{"a+b-c.d:rest", true},
+		{`C:\x`, false},   // single-letter scheme is a Windows drive letter
+		{`C:/x`, false},   // same, with forward slash
+		{`D:`, false},     // bare drive
+		{"a.dtd", false},  // relative reference
+		{"/abs/x", false}, // POSIX absolute path, no scheme
+		{`\\srv\s`, false},
+		{"", false},
+		{"http", false}, // no colon
+		{":nohead", false},
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, uripath.HasURIScheme(tc.in), "in=%q", tc.in)
+	}
+}
+
 func TestIsWindowsAbsolute(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/node_base.go
+++ b/node_base.go
@@ -79,6 +79,17 @@ func BuildURI(systemID, base string) string {
 		return systemID
 	}
 
+	// An absolute-URI systemID (one carrying a scheme, e.g. "http://host/p" or
+	// "file:///x") stands on its own too, REGARDLESS of the base's shape. This
+	// must be checked before the Windows-base branch below: when the base is a
+	// native Windows path, that branch would otherwise treat the absolute URI as
+	// a relative path segment and join it onto the base — collapsing "http://"
+	// to "http:/" via path.Join. POSIX behavior is unchanged because the same
+	// absoluteness is detected by url.Parse/IsAbs further down.
+	if uripath.HasURIScheme(systemID) {
+		return systemID
+	}
+
 	// When the base is a native Windows path, resolve the (relative) systemID
 	// against it with local-path semantics, bypassing the URI machinery so the
 	// drive letter is never mistaken for a scheme.

--- a/node_base.go
+++ b/node_base.go
@@ -3,7 +3,6 @@ package helium
 import (
 	"net/url"
 	"path"
-	"path/filepath"
 	"slices"
 	"strings"
 
@@ -64,8 +63,9 @@ func SetNodeBaseURI(n Node, uri string) {
 }
 
 // BuildURI resolves a relative system ID against a base URI.
-// For local file paths (no scheme or file: scheme), it uses filepath.Join.
-// For other schemes, it uses url.ResolveReference.
+// For local file paths (no scheme or file: scheme), it joins with
+// forward-slash (path) semantics. For other schemes, it uses
+// url.ResolveReference.
 //
 // Native Windows paths (a drive-letter prefix such as "C:\\dir\\doc.xml" or a
 // backslash/UNC path) are recognized and resolved with local-path semantics
@@ -103,18 +103,22 @@ func BuildURI(systemID, base string) string {
 		return baseURL.ResolveReference(u).String()
 	}
 
-	if filepath.IsAbs(systemID) || uripath.IsPOSIXAbsolute(systemID) {
+	if uripath.IsPOSIXAbsolute(systemID) {
 		return systemID
 	}
 	basePath := baseURL.Path
 	if basePath == "" {
 		basePath = base
 	}
-	dir := filepath.Dir(basePath)
+	// Resolve with forward-slash (path) semantics, not filepath, so the
+	// returned URI/path uses '/' on every OS. On Windows filepath.Dir/Join
+	// would emit '\' here and corrupt a POSIX-shaped or file:-URI base (a
+	// sibling "a.dtd" against "/dir/doc.xml" would become "\\dir\\a.dtd").
+	dir := path.Dir(basePath)
 	if strings.HasSuffix(basePath, "/") {
 		dir = strings.TrimRight(basePath, "/")
 	}
-	result := filepath.Join(dir, systemID)
+	result := path.Join(dir, systemID)
 	if strings.HasSuffix(systemID, "/") && !strings.HasSuffix(result, "/") {
 		result += "/"
 	}

--- a/node_base.go
+++ b/node_base.go
@@ -92,8 +92,16 @@ func BuildURI(systemID, base string) string {
 
 	// When the base is a native Windows path, resolve the (relative) systemID
 	// against it with local-path semantics, bypassing the URI machinery so the
-	// drive letter is never mistaken for a scheme.
-	if uripath.IsWindowsAbsolute(base) {
+	// drive letter is never mistaken for a scheme. This also covers a RELATIVE
+	// Windows base (a backslash-bearing path with no URI scheme, e.g.
+	// "..\dir\doc.xml" as produced by filepath.Join on Windows): url.Parse would
+	// treat the backslashes as opaque, drop the directory via path.Dir, and
+	// resolve "world.txt" to a bare "world.txt" that no longer points inside the
+	// base directory. buildLocalPathURI normalizes with uripath.ToSlash first, so
+	// the directory is preserved on every OS. A backslash in a POSIX filename is
+	// pathological and not a real base shape, so gating on '\' is safe.
+	if uripath.IsWindowsAbsolute(base) ||
+		(!uripath.HasURIScheme(base) && strings.ContainsRune(base, '\\')) {
 		return buildLocalPathURI(systemID, base)
 	}
 
@@ -133,7 +141,26 @@ func BuildURI(systemID, base string) string {
 	if strings.HasSuffix(systemID, "/") && !strings.HasSuffix(result, "/") {
 		result += "/"
 	}
+	// A "file:" base with a Windows drive letter (url.Parse("file:///D:/x").Path
+	// == "/D:/x") yields a drive-rooted "/D:/..." result here, which is neither a
+	// usable native path nor a "file:" URI: an fs.FS keyed on native paths can't
+	// open "/D:/...". Re-attach the "file://" scheme so the value round-trips as
+	// a proper file: URI ("file:///D:/...") that downstream file-URI-aware
+	// loaders (normalizingFS, the entity resolver, catalogs) convert back to a
+	// native path. A POSIX file: base ("file:///tmp/x" -> "/tmp/...") is left
+	// untouched, so POSIX behavior is identical.
+	if baseURL.Scheme == "file" && isDriveRootedPath(result) {
+		return "file://" + result
+	}
 	return result
+}
+
+// isDriveRootedPath reports whether p has the shape "/X:/..." — a leading slash
+// followed by a Windows drive letter and colon. This is the malformed form that
+// url.Parse produces for the path component of a "file:///X:/..." URI. The check
+// is purely string-based, so it is GOOS-independent (and testable on POSIX).
+func isDriveRootedPath(p string) bool {
+	return len(p) >= 3 && p[0] == '/' && uripath.IsWindowsDriveLetter(p[1]) && p[2] == ':'
 }
 
 // buildLocalPathURI resolves a relative systemID against a native Windows base

--- a/node_base.go
+++ b/node_base.go
@@ -2,11 +2,13 @@ package helium
 
 import (
 	"net/url"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
 
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/uripath"
 )
 
 // NodeGetBase returns the effective base URI for a node by walking ancestors
@@ -64,7 +66,26 @@ func SetNodeBaseURI(n Node, uri string) {
 // BuildURI resolves a relative system ID against a base URI.
 // For local file paths (no scheme or file: scheme), it uses filepath.Join.
 // For other schemes, it uses url.ResolveReference.
+//
+// Native Windows paths (a drive-letter prefix such as "C:\\dir\\doc.xml" or a
+// backslash/UNC path) are recognized and resolved with local-path semantics
+// rather than being handed to url.Parse, which would otherwise read the drive
+// letter "C" as a URI scheme and emit garbage like "c:///child.xml". POSIX
+// behavior is unchanged: only inputs whose string shape is Windows-native take
+// the native branch, so the shape is recognized — and tested — on any GOOS.
 func BuildURI(systemID, base string) string {
+	// An absolute systemID under either OS convention stands on its own.
+	if uripath.IsWindowsAbsolute(systemID) {
+		return systemID
+	}
+
+	// When the base is a native Windows path, resolve the (relative) systemID
+	// against it with local-path semantics, bypassing the URI machinery so the
+	// drive letter is never mistaken for a scheme.
+	if uripath.IsWindowsAbsolute(base) {
+		return buildLocalPathURI(systemID, base)
+	}
+
 	u, err := url.Parse(systemID)
 	if err != nil {
 		return ""
@@ -82,7 +103,7 @@ func BuildURI(systemID, base string) string {
 		return baseURL.ResolveReference(u).String()
 	}
 
-	if filepath.IsAbs(systemID) {
+	if filepath.IsAbs(systemID) || uripath.IsPOSIXAbsolute(systemID) {
 		return systemID
 	}
 	basePath := baseURL.Path
@@ -95,6 +116,38 @@ func BuildURI(systemID, base string) string {
 	}
 	result := filepath.Join(dir, systemID)
 	if strings.HasSuffix(systemID, "/") && !strings.HasSuffix(result, "/") {
+		result += "/"
+	}
+	return result
+}
+
+// buildLocalPathURI resolves a relative systemID against a native Windows base
+// path. It works entirely in forward-slash space (so it is deterministic and
+// testable on any GOOS): it normalizes both inputs with uripath.ToSlash (an
+// unconditional backslash→slash conversion, unlike filepath.ToSlash which is a
+// no-op on POSIX), strips the base's last path segment, and joins with path.Join
+// (slash semantics). The forward-slash result is a valid path on Windows (the
+// Win32 file APIs accept "/") and avoids the drive-letter-as-scheme corruption
+// that url.Parse would produce. systemID is already known not to be
+// Windows-absolute.
+func buildLocalPathURI(systemID, base string) string {
+	slashBase := uripath.ToSlash(base)
+	slashRef := uripath.ToSlash(systemID)
+
+	dir := slashBase
+	if idx := strings.LastIndexByte(slashBase, '/'); idx >= 0 {
+		// Keep everything up to (not including) the last slash. For a
+		// drive-only base like "C:" with no slash, dir stays the whole base.
+		dir = slashBase[:idx]
+	}
+
+	result := path.Join(dir, slashRef)
+	// path.Join cleans the result, which collapses a leading "//" (UNC) to a
+	// single "/". Restore the UNC double-slash when the base was a UNC path.
+	if strings.HasPrefix(slashBase, "//") && !strings.HasPrefix(result, "//") {
+		result = "/" + result
+	}
+	if strings.HasSuffix(slashRef, "/") && !strings.HasSuffix(result, "/") {
 		result += "/"
 	}
 	return result

--- a/relaxng/parse.go
+++ b/relaxng/parse.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net/url"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/iofs"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/uripath"
 	"github.com/lestrrat-go/helium/internal/xmlchar"
 )
 
@@ -489,7 +491,12 @@ func (c *compiler) resolveHref(_ context.Context, elem *helium.Element, href str
 	// branches from bypassing the containment guard.
 	var resolved string
 	switch {
-	case filepath.IsAbs(href):
+	case uripath.IsAbsolutePath(href):
+		// uripath.IsAbsolutePath recognizes both POSIX- ("/etc/passwd") and
+		// Windows-absolute ("C:\\x", UNC) shapes regardless of GOOS, so an
+		// absolute href is kept verbatim — and the containment guard below sees
+		// it as absolute — on every OS. filepath.IsAbs alone would miss
+		// "/etc/passwd" on Windows and wrongly join it onto baseDir.
 		resolved = href
 	default:
 		if doc := elem.OwnerDocument(); doc != nil {
@@ -538,18 +545,35 @@ func (c *compiler) resolveHref(_ context.Context, elem *helium.Element, href str
 		return resolved, nil
 	}
 
-	// filepath.Rel fails when one path is absolute and the other relative
-	// (e.g. a relative baseDir against an absolute href). That mismatch is
-	// itself a containment failure: an absolute href can never be proven to
-	// live inside a relative baseDir, so reject rather than silently skip.
-	rel, err := filepath.Rel(c.baseDir, filepath.Clean(checkPath))
+	// Containment is computed in forward-slash space so it is GOOS-independent:
+	// on Windows filepath.Rel/Separator would key off '\' and mis-handle the
+	// POSIX-shaped paths that flow through here (e.g. a "/etc/passwd" href).
+	//
+	// An absolute checkPath (under either OS convention) can never be proven to
+	// live inside a relative baseDir, and filepath.Rel mixing absolute+relative
+	// is itself a containment failure — so reject up front when only one side is
+	// absolute.
+	slashBase := uripath.ToSlash(c.baseDir)
+	slashTarget := path.Clean(uripath.ToSlash(checkPath))
+	baseAbs := uripath.IsAbsolutePath(slashBase)
+	targetAbs := uripath.IsAbsolutePath(slashTarget)
+	if baseAbs != targetAbs {
+		return "", fmt.Errorf("href %q escapes base directory", href)
+	}
+	rel, err := filepath.Rel(slashBase, slashTarget)
 	if err != nil {
 		return "", fmt.Errorf("href %q escapes base directory", href)
 	}
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	rel = uripath.ToSlash(rel)
+	if rel == ".." || strings.HasPrefix(rel, "../") {
 		return "", fmt.Errorf("href %q escapes base directory", href)
 	}
-	return resolved, nil
+	// The returned path is used as a key into the configured fs.FS, whose
+	// contract mandates forward slashes (see io/fs.ValidPath). On Windows
+	// filepath.Join above would have produced backslashes, which never match a
+	// MapFS / os.DirFS key, so normalize to slashes here. POSIX paths already
+	// use '/', so this is a no-op there.
+	return uripath.ToSlash(resolved), nil
 }
 
 // uriScheme returns the URI scheme of s if s begins with a "<scheme>://"
@@ -654,7 +678,7 @@ func (c *compiler) parseInclude(ctx context.Context, elem *helium.Element) {
 
 	// Parse the included grammar content, skipping overridden components.
 	oldBaseDir := c.baseDir
-	c.baseDir = filepath.Dir(path)
+	c.baseDir = uripath.SlashDir(path)
 	c.parseGrammarContentSkipping(ctx, root, skip)
 	c.baseDir = oldBaseDir
 
@@ -1064,7 +1088,7 @@ func (c *compiler) parseExternalRef(ctx context.Context, node *helium.Element) *
 	}
 
 	oldBaseDir := c.baseDir
-	c.baseDir = filepath.Dir(path)
+	c.baseDir = uripath.SlashDir(path)
 
 	// An <externalRef> target is an INDEPENDENT schema (unlike <include>, which
 	// merges into the includer). It must NOT see the includer's grammar scope:

--- a/relaxng/resolve_href_internal_test.go
+++ b/relaxng/resolve_href_internal_test.go
@@ -1,0 +1,50 @@
+package relaxng
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveHrefWindowsBase locks include/externalRef href resolution when the
+// schema was loaded from a native Windows path: CompileFile derives baseDir via
+// filepath.Dir and SetURL stores the native path, so on Windows both carry
+// backslashes. A sibling href ("inline2.rng") must resolve INSIDE the base
+// directory rather than tripping the ".."-escape guard — the tutor9_* RelaxNG
+// golden regression. The inputs are plain strings, so the Windows behavior is
+// exercised on Linux.
+func TestResolveHrefWindowsBase(t *testing.T) {
+	t.Parallel()
+
+	newCompiler := func(baseDir string) *compiler {
+		return &compiler{baseDir: baseDir}
+	}
+
+	// Build a tiny document with a backslash URL and an <include href=...> elem.
+	mkElem := func(docURL, href string) *helium.Element {
+		doc := helium.NewDefaultDocument()
+		doc.SetURL(docURL)
+		elem := doc.CreateElement("include")
+		_, err := elem.SetAttribute("href", href)
+		require.NoError(t, err)
+		require.NoError(t, doc.AddChild(elem))
+		return elem
+	}
+
+	t.Run("sibling href against windows base resolves inside base", func(t *testing.T) {
+		c := newCompiler(`..\testdata\relaxng\test`)
+		elem := mkElem(`..\testdata\relaxng\test\tutor9_7.rng`, "inline2.rng")
+		got, err := c.resolveHref(t.Context(), elem, "inline2.rng")
+		require.NoError(t, err)
+		require.Equal(t, "../testdata/relaxng/test/inline2.rng", got)
+	})
+
+	t.Run("escaping href against windows base still rejected", func(t *testing.T) {
+		c := newCompiler(`..\testdata\relaxng\test`)
+		elem := mkElem(`..\testdata\relaxng\test\tutor9_7.rng`, `..\..\..\etc\passwd`)
+		_, err := c.resolveHref(t.Context(), elem, `..\..\..\etc\passwd`)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "escapes base directory")
+	})
+}

--- a/tools/xslt3gen/main.go
+++ b/tools/xslt3gen/main.go
@@ -28,6 +28,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/uripath"
 	"github.com/lestrrat-go/helium/tools/internal/gen"
 	"golang.org/x/net/html/charset"
 )
@@ -1070,7 +1071,7 @@ func addTransitiveDeps(assetFiles map[string]struct{}, sourceDir, relPath string
 // absolute path, or ok=false (with a logged warning) when the reference is
 // absolute or escapes the root.
 func resolveDep(root, dir, ref string) (string, bool) {
-	if filepath.IsAbs(ref) {
+	if isAbsoluteAnyOS(ref) {
 		log.Printf("xslt3gen: skipping absolute dependency %q", ref)
 		return "", false
 	}
@@ -2078,7 +2079,7 @@ func catalogRelPath(sourceDir, tsDir, file string) (string, bool) {
 	if file == "" {
 		return "", false
 	}
-	if filepath.IsAbs(file) || filepath.IsAbs(normalizeAssetPath(file)) {
+	if isAbsoluteAnyOS(file) || isAbsoluteAnyOS(normalizeAssetPath(file)) {
 		log.Printf("xslt3gen: skipping absolute catalog path %q (under %q)", file, tsDir)
 		return "", false
 	}
@@ -2102,7 +2103,7 @@ func catalogRelPath(sourceDir, tsDir, file string) (string, bool) {
 // "../../xslt3/pwn.go" or "/etc/passwd") from causing the generator to read or
 // write outside the intended testdata tree.
 func containedPath(root, relPath string) (string, error) {
-	if filepath.IsAbs(relPath) {
+	if isAbsoluteAnyOS(relPath) {
 		return "", fmt.Errorf("absolute path not allowed: %q", relPath)
 	}
 	cleaned := filepath.Clean(filepath.Join(root, relPath))
@@ -2114,6 +2115,16 @@ func containedPath(root, relPath string) (string, error) {
 		return "", fmt.Errorf("path escapes root %q: %q", root, relPath)
 	}
 	return cleaned, nil
+}
+
+// isAbsoluteAnyOS reports whether p is absolute under EITHER POSIX or Windows
+// conventions, regardless of the host OS. The containment guards above must use
+// this rather than filepath.IsAbs: on Windows filepath.IsAbs("/etc/passwd") is
+// false (no drive letter) and on POSIX filepath.IsAbs("C:\\Windows") is false,
+// so a single-OS check lets a path that is absolute on the "other" OS slip past
+// the path-traversal rejection. This closes that gap on every platform.
+func isAbsoluteAnyOS(p string) bool {
+	return filepath.IsAbs(p) || uripath.IsAbsolutePath(p)
 }
 
 func boolAttrTrue(v string) bool {

--- a/tools/xslt3gen/main_test.go
+++ b/tools/xslt3gen/main_test.go
@@ -142,6 +142,43 @@ func TestCatalogRelPath(t *testing.T) {
 	})
 }
 
+// TestContainmentRejectsAbsoluteAnyOS is the security regression for the
+// path-traversal guard: a reference that is absolute under EITHER POSIX or
+// Windows conventions must be rejected on every host OS. Before the fix the
+// guards used filepath.IsAbs, which is single-OS: a POSIX "/etc/passwd" slipped
+// through on Windows and a Windows "C:\\Windows\\..." slipped through on POSIX.
+// These string inputs exercise BOTH shapes, so the Windows-absolute path is
+// covered even when the test runs on Linux.
+func TestContainmentRejectsAbsoluteAnyOS(t *testing.T) {
+	root := filepath.Join("/tmp", "assets")
+	dir := filepath.Join(root, "tests", "insn")
+	sourceDir := filepath.Join("/tmp", "source")
+
+	absRefs := []string{
+		"/etc/passwd",         // POSIX-absolute
+		`C:\Windows\system32`, // Windows drive-absolute, backslash
+		`C:/Windows/system32`, // Windows drive-absolute, forward slash
+		`D:\secrets\key.pem`,  // another drive
+		`\\evil-host\share\x`, // UNC
+		`\rooted\escape`,      // backslash-rooted
+	}
+
+	for _, ref := range absRefs {
+		t.Run("containedPath rejects "+ref, func(t *testing.T) {
+			_, err := containedPath(root, ref)
+			require.Error(t, err, "absolute ref %q must be rejected", ref)
+		})
+		t.Run("resolveDep rejects "+ref, func(t *testing.T) {
+			_, ok := resolveDep(root, dir, ref)
+			require.False(t, ok, "absolute ref %q must be rejected", ref)
+		})
+		t.Run("catalogRelPath rejects "+ref, func(t *testing.T) {
+			_, ok := catalogRelPath(sourceDir, "tests/insn", ref)
+			require.False(t, ok, "absolute ref %q must be rejected", ref)
+		})
+	}
+}
+
 // TestAddTransitiveDepsContainment verifies that the dependency-collection entry
 // point used while populating the asset set never records a dependency that
 // escapes sourceDir, even when the entry stylesheet imports an outside file.

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"net/url"
-	"path/filepath"
 	"strings"
 
 	"github.com/lestrrat-go/helium/enum"
@@ -14,6 +13,7 @@ import (
 	"github.com/lestrrat-go/helium/internal/iolimit"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/strcursor"
+	"github.com/lestrrat-go/helium/internal/uripath"
 	"github.com/lestrrat-go/helium/sax"
 )
 
@@ -354,13 +354,26 @@ func (t *TreeBuilder) ExternalSubset(ctxif context.Context, name, eid, uri strin
 		return nil
 	}
 
-	// Resolve system URI against document's base URI
+	// Resolve the system URI against the document's base URI. Use BuildURI (the
+	// same GOOS-independent, forward-slash/file:-URI-aware resolver used for
+	// entity URIs) rather than filepath.Dir/Join: on Windows filepath.Join
+	// mangles a "file:///C:/dir/doc.xml" base (it cleans "file://" to "file:/"
+	// and emits '\' separators), so a nested external DTD declared with a
+	// relative SYSTEM id ("inc.dtd") never resolves and is silently dropped.
+	// BuildURI keeps a drive-rooted result wrapped as "file:///C:/dir/inc.dtd",
+	// which the fsys (normalizingFS) converts back to a native path. POSIX
+	// output is unchanged: "file:///tmp/doc.xml" + "inc.dtd" -> "file:///tmp/inc.dtd".
 	resolved := uri
-	if !filepath.IsAbs(uri) && ctx.baseURI != "" {
-		resolved = filepath.Join(filepath.Dir(ctx.baseURI), uri)
+	if !uripath.IsAbsolutePath(uri) && !uripath.HasURIScheme(uri) && ctx.baseURI != "" {
+		if built := BuildURI(uri, ctx.baseURI); built != "" {
+			resolved = built
+		}
 	}
 
-	f, err := ctx.fsys.Open(resolved)
+	// resolved may be a "file:" URI (e.g. "file:///C:/dir/inc.dtd" from a
+	// drive-rooted base); convert it to a native path before Open, the same way
+	// a catalog-resolved file: URI is handled. A plain path is returned verbatim.
+	f, err := ctx.fsys.Open(catalogOpenName(resolved))
 	if err != nil {
 		// Silently ignore missing external DTDs
 		return nil

--- a/xinclude/resolve_uri_internal_test.go
+++ b/xinclude/resolve_uri_internal_test.go
@@ -1,0 +1,36 @@
+package xinclude
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveBaseWindowsShaped locks the resolveBase/resolveURI chain for a
+// native Windows base. The values are plain strings, so the Windows behavior is
+// exercised on every OS. Before the fix, url.Parse read the drive letter as a
+// scheme and resolveBase("D:\\..\\base.xml", "one/two") returned the garbage
+// "d:///one/two", which then dropped the include directory entirely — the
+// libxml2 base.xml golden case.
+func TestResolveBaseWindowsShaped(t *testing.T) {
+	t.Parallel()
+
+	t.Run("drive-letter base keeps directory through xml:base + relative href", func(t *testing.T) {
+		const winBase = `D:\a\helium\helium\testdata\xinclude\docs\base.xml`
+		b := resolveBase(winBase, "one/two")
+		require.Equal(t, "D:/a/helium/helium/testdata/xinclude/docs/one/two", b)
+
+		u, err := resolveURI("../../ents/base-inc.xml", b)
+		require.NoError(t, err)
+		require.Equal(t, "D:/a/helium/helium/testdata/xinclude/ents/base-inc.xml", u)
+	})
+
+	t.Run("posix base unchanged", func(t *testing.T) {
+		b := resolveBase("/a/b/docs/base.xml", "one/two")
+		require.Equal(t, "/a/b/docs/one/two", b)
+	})
+
+	t.Run("absolute xml:base replaces base verbatim", func(t *testing.T) {
+		require.Equal(t, "http://x/y", resolveBase(`D:\dir\doc.xml`, "http://x/y"))
+	})
+}

--- a/xinclude/resolve_uri_internal_test.go
+++ b/xinclude/resolve_uri_internal_test.go
@@ -3,6 +3,7 @@ package xinclude
 import (
 	"testing"
 
+	helium "github.com/lestrrat-go/helium"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,5 +33,46 @@ func TestResolveBaseWindowsShaped(t *testing.T) {
 
 	t.Run("absolute xml:base replaces base verbatim", func(t *testing.T) {
 		require.Equal(t, "http://x/y", resolveBase(`D:\dir\doc.xml`, "http://x/y"))
+	})
+}
+
+// TestComputeFixupBasesWindowsShaped locks the xml:base fixup relativization for
+// a native Windows target base mixed with a forward-slash include source URI
+// (the exact shape on a Windows runner: p.baseURI is an OS path while the
+// resolved include URI uses '/'). The values are plain strings, so the Windows
+// branch is exercised on every OS. Before the fix, computeFixupBases used
+// filepath.IsAbs / commonAncestorDir / filepath.Rel, which split on '\' and
+// failed to find the common ancestor of the mixed-separator inputs, producing
+// wrong relative bases (the libxml2 base.xml golden failure: "two2" instead of
+// "../../ents/one/two2"). The relativization is now pure forward-slash.
+func TestComputeFixupBasesWindowsShaped(t *testing.T) {
+	t.Parallel()
+
+	const (
+		winBase   = `D:\proj\xinclude\docs\base.xml`
+		sourceURI = "D:/proj/xinclude/ents/base-inc.xml"
+	)
+
+	// An xi:include element with no xml:base of its own, so the effective target
+	// base reduces to the relativized target document path.
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	inc := doc.CreateElement("include")
+	require.NoError(t, doc.AddChild(inc))
+
+	p := &processor{baseURI: winBase}
+	relSource, target := p.computeFixupBases(inc, sourceURI)
+	require.Equal(t, "ents/base-inc.xml", relSource,
+		"include source must relativize against the common ancestor with forward-slash semantics")
+	require.Equal(t, "docs/base.xml", target,
+		"target document base must relativize against the common ancestor")
+
+	t.Run("posix unchanged", func(t *testing.T) {
+		pdoc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+		pinc := pdoc.CreateElement("include")
+		require.NoError(t, pdoc.AddChild(pinc))
+		pp := &processor{baseURI: "/proj/xinclude/docs/base.xml"}
+		rs, tgt := pp.computeFixupBases(pinc, "/proj/xinclude/ents/base-inc.xml")
+		require.Equal(t, "ents/base-inc.xml", rs)
+		require.Equal(t, "docs/base.xml", tgt)
 	})
 }

--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -1274,6 +1274,24 @@ func resolveBase(currentBase, xmlBase string) string {
 		return xmlBase
 	}
 
+	// A native Windows base ("D:\\dir\\doc.xml", "D:/dir/doc.xml", or a UNC path)
+	// is a local filesystem path, not a URI. url.Parse would read its drive
+	// letter as a scheme and emit garbage like "d:///one/two", so resolve it with
+	// local-path (forward-slash) semantics, matching resolveURI's Windows branch.
+	// xmlBase is relative here (absolute was handled above), so its directory is
+	// dropped and the new base segment is appended. The shape is detected from
+	// the string alone, so the branch runs on POSIX too.
+	if uripath.IsWindowsAbsolute(currentBase) {
+		slashBase := uripath.ToSlash(currentBase)
+		const syntheticPrefix = "synthetic://h/"
+		absBase, perr := url.Parse(syntheticPrefix + slashBase)
+		if perr != nil {
+			return path.Join(path.Dir(slashBase), xmlBase)
+		}
+		resolved := absBase.ResolveReference(xmlBaseURL)
+		return strings.TrimPrefix(resolved.String(), syntheticPrefix)
+	}
+
 	baseURL, err := url.Parse(currentBase)
 	if err != nil {
 		return xmlBase

--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lestrrat-go/helium/internal/iofs"
 	"github.com/lestrrat-go/helium/internal/iolimit"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/uripath"
 	"github.com/lestrrat-go/helium/xpointer"
 )
 
@@ -994,6 +995,24 @@ func findAttr(elem *helium.Element, name string) (string, bool) {
 }
 
 func resolveURI(href, base string) (string, error) {
+	// A native Windows base ("D:\\dir\\main.xml", "D:/dir/main.xml", or a UNC
+	// "\\host\\share") is a local filesystem path, not a URI. url.Parse would
+	// read its drive letter "D" as a URI scheme and emit garbage like
+	// "d:///fragment.xml", so resolve it with local-path (forward-slash)
+	// semantics BEFORE the URI machinery. The shape is detected from the string
+	// alone (uripath), so this branch is exercised on POSIX too.
+	if uripath.IsWindowsAbsolute(base) {
+		hrefURL, perr := url.Parse(href)
+		if perr != nil {
+			return "", fmt.Errorf("xi:include: invalid href %q: %w", href, perr)
+		}
+		if hrefURL.IsAbs() {
+			return href, nil
+		}
+		slashBase := uripath.ToSlash(base)
+		return path.Join(path.Dir(slashBase), href), nil
+	}
+
 	hrefURL, err := url.Parse(href)
 	if err != nil {
 		return "", fmt.Errorf("xi:include: invalid href %q: %w", href, err)
@@ -1007,7 +1026,7 @@ func resolveURI(href, base string) (string, error) {
 		return href, nil
 	}
 
-	// For file-like paths (no scheme), use filepath-based resolution
+	// For file-like paths (no scheme), use slash-based resolution
 	// to avoid Go's url.ResolveReference quirk that adds leading '/'
 	// to purely relative paths.
 	// If base fails to parse as a URL, fall back to returning href unresolved.
@@ -1020,7 +1039,9 @@ func resolveURI(href, base string) (string, error) {
 		if basePath == "" {
 			basePath = base
 		}
-		return filepath.Join(filepath.Dir(basePath), href), nil
+		// Join with forward-slash (path) semantics so the result uses '/' on
+		// every OS; on Windows filepath.Dir/Join would emit '\'.
+		return path.Join(path.Dir(uripath.ToSlash(basePath)), href), nil
 	}
 
 	return baseURL.ResolveReference(hrefURL).String(), nil

--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -1147,23 +1147,19 @@ func relativeURI(target, base string) string {
 	return makeRelativePath(targetPath, basePath)
 }
 
-// makeRelativePath computes a relative path from basePath's directory to targetPath.
+// makeRelativePath computes a relative path from basePath's directory to
+// targetPath. The computation is pure forward-slash (RFC 3986 dot-segment)
+// semantics via [uripath.SlashRel], NOT filepath.Rel: the result is an xml:base
+// relative reference that MUST be byte-identical on POSIX and Windows (where
+// filepath.Rel splits on '\', mishandles '/'-bearing inputs, and applies
+// drive-letter rules, producing wrong "../" sequences).
 func makeRelativePath(targetPath, basePath string) string {
-	// Split into directory components
-	baseDir := filepath.Dir(basePath)
+	baseDir := uripath.SlashDir(basePath)
 	if baseDir == "." {
-		// Base has no directory component — target is already relative
-		return targetPath
+		// Base has no directory component — target is already relative.
+		return uripath.ToSlash(targetPath)
 	}
-
-	// Use filepath.Rel for the computation
-	rel, err := filepath.Rel(baseDir, targetPath)
-	if err != nil {
-		return targetPath
-	}
-
-	// filepath.Rel uses OS separators; normalize to forward slashes
-	return strings.ReplaceAll(rel, string(filepath.Separator), "/")
+	return uripath.SlashRel(baseDir, targetPath)
 }
 
 func newXIncludeMarker(doc *helium.Document, etype helium.ElementType, name string) helium.Node {
@@ -1309,35 +1305,13 @@ func resolveBase(currentBase, xmlBase string) string {
 	syntheticBase := syntheticPrefix + currentBase
 	absBase, err := url.Parse(syntheticBase)
 	if err != nil {
-		return filepath.Join(filepath.Dir(currentBase), xmlBase)
+		// Forward-slash fallback (never filepath.Join, which emits '\' on
+		// Windows): drop the base's last segment and append the relative base.
+		return uripath.JoinLocalBaseDir(uripath.SlashDir(currentBase), xmlBase)
 	}
 	resolved := absBase.ResolveReference(xmlBaseURL)
 	result := strings.TrimPrefix(resolved.String(), syntheticPrefix)
 	return result
-}
-
-// commonAncestorDir returns the longest common directory prefix of two paths.
-func commonAncestorDir(a, b string) string {
-	aDir := filepath.Dir(filepath.Clean(a))
-	bDir := filepath.Dir(filepath.Clean(b))
-	aParts := strings.Split(aDir, string(filepath.Separator))
-	bParts := strings.Split(bDir, string(filepath.Separator))
-
-	n := min(len(aParts), len(bParts))
-
-	common := 0
-	for i := range n {
-		if aParts[i] != bParts[i] {
-			break
-		}
-		common = i + 1
-	}
-
-	if common == 0 {
-		return "."
-	}
-
-	return strings.Join(aParts[:common], string(filepath.Separator))
 }
 
 // computeFixupBases computes relative URI bases for xml:base fixup.
@@ -1345,18 +1319,21 @@ func commonAncestorDir(a, b string) string {
 // they are converted to relative paths against their common ancestor
 // directory. This ensures that ".." traversal in xml:base attributes
 // is bounded at the logical root, matching RFC 3986 URI resolution.
+//
+// The relativization is pure forward-slash ([uripath.SlashCommonDir] +
+// [uripath.SlashRel]), NOT filepath.*: sourceURI arrives in forward-slash form
+// (resolveURI normalizes it) while p.baseURI is a native OS path, so on Windows
+// they mix '/' and '\'. filepath.Clean/Dir/Rel then split on '\', fail to find
+// the common ancestor, and emit wrong "../" sequences. uripath normalizes both
+// to '/' first so the output is byte-identical on POSIX and Windows.
 func (p *processor) computeFixupBases(inc *helium.Element, sourceURI string) (string, string) {
-	relSource := sourceURI
-	relTarget := p.baseURI
+	relSource := uripath.ToSlash(sourceURI)
+	relTarget := uripath.ToSlash(p.baseURI)
 
-	if filepath.IsAbs(sourceURI) && filepath.IsAbs(p.baseURI) {
-		root := commonAncestorDir(sourceURI, p.baseURI)
-		if rel, err := filepath.Rel(root, sourceURI); err == nil {
-			relSource = rel
-		}
-		if rel, err := filepath.Rel(root, p.baseURI); err == nil {
-			relTarget = rel
-		}
+	if uripath.IsAbsolutePath(sourceURI) && uripath.IsAbsolutePath(p.baseURI) {
+		root := uripath.SlashCommonDir(sourceURI, p.baseURI)
+		relSource = uripath.SlashRel(root, sourceURI)
+		relTarget = uripath.SlashRel(root, p.baseURI)
 	}
 
 	return relSource, effectiveBaseURI(inc, relTarget)

--- a/xinclude/xinclude_test.go
+++ b/xinclude/xinclude_test.go
@@ -23,6 +23,19 @@ func parseXML(t *testing.T, s string) *helium.Document {
 	return doc
 }
 
+// fileURIFromPath builds a proper "file:///" URI from a native absolute path on
+// any OS. Setting url.URL.Path to a Windows drive path ("C:/x") yields
+// "file://C:/x", where "C:" is mis-parsed as the host; ensuring a single
+// leading slash before the slash-normalized path yields "file:///C:/x" (and
+// keeps "file:///tmp/x" on POSIX).
+func fileURIFromPath(path string) string {
+	p := filepath.ToSlash(path)
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return (&url.URL{Scheme: "file", Path: p}).String()
+}
+
 func docElement(doc *helium.Document) *helium.Element {
 	for n := doc.FirstChild(); n != nil; n = n.NextSibling() {
 		if n.Type() == helium.ElementNode {
@@ -1654,7 +1667,7 @@ func TestXIncludeFileURIHref(t *testing.T) {
 	target := filepath.Join(dir, "inc.xml")
 	require.NoError(t, os.WriteFile(target, []byte(`<loaded>FromFileURI</loaded>`), 0o600))
 
-	fileURI := (&url.URL{Scheme: "file", Path: filepath.ToSlash(target)}).String()
+	fileURI := fileURIFromPath(target)
 
 	doc := parseXML(t, fmt.Sprintf(`<root xmlns:xi="http://www.w3.org/2001/XInclude">
 		<xi:include href="%s"/>
@@ -1699,7 +1712,7 @@ func TestXIncludeFileURINestedExternalDTD(t *testing.T) {
 			`<!DOCTYPE chapter SYSTEM "inc.dtd">`+
 			`<chapter>text</chapter>`), 0o600))
 
-	fileURI := (&url.URL{Scheme: "file", Path: filepath.ToSlash(filepath.Join(dir, "inc.xml"))}).String()
+	fileURI := fileURIFromPath(filepath.Join(dir, "inc.xml"))
 
 	doc := parseXML(t, fmt.Sprintf(`<root xmlns:xi="http://www.w3.org/2001/XInclude">
 		<xi:include href="%s"/>

--- a/xpath3/functions_env_internal_test.go
+++ b/xpath3/functions_env_internal_test.go
@@ -1,0 +1,45 @@
+package xpath3
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnvironmentVariableCaseSensitive locks the invariant that
+// fn:environment-variable and fn:available-environment-variables agree on every
+// OS: a name is resolvable by environment-variable() iff it appears verbatim in
+// available-environment-variables(). On Windows os.LookupEnv is
+// case-insensitive, which previously let environment-variable("path") return a
+// value while available-environment-variables() listed only "Path" — breaking
+// W3C function-1501. The fix enumerates os.Environ() with an exact match, so the
+// two accessors stay in lock step. This test is GOOS-independent.
+func TestEnvironmentVariableCaseSensitive(t *testing.T) {
+	const name = "HeliumEnvCaseTest"
+	const want = "yes"
+	t.Setenv(name, want)
+
+	avail, err := fnAvailableEnvVars(t.Context(), nil)
+	require.NoError(t, err)
+	names := make([]string, 0, avail.Len())
+	for i := range avail.Len() {
+		names = append(names, avail.Get(i).(AtomicValue).Value.(string))
+	}
+	require.True(t, slices.Contains(names, name), "exact-cased name must be listed")
+
+	// Exact case resolves.
+	got, err := fnEnvironmentVariable(t.Context(), []Sequence{SingleString(name)})
+	require.NoError(t, err)
+	require.Equal(t, 1, got.Len())
+	require.Equal(t, want, got.Get(0).(AtomicValue).Value)
+
+	// A differently-cased name that is NOT listed must NOT resolve, even on a
+	// case-insensitive OS. This is the case-consistency guarantee.
+	const wrongCase = "heliumenvcasetest"
+	if !slices.Contains(names, wrongCase) {
+		miss, err := fnEnvironmentVariable(t.Context(), []Sequence{SingleString(wrongCase)})
+		require.NoError(t, err)
+		require.Equal(t, 0, seqLen(miss), "case-variant name must not resolve when it is not listed")
+	}
+}

--- a/xpath3/functions_misc.go
+++ b/xpath3/functions_misc.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/lestrrat-go/helium/internal/lexicon"
@@ -90,11 +91,21 @@ func fnEnvironmentVariable(_ context.Context, args []Sequence) (Sequence, error)
 	if val, ok := qt3EnvironmentVariables[name]; ok {
 		return SingleString(val), nil
 	}
-	val, ok := os.LookupEnv(name)
-	if !ok {
-		return validNilSequence, nil
+	// Look the name up against os.Environ() with an EXACT, case-sensitive match
+	// rather than os.LookupEnv. On Windows os.LookupEnv is case-insensitive and
+	// the canonical name differs in case (e.g. "Path"), so environment-variable
+	// ("path") would return a value while available-environment-variables()
+	// lists only "Path" — making the two accessors mutually inconsistent and
+	// breaking F&O conformance (env var names are case-sensitive). Enumerating
+	// os.Environ() (the same source fnAvailableEnvVars uses) keeps them in lock
+	// step on every OS. POSIX behavior is unchanged.
+	for _, env := range os.Environ() {
+		k, v, ok := strings.Cut(env, "=")
+		if ok && k == name {
+			return SingleString(v), nil
+		}
 	}
-	return SingleString(val), nil
+	return validNilSequence, nil
 }
 
 func fnCurrentDateTime(ctx context.Context, _ []Sequence) (Sequence, error) {

--- a/xpath3/qt3_helpers_test.go
+++ b/xpath3/qt3_helpers_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/heliumtest"
 	"github.com/lestrrat-go/helium/internal/unparsedtext"
+	"github.com/lestrrat-go/helium/internal/uripath"
 	"github.com/lestrrat-go/helium/xpath3"
 	"github.com/stretchr/testify/require"
 )
@@ -410,17 +411,32 @@ func qt3NeedsParseXMLBaseURI(expr string) bool {
 		strings.Contains(expr, "parse-xml-fragment(")
 }
 
-func qt3ParseDoc(t *testing.T, path string) helium.Node {
+func qt3ParseDoc(t *testing.T, p string) helium.Node {
 	t.Helper()
-	data, err := os.ReadFile(path)
-	require.NoError(t, err, "reading %s", path)
+	data, err := os.ReadFile(p)
+	require.NoError(t, err, "reading %s", p)
 	doc, err := helium.NewParser().Parse(t.Context(), data)
-	require.NoError(t, err, "parsing %s", path)
-	absPath, err := filepath.Abs(path)
+	require.NoError(t, err, "parsing %s", p)
+	absPath, err := filepath.Abs(p)
 	if err == nil {
-		doc.SetURL(absPath)
+		doc.SetURL(qt3DocBaseURI(absPath))
 	}
 	return doc
+}
+
+// qt3DocBaseURI turns a native absolute path into the base URI stored on a
+// parsed QT3 document. On POSIX the absolute path ("/abs/x.xml") is used as-is,
+// preserving the historical behavior. On Windows the path is "D:\\a\\x.xml":
+// stored verbatim, url.Parse would read the drive letter "D" as a URI scheme
+// and mangle every relative-reference resolution (e.g. an absolute http: ref in
+// a resource map would be wrongly filepath-joined). Convert such a path to a
+// canonical "file:///D:/a/x.xml" URI so resolution behaves identically on both
+// platforms. Detection is string-shaped (uripath), so POSIX output is unchanged.
+func qt3DocBaseURI(absPath string) string {
+	if uripath.IsWindowsAbsolute(absPath) {
+		return uripath.WindowsToFileURI(absPath)
+	}
+	return absPath
 }
 
 func qt3ParseDocSource(t *testing.T, src qt3SourceDoc) helium.Node {

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"io/fs"
 	"maps"
-	"path/filepath"
+	"path"
 
 	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/uripath"
 )
 
 // errImportDepthExceeded signals that xs:import recursion reached the
@@ -78,7 +79,10 @@ func schemaBaseDir(loc string) string {
 	if uriScheme(loc) != "" {
 		return loc
 	}
-	return filepath.Dir(loc)
+	// loc is an fs.FS key in forward-slash form (see ResolveSchemaURI); derive
+	// its parent directory with path.Dir so the result stays slash-separated on
+	// every OS rather than gaining backslashes via filepath.Dir on Windows.
+	return path.Dir(uripath.ToSlash(loc))
 }
 
 // schemaDisplayLoc builds the human-readable location shown in import/include
@@ -95,7 +99,9 @@ func schemaDisplayLoc(filename, loc string) string {
 			return resolved
 		}
 	}
-	return filepath.Join(filepath.Dir(filename), loc)
+	// Join in forward-slash space so the diagnostic path is stable across OSes
+	// (filepath.Join would emit '\' on Windows).
+	return path.Join(path.Dir(uripath.ToSlash(filename)), uripath.ToSlash(loc))
 }
 
 // processIncludes handles xs:include and xs:import elements.

--- a/xsd/compile_imports_internal_test.go
+++ b/xsd/compile_imports_internal_test.go
@@ -112,6 +112,18 @@ func TestValidateSchemaPathLocalUnchanged(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, filepath.Join("/tmp/s", "/etc/passwd"), got)
 	})
+	// Windows-shaped fixtures (plain strings) exercise the forward-slash
+	// resolution and the escape guard on Linux. The returned name is an fs.FS
+	// key, which must be slash-separated on every OS — never "schemas\\x".
+	t.Run("windows-shaped base joins with forward slashes", func(t *testing.T) {
+		got, err := validateSchemaPath(`schemas\sub`, "part.xsd")
+		require.NoError(t, err)
+		require.Equal(t, "schemas/sub/part.xsd", got)
+	})
+	t.Run("windows-shaped backslash escape denied", func(t *testing.T) {
+		_, err := validateSchemaPath("schemas", `..\..\etc\passwd`)
+		require.ErrorIs(t, err, errSchemaPathEscape)
+	})
 }
 
 // TestSchemaBaseDir verifies the nested-include base used for the import
@@ -121,4 +133,7 @@ func TestSchemaBaseDir(t *testing.T) {
 	require.Equal(t, "https://example.com/s/main.xsd", schemaBaseDir("https://example.com/s/main.xsd"))
 	require.Equal(t, "file:///tmp/s/main.xsd", schemaBaseDir("file:///tmp/s/main.xsd"))
 	require.Equal(t, filepath.Dir("/tmp/s/main.xsd"), schemaBaseDir("/tmp/s/main.xsd"))
+	// An fs.FS-key loc is slash-separated; its parent stays slash-separated on
+	// every OS (a backslash-shaped input is normalized, exercising Windows on Linux).
+	require.Equal(t, "schemas", schemaBaseDir(`schemas\intermediate.xsd`))
 }

--- a/xsd/compile_imports_internal_test.go
+++ b/xsd/compile_imports_internal_test.go
@@ -1,7 +1,6 @@
 package xsd
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -96,12 +95,14 @@ func TestValidateSchemaPathLocalUnchanged(t *testing.T) {
 	t.Run("relative join", func(t *testing.T) {
 		got, err := validateSchemaPath("/tmp/s", part)
 		require.NoError(t, err)
-		require.Equal(t, filepath.Join("/tmp/s", part), got)
+		// ResolveSchemaURI resolves in forward-slash (fs.FS-key) space, so the
+		// result is slash-separated on every OS — never filepath.Join's "\tmp\s".
+		require.Equal(t, "/tmp/s/"+part, got)
 	})
 	t.Run("empty base cleans", func(t *testing.T) {
 		got, err := validateSchemaPath("", "./a/../part.xsd")
 		require.NoError(t, err)
-		require.Equal(t, filepath.Clean("./a/../part.xsd"), got)
+		require.Equal(t, part, got)
 	})
 	t.Run("escape denied", func(t *testing.T) {
 		_, err := validateSchemaPath("/tmp/s", "../../etc/passwd")
@@ -110,7 +111,7 @@ func TestValidateSchemaPathLocalUnchanged(t *testing.T) {
 	t.Run("absolute local location lands inside base", func(t *testing.T) {
 		got, err := validateSchemaPath("/tmp/s", "/etc/passwd")
 		require.NoError(t, err)
-		require.Equal(t, filepath.Join("/tmp/s", "/etc/passwd"), got)
+		require.Equal(t, "/tmp/s/etc/passwd", got)
 	})
 	// Windows-shaped fixtures (plain strings) exercise the forward-slash
 	// resolution and the escape guard on Linux. The returned name is an fs.FS
@@ -132,7 +133,9 @@ func TestValidateSchemaPathLocalUnchanged(t *testing.T) {
 func TestSchemaBaseDir(t *testing.T) {
 	require.Equal(t, "https://example.com/s/main.xsd", schemaBaseDir("https://example.com/s/main.xsd"))
 	require.Equal(t, "file:///tmp/s/main.xsd", schemaBaseDir("file:///tmp/s/main.xsd"))
-	require.Equal(t, filepath.Dir("/tmp/s/main.xsd"), schemaBaseDir("/tmp/s/main.xsd"))
+	// schemaBaseDir uses path.Dir (slash space), so the parent is slash-separated
+	// on every OS — never filepath.Dir's "\tmp\s" on Windows.
+	require.Equal(t, "/tmp/s", schemaBaseDir("/tmp/s/main.xsd"))
 	// An fs.FS-key loc is slash-separated; its parent stays slash-separated on
 	// every OS (a backslash-shaped input is normalized, exercising Windows on Linux).
 	require.Equal(t, "schemas", schemaBaseDir(`schemas\intermediate.xsd`))

--- a/xsd/resolve_uri.go
+++ b/xsd/resolve_uri.go
@@ -3,8 +3,11 @@ package xsd
 import (
 	"fmt"
 	"net/url"
+	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/lestrrat-go/helium/internal/uripath"
 )
 
 // URIScheme reports the scheme of s when s is an absolute URI reference (it has
@@ -74,17 +77,26 @@ func ResolveSchemaURI(ref, base string) (string, error) {
 	if uriScheme(base) != "" {
 		return resolveURIReference(base, ref)
 	}
+	// Local filesystem base + ref. Resolve in FORWARD-SLASH space so the
+	// returned name — used as a key into the configured fs.FS, whose contract
+	// mandates '/' (io/fs.ValidPath) — never gains backslashes on Windows, where
+	// filepath.Join/Rel/Separator would otherwise produce "schemas\\x" and miss
+	// every MapFS / os.DirFS key. The shape-based detection and slash math are
+	// GOOS-independent, so the escape guard is exercised identically on POSIX.
+	slashRef := uripath.ToSlash(ref)
 	if base == "" {
-		return filepath.Clean(ref), nil
+		return path.Clean(slashRef), nil
 	}
-	p := filepath.Join(base, ref)
-	rel, err := filepath.Rel(base, p)
+	slashBase := uripath.ToSlash(base)
+	p := path.Join(slashBase, slashRef)
+	rel, err := filepath.Rel(slashBase, p)
 	if err != nil {
 		// Rel only fails when one is absolute and the other isn't;
 		// nothing actionable here — accept and let the loader decide.
 		return p, nil //nolint:nilerr
 	}
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	rel = uripath.ToSlash(rel)
+	if rel == ".." || strings.HasPrefix(rel, "../") {
 		return "", fmt.Errorf("%w: %q", errSchemaPathEscape, ref)
 	}
 	return p, nil

--- a/xslt3/compile_formats.go
+++ b/xslt3/compile_formats.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"maps"
-	"path/filepath"
+	"path"
 	"strconv"
 	"strings"
 	"unicode"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/uripath"
 	"github.com/lestrrat-go/helium/internal/xmlchar"
 	"github.com/lestrrat-go/helium/xpath3"
 	"github.com/lestrrat-go/helium/xsd"
@@ -534,8 +535,13 @@ func loadParameterDocumentFromFile(ctx context.Context, outDef *OutputDef, baseU
 			if rErr == nil {
 				uri = resolved
 			}
-		case !filepath.IsAbs(href):
-			uri = filepath.Join(filepath.Dir(baseURI), href)
+		case !uripath.IsAbsolutePath(href):
+			// Local filesystem base: resolve with forward-slash (path)
+			// semantics so the result uses '/' on every OS; on Windows
+			// filepath.Dir/Join would emit '\'. uripath.IsAbsolutePath
+			// recognizes both POSIX- and Windows-absolute hrefs regardless
+			// of GOOS.
+			uri = uripath.JoinLocalBaseDir(path.Dir(uripath.ToSlash(baseURI)), href)
 		}
 	}
 

--- a/xslt3/compile_imports.go
+++ b/xslt3/compile_imports.go
@@ -3,12 +3,13 @@ package xslt3
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 	"slices"
 	"strings"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/uripath"
 	"github.com/lestrrat-go/helium/xpath3"
 	"github.com/lestrrat-go/helium/xsd"
 )
@@ -82,11 +83,17 @@ func resolveModuleURI(href, baseURI string) (string, error) {
 	if xsd.URIScheme(href) != "" || xsd.URIScheme(baseURI) != "" {
 		return xsd.ResolveSchemaURI(href, baseURI) //nolint:wrapcheck // static error passthrough
 	}
-	// Local filesystem base (a FILE path): keep historical filepath semantics.
-	if filepath.IsAbs(href) {
+	// Local filesystem base (a FILE path): resolve with forward-slash (path)
+	// semantics so the result uses '/' on every OS. A Windows-absolute href was
+	// already handled by isWindowsDrivePath above; uripath.IsAbsolutePath here
+	// keeps a POSIX-absolute href verbatim. On Windows filepath.Dir/Join would
+	// emit '\' and corrupt a virtual or POSIX-shaped base (e.g. "/virtual/x.xsl"
+	// against href "common.xsl" -> "\\virtual\\common.xsl"), missing a resolver
+	// keyed on the forward-slash form.
+	if uripath.IsAbsolutePath(href) {
 		return href, nil
 	}
-	return filepath.Join(filepath.Dir(baseURI), href), nil
+	return uripath.JoinLocalBaseDir(path.Dir(uripath.ToSlash(baseURI)), href), nil
 }
 
 // isWindowsDrivePath reports whether s begins with a Windows drive-letter prefix

--- a/xslt3/execute_globals.go
+++ b/xslt3/execute_globals.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/uripath"
 	"github.com/lestrrat-go/helium/internal/xpathstream"
 	"github.com/lestrrat-go/helium/xpath3"
 )
@@ -625,13 +626,20 @@ func (ec *execContext) evaluateBodySeparateText(ctx context.Context, body []inst
 
 // ensureFileURI converts an absolute file system path to a file:// URI.
 // Paths that already contain a scheme (e.g. "http://", "file://") are
-// returned unchanged.
+// returned unchanged. Both POSIX-absolute ("/a/b" -> "file:///a/b") and
+// Windows-absolute ("D:\\a\\b" -> "file:///D:/a/b", "\\\\host\\share" ->
+// "file://host/share") paths are normalized so a later url.Parse does not read
+// a Windows drive letter as a URI scheme. The Windows shapes are detected by
+// string pattern (uripath), so this conversion is exercised on Linux CI too.
 func ensureFileURI(path string) string {
 	if path == "" {
 		return path
 	}
 	if strings.Contains(path, "://") {
 		return path
+	}
+	if uripath.IsWindowsAbsolute(path) {
+		return uripath.WindowsToFileURI(path)
 	}
 	if strings.HasPrefix(path, "/") {
 		return "file://" + path

--- a/xslt3/functions.go
+++ b/xslt3/functions.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/iofs"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/sequence"
 	"github.com/lestrrat-go/helium/xpath3"
@@ -715,8 +716,15 @@ func (ec *execContext) resolveDocumentURI(uri string, baseDir string) string {
 	if idx := strings.IndexByte(cleanURI, '#'); idx >= 0 {
 		cleanURI = cleanURI[:idx]
 	}
-	// Convert file:// URIs to local paths.
+	// Convert file:// URIs to local paths. Use iofs.FileURIToPath so a Windows
+	// drive-letter URI ("file:///D:/a/b") yields a native path ("D:\\a\\b" on
+	// Windows) rather than a spurious leading-slash path ("/D:/a/b"). The helper
+	// is GOOS-parameterized, so POSIX behavior ("file:///a/b" -> "/a/b") is
+	// unchanged. On any parse failure, fall back to the original strip.
 	if strings.HasPrefix(cleanURI, "file:///") {
+		if p, err := iofs.FileURIToPath(cleanURI); err == nil {
+			return p
+		}
 		return cleanURI[len("file://"):]
 	}
 	// Decide absoluteness with xsd.URIScheme (RFC 3986), not a "://" substring

--- a/xslt3/functions.go
+++ b/xslt3/functions.go
@@ -716,13 +716,17 @@ func (ec *execContext) resolveDocumentURI(uri string, baseDir string) string {
 		cleanURI = cleanURI[:idx]
 	}
 	// Convert file:// URIs to local paths. Use iofs.FileURIToPath so a Windows
-	// drive-letter URI ("file:///D:/a/b") yields a native path ("D:\\a\\b" on
-	// Windows) rather than a spurious leading-slash path ("/D:/a/b"). The helper
-	// is GOOS-parameterized, so POSIX behavior ("file:///a/b" -> "/a/b") is
-	// unchanged. On any parse failure, fall back to the original strip.
+	// drive-letter URI ("file:///D:/a/b") yields a drive path ("D:\\a\\b" on
+	// Windows) rather than a spurious leading-slash path ("/D:/a/b"). The result
+	// is then normalized with uripath.ToSlash so a non-drive POSIX-shaped URI
+	// ("file:///abs/x.xml") resolves to a forward-slash path ("/abs/x.xml") on
+	// EVERY OS — FileURIToPath would otherwise emit "\\abs\\x.xml" on Windows.
+	// The forward-slash form is what every other helium resolver consumes (Win32
+	// accepts '/'); POSIX behavior is unchanged. On parse failure, fall back to
+	// the original strip.
 	if strings.HasPrefix(cleanURI, "file:///") {
 		if p, err := iofs.FileURIToPath(cleanURI); err == nil {
-			return p
+			return uripath.ToSlash(p)
 		}
 		return cleanURI[len("file://"):]
 	}

--- a/xslt3/functions.go
+++ b/xslt3/functions.go
@@ -7,13 +7,14 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/iofs"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/sequence"
+	"github.com/lestrrat-go/helium/internal/uripath"
 	"github.com/lestrrat-go/helium/xpath3"
 	"github.com/lestrrat-go/helium/xsd"
 )
@@ -651,12 +652,14 @@ func resolveAgainstBaseURI(uri string, baseURI string) string {
 		}
 		return resolved
 	}
-	// Both base and ref are local filesystem paths.
-	if filepath.IsAbs(uri) {
+	// Both base and ref are local filesystem paths. Resolve with forward-slash
+	// (path) semantics so the result uses '/' on every OS; uripath.IsAbsolutePath
+	// recognizes both POSIX- and Windows-absolute refs regardless of GOOS.
+	if uripath.IsAbsolutePath(uri) {
 		return uri
 	}
 	baseDir := baseURIDir(baseURI)
-	return filepath.Join(baseDir, uri)
+	return uripath.JoinLocalBaseDir(baseDir, uri)
 }
 
 func splitURIFragment(uri string) (string, string) {
@@ -679,8 +682,10 @@ func splitURIFragment(uri string) (string, string) {
 // sibling "doc.xml" wrongly resolves to "mem:/pkg/doc.xml" instead of
 // "mem://pkg/doc.xml".
 //
-// For a genuine local filesystem base, filepath.Dir is used as before so a
-// sibling reference resolves against the containing directory.
+// For a genuine local filesystem base, the containing directory is taken with
+// forward-slash (path.Dir) semantics so the result uses '/' on every OS; on
+// Windows filepath.Dir would emit '\' here and corrupt the later slash-based
+// join.
 func documentBaseDir(base string) string {
 	if base == "" {
 		return ""
@@ -688,22 +693,16 @@ func documentBaseDir(base string) string {
 	if xsd.URIScheme(base) != "" {
 		return base
 	}
-	return filepath.Dir(base)
+	return path.Dir(uripath.ToSlash(base))
 }
 
-// baseURIDir extracts the directory from a base URI. If the base URI looks
-// like a file path (last segment contains a dot), filepath.Dir is used.
-// Otherwise the base URI itself is treated as a directory.
+// baseURIDir extracts the directory from a local-filesystem base URI in
+// forward-slash form. If the base looks like a file path (last segment contains
+// a dot) the last segment is dropped; otherwise the base itself is treated as a
+// directory. uripath.LocalBaseDir performs this in slash space on every OS, so
+// the result never gains backslashes on Windows.
 func baseURIDir(baseURI string) string {
-	if strings.HasSuffix(baseURI, "/") || strings.HasSuffix(baseURI, string(filepath.Separator)) {
-		return strings.TrimRight(baseURI, "/"+string([]byte{filepath.Separator}))
-	}
-	base := filepath.Base(baseURI)
-	if strings.Contains(base, ".") {
-		return filepath.Dir(baseURI)
-	}
-	// No extension in the last segment — treat the entire path as a directory.
-	return baseURI
+	return uripath.LocalBaseDir(baseURI)
 }
 
 // resolveDocumentURI resolves a URI against a base directory.
@@ -742,11 +741,14 @@ func (ec *execContext) resolveDocumentURI(uri string, baseDir string) string {
 		}
 		return resolved
 	}
-	if filepath.IsAbs(cleanURI) {
+	// Both local: resolve with forward-slash (path) semantics so the result uses
+	// '/' on every OS. uripath.IsAbsolutePath recognizes both POSIX- and
+	// Windows-absolute refs regardless of GOOS.
+	if uripath.IsAbsolutePath(cleanURI) {
 		return cleanURI
 	}
 	if baseDir != "" {
-		return filepath.Join(baseDir, cleanURI)
+		return uripath.JoinLocalBaseDir(baseDir, cleanURI)
 	}
 	return cleanURI
 }

--- a/xslt3/functions_transform.go
+++ b/xslt3/functions_transform.go
@@ -3,12 +3,13 @@ package xslt3
 import (
 	"bytes"
 	"context"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/sequence"
+	"github.com/lestrrat-go/helium/internal/uripath"
 	"github.com/lestrrat-go/helium/xpath3"
 	"github.com/lestrrat-go/helium/xsd"
 )
@@ -298,7 +299,9 @@ func resolveRelativeURI(base, ref string) string {
 		}
 		return resolved
 	}
-	return filepath.Join(filepath.Dir(base), ref)
+	// Local filesystem base: resolve with forward-slash (path) semantics so the
+	// result uses '/' on every OS; on Windows filepath.Dir/Join would emit '\'.
+	return uripath.JoinLocalBaseDir(path.Dir(uripath.ToSlash(base)), ref)
 }
 
 // resolveStylesheetLocation resolves an fn:transform stylesheet-location loc
@@ -314,7 +317,10 @@ func resolveStylesheetLocation(base, loc string) string {
 	if base == "" {
 		return loc
 	}
-	if xsd.URIScheme(base) != "" || !filepath.IsAbs(loc) {
+	// uripath.IsAbsolutePath recognizes both POSIX- and Windows-absolute shapes
+	// regardless of GOOS, so a purely-local absolute loc against a local base is
+	// left unchanged on every OS.
+	if xsd.URIScheme(base) != "" || !uripath.IsAbsolutePath(loc) {
 		return resolveRelativeURI(base, loc)
 	}
 	return loc

--- a/xslt3/resolve_uri_internal_test.go
+++ b/xslt3/resolve_uri_internal_test.go
@@ -40,6 +40,32 @@ func TestResolveAgainstBaseURIAbsolute(t *testing.T) {
 	}
 }
 
+// TestEnsureFileURI verifies that ensureFileURI normalizes both POSIX- and
+// Windows-absolute filesystem paths into "file:" URIs (so a later url.Parse
+// never reads a Windows drive letter as a URI scheme), and leaves paths that
+// already carry a scheme untouched. The Windows shapes are plain strings, so
+// the Windows behavior is exercised on Linux CI.
+func TestEnsureFileURI(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"posix absolute", "/a/b/main.xsl", "file:///a/b/main.xsl"},
+		{"windows drive backslash", `D:\a\helium\main.xsl`, "file:///D:/a/helium/main.xsl"},
+		{"windows drive forward slash", `C:/styles/main.xsl`, "file:///C:/styles/main.xsl"},
+		{"windows unc", `\\host\share\main.xsl`, "file://host/share/main.xsl"},
+		{"already file uri", "file:///a/b.xsl", "file:///a/b.xsl"},
+		{"already http uri", "http://example.com/a.xsl", "http://example.com/a.xsl"},
+		{"relative left alone", "child.xsl", "child.xsl"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, ensureFileURI(tc.in))
+		})
+	}
+}
+
 // TestLoadParameterDocumentURIAbsolute verifies that the serialization
 // parameter-document loader hands an absolute-URI href (scheme, no "://")
 // to its loader unchanged rather than filepath.Join'ing it onto the base.

--- a/xslt3/resolve_uri_internal_test.go
+++ b/xslt3/resolve_uri_internal_test.go
@@ -11,6 +11,7 @@ const (
 	testStylesMainXSL = "/styles/main.xsl"
 	testDocsDir       = "/docs"
 	testDocsMainXML   = "/docs/main.xml"
+	testChildXML      = "child.xml"
 )
 
 // TestResolveAgainstBaseURIAbsolute verifies that resolveAgainstBaseURI
@@ -28,10 +29,10 @@ func TestResolveAgainstBaseURIAbsolute(t *testing.T) {
 		{"urn opaque", "urn:shared", testDocsMainXML, "urn:shared"},
 		{"file single slash", "file:/docs/d.xml", testDocsMainXML, "file:/docs/d.xml"},
 		{"http authority", "http://example.com/d.xml", testDocsMainXML, "http://example.com/d.xml"},
-		{"relative against local base", "child.xml", testDocsMainXML, "/docs/child.xml"},
+		{"relative against local base", testChildXML, testDocsMainXML, "/docs/child.xml"},
 		// Root-relative ref against a URI base keeps scheme+authority.
 		{"root-relative against uri base", "/other/d.xml", "mem:/docs/main.xml", "mem:/other/d.xml"},
-		{"relative against uri base", "child.xml", "mem:/docs/main.xml", "mem:/docs/child.xml"},
+		{"relative against uri base", testChildXML, "mem:/docs/main.xml", "mem:/docs/child.xml"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got := resolveAgainstBaseURI(tc.uri, tc.base)
@@ -144,12 +145,16 @@ func TestResolveDocumentURIAbsolute(t *testing.T) {
 		{"file single slash", "file:/x.xml", testDocsDir, "file:/x.xml"},
 		{"http authority", "http://example.com/d.xml", testDocsDir, "http://example.com/d.xml"},
 		// Relative ref against a URI base keeps scheme/authority.
-		{"relative under uri base", "child.xml", "mem://pkg", "mem://pkg/child.xml"},
+		{"relative under uri base", testChildXML, "mem://pkg", "mem://pkg/child.xml"},
 		{"root-relative under uri base", "/other.xml", "mem://pkg/sub", "mem://pkg/other.xml"},
 		// Both local: historical filepath behavior preserved.
-		{"local relative", "child.xml", testDocsDir, "/docs/child.xml"},
+		{"local relative", testChildXML, testDocsDir, "/docs/child.xml"},
 		{"local absolute", "/abs.xml", testDocsDir, "/abs.xml"},
 		{"file triple slash", "file:///abs/x.xml", testDocsDir, "/abs/x.xml"},
+		// Windows-shaped local base resolves with forward-slash output on any OS
+		// (a plain string here, so the Windows behavior is exercised on Linux).
+		{"windows base relative ref", testChildXML, `C:\docs`, "C:/docs/child.xml"},
+		{"windows-absolute ref verbatim", `C:\abs.xml`, `C:\docs`, `C:\abs.xml`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got := ec.resolveDocumentURI(tc.uri, tc.baseDir)

--- a/xslt3/resolve_uri_internal_test.go
+++ b/xslt3/resolve_uri_internal_test.go
@@ -150,6 +150,11 @@ func TestResolveDocumentURIAbsolute(t *testing.T) {
 		// Both local: historical filepath behavior preserved.
 		{"local relative", testChildXML, testDocsDir, "/docs/child.xml"},
 		{"local absolute", "/abs.xml", testDocsDir, "/abs.xml"},
+		// A POSIX-shaped file: URI resolves to a forward-slash path on every OS;
+		// the ToSlash normalization on the FileURIToPath result is what stops
+		// Windows from emitting "\abs\x.xml" here. (A drive-letter file: URI is
+		// GOOS-dependent via FileURIToPath, so it is not asserted in this
+		// cross-OS table.)
 		{"file triple slash", "file:///abs/x.xml", testDocsDir, "/abs/x.xml"},
 		// Windows-shaped local base resolves with forward-slash output on any OS
 		// (a plain string here, so the Windows behavior is exercised on Linux).

--- a/xslt3/schema_resolver_fs.go
+++ b/xslt3/schema_resolver_fs.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/lestrrat-go/helium/internal/uripath"
 	"github.com/lestrrat-go/helium/xsd"
 )
 
@@ -97,8 +98,8 @@ func isFatalSchemaLoadError(err error) bool {
 // the full FILE path of the referencing stylesheet or document. An absolute
 // local ref is returned as-is; otherwise the ref is joined onto the base's
 // directory. The base may be a full file path (e.g. "/a/b/style.xsl") or a
-// directory-like path from xml:base processing (e.g. "/a/b"); baseURIDir
-// distinguishes the two so a directory base is not truncated by filepath.Dir.
+// directory-like path from xml:base processing (e.g. "/a/b"); uripath.LocalBaseDir
+// distinguishes the two so a directory base is not truncated.
 func resolveSchemaURI(ref, baseURI string) (string, error) {
 	if ref == "" || baseURI == "" {
 		return ref, nil
@@ -111,11 +112,13 @@ func resolveSchemaURI(ref, baseURI string) (string, error) {
 		return xsd.ResolveSchemaURI(ref, baseURI)
 	}
 
-	// Local filesystem base (a FILE path): keep historical filepath semantics.
-	if filepath.IsAbs(ref) {
+	// Local filesystem base (a FILE path): resolve with forward-slash
+	// (path) semantics so the result uses '/' on every OS. uripath.IsAbsolutePath
+	// recognizes both POSIX- and Windows-absolute shapes regardless of GOOS.
+	if uripath.IsAbsolutePath(ref) {
 		return ref, nil
 	}
-	return filepath.Join(baseURIDir(baseURI), ref), nil
+	return uripath.JoinLocalBaseDir(uripath.LocalBaseDir(baseURI), ref), nil
 }
 
 // schemaCompileBaseDir maps a base URI/path to the value passed to

--- a/xslt3/schema_resolver_fs_internal_test.go
+++ b/xslt3/schema_resolver_fs_internal_test.go
@@ -57,6 +57,11 @@ func TestResolveSchemaURI(t *testing.T) {
 		// xml:base): treated as a directory, NOT truncated by filepath.Dir.
 		{"local dir base, relative ref", "/work/schemas", sxsd, "/work/schemas/s.xsd"},
 		{"local dir base trailing slash, relative ref", "/work/schemas/", sxsd, "/work/schemas/s.xsd"},
+		// Windows-shaped local base: resolution stays in forward-slash space on
+		// every OS (plain strings, so exercised on Linux). The slashed base's
+		// last segment carries an extension, so it is the document and is dropped.
+		{"windows file base, relative ref", `C:\work\main.xsl`, sxsd, "C:/work/s.xsd"},
+		{"windows dir base, relative ref", `C:\work\schemas`, sxsd, "C:/work/schemas/s.xsd"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := resolveSchemaURI(tc.ref, tc.base)

--- a/xslt3/w3c_helpers_test.go
+++ b/xslt3/w3c_helpers_test.go
@@ -1004,8 +1004,7 @@ func w3cRunOne(t *testing.T, tc w3cTest) {
 		sourceParser := helium.NewParser().LoadExternalDTD(true).DefaultDTDAttributes(true)
 		if tc.SourceDocPath != "" {
 			sourceParser = sourceParser.SubstituteEntities(true).FixBaseURIs(false)
-			srcAbsPath, _ := filepath.Abs(w3cResolvePath(tc.SourceDocPath))
-			sourceParser = sourceParser.BaseURI(srcAbsPath)
+			sourceParser = sourceParser.BaseURI(w3cAbsBaseURI(tc.SourceDocPath))
 		}
 		var parseErr error
 		sourceDoc, parseErr = sourceParser.Parse(t.Context(), sourceData)
@@ -1016,11 +1015,9 @@ func w3cRunOne(t *testing.T, tc w3cTest) {
 			t.Fatalf("cannot parse source: %v", parseErr)
 		}
 		if tc.SourceDocPath != "" {
-			srcAbsPath, _ := filepath.Abs(w3cResolvePath(tc.SourceDocPath))
-			sourceDoc.SetURL(srcAbsPath)
+			sourceDoc.SetURL(w3cAbsBaseURI(tc.SourceDocPath))
 		} else if tc.SourceContent != "" && tc.StylesheetPath != "" {
-			ssAbsPath, _ := filepath.Abs(w3cResolvePath(tc.StylesheetPath))
-			sourceDoc.SetURL(ssAbsPath)
+			sourceDoc.SetURL(w3cAbsBaseURI(tc.StylesheetPath))
 		}
 	}
 
@@ -1031,13 +1028,12 @@ func w3cRunOne(t *testing.T, tc w3cTest) {
 	if tc.EmbeddedStylesheet && tc.StylesheetPath == "" {
 		// Extract embedded stylesheet from source document
 		ssDoc := w3cExtractEmbeddedStylesheet(t, sourceDoc)
-		srcAbsPath, _ := filepath.Abs(w3cResolvePath(tc.SourceDocPath))
-		compiler := xslt3.NewCompiler().BaseURI(srcAbsPath).URIResolver(w3cTestCompileResolver).AllowExternalEntities(true)
+		compiler := xslt3.NewCompiler().BaseURI(w3cAbsBaseURI(tc.SourceDocPath)).URIResolver(w3cTestCompileResolver).AllowExternalEntities(true)
 		ss, err = compiler.Compile(t.Context(), ssDoc)
 	} else if len(tc.PackageDeps) > 0 || len(tc.Params) > 0 || len(tc.ImportSchemaPaths) > 0 {
 		// When package deps, external params, or import schemas exist, compile without caching.
 		ssPath := w3cResolvePath(tc.StylesheetPath)
-		absPath, _ := filepath.Abs(ssPath)
+		absPath := w3cAbsBaseURI(tc.StylesheetPath)
 		compiler := xslt3.NewCompiler().BaseURI(absPath).URIResolver(w3cTestCompileResolver).AllowExternalEntities(true)
 		if len(tc.PackageDeps) > 0 {
 			compiler = compiler.PackageResolver(w3cPackageResolver{deps: tc.PackageDeps, versionResolution: tc.VersionResolution})
@@ -1085,8 +1081,7 @@ func w3cRunOne(t *testing.T, tc w3cTest) {
 		// The source doc has an embedded stylesheet that imports/includes the
 		// standalone stylesheet. Extract and compile the embedded one.
 		ssDoc := w3cExtractEmbeddedStylesheet(t, sourceDoc)
-		srcAbsPath, _ := filepath.Abs(w3cResolvePath(tc.SourceDocPath))
-		compiler := xslt3.NewCompiler().BaseURI(srcAbsPath).URIResolver(w3cTestCompileResolver).AllowExternalEntities(true)
+		compiler := xslt3.NewCompiler().BaseURI(w3cAbsBaseURI(tc.SourceDocPath)).URIResolver(w3cTestCompileResolver).AllowExternalEntities(true)
 		ss, err = compiler.Compile(t.Context(), ssDoc)
 	} else {
 		ssPath := w3cResolvePath(tc.StylesheetPath)
@@ -2597,6 +2592,10 @@ func w3cCompileCached(ctx context.Context, path string) (*xslt3.Stylesheet, erro
 	if absErr != nil {
 		absPath = path
 	}
+	// A base URI is a URI: force forward-slash so static-base-uri(), $err:module
+	// (tokenized on '/'), and document-uri() are OS-independent (see
+	// w3cAbsBaseURI). On POSIX this is a no-op.
+	absPath = filepath.ToSlash(absPath)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -2634,6 +2633,18 @@ func w3cResolvePath(rel string) string {
 		return rel
 	}
 	return filepath.Join(w3cTestdataDir, rel)
+}
+
+// w3cAbsBaseURI returns the absolute base URI for a stylesheet/source path in
+// FORWARD-SLASH form. A base URI is a URI, not a native path: tests such as
+// try-004 do tokenize($err:module, '/') and accessor/base-uri tests resolve
+// relative URIs against it, all of which assume '/' separators. On POSIX
+// filepath.Abs already yields '/'; on Windows it yields backslashes, which
+// would leak into static-base-uri()/$err:module and break those tests. Passing
+// a forward-slash base makes the harness behave identically on every OS.
+func w3cAbsBaseURI(rel string) string {
+	abs, _ := filepath.Abs(w3cResolvePath(rel))
+	return filepath.ToSlash(abs)
 }
 
 // w3cCollectionResolver implements xpath3.CollectionResolver for W3C tests.

--- a/xslt3/xxe_default_test.go
+++ b/xslt3/xxe_default_test.go
@@ -23,6 +23,14 @@ type xxeResolver struct {
 func (r *xxeResolver) Resolve(uri string) (io.ReadCloser, error) {
 	body, ok := r.files[uri]
 	if !ok {
+		// The map is keyed on native paths (filepath.Join). helium's URI
+		// resolution emits forward slashes on every OS, so on Windows the
+		// resolved URI is "C:/dir/x" while the key is "C:\\dir\\x". Retry with
+		// the native-separator form so the lookup matches on both platforms
+		// (filepath.FromSlash is a no-op on POSIX).
+		body, ok = r.files[filepath.FromSlash(uri)]
+	}
+	if !ok {
 		return nil, os.ErrNotExist
 	}
 	return io.NopCloser(strings.NewReader(body)), nil


### PR DESCRIPTION
- run the test suite on a ubuntu/macOS/windows matrix; split generation/tidy/build hygiene into a ubuntu-only `verify` job
- pin `stringer@v0.46.0` (was `@latest`); add a pinned `govulncheck@v1.4.0` job
- add `toolchain go1.26.4` to go.mod, clearing 8 stdlib CVEs reported by govulncheck (keeps the `go 1.26.1` consumer minimum)