### PR TITLE
fix c14n empty default-namespace rendering

### DIFF
--- a/.claude/docs/libxml2-parity.md
+++ b/.claude/docs/libxml2-parity.md
@@ -8,7 +8,7 @@
 |---------|-------|------|------|------|--------------|
 | Core XML (DOM) | 150+ | all | 0 | ~100% | — |
 | Core XML (SAX2) | 150+ | all | 0 | ~100% | — |
-| C14N | 76 | 76 | 0 | 100% | — |
+| C14N | 73 | 73 | 0 | 100% | — |
 | XSD | 226 | 225 | 1 | 99.6% | libxml2 IDC quirk with ref + attributeFormDefault |
 | RELAX NG | 159 | 159 | 0 | 100% | — |
 | Schematron | 42 | 42 | 0 | 100% | — |

--- a/.claude/docs/libxml2-parity.md
+++ b/.claude/docs/libxml2-parity.md
@@ -8,7 +8,7 @@
 |---------|-------|------|------|------|--------------|
 | Core XML (DOM) | 150+ | all | 0 | ~100% | — |
 | Core XML (SAX2) | 150+ | all | 0 | ~100% | — |
-| C14N | 76 | 66 | 10 | 87% | Parser: duplicate xmlns (7), entity-ref in single-quoted attr (3) |
+| C14N | 76 | 76 | 0 | 100% | — |
 | XSD | 226 | 225 | 1 | 99.6% | libxml2 IDC quirk with ref + attributeFormDefault |
 | RELAX NG | 159 | 159 | 0 | 100% | — |
 | Schematron | 42 | 42 | 0 | 100% | — |
