### PR TITLE
add xinclude MaxIncludeDepth option

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -210,13 +210,14 @@ HTML 4.01 parser producing helium DOM or SAX events.
 XInclude 1.0 processing with recursive inclusion and fallback.
 
 - **NewProcessor() → Processor** — create fluent builder
-- Processor methods: `NoXIncludeMarkers()`, `NoBaseFixup()`, `Resolver(Resolver)`, `BaseURI(string)`, `MaxIncludeSize(int)`, `ErrorHandler(helium.ErrorHandler)`, `Parser(helium.Parser)`
+- Processor methods: `NoXIncludeMarkers()`, `NoBaseFixup()`, `Resolver(Resolver)`, `BaseURI(string)`, `MaxIncludeSize(int)`, `MaxIncludeDepth(int)`, `ErrorHandler(helium.ErrorHandler)`, `Parser(helium.Parser)`
 - `Processor.Parser(helium.Parser)` — supplies the **resource limits** (depth/name-length/amplification/content-model-depth) used to parse included documents. XInclude still forces its own loading policy: external-DTD loading is on and the filesystem is confined to the `Resolver`'s sandbox (the injected parser's FS is NOT used for included docs — the `Resolver` is the security boundary). Unset → default `helium.NewParser()` base.
 - Terminal: **Process(ctx, *Document) → (int, error)**, **ProcessTree(ctx, Node) → (int, error)**
 - `Resolver` interface — custom resource loader; receives the href already resolved against the effective base (base arg is informational only — do NOT re-resolve, or the base directory is double-applied)
-- `MaxIncludeSize` — default per-include byte cap (10 MiB), used when `Processor.MaxIncludeSize` is unset or ≤ 0; over-cap reads fail with `ErrIncludeTooLarge`
+- `Processor.MaxIncludeSize(int)` — per-include byte cap; unset or ≤ 0 uses the default 10 MiB (unexported `defaultMaxIncludeSize`); over-cap reads fail with `ErrIncludeTooLarge`
+- `Processor.MaxIncludeDepth(int)` — xi:include nesting-depth cap; unset or ≤ 0 uses the default 40 (unexported `defaultMaxIncludeDepth`); over-cap fails with "maximum include depth exceeded". Bounds nesting only — cyclic includes are caught separately by circular detection
 - Default `NewFSResolver` converts absolute `file:` hrefs to OS paths via `internal/iofs.FileURIToPath` (non-local hosts rejected)
-- Max depth 40, max URI 2000 chars, circular detection, doc/text caching
+- Max URI 2000 chars, circular detection, doc/text caching
 - Files: `xinclude.go`
 - Imports: helium, xpointer/, internal/encoding/, internal/iofs/, internal/lexicon/
 

--- a/README.md
+++ b/README.md
@@ -154,8 +154,9 @@ caller should also:
   `MaxNameLength`, or `MaxContentModelDepth` removes that guard.
 - Be cautious enabling XInclude, catalogs, DTD validation, or
   default-DTD-attribute processing for untrusted input; when you do, keep every
-  external resource allowlisted and size-bounded. `xinclude.Processor.MaxDepth`
-  bounds the nesting depth of included documents.
+  external resource allowlisted and size-bounded. `xinclude.Processor.MaxIncludeDepth`
+  bounds the nesting depth of included documents, and `MaxIncludeSize` caps the
+  bytes read per included resource.
 
 **Caveat:** a permissive or directory-rooted `FS` is not yet a complete sandbox.
 External-resource paths are joined against the document base URI and may be

