### PR TITLE
capture attribute result-nodes in sequence mode

### DIFF
--- a/xslt3/execute_templates.go
+++ b/xslt3/execute_templates.go
@@ -675,8 +675,13 @@ func (ec *execContext) executeTemplateBodyWithAs(ctx context.Context, tmpl *temp
 				}
 			}
 			// Attribute nodes must be set as attributes on the current
-			// element, not added as child nodes.
-			if v.Node.Type() == helium.AttributeNode {
+			// element, not added as child nodes — except in capture/sequence
+			// mode (xsl:function / xsl:variable with as=, etc.), where the
+			// attribute is a free-standing sequence item that must be captured
+			// intact (out.current is not the eventual owner element). Falling
+			// through to ec.addNode captures it as a pendingItem in that case,
+			// mirroring copyNodeToOutput's sequenceMode handling.
+			if v.Node.Type() == helium.AttributeNode && !out.captureItems && !out.sequenceMode {
 				attr, ok := v.Node.(*helium.Attribute)
 				if ok {
 					if elem, ok := out.current.(*helium.Element); ok {

--- a/xslt3/w3c_helpers_test.go
+++ b/xslt3/w3c_helpers_test.go
@@ -1723,9 +1723,6 @@ var w3cImplicitSkips = map[string]string{
 
 	"base-uri-052": "XInclude processing not applied to source documents",
 
-	// snapshot: f:snapshot reference impl namespace-node graft produces empty root
-	"snapshot-0102a": "snapshot()/root() returns empty for some namespace nodes",
-
 	// XSD 1.1 features: newly unlocked but failing
 	"validation-1301":   "XSD 1.1 xs:alternative type selection not implemented",
 	"import-schema-164": "XSD validation fails for namespaced attribute ref with default",


### PR DESCRIPTION
- a template with as="attribute()" silently dropped attribute result-nodes in capture/sequence mode (xsl:function bodies), so f:snapshot() returned empty
- guard the attribute-as-element path with !captureItems && !sequenceMode, mirroring the document-node branch; closes snapshot-0102a