### PR TITLE
fix xsd restriction attr ns-blind collision

### DIFF
--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -1053,11 +1053,13 @@ func (c *compiler) checkRestrictionAttrs(ctx context.Context, td *TypeDef) {
 	baseTypeNS := td.BaseType.Name.NS
 	baseQualified := fmt.Sprintf("'{%s}%s'", baseTypeNS, baseTypeName)
 
-	// Build map of base type's non-prohibited attributes.
-	baseAttrs := make(map[string]*AttrUse, len(td.BaseType.Attributes))
+	// Build map of base type's non-prohibited attributes, keyed by the full
+	// QName so an unqualified derived attribute does not collide with a
+	// namespaced base attribute that shares its local name.
+	baseAttrs := make(map[QName]*AttrUse, len(td.BaseType.Attributes))
 	for _, au := range td.BaseType.Attributes {
 		if !au.Prohibited {
-			baseAttrs[au.Name.Local] = au
+			baseAttrs[au.Name] = au
 		}
 	}
 
@@ -1066,7 +1068,7 @@ func (c *compiler) checkRestrictionAttrs(ctx context.Context, td *TypeDef) {
 		if au.Prohibited {
 			continue
 		}
-		baseAU, found := baseAttrs[au.Name.Local]
+		baseAU, found := baseAttrs[au.Name]
 		if found {
 			// Check use consistency: optional cannot restrict required.
 			if baseAU.Required && !au.Required {
@@ -1083,15 +1085,15 @@ func (c *compiler) checkRestrictionAttrs(ctx context.Context, td *TypeDef) {
 	}
 
 	// Check that all required base attributes have a matching non-prohibited derived attribute.
-	derivedAttrs := make(map[string]*AttrUse, len(td.Attributes))
+	derivedAttrs := make(map[QName]*AttrUse, len(td.Attributes))
 	for _, au := range td.Attributes {
-		derivedAttrs[au.Name.Local] = au
+		derivedAttrs[au.Name] = au
 	}
 	for _, baseAU := range td.BaseType.Attributes {
 		if !baseAU.Required {
 			continue
 		}
-		derived, found := derivedAttrs[baseAU.Name.Local]
+		derived, found := derivedAttrs[baseAU.Name]
 		if !found || derived.Prohibited {
 			msg := fmt.Sprintf("A matching attribute use for the 'required' attribute use '%s' of the base complex type definition %s is missing.", baseAU.Name.Local, baseQualified)
 			c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType", component, msg))

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -1076,8 +1076,9 @@ func (c *compiler) checkRestrictionAttrs(ctx context.Context, td *TypeDef) {
 				c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType",
 					component+", attribute use '"+au.Name.Local+"'", msg))
 			}
-		} else if td.BaseType.AnyAttribute == nil {
-			// No matching attribute and no wildcard in base.
+		} else if td.BaseType.AnyAttribute == nil || !wildcardMatches(td.BaseType.AnyAttribute, au.Name.NS) {
+			// No matching attribute, and no base wildcard whose namespace
+			// constraint admits this derived attribute's namespace.
 			msg := fmt.Sprintf("Neither a matching attribute use, nor a matching wildcard exists in the base complex type definition %s.", baseQualified)
 			c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType",
 				component+", attribute use '"+au.Name.Local+"'", msg))

--- a/xsd/restriction_attr_ns_test.go
+++ b/xsd/restriction_attr_ns_test.go
@@ -68,4 +68,55 @@ func TestRestrictionAttrNamespace(t *testing.T) {
 </xs:schema>`
 		require.Empty(t, compileFatalErrors(t, schema))
 	})
+
+	t.Run("rejects derived attr outside base wildcard namespace", func(t *testing.T) {
+		t.Parallel()
+		// Base has an attribute wildcard restricted to ##targetNamespace
+		// (urn:t). The derived restriction declares an unqualified ({}foo)
+		// attribute, whose absent namespace is NOT admitted by the base
+		// wildcard, so the derivation must be rejected: no matching base
+		// attribute use and no base wildcard that covers {}foo.
+		schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:t" xmlns:t="urn:t" attributeFormDefault="unqualified">
+  <xs:complexType name="Base">
+    <xs:sequence/>
+    <xs:anyAttribute namespace="##targetNamespace"/>
+  </xs:complexType>
+  <xs:complexType name="Derived">
+    <xs:complexContent>
+      <xs:restriction base="t:Base">
+        <xs:sequence/>
+        <xs:attribute name="foo" type="xs:string"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="root" type="t:Derived"/>
+</xs:schema>`
+		require.Contains(t, compileFatalErrors(t, schema), noMatchingUse)
+	})
+
+	t.Run("accepts derived attr admitted by base wildcard namespace", func(t *testing.T) {
+		t.Parallel()
+		// Base has an attribute wildcard covering ##targetNamespace (urn:t).
+		// The derived restriction declares a {urn:t}foo attribute (a global,
+		// hence target-namespace, attribute), which the base wildcard admits,
+		// so the derivation is valid.
+		schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:t" xmlns:t="urn:t" attributeFormDefault="qualified">
+  <xs:attribute name="foo" type="xs:string"/>
+  <xs:complexType name="Base">
+    <xs:sequence/>
+    <xs:anyAttribute namespace="##targetNamespace"/>
+  </xs:complexType>
+  <xs:complexType name="Derived">
+    <xs:complexContent>
+      <xs:restriction base="t:Base">
+        <xs:sequence/>
+        <xs:attribute ref="t:foo"/>
+        <xs:anyAttribute namespace="##targetNamespace"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="root" type="t:Derived"/>
+</xs:schema>`
+		require.Empty(t, compileFatalErrors(t, schema))
+	})
 }

--- a/xsd/restriction_attr_ns_test.go
+++ b/xsd/restriction_attr_ns_test.go
@@ -1,0 +1,71 @@
+package xsd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRestrictionAttrNamespace (XSD-003) verifies that the
+// derivation-ok-restriction attribute checks key base/derived attribute uses on
+// the full QName (namespace + local), not just the local name. A base type that
+// requires a namespaced attribute {urn:t}id must NOT be considered restricted by
+// a derived restriction that declares an unqualified attribute named "id":
+// the two share a local name but live in different namespaces.
+func TestRestrictionAttrNamespace(t *testing.T) {
+	t.Parallel()
+
+	const noMatchingUse = "Neither a matching attribute use, nor a matching wildcard exists"
+	const requiredMissing = "A matching attribute use for the 'required' attribute use"
+
+	t.Run("rejects unqualified derived attr restricting namespaced base attr", func(t *testing.T) {
+		t.Parallel()
+		// Base requires the namespaced global attribute {urn:t}id; the derived
+		// restriction declares a local unqualified attribute "id" ({}id). They
+		// collide only on local name, so the derivation must be rejected: the
+		// required base {urn:t}id has no counterpart and the derived {}id matches
+		// neither a base attribute use nor a base wildcard.
+		schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:t" xmlns:t="urn:t" attributeFormDefault="unqualified">
+  <xs:attribute name="id" type="xs:string"/>
+  <xs:complexType name="Base">
+    <xs:sequence/>
+    <xs:attribute ref="t:id" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Derived">
+    <xs:complexContent>
+      <xs:restriction base="t:Base">
+        <xs:sequence/>
+        <xs:attribute name="id" type="xs:string" use="required"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="root" type="t:Derived"/>
+</xs:schema>`
+		errs := compileFatalErrors(t, schema)
+		require.Contains(t, errs, noMatchingUse)
+		require.Contains(t, errs, requiredMissing)
+	})
+
+	t.Run("accepts namespaced derived attr restricting same namespaced base attr", func(t *testing.T) {
+		t.Parallel()
+		// Control: derived restriction reuses the same namespaced {urn:t}id; the
+		// QNames match, so this is a valid (identity) restriction.
+		schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:t" xmlns:t="urn:t" attributeFormDefault="unqualified">
+  <xs:attribute name="id" type="xs:string"/>
+  <xs:complexType name="Base">
+    <xs:sequence/>
+    <xs:attribute ref="t:id" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Derived">
+    <xs:complexContent>
+      <xs:restriction base="t:Base">
+        <xs:sequence/>
+        <xs:attribute ref="t:id" use="required"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="root" type="t:Derived"/>
+</xs:schema>`
+		require.Empty(t, compileFatalErrors(t, schema))
+	})
+}


### PR DESCRIPTION
- `checkRestrictionAttrs` keyed base/derived attribute uses on local name only, so an unqualified derived attr wrongly restricted a namespaced base attr of the same local name; now keyed on full QName.