@@ -65,11 +65,12 @@ Test data: `testdata/libxml2-compat/` (golden files generated from libxml2's xml
 
 ## Parser Limitations
 
-These affect multiple packages (especially C14N test skips):
+Cross-element redundant namespace redeclarations and entity references in
+single-quoted attributes (formerly the cause of all 10 C14N skips) now parse
+correctly; the C14N suite runs with no skips. Same-element duplicate namespace
+declarations remain a well-formedness error, as in libxml2.
 
-1. **Duplicate namespace declarations** — helium rejects, libxml2 uses last. Affects 7 C14N tests.
-2. **Entity refs in single-quoted attributes** — not expanded. Affects 3 C14N tests.
-3. **External entity resolution** — limited; requires explicit config. `NewParser` is **secure by default**: `BlockXXE` is on, the `FS` is a deny-all FS, and network is off — so external loading is blocked even when `LoadExternalDTD(true)`/`SubstituteEntities(true)` are set, until `BlockXXE(false)` is also set AND an FS is supplied (`helium.PermissiveFS()` or a confined `fs.FS`). External subsets need `LoadExternalDTD(true)`, and inline expansion of parsed external entities needs `SubstituteEntities(true)`. External DTD subsets are read through a strict byte cap (`MaxExternalDTDSize`, 10 MiB default; overridable via `MaxExternalDTDBytes`) enforced against the actual bytes read — not any advisory `Stat` size — and a subset exceeding the cap is rejected with `ErrExternalDTDTooLarge`.
+1. **External entity resolution** — limited; requires explicit config. `NewParser` is **secure by default**: `BlockXXE` is on, the `FS` is a deny-all FS, and network is off — so external loading is blocked even when `LoadExternalDTD(true)`/`SubstituteEntities(true)` are set, until `BlockXXE(false)` is also set AND an FS is supplied (`helium.PermissiveFS()` or a confined `fs.FS`). External subsets need `LoadExternalDTD(true)`, and inline expansion of parsed external entities needs `SubstituteEntities(true)`. External DTD subsets are read through a strict byte cap (`MaxExternalDTDSize`, 10 MiB default; overridable via `MaxExternalDTDBytes`) enforced against the actual bytes read — not any advisory `Stat` size — and a subset exceeding the cap is rejected with `ErrExternalDTDTooLarge`.
 
 ## Feature Status
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ go test -tags cgo,libxml2bench -bench=. -benchmem ./bench/
 * Core functionality is implemented: XML/HTML parsing, DOM building, SAX2, XPath 1.0, XPath 3.1, Basic XSLT 3.0, XInclude, C14N, RELAX NG, Schematron, XSD, XML Catalog, streaming XML writer, and `encoding/xml` compatibility (`shim` package).
 * Experimental: W3C XML Digital Signatures 1.1 (`xmldsig1`) and XML Encryption 1.1 (`xmlenc1`). These APIs may change and may move to a separate repository.
 * W3C conformance suites: ~22,250 / 22,744 QT3 tests pass for XPath 3.1; ~11,780 / 13,129 W3C tests pass for XSLT 3.0 (skips are XSLT 1.0/2.0 backwards compatibility and other out-of-scope features).
-* libxml2-compat golden tests: core XML parsing 100%, XSD 99.6%, RELAX NG 100%, Schematron 100%, C14N 87%, HTML 100%.
+* libxml2-compat golden tests: core XML parsing 100%, XSD 99.6%, RELAX NG 100%, Schematron 100%, C14N 100%, HTML 100%.
 * XSLT support is intentionally scoped to Basic XSLT 3.0. Backwards compatibility modes for XSLT 1.0/2.0 are not part of the target feature set.
 * A `helium` CLI provides `lint`, `xpath`, `xslt`, `xsd validate`, `relaxng validate`, and `schematron validate` subcommands.
 * Some edge cases and parity gaps are still being iterated on; contributions and issue reports are welcome.

--- a/c14n/c14n_test.go
+++ b/c14n/c14n_test.go
@@ -12,25 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	testdataBase       = "../testdata/libxml2-compat/c14n"
-	parseFailDupNSDecl = "duplicate namespace declaration handling"
-)
-
-// knownParseFailures lists test cases that fail during parsing due to
-// helium parser limitations (not C14N bugs).
-var knownParseFailures = map[string]string{
-	"without-comments/example-3":     parseFailDupNSDecl,
-	"without-comments/example-4":     "entity reference in single-quoted attribute",
-	"without-comments/test-2":        parseFailDupNSDecl,
-	"without-comments/test-3":        parseFailDupNSDecl,
-	"with-comments/example-3":        parseFailDupNSDecl,
-	"with-comments/example-4":        "entity reference in single-quoted attribute",
-	"exc-without-comments/test-0":    parseFailDupNSDecl,
-	"exc-without-comments/test-1":    parseFailDupNSDecl,
-	"1-1-without-comments/example-3": parseFailDupNSDecl,
-	"1-1-without-comments/example-4": "entity reference in single-quoted attribute",
-}
+const testdataBase = "../testdata/libxml2-compat/c14n"
 
 func parseTestDoc(t *testing.T, path string) *helium.Document {
 	t.Helper()
@@ -129,11 +111,6 @@ func evaluateNodeSet(t *testing.T, doc *helium.Document, expr string, nss map[st
 
 func runC14NTest(t *testing.T, category, name string, mode c14n.Mode, can c14n.Canonicalizer) {
 	t.Helper()
-
-	key := category + "/" + name
-	if reason, ok := knownParseFailures[key]; ok {
-		t.Skipf("skipping due to parser limitation: %s", reason)
-	}
 
 	inputPath := filepath.Join(testdataBase, category, "test", name+".xml")
 	expectedPath := filepath.Join(testdataBase, category, "result", name)

--- a/c14n/canonicalizer.go
+++ b/c14n/canonicalizer.go
@@ -493,12 +493,19 @@ func (c *canonicalizer) findNearestRenderedDefaultNS(e *helium.Element) string {
 		if !c.isVisible(anc) {
 			continue
 		}
-		ancNS := c.nsNodesByElement[anc]
-		for _, ans := range ancNS {
+		// The nearest visible ancestor determines the default namespace in
+		// scope for e in the canonical output, so this ancestor is
+		// authoritative — never walk further up. The XPath namespace axis only
+		// yields a default-namespace node when the in-scope default URI is
+		// non-empty; its absence here means the default namespace is empty (it
+		// was reset via xmlns=""). Returning "" in that case stops us from
+		// reaching past a reset to a more distant, no-longer-in-scope default.
+		for _, ans := range c.nsNodesByElement[anc] {
 			if ans.prefix == "" {
 				return ans.uri
 			}
 		}
+		return ""
 	}
 	return ""
 }
@@ -577,9 +584,15 @@ func (c *canonicalizer) renderNamespacesExclusiveNodeSet(e *helium.Element) erro
 	// Determine "candidate" prefixes: visibly utilized ∪ inclusive
 	candidates := make(map[string]bool)
 
-	// Element's own namespace prefix
+	// Element's own namespace prefix. An element in no namespace (e.g. after an
+	// xmlns="" reset) has a nil active namespace; it still visibly utilizes the
+	// empty default-namespace prefix, so make "" a candidate. The undeclaration
+	// check below then emits xmlns="" iff an output ancestor left a non-empty
+	// default namespace in scope (mirrors the whole-document exclusive path).
 	if ns := e.Namespace(); ns != nil {
 		candidates[ns.Prefix()] = true
+	} else {
+		candidates[""] = true
 	}
 
 	// Attribute namespace prefixes (only visible attributes)


### PR DESCRIPTION
- node-set inclusive C14N: stop default-ns reset lookup at nearest visible ancestor, so an `xmlns=""` reset is not skipped for a more distant in-scope default
- node-set exclusive C14N: treat an element in no namespace as visibly utilizing the empty default prefix, emitting `xmlns=""` to undeclare an ancestor default
- remove the 10 c14n compat skips (`knownParseFailures`); all now parse and canonicalize correctly