### PR TITLE
declare namespace when splicing schema-attribute result

### DIFF
--- a/xslt3/execute_templates.go
+++ b/xslt3/execute_templates.go
@@ -691,10 +691,12 @@ func (ec *execContext) executeTemplateBodyWithAs(ctx context.Context, tmpl *temp
 								"cannot add attribute to element after children have been added")
 						}
 						if attr.URI() != "" {
-							ns, _ := out.doc.CreateNamespace(attr.Prefix(), attr.URI())
-							if err := elem.SetLiteralAttributeNS(attr.LocalName(), string(attr.Content()), ns); err != nil {
-								return err
-							}
+							// Use copyAttributeToElement so the attribute's
+							// namespace is declared on the element (and prefix
+							// conflicts are resolved). Setting only the attribute
+							// without a namespace declaration would leave the
+							// prefix undeclared in the serialized output.
+							copyAttributeToElement(elem, attr)
 						} else {
 							if _, err := elem.SetAttribute(attr.LocalName(), string(attr.Content())); err != nil {
 								return err

--- a/xslt3/w3c_helpers_test.go
+++ b/xslt3/w3c_helpers_test.go
@@ -50,8 +50,7 @@ const (
 	versionResolutionLowest = "lowest"
 
 	// W3C test skip messages reused by multiple tests.
-	skipXML11NSUndecl       = "XML 1.1: namespace undeclaration not supported by parser"
-	skipSchemaAttrTypeCheck = "schema-attribute type check fails"
+	skipXML11NSUndecl = "XML 1.1: namespace undeclaration not supported by parser"
 
 	// Collection URI used by merge tests for log-file collections.
 	w3cLogFilesCollectionURI = "log-files"
@@ -1637,11 +1636,6 @@ var w3cImplicitSkips = map[string]string{
 	"validation-0701": "schema-aware XSLT schema querying fails",
 	"validation-1202": "instance of schema-element fails",
 	"validation-1204": "instance of schema-element fails",
-
-	// as tests: schema-attribute type checks
-	"as-1812": skipSchemaAttrTypeCheck,
-	"as-1813": skipSchemaAttrTypeCheck,
-	"as-1814": skipSchemaAttrTypeCheck,
 
 	// override: schema-aware union types from xsl:import-schema
 	"override-f-031": "schema-aware union type conversion fails",


### PR DESCRIPTION
- a namespaced attribute returned by xsl:call-template as="schema-attribute(...)" was spliced onto the caller without declaring its namespace, yielding ill-formed output (undeclared prefix)
- route through copyAttributeToElement like every other attribute-splice site; closes as-1812/1813/1814