### PR TITLE
classify ignore_doc_failure tests via generator dep

### DIFF
--- a/tools/xslt3gen/main.go
+++ b/tools/xslt3gen/main.go
@@ -900,6 +900,18 @@ func getDepsSkipReason(deps *xslDependencies) string {
 			if d.Satisfied == "false" {
 				return "test requires assertions disabled; we evaluate assertions"
 			}
+		case "ignore_doc_failure":
+			// XSLT 3.0 makes the handling of a failed document()/fn:doc()
+			// retrieval implementation-defined: a processor may either raise
+			// the dynamic error FODC0002 or recover by returning an empty
+			// sequence. Our processor always raises FODC0002 (secure-by-default
+			// document loading), i.e. it does NOT ignore document failures.
+			// A test with satisfied="true" only applies to processors that
+			// recover silently, so skip it. satisfied="false" matches us and
+			// runs (expects the FODC0002 error).
+			if d.Satisfied == "true" {
+				return "processor raises FODC0002 instead of ignoring document() failures"
+			}
 		}
 	}
 	return ""

--- a/xslt3/w3c_helpers_test.go
+++ b/xslt3/w3c_helpers_test.go
@@ -1661,8 +1661,9 @@ var w3cImplicitSkips = map[string]string{
 	"use-package-108":  "package-scoped namespace alias serialization not implemented",
 	"use-package-108b": "package-scoped namespace alias serialization not implemented",
 
-	// error-FODC0002a-ignore: processor now raises FODC0002 (ignore_doc_failure=false)
-	"error-FODC0002a-ignore": "processor raises FODC0002 instead of ignoring document failures",
+	// error-FODC0002a-ignore is now skipped by the generator via the
+	// ignore_doc_failure dependency (see tools/xslt3gen getDepsSkipReason),
+	// so it no longer needs a name-based skip here.
 
 	// merge: schema-element instance test on merged items
 	"merge-049":   "schema-element() instance test on merged items fails",

--- a/xslt3/w3c_misc_gen_test.go
+++ b/xslt3/w3c_misc_gen_test.go
@@ -1880,7 +1880,7 @@ func TestW3C_error(t *testing.T) {
 </doc>`, ExpectError: true, ErrorCode: "FODC0002"},
 		{Name: "error-FODC0002a-ignore", StylesheetPath: "tests/misc/error/error-FODC0002a.xsl", SourceContent: `<doc>
   <element attribute="3"/>
-</doc>`, Assertions: []w3cAssertion{w3cAssertXML("<root/>")}},
+</doc>`, Assertions: []w3cAssertion{w3cAssertXML("<root/>")}, Skip: "processor raises FODC0002 instead of ignoring document() failures"},
 		{Name: "error-FOER0001a", StylesheetPath: "tests/misc/error/error-FOER0001a.xsl", SourceContent: `<doc>
   <element attribute="3"/>
 </doc>`, ExpectError: true, ErrorCode: "FOER0000"},


### PR DESCRIPTION
- our FODC0002-on-document-failure is spec-conformant (handling is implementation-defined); satisfied=true variant only applies to silent-recovery processors
- xslt3gen now skips ignore_doc_failure satisfied=true via the W3C dependency, replacing a hand-maintained name skip