### PR TITLE
raise schema diagnostics for pattern and evaluate refs

### DIFF
--- a/xslt3/compile_schema.go
+++ b/xslt3/compile_schema.go
@@ -399,13 +399,9 @@ func checkPatternAgainstSchema(p *pattern, reg *schemaRegistry) error {
 func checkExprAgainstSchema(expr xpath3.Expr, reg *schemaRegistry, xpathDefaultNS string, nsBindings map[string]string) error {
 	switch e := expr.(type) {
 	case xpath3.LocationPath:
-		if len(e.Steps) > 0 {
-			return checkStepAgainstSchema(e.Steps[0], reg, xpathDefaultNS, nsBindings)
-		}
+		return checkStepsAgainstSchema(e.Steps, reg, xpathDefaultNS, nsBindings)
 	case *xpath3.LocationPath:
-		if len(e.Steps) > 0 {
-			return checkStepAgainstSchema(e.Steps[0], reg, xpathDefaultNS, nsBindings)
-		}
+		return checkStepsAgainstSchema(e.Steps, reg, xpathDefaultNS, nsBindings)
 	case xpath3.PathStepExpr:
 		// For path/step, check the leftmost expression's first step
 		return checkExprAgainstSchema(e.Left, reg, xpathDefaultNS, nsBindings)
@@ -425,6 +421,32 @@ func checkExprAgainstSchema(expr xpath3.Expr, reg *schemaRegistry, xpathDefaultN
 			return err
 		}
 		return checkExprAgainstSchema(e.Right, reg, xpathDefaultNS, nsBindings)
+	}
+	return nil
+}
+
+// checkStepsAgainstSchema applies the XTSE3105 element-name check to a location
+// path's step sequence. Per the spec the check targets the first StepExprP whose
+// axis has principal node kind Element and whose NodeTest is an EQName. Leading
+// steps that are not element-name tests — the synthetic descendant-or-self::node()
+// produced by the "//" abbreviation, a root/document-node step, an attribute axis,
+// or a kind test such as element(*) — are not EQName element-axis steps and are
+// skipped so the first genuine element NameTest (e.g. the "foo" in "//foo") is the
+// one checked. Once such a step is found the check is applied to it alone; a later
+// step in the same path (e.g. the "b" in "a/b") is not an additional XTSE3105 site.
+func checkStepsAgainstSchema(steps []xpath3.Step, reg *schemaRegistry, xpathDefaultNS string, nsBindings map[string]string) error {
+	for _, step := range steps {
+		// Skip steps on axes whose principal node kind is not Element.
+		if step.Axis == xpath3.AxisAttribute || step.Axis == xpath3.AxisNamespace {
+			continue
+		}
+		// Only an EQName NodeTest (NameTest, non-wildcard) is an XTSE3105 site;
+		// kind tests, node() (from "//"), and wildcards are skipped.
+		nt, ok := step.NodeTest.(xpath3.NameTest)
+		if !ok || nt.Local == "*" || nt.Prefix == "*" {
+			continue
+		}
+		return checkStepAgainstSchema(step, reg, xpathDefaultNS, nsBindings)
 	}
 	return nil
 }

--- a/xslt3/execute_misc.go
+++ b/xslt3/execute_misc.go
@@ -754,21 +754,41 @@ func (ec *execContext) execEvaluate(ctx context.Context, inst *evaluateInst) err
 		nsBindings[""] = ec.xpathDefaultNS
 	}
 
