### PR TITLE
type-annotate json-to-xml result with validate option

### DIFF
--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -92,6 +92,18 @@ Misc: `adjust-dateTime-to-timezone`, `adjust-date-to-timezone`, `adjust-time-to-
 ### `functions_json_xml.go`
 `json-to-xml`, `xml-to-json`
 
+`json-to-xml` with the `validate:true()` option type-annotates the result tree:
+each result element records the type defined by the json-to-xml result schema
+(`schema-for-json.xsd`, target namespace = fn namespace) keyed by node into
+`ec.typeAnnotations`, so downstream `instance of element(j:map, j:mapType)` /
+`element(j:string, j:stringType)` / `element(j:boolean, xs:boolean)` tests over
+the produced tree succeed. The mapping is a fixed function of each node's JSON
+kind (`mapType`/`arrayType`/`stringType`/`numberType`/`nullType` in the fn
+namespace; `boolean` → `xs:boolean`), so no general XSD validation pass runs.
+`ec.typeAnnotations` (handed in by the caller and shared across concurrent
+`Evaluate` calls) is copied into a fresh per-evaluation map before the new nodes'
+annotations are merged in — the shared config map is never mutated.
+
 ### `functions_serialize.go`
 `serialize`
 

--- a/xpath3/functions_json.go
+++ b/xpath3/functions_json.go
@@ -24,6 +24,7 @@ type jsonOptions struct {
 	liberal    bool
 	duplicates string // "reject", "use-first", "use-last" (default)
 	escape     bool
+	validate   bool // validate=true(): type-annotate the json-to-xml result tree
 	fallback   *FunctionItem
 	invalidEsc map[rune]string
 }

--- a/xpath3/functions_json_xml.go
+++ b/xpath3/functions_json_xml.go
@@ -55,21 +55,80 @@ func fnJSONToXML(ctx context.Context, args []Sequence) (Sequence, error) {
 		return nil, &XPathError{Code: errCodeFOJS0001, Message: fmt.Sprintf("invalid trailing content: %v", err)}
 	}
 
+	ec := getFnContext(ctx)
 	doc := helium.NewDefaultDocument()
-	if ec := getFnContext(ctx); ec != nil && ec.baseURI != "" {
+	if ec != nil && ec.baseURI != "" {
 		doc.SetURL(ec.baseURI)
 	}
-	root, err := buildJSONToXMLTree(doc, item, opts, true)
+
+	// When validate=true(), record a type annotation for every result node so
+	// that downstream instance-of / schema-aware type tests over the produced
+	// tree (element(j:map, j:mapType), element(j:string, j:stringType), ...)
+	// observe the types defined by the json-to-xml result schema. The mapping
+	// is a fixed function of each node's JSON kind, so no general XSD validation
+	// pass is required.
+	var annotations map[helium.Node]string
+	if opts.validate {
+		annotations = make(map[helium.Node]string)
+	}
+
+	root, err := buildJSONToXMLTree(doc, item, opts, true, annotations)
 	if err != nil {
 		return nil, err
 	}
 	if err := doc.SetDocumentElement(root); err != nil {
 		return nil, &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("json-to-xml: failed to build result: %v", err)}
 	}
+
+	if opts.validate && ec != nil && len(annotations) > 0 {
+		installJSONToXMLAnnotations(ec, annotations)
+	}
+
 	return ItemSlice{NodeItem{Node: doc}}, nil
 }
 
-func buildJSONToXMLTree(doc *helium.Document, item Item, opts jsonOptions, root bool) (*helium.Element, error) {
+// installJSONToXMLAnnotations merges the json-to-xml result-tree annotations
+// into the evaluation context's node→type map. The map handed to the evaluator
+// by the caller (cfg.typeAnnotations) is shared across concurrent Evaluate
+// calls and must not be mutated in place; this copies it into a fresh map owned
+// by the per-evaluation evalContext before adding the new nodes' annotations.
+// The new nodes only exist in this call's freshly built result tree, so the
+// merge cannot collide with annotations for any pre-existing input node.
+func installJSONToXMLAnnotations(ec *evalContext, annotations map[helium.Node]string) {
+	merged := make(map[helium.Node]string, len(ec.typeAnnotations)+len(annotations))
+	for n, ann := range ec.typeAnnotations {
+		merged[n] = ann
+	}
+	for n, ann := range annotations {
+		merged[n] = ann
+	}
+	ec.typeAnnotations = merged
+}
+
+// jsonToXMLTypeAnnotation maps a json-to-xml result element name to the type
+// annotation defined by the json-to-xml result schema (schema-for-json.xsd),
+// whose target namespace is the fn namespace. The boolean element is typed
+// directly as xs:boolean; the others use the named complex/simple types.
+func jsonToXMLTypeAnnotation(name string) string {
+	switch name {
+	case jsonKindMap:
+		return QAnnotation(NSFn, "mapType")
+	case jsonKindArray:
+		return QAnnotation(NSFn, "arrayType")
+	case lexicon.TypeString:
+		return QAnnotation(NSFn, "stringType")
+	case lexicon.TypeNumber:
+		return QAnnotation(NSFn, "numberType")
+	case lexicon.TypeBoolean:
+		return TypeBoolean
+	case jsonKindNull:
+		return QAnnotation(NSFn, "nullType")
+	default:
+		return ""
+	}
+}
+
+func buildJSONToXMLTree(doc *helium.Document, item Item, opts jsonOptions, root bool, annotations map[helium.Node]string) (*helium.Element, error) {
 	name := jsonKindNull
 	switch v := item.(type) {
 	case MapItem:
@@ -89,6 +148,11 @@ func buildJSONToXMLTree(doc *helium.Document, item Item, opts jsonOptions, root 
 	}
 
 	elem := doc.CreateElement(name)
+	if annotations != nil {
+		if ann := jsonToXMLTypeAnnotation(name); ann != "" {
+			annotations[elem] = ann
+		}
+	}
 	if root {
 		if err := elem.DeclareNamespace("", NSFn); err != nil {
 			return nil, &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("json-to-xml: failed to build result: %v", err)}
@@ -103,7 +167,7 @@ func buildJSONToXMLTree(doc *helium.Document, item Item, opts jsonOptions, root 
 		return elem, nil
 	case MapItem:
 		if err := v.forEach0(func(key AtomicValue, value Sequence) error {
-			child, err := buildJSONToXMLTree(doc, jsonSequenceToItem(value), opts, false)
+			child, err := buildJSONToXMLTree(doc, jsonSequenceToItem(value), opts, false, annotations)
 			if err != nil {
 				return err
 			}
@@ -121,7 +185,7 @@ func buildJSONToXMLTree(doc *helium.Document, item Item, opts jsonOptions, root 
 		}
 	case ArrayItem:
 		for _, member := range v.members0() {
-			child, err := buildJSONToXMLTree(doc, jsonSequenceToItem(member), opts, false)
+			child, err := buildJSONToXMLTree(doc, jsonSequenceToItem(member), opts, false, annotations)
 			if err != nil {
 				return nil, err
 			}
@@ -214,6 +278,7 @@ func parseJSONToXMLOptions(args []Sequence) (jsonOptions, error) {
 	} else if found {
 		validateSet = true
 		validate = validateValue
+		opts.validate = validateValue
 	}
 
 	if escape, found, err := readBool("escape"); err != nil {

--- a/xpath3/functions_json_xml.go
+++ b/xpath3/functions_json_xml.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"strings"
 	"unicode/utf8"
 
@@ -96,12 +97,8 @@ func fnJSONToXML(ctx context.Context, args []Sequence) (Sequence, error) {
 // merge cannot collide with annotations for any pre-existing input node.
 func installJSONToXMLAnnotations(ec *evalContext, annotations map[helium.Node]string) {
 	merged := make(map[helium.Node]string, len(ec.typeAnnotations)+len(annotations))
-	for n, ann := range ec.typeAnnotations {
-		merged[n] = ann
-	}
-	for n, ann := range annotations {
-		merged[n] = ann
-	}
+	maps.Copy(merged, ec.typeAnnotations)
+	maps.Copy(merged, annotations)
 	ec.typeAnnotations = merged
 }
 

--- a/xslt3/w3c_helpers_test.go
+++ b/xslt3/w3c_helpers_test.go
@@ -51,7 +51,6 @@ const (
 
 	// W3C test skip messages reused by multiple tests.
 	skipXML11NSUndecl       = "XML 1.1: namespace undeclaration not supported by parser"
-	skipJSONToXMLValidate   = "json-to-xml validate option does not annotate result nodes"
 	skipSchemaAttrTypeCheck = "schema-attribute type check fails"
 
 	// Collection URI used by merge tests for log-file collections.
@@ -1607,15 +1606,6 @@ var w3cImplicitSkips = map[string]string{
 
 	// nodetest: child::schema-attribute axis conversion produces non-empty result
 	"nodetest-032": "child::schema-attribute axis conversion vs XPath 2.0 expected output mismatch",
-
-	// json-to-xml typed tests: fn:json-to-xml validate option does not type-annotate result
-	"json-to-xml-typed-001": skipJSONToXMLValidate,
-	"json-to-xml-typed-002": skipJSONToXMLValidate,
-	"json-to-xml-typed-003": skipJSONToXMLValidate,
-	"json-to-xml-typed-004": skipJSONToXMLValidate,
-	"json-to-xml-typed-005": skipJSONToXMLValidate,
-	"json-to-xml-typed-006": skipJSONToXMLValidate,
-	"json-to-xml-typed-007": skipJSONToXMLValidate,
 
 	// import-schema-029: the full XSLT 2.0 schema (schema-for-xslt20.xsd)
 	// triggers a fatal schema-construction diagnostic in our xsd compiler


### PR DESCRIPTION
- fn:json-to-xml ignored the validate option, leaving the result tree untyped, so instance-of/xs:boolean type tests over it failed
- validate=true() now annotates result nodes with the schema-for-json types (mapType/arrayType/stringType/numberType/nullType/xs:boolean); closes json-to-xml-typed-001..007
- default (no validate) output unchanged