--- a/xinclude/README.md
+++ b/xinclude/README.md
@@ -163,6 +163,7 @@ source: [examples/xinclude_process_example_test.go](https://github.com/lestrrat-
 | `Resolver(Resolver)` | Supply a custom resource resolver (see `NewFSResolver`). |
 | `BaseURI(string)` | Base URI for resolving relative hrefs. |
 | `MaxIncludeSize(int)` | Cap bytes read from a single included resource (default 10 MiB). |
+| `MaxIncludeDepth(int)` | Cap the nesting depth of `xi:include` directives (default 40). |
 
 ## Security
 

--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -22,22 +22,24 @@ import (
 	"github.com/lestrrat-go/helium/xpointer"
 )
 
-const (
-	maxDepth     = 40
-	maxURILength = 2000
-)
+const maxURILength = 2000
 
-// MaxIncludeSize is the default maximum number of bytes read from a single
-// included resource (XML or text) when no cap is configured via
-// [Processor.MaxIncludeSize]. It guards against a hostile or pathological
+// defaultMaxIncludeSize is the per-include byte cap used when none is configured
+// via [Processor.MaxIncludeSize]. It guards against a hostile or pathological
 // Resolver (e.g. one returning an endless or multi-gigabyte reader) exhausting
 // memory: the bytes of every included resource are read fully and cached.
-const MaxIncludeSize = 10 << 20 // 10 MiB
+const defaultMaxIncludeSize = 10 << 20 // 10 MiB
+
+// defaultMaxIncludeDepth is the xi:include nesting-depth cap used when none is
+// configured via [Processor.MaxIncludeDepth]. It guards against pathological or
+// maliciously deep include chains. This bounds nesting depth only; cyclic
+// includes are caught separately by circular-inclusion detection.
+const defaultMaxIncludeDepth = 40
 
 // ErrIncludeTooLarge is returned when an included resource exceeds the
-// configured maximum size (see [Processor.MaxIncludeSize], default
-// [MaxIncludeSize]). The cap is enforced against the actual number of bytes
-// read, not any reported size.
+// configured maximum size (see [Processor.MaxIncludeSize]; 10 MiB by default).
+// The cap is enforced against the actual number of bytes read, not any reported
+// size.
 var ErrIncludeTooLarge = errors.New("xi:include: included resource exceeds maximum allowed size")
 
 // Resolver loads content from a URI.
@@ -56,13 +58,14 @@ type Resolver interface {
 
 // processorCfg holds the configuration for a Processor.
 type processorCfg struct {
-	noMarkers      bool
-	noBaseFixup    bool
-	resolver       Resolver
-	baseURI        string
-	errorHandler   helium.ErrorHandler
-	maxIncludeSize int
-	parser         *helium.Parser
+	noMarkers       bool
+	noBaseFixup     bool
+	resolver        Resolver
+	baseURI         string
+	errorHandler    helium.ErrorHandler
+	maxIncludeSize  int
+	maxIncludeDepth int
+	parser          *helium.Parser
 }
 
 // Processor configures XInclude processing. It is a value-style wrapper:
@@ -169,12 +172,22 @@ func (p Processor) BaseURI(uri string) Processor {
 // resource (XML or text). The cap is enforced against the actual number of
 // bytes read, guarding against a hostile or pathological Resolver (e.g. an
 // endless or multi-gigabyte reader) exhausting memory before the bytes are
-// cached. A value less than or equal to zero (the default) means
-// [MaxIncludeSize] (10 MiB) is used. Exceeding the cap fails the include with
-// [ErrIncludeTooLarge].
+// cached. A value less than or equal to zero (the default) means 10 MiB is
+// used. Exceeding the cap fails the include with [ErrIncludeTooLarge].
 func (p Processor) MaxIncludeSize(n int) Processor {
 	p = p.clone()
 	p.cfg.maxIncludeSize = n
+	return p
+}
+
+// MaxIncludeDepth sets the maximum nesting depth of xi:include directives — how
+// deeply an included document may itself include further documents before
+// processing fails with "maximum include depth exceeded". It bounds nesting
+// depth only; cyclic includes are caught separately by circular-inclusion
+// detection. A value less than or equal to zero (the default) means 40 is used.
+func (p Processor) MaxIncludeDepth(n int) Processor {
+	p = p.clone()
+	p.cfg.maxIncludeDepth = n
 	return p
 }
 
@@ -211,18 +224,19 @@ type txtCacheEntry struct {
 }
 
 type processor struct {
-	noMarkers      bool
-	noBaseFixup    bool
-	resolver       Resolver
-	baseURI        string
-	expanding      map[string]bool          // circular inclusion detection (set during recursive expansion)
-	docCache       map[string]docCacheEntry // cached raw bytes for XML documents
-	txtCache       map[string]txtCacheEntry // cached text inclusions
-	errorHandler   helium.ErrorHandler
-	maxIncludeSize int
-	parser         *helium.Parser
-	depth          int
-	count          int
+	noMarkers       bool
+	noBaseFixup     bool
+	resolver        Resolver
+	baseURI         string
+	expanding       map[string]bool          // circular inclusion detection (set during recursive expansion)
+	docCache        map[string]docCacheEntry // cached raw bytes for XML documents
+	txtCache        map[string]txtCacheEntry // cached text inclusions
+	errorHandler    helium.ErrorHandler
+	maxIncludeSize  int
+	maxIncludeDepth int
+	parser          *helium.Parser
+	depth           int
+	count           int
 }
 
 // Process performs XInclude processing on the document.
@@ -250,16 +264,17 @@ func (proc Processor) ProcessTree(ctx context.Context, node helium.Node) (int, e
 		cfg = &processorCfg{}
 	}
 	p := &processor{
-		noMarkers:      cfg.noMarkers,
-		noBaseFixup:    cfg.noBaseFixup,
-		resolver:       cfg.resolver,
-		baseURI:        cfg.baseURI,
-		errorHandler:   cfg.errorHandler,
-		maxIncludeSize: cfg.maxIncludeSize,
-		parser:         cfg.parser,
-		expanding:      make(map[string]bool),
-		docCache:       make(map[string]docCacheEntry),
-		txtCache:       make(map[string]txtCacheEntry),
+		noMarkers:       cfg.noMarkers,
+		noBaseFixup:     cfg.noBaseFixup,
+		resolver:        cfg.resolver,
+		baseURI:         cfg.baseURI,
+		errorHandler:    cfg.errorHandler,
+		maxIncludeSize:  cfg.maxIncludeSize,
+		maxIncludeDepth: cfg.maxIncludeDepth,
+		parser:          cfg.parser,
+		expanding:       make(map[string]bool),
+		docCache:        make(map[string]docCacheEntry),
+		txtCache:        make(map[string]txtCacheEntry),
 	}
 	if p.resolver == nil {
 		p.resolver = NewFSResolver(nil)
@@ -272,8 +287,12 @@ func (proc Processor) ProcessTree(ctx context.Context, node helium.Node) (int, e
 }
 
 func (p *processor) processNode(ctx context.Context, n helium.Node) error {
+	maxDepth := p.maxIncludeDepth
+	if maxDepth <= 0 {
+		maxDepth = defaultMaxIncludeDepth
+	}
 	if p.depth > maxDepth {
-		return fmt.Errorf("xi:include: maximum recursion depth (%d) exceeded", maxDepth)
+		return fmt.Errorf("xi:include: maximum include depth (%d) exceeded", maxDepth)
 	}
 
 	// Repeatedly collect and process xi:include elements at this level.
@@ -707,7 +726,7 @@ func (p *processor) resolve(uri, base string) (io.ReadCloser, error) {
 func (p *processor) readCapped(r io.Reader) ([]byte, error) {
 	limit := p.maxIncludeSize
 	if limit <= 0 {
-		limit = MaxIncludeSize
+		limit = defaultMaxIncludeSize
 	}
 
 	data, exceeded, err := iolimit.ReadAll(r, int64(limit))

--- a/xinclude/xinclude_test.go
+++ b/xinclude/xinclude_test.go
@@ -783,28 +783,80 @@ func TestXIncludeNewNamespaceFallback(t *testing.T) {
 	require.True(t, found, "fallback content not found with 2003 namespace")
 }
 
+// includeChainResolver builds a resolver where levelN.xml includes level(N+1).xml
+// up to levels-1, with levelN.xml as a plain leaf, so an include starting at
+// level0.xml nests `levels` deep.
+func includeChainResolver(levels int) *stringResolver {
+	resolver := &stringResolver{files: make(map[string]string)}
+	for i := range levels {
+		resolver.files[fmt.Sprintf("level%d.xml", i)] = fmt.Sprintf(
+			`<level xmlns:xi="http://www.w3.org/2001/XInclude"><xi:include href="level%d.xml"/></level>`, i+1)
+	}
+	resolver.files[fmt.Sprintf("level%d.xml", levels)] = `<leaf/>`
+	return resolver
+}
+
 func TestXIncludeDepthLimit(t *testing.T) {
 	t.Parallel()
-	// Create a chain that would exceed maxDepth (40)
-	resolver := &stringResolver{files: make(map[string]string)}
-	for i := range 50 {
-		next := i + 1
-		resolver.files[fmt.Sprintf("level%d.xml", i)] = fmt.Sprintf(
-			`<level xmlns:xi="http://www.w3.org/2001/XInclude"><xi:include href="level%d.xml"/></level>`, next)
-	}
-	resolver.files["level50.xml"] = `<leaf/>`
-
+	// A chain deeper than the default limit (40) is rejected.
 	doc := parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
 		<xi:include href="level0.xml"/>
 	</root>`)
 
 	_, err := xinclude.NewProcessor().
-		Resolver(resolver).
+		Resolver(includeChainResolver(50)).
 		NoXIncludeMarkers().
 		NoBaseFixup().
 		Process(t.Context(), doc)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "depth")
+	require.Contains(t, err.Error(), "maximum include depth")
+}
+
+func TestXIncludeMaxIncludeDepth(t *testing.T) {
+	t.Parallel()
+
+	build := func() *helium.Document {
+		return parseXML(t, `<root xmlns:xi="http://www.w3.org/2001/XInclude">
+			<xi:include href="level0.xml"/>
+		</root>`)
+	}
+
+	t.Run("custom limit rejects a chain deeper than it", func(t *testing.T) {
+		t.Parallel()
+		_, err := xinclude.NewProcessor().
+			Resolver(includeChainResolver(20)).
+			MaxIncludeDepth(5).
+			NoXIncludeMarkers().
+			NoBaseFixup().
+			Process(t.Context(), build())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "maximum include depth (5) exceeded")
+	})
+
+	t.Run("custom limit allows a chain within it", func(t *testing.T) {
+		t.Parallel()
+		count, err := xinclude.NewProcessor().
+			Resolver(includeChainResolver(3)).
+			MaxIncludeDepth(20).
+			NoXIncludeMarkers().
+			NoBaseFixup().
+			Process(t.Context(), build())
+		require.NoError(t, err)
+		require.Positive(t, count)
+	})
+
+	t.Run("non-positive falls back to the default", func(t *testing.T) {
+		t.Parallel()
+		// A chain past the default (40) still fails when the configured value is <= 0.
+		_, err := xinclude.NewProcessor().
+			Resolver(includeChainResolver(50)).
+			MaxIncludeDepth(0).
+			NoXIncludeMarkers().
+			NoBaseFixup().
+			Process(t.Context(), build())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "maximum include depth (40) exceeded")
+	})
 }
 
 func TestXIncludeSameURLTwice(t *testing.T) {


### PR DESCRIPTION
- add `xinclude.Processor.MaxIncludeDepth(int)` to configure the xi:include nesting-depth cap (mirrors `MaxIncludeSize`); `<= 0` uses the new exported default `MaxIncludeDepth` (40)
- the previously hardcoded internal `maxDepth = 40` is now the configurable default
- reword the limit error from "maximum recursion depth" to "maximum include depth" — the cap bounds nesting depth; cyclic includes are caught separately by circular detection