-	// 4b. Evaluate schema-aware avt if present
+	// 4b. Evaluate schema-aware avt if present. The default is "no": only an
+	// explicit yes/true/1 makes the dynamic expression schema-aware.
+	schemaAware := false
 	if inst.SchemaAwareAVT != nil {
 		saStr, saErr := inst.SchemaAwareAVT.evaluate(ctx, ec.contextNode)
 		if saErr != nil {
 			return saErr
 		}
-		if _, ok := parseXSDBool(saStr); !ok {
+		sa, ok := parseXSDBool(saStr)
+		if !ok {
 			return staticError(errCodeXTSE0020, "xsl:evaluate: invalid value %q for schema-aware attribute", saStr)
 		}
+		schemaAware = sa
 	}
 
 	// 5. Compile the dynamic XPath expression.
 	dynExpr, compileErr := xpath3.NewCompiler().Compile(xpathStr)
 	if compileErr != nil {
 		return dynamicError(errCodeXTDE3160, "xsl:evaluate: cannot compile XPath expression %q: %v", xpathStr, compileErr)
+	}
+
+	// 5b. XTDE3160: per XSLT 3.0 §20.3, when the dynamic expression is NOT
+	// schema-aware its static context includes only the built-in schema
+	// components — none of the schema types imported by xsl:import-schema. A
+	// SequenceType in the target expression (instance of / cast as / castable as
+	// / treat as) that names a user-defined schema type is therefore a static
+	// error when analyzing the string, surfaced as the dynamic error XTDE3160.
+	// (When schema-aware is yes the imported types ARE in scope, so the gate is
+	// skipped.) The unprefixed / no-default-namespace form already fails through
+	// the xs:-prefix resolution path; this closes the prefixed form.
+	if !schemaAware {
+		if badType := dynExprReferencesSchemaType(dynExpr.AST(), nsBindings); badType != "" {
+			return dynamicError(errCodeXTDE3160,
+				"xsl:evaluate: type %q is not in scope (schema-aware is not enabled)", badType)
+		}
 	}
 
 	// 5a. XTDE3160: certain XSLT functions are not allowed in xsl:evaluate
@@ -905,6 +925,54 @@ func (ec *execContext) execEvaluate(ctx context.Context, inst *evaluateInst) err
 
 	// 9. Output the result sequence.
 	return ec.outputSequence(seq)
+}
+
+// dynExprReferencesSchemaType reports the first SequenceType atomic/union type in
+// a dynamic xsl:evaluate target expression that names a user-defined schema type
+// (a type whose namespace is non-empty and is not the XSD built-in namespace). It
+// is used to detect XTDE3160 when the dynamic expression is not schema-aware: such
+// a type is not in the dynamic static context, so referencing it (in instance of /
+// cast as / castable as / treat as) is a static error.
+//
+// A prefix that resolves to no namespace, or to the XSD namespace, names a
+// built-in type and is always in scope; only a prefix bound to a non-XSD
+// namespace identifies an imported schema type. The unprefixed form is handled
+// elsewhere (it resolves through the xs: built-in path and already fails), so it
+// is not flagged here. Returns "" when no such reference is present.
+func dynExprReferencesSchemaType(ast xpath3.Expr, nsBindings map[string]string) string {
+	var found string
+	check := func(prefix, name string) bool {
+		if prefix == "" || prefix == "xs" || prefix == "xsd" {
+			return false
+		}
+		uri, ok := nsBindings[prefix]
+		if !ok || uri == "" || uri == lexicon.NamespaceXSD {
+			return false
+		}
+		found = prefix + ":" + name
+		return true
+	}
+	xpathstream.WalkExpr(ast, func(e xpath3.Expr) bool {
+		if found != "" {
+			return false
+		}
+		switch n := e.(type) {
+		case xpath3.InstanceOfExpr:
+			if t, ok := n.Type.ItemTest.(xpath3.AtomicOrUnionType); ok {
+				check(t.Prefix, t.Name)
+			}
+		case xpath3.TreatAsExpr:
+			if t, ok := n.Type.ItemTest.(xpath3.AtomicOrUnionType); ok {
+				check(t.Prefix, t.Name)
+			}
+		case xpath3.CastExpr:
+			check(n.Type.Prefix, n.Type.Name)
+		case xpath3.CastableExpr:
+			check(n.Type.Prefix, n.Type.Name)
+		}
+		return found == ""
+	})
+	return found
 }
 
 // checkEvaluateAsType checks the xsl:evaluate as= type constraint.

--- a/xslt3/w3c_helpers_test.go
+++ b/xslt3/w3c_helpers_test.go
@@ -1695,13 +1695,10 @@ var w3cImplicitSkips = map[string]string{
 	"match-210": "schema-aware attribute type pattern match fails",
 	"match-221": "schema-aware numeric type pattern match fails",
 	"match-232": "schema-aware type pattern match missing items",
-	"match-244": "expected error XTSE3105 not raised for schema pattern",
 	"match-262": "deep-copy does not preserve type annotations",
 	"match-263": "deep-copy does not preserve type annotations",
 
 	// evaluate tests requiring schema-aware processing
-	"evaluate-012": "schema-aware xsl:evaluate: expected XTDE3160 not raised",
-	"evaluate-013": "schema-aware xsl:evaluate: expected XTDE3160 not raised",
 	"evaluate-048": "requires network access to saxonica.com",
 
 	// slow xsl:evaluate tests (~30s each with -race on CI)


### PR DESCRIPTION
- XTSE3105: typed=strict pattern check now walks past // and root steps to the element NameTest, catching undeclared element refs in //-patterns (match-244)
- XTDE3160: a non-schema-aware xsl:evaluate that references an imported schema type now raises the error instead of silently returning false (evaluate-012/013)