### PR TITLE
fix data race in parallel coverage subtests

### DIFF
--- a/coverage_round2_test.go
+++ b/coverage_round2_test.go
@@ -18,6 +18,11 @@ import (
 func TestDTDDeclarationNodeWrappers(t *testing.T) {
 	t.Parallel()
 
+	// The ElementDecl/AttributeDecl subtests below share and mutate a single
+	// parsed doc (AppendText/AddChild allocate text and comment nodes off the
+	// document). helium Documents are a DOM tree and are not concurrency-safe,
+	// so these subtests must run sequentially — do NOT add t.Parallel() to them.
+
 	// Parse a doc that declares both an element and an attribute so we obtain
 	// real ElementDecl and AttributeDecl nodes from the DTD.
 	const src = `<?xml version="1.0"?>
@@ -32,7 +37,6 @@ func TestDTDDeclarationNodeWrappers(t *testing.T) {
 	require.NotNil(t, dtd)
 
 	t.Run("ElementDecl wrappers", func(t *testing.T) {
-		t.Parallel()
 		edecl, ok := dtd.LookupElement("doc", "")
 		require.True(t, ok)
 		require.Equal(t, helium.ElementDeclNode, edecl.Type())
@@ -49,7 +53,6 @@ func TestDTDDeclarationNodeWrappers(t *testing.T) {
 	})
 
 	t.Run("AttributeDecl wrappers", func(t *testing.T) {
-		t.Parallel()
 		adecls := dtd.AttributesForElement("doc")
 		require.NotEmpty(t, adecls)
 		adecl := adecls[0]
@@ -62,7 +65,6 @@ func TestDTDDeclarationNodeWrappers(t *testing.T) {
 	})
 
 	t.Run("DTD AppendText and Free", func(t *testing.T) {
-		t.Parallel()
 		d3 := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
 		dtd3, derr := d3.CreateInternalSubset("doc", "", "")
 		require.NoError(t, derr)
@@ -71,7 +73,6 @@ func TestDTDDeclarationNodeWrappers(t *testing.T) {
 	})
 
 	t.Run("Entity AddSibling and Replace", func(t *testing.T) {
-		t.Parallel()
 		d4 := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
 		dtd4, derr := d4.CreateInternalSubset("doc", "", "")
 		require.NoError(t, derr)


### PR DESCRIPTION
- `TestDTDDeclarationNodeWrappers` ran `t.Parallel()` subtests that shared and mutated one parsed `*helium.Document` (non-concurrency-safe DOM), racing on `Document.allocText`.
- Dropped `t.Parallel()` from the four subtests so they run sequentially; coverage unchanged.