### PR TITLE
externalize trivially-movable internal tests

### DIFF
--- a/internal/strcursor/bytecursor_test.go
+++ b/internal/strcursor/bytecursor_test.go
@@ -1,4 +1,4 @@
-package strcursor
+package strcursor_test
 
 import (
 	"errors"
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lestrrat-go/helium/internal/strcursor"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,7 +31,7 @@ func (r *dataThenErrReader) Read(p []byte) (int, error) {
 
 func TestByteCursorSurfacesErrorReturnedWithData(t *testing.T) {
 	wantErr := errors.New("checksum mismatch")
-	cur := NewByteCursor(&dataThenErrReader{
+	cur := strcursor.NewByteCursor(&dataThenErrReader{
 		data: []byte("<root/>"),
 		err:  wantErr,
 	})
@@ -57,7 +58,7 @@ func (zeroProgressReader) Read(p []byte) (int, error) {
 }
 
 func TestByteCursorZeroProgressReaderDoesNotHang(t *testing.T) {
-	cur := NewByteCursor(zeroProgressReader{})
+	cur := strcursor.NewByteCursor(zeroProgressReader{})
 
 	type result struct {
 		done bool
@@ -105,7 +106,7 @@ func (r *slowSplitReader) Read(p []byte) (int, error) {
 }
 
 func TestByteCursorSlowSplitReaderMakesProgress(t *testing.T) {
-	cur := NewByteCursor(&slowSplitReader{data: []byte("<root/>")})
+	cur := strcursor.NewByteCursor(&slowSplitReader{data: []byte("<root/>")})
 
 	type result struct {
 		hasPrefix bool
@@ -127,7 +128,7 @@ func TestByteCursorSlowSplitReaderMakesProgress(t *testing.T) {
 }
 
 func TestByteCursorTreatsEOFWithDataAsCleanEnd(t *testing.T) {
-	cur := NewByteCursor(&dataThenErrReader{
+	cur := strcursor.NewByteCursor(&dataThenErrReader{
 		data: []byte("<root/>"),
 		err:  io.EOF,
 	})

--- a/internal/strcursor/utf8cursor_test.go
+++ b/internal/strcursor/utf8cursor_test.go
@@ -1,4 +1,4 @@
-package strcursor
+package strcursor_test
 
 import (
 	"io"
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lestrrat-go/helium/internal/strcursor"
 	"github.com/stretchr/testify/require"
 )
 
 func TestUTF8CursorZeroProgressReaderDoesNotHang(t *testing.T) {
-	cur := NewUTF8Cursor(zeroProgressReader{})
+	cur := strcursor.NewUTF8Cursor(zeroProgressReader{})
 
 	type result struct {
 		done bool
@@ -32,7 +33,7 @@ func TestUTF8CursorZeroProgressReaderDoesNotHang(t *testing.T) {
 }
 
 func TestUTF8CursorSlowSplitReaderMakesProgress(t *testing.T) {
-	cur := NewUTF8Cursor(&slowSplitReader{data: []byte("héllo")})
+	cur := strcursor.NewUTF8Cursor(&slowSplitReader{data: []byte("héllo")})
 
 	type result struct {
 		peeked string
@@ -69,7 +70,7 @@ func (r *chunkedReader) Read(p []byte) (int, error) {
 }
 
 func TestUTF8CursorScanCharDataSliceSpansBufferEdge(t *testing.T) {
-	cur := NewUTF8Cursor(&chunkedReader{
+	cur := strcursor.NewUTF8Cursor(&chunkedReader{
 		data:  []byte("    <"),
 		chunk: 2,
 	})
@@ -80,7 +81,7 @@ func TestUTF8CursorScanCharDataSliceSpansBufferEdge(t *testing.T) {
 }
 
 func TestUTF8CursorScanCharDataSliceConsumesCRLFAcrossBufferEdge(t *testing.T) {
-	cur := NewUTF8Cursor(&chunkedReader{
+	cur := strcursor.NewUTF8Cursor(&chunkedReader{
 		data:  []byte("\r\n<"),
 		chunk: 1,
 	})
@@ -91,7 +92,7 @@ func TestUTF8CursorScanCharDataSliceConsumesCRLFAcrossBufferEdge(t *testing.T) {
 }
 
 func TestUTF8CursorScanCharDataSlicePreservesWhitespaceRunAcrossBufferEdge(t *testing.T) {
-	cur := NewUTF8Cursor(&chunkedReader{
+	cur := strcursor.NewUTF8Cursor(&chunkedReader{
 		data:  []byte(strings.Repeat(" ", 7) + "<"),
 		chunk: 3,
 	})
@@ -102,7 +103,7 @@ func TestUTF8CursorScanCharDataSlicePreservesWhitespaceRunAcrossBufferEdge(t *te
 }
 
 func TestUTF8CursorScanQNameBytesASCIIUnprefixed(t *testing.T) {
-	cur := NewUTF8Cursor(strings.NewReader("root attr"))
+	cur := strcursor.NewUTF8Cursor(strings.NewReader("root attr"))
 
 	prefix, local, n, ok := cur.ScanQNameBytes()
 	require.True(t, ok)
@@ -112,7 +113,7 @@ func TestUTF8CursorScanQNameBytesASCIIUnprefixed(t *testing.T) {
 }
 
 func TestUTF8CursorScanQNameBytesASCIIPrefixed(t *testing.T) {
-	cur := NewUTF8Cursor(strings.NewReader("x:item attr"))
+	cur := strcursor.NewUTF8Cursor(strings.NewReader("x:item attr"))
 
 	prefix, local, n, ok := cur.ScanQNameBytes()
 	require.True(t, ok)
@@ -122,7 +123,7 @@ func TestUTF8CursorScanQNameBytesASCIIPrefixed(t *testing.T) {
 }
 
 func TestUTF8CursorScanQNameBytesSpansBufferEdge(t *testing.T) {
-	cur := NewUTF8Cursor(&chunkedReader{
+	cur := strcursor.NewUTF8Cursor(&chunkedReader{
 		data:  []byte("x:item attr"),
 		chunk: 2,
 	})
@@ -135,7 +136,7 @@ func TestUTF8CursorScanQNameBytesSpansBufferEdge(t *testing.T) {
 }
 
 func TestUTF8CursorScanQNameBytesRejectsSecondColon(t *testing.T) {
-	cur := NewUTF8Cursor(strings.NewReader("a:b:c"))
+	cur := strcursor.NewUTF8Cursor(strings.NewReader("a:b:c"))
 
 	prefix, local, n, ok := cur.ScanQNameBytes()
 	require.False(t, ok)
@@ -146,7 +147,7 @@ func TestUTF8CursorScanQNameBytesRejectsSecondColon(t *testing.T) {
 }
 
 func TestRuneCursorReadShortBufferBufferedRune(t *testing.T) {
-	cur := NewRuneCursor(strings.NewReader("é"))
+	cur := strcursor.NewRuneCursor(strings.NewReader("é"))
 	// Buffer the multibyte rune in the ring.
 	require.Equal(t, 'é', cur.Peek())
 
@@ -175,7 +176,7 @@ func TestRuneCursorReadShortBufferBufferedRune(t *testing.T) {
 }
 
 func TestRuneCursorReadShortBufferPartialRuneFit(t *testing.T) {
-	cur := NewRuneCursor(strings.NewReader("aé"))
+	cur := strcursor.NewRuneCursor(strings.NewReader("aé"))
 	// Buffer both runes in the ring.
 	require.Equal(t, 'a', cur.Peek())
 	require.Equal(t, 'é', cur.PeekN(2))

--- a/options_test.go
+++ b/options_test.go
@@ -1,9 +1,10 @@
-package helium
+package helium_test
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/bitset"
 	"github.com/stretchr/testify/require"
 )
@@ -11,26 +12,26 @@ import (
 func TestLoadSubsetOptionFlagsAreUnique(t *testing.T) {
 	t.Parallel()
 
-	assertUniqueFlags(t, []LoadSubsetOption{
-		DetectIDs,
-		CompleteAttrs,
-		SkipIDs,
+	assertUniqueFlags(t, []helium.LoadSubsetOption{
+		helium.DetectIDs,
+		helium.CompleteAttrs,
+		helium.SkipIDs,
 	})
 }
 
 func TestSetAndIsSet(t *testing.T) {
 	t.Parallel()
 
-	var l LoadSubsetOption
-	require.False(t, l.IsSet(DetectIDs))
+	var l helium.LoadSubsetOption
+	require.False(t, l.IsSet(helium.DetectIDs))
 
-	l.Set(DetectIDs)
-	require.True(t, l.IsSet(DetectIDs))
-	require.False(t, l.IsSet(CompleteAttrs))
+	l.Set(helium.DetectIDs)
+	require.True(t, l.IsSet(helium.DetectIDs))
+	require.False(t, l.IsSet(helium.CompleteAttrs))
 
-	l.Set(CompleteAttrs)
-	require.True(t, l.IsSet(DetectIDs))
-	require.True(t, l.IsSet(CompleteAttrs))
+	l.Set(helium.CompleteAttrs)
+	require.True(t, l.IsSet(helium.DetectIDs))
+	require.True(t, l.IsSet(helium.CompleteAttrs))
 }
 
 func assertUniqueFlags[T bitset.Field](t *testing.T, flags []T) {


### PR DESCRIPTION
- move `options_test.go` to `helium_test`, both `internal/strcursor` test files to `strcursor_test`
- only files in the module whose tests use solely exported API; no symbols exported, no behavior change
- identical test/helper sets vs main; gauntlet adversarial review found no issues