### PR TITLE
fix dtd default xmlns overriding explicit binding

### DIFF
--- a/.claude/docs/parser-internals.md
+++ b/.claude/docs/parser-internals.md
@@ -250,9 +250,15 @@ When a UTF-8 fast path has already proven the consumed bytes contain no newlines
 
 After parsing start tag:
 1. Look up DTD defaults for element
-2. Apply default `xmlns="..."` first (namespace in scope)
-3. Apply default `xmlns:prefix="..."` next
+2. Apply default `xmlns="..."` first (namespace in scope) — only if the default
+   namespace was NOT explicitly declared on the same start tag
+3. Apply default `xmlns:prefix="..."` next — only if that prefix (including the
+   reserved `xml` prefix) was NOT explicitly declared on the same start tag
 4. Apply remaining defaults (skip if explicit attr exists)
+
+Explicit namespace declarations on the start tag always win over DTD ATTLIST
+defaults; a defaulted `xmlns`/`xmlns:prefix` is applied only when the prefix is
+otherwise undeclared on that element.
 
 ## Recovery Mode (RecoverOnError)
 

--- a/attr_test.go
+++ b/attr_test.go
@@ -262,6 +262,70 @@ func TestDTDDefaultNamespaceDoesNotOverrideExplicit(t *testing.T) {
 		require.NotNil(t, lang)
 		require.Equal(t, "http://www.w3.org/XML/1998/namespace", lang.URI())
 	})
+
+	t.Run("conflicting DTD default xmlns:xml is rejected without explicit decl", func(t *testing.T) {
+		t.Parallel()
+		// No explicit xmlns:xml on the tag. A DTD-defaulted xmlns:xml that maps
+		// the reserved xml prefix to the wrong URI must be rejected before it is
+		// pushed; otherwise xml:lang would resolve through "urn:dtd" instead of
+		// the reserved XML namespace.
+		xml := `<!DOCTYPE r [<!ATTLIST r xmlns:xml CDATA "urn:dtd">]>` +
+			`<r xml:lang="en"/>`
+
+		p := helium.NewParser().DefaultDTDAttributes(true)
+		_, err := p.Parse(t.Context(), []byte(xml))
+		require.Error(t, err)
+	})
+
+	t.Run("well-formed DTD default xmlns:xml keeps the implicit XML namespace", func(t *testing.T) {
+		t.Parallel()
+		// A DTD-defaulted xmlns:xml that maps to the correct URI must not shadow
+		// the implicit reserved binding; xml:lang stays in the XML namespace.
+		xml := `<!DOCTYPE r [<!ATTLIST r xmlns:xml CDATA "http://www.w3.org/XML/1998/namespace">]>` +
+			`<r xml:lang="en"/>`
+
+		p := helium.NewParser().DefaultDTDAttributes(true)
+		doc, err := p.Parse(t.Context(), []byte(xml))
+		require.NoError(t, err)
+
+		root := doc.DocumentElement()
+		require.NotNil(t, root)
+
+		var lang *helium.Attribute
+		for _, a := range root.Attributes() {
+			if a.Name() == "xml:lang" {
+				lang = a
+				break
+			}
+		}
+		require.NotNil(t, lang)
+		require.Equal(t, "http://www.w3.org/XML/1998/namespace", lang.URI())
+	})
+
+	t.Run("DTD default xmlns:xmlns is rejected", func(t *testing.T) {
+		t.Parallel()
+		xml := `<!DOCTYPE r [<!ATTLIST r xmlns:xmlns CDATA "urn:dtd">]><r/>`
+
+		p := helium.NewParser().DefaultDTDAttributes(true)
+		_, err := p.Parse(t.Context(), []byte(xml))
+		require.Error(t, err)
+	})
+
+	t.Run("DTD default prefixed xmlns with empty URI creates no binding", func(t *testing.T) {
+		t.Parallel()
+		// An empty default value is never registered as an attribute default
+		// (mirrors libxml2: empty defaults are not applied), so the empty-URI
+		// case cannot reach the defaulting path and no namespace is pushed.
+		xml := `<!DOCTYPE r [<!ATTLIST r xmlns:p CDATA "">]><r/>`
+
+		p := helium.NewParser().DefaultDTDAttributes(true)
+		doc, err := p.Parse(t.Context(), []byte(xml))
+		require.NoError(t, err)
+
+		root := doc.DocumentElement()
+		require.NotNil(t, root)
+		require.Empty(t, root.URI())
+	})
 }
 
 func TestGetAttribute(t *testing.T) {

--- a/attr_test.go
+++ b/attr_test.go
@@ -194,7 +194,11 @@ func TestDTDDefaultNamespaceDoesNotOverrideExplicit(t *testing.T) {
 
 	t.Run("explicit prefixed xmlns wins over DTD default", func(t *testing.T) {
 		t.Parallel()
-		xml := `<!DOCTYPE r [<!ATTLIST r xmlns:p CDATA "urn:dtd">]><p:r xmlns:p="urn:explicit"/>`
+		// The ATTLIST must be declared for the qualified element name "p:r"
+		// (the DTD-default lookup key for prefixed elements is the literal
+		// "prefix:local"); otherwise the default never applies and the test
+		// would pass regardless of the fix.
+		xml := `<!DOCTYPE p:r [<!ATTLIST p:r xmlns:p CDATA "urn:dtd">]><p:r xmlns:p="urn:explicit"/>`
 
 		p := helium.NewParser().DefaultDTDAttributes(true)
 		doc, err := p.Parse(t.Context(), []byte(xml))
@@ -208,6 +212,19 @@ func TestDTDDefaultNamespaceDoesNotOverrideExplicit(t *testing.T) {
 	t.Run("DTD default applies when no explicit declaration", func(t *testing.T) {
 		t.Parallel()
 		xml := `<!DOCTYPE r [<!ATTLIST r xmlns CDATA "urn:dtd">]><r/>`
+
+		p := helium.NewParser().DefaultDTDAttributes(true)
+		doc, err := p.Parse(t.Context(), []byte(xml))
+		require.NoError(t, err)
+
+		root := doc.DocumentElement()
+		require.NotNil(t, root)
+		require.Equal(t, "urn:dtd", root.URI())
+	})
+
+	t.Run("prefixed DTD default applies when no explicit declaration", func(t *testing.T) {
+		t.Parallel()
+		xml := `<!DOCTYPE p:r [<!ATTLIST p:r xmlns:p CDATA "urn:dtd">]><p:r/>`
 
 		p := helium.NewParser().DefaultDTDAttributes(true)
 		doc, err := p.Parse(t.Context(), []byte(xml))

--- a/attr_test.go
+++ b/attr_test.go
@@ -326,6 +326,50 @@ func TestDTDDefaultNamespaceDoesNotOverrideExplicit(t *testing.T) {
 		require.NotNil(t, root)
 		require.Empty(t, root.URI())
 	})
+
+	t.Run("literal non-xml prefix bound to reserved XML namespace is rejected", func(t *testing.T) {
+		t.Parallel()
+		// Only the xml prefix may bind the reserved XML namespace URI; a
+		// literal xmlns:p declaration of it must be rejected.
+		xml := `<r xmlns:p="http://www.w3.org/XML/1998/namespace"/>`
+
+		p := helium.NewParser()
+		_, err := p.Parse(t.Context(), []byte(xml))
+		require.Error(t, err)
+	})
+
+	t.Run("DTD default non-xml prefix bound to reserved XML namespace is rejected", func(t *testing.T) {
+		t.Parallel()
+		// Same constraint via the DTD-defaulting path.
+		xml := `<!DOCTYPE r [<!ATTLIST r xmlns:p CDATA "http://www.w3.org/XML/1998/namespace">]><r/>`
+
+		p := helium.NewParser().DefaultDTDAttributes(true)
+		_, err := p.Parse(t.Context(), []byte(xml))
+		require.Error(t, err)
+	})
+
+	t.Run("literal xmlns:xml bound to reserved XML namespace is allowed", func(t *testing.T) {
+		t.Parallel()
+		// The xml prefix may explicitly bind its reserved namespace URI.
+		xml := `<r xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en"/>`
+
+		p := helium.NewParser()
+		doc, err := p.Parse(t.Context(), []byte(xml))
+		require.NoError(t, err)
+
+		root := doc.DocumentElement()
+		require.NotNil(t, root)
+
+		var lang *helium.Attribute
+		for _, a := range root.Attributes() {
+			if a.Name() == "xml:lang" {
+				lang = a
+				break
+			}
+		}
+		require.NotNil(t, lang)
+		require.Equal(t, "http://www.w3.org/XML/1998/namespace", lang.URI())
+	})
 }
 
 func TestGetAttribute(t *testing.T) {

--- a/attr_test.go
+++ b/attr_test.go
@@ -176,6 +176,49 @@ func TestAttributeAType(t *testing.T) {
 	})
 }
 
+func TestDTDDefaultNamespaceDoesNotOverrideExplicit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("explicit default xmlns wins over DTD default", func(t *testing.T) {
+		t.Parallel()
+		xml := `<!DOCTYPE r [<!ATTLIST r xmlns CDATA "urn:dtd">]><r xmlns="urn:explicit"/>`
+
+		p := helium.NewParser().DefaultDTDAttributes(true)
+		doc, err := p.Parse(t.Context(), []byte(xml))
+		require.NoError(t, err)
+
+		root := doc.DocumentElement()
+		require.NotNil(t, root)
+		require.Equal(t, "urn:explicit", root.URI())
+	})
+
+	t.Run("explicit prefixed xmlns wins over DTD default", func(t *testing.T) {
+		t.Parallel()
+		xml := `<!DOCTYPE r [<!ATTLIST r xmlns:p CDATA "urn:dtd">]><p:r xmlns:p="urn:explicit"/>`
+
+		p := helium.NewParser().DefaultDTDAttributes(true)
+		doc, err := p.Parse(t.Context(), []byte(xml))
+		require.NoError(t, err)
+
+		root := doc.DocumentElement()
+		require.NotNil(t, root)
+		require.Equal(t, "urn:explicit", root.URI())
+	})
+
+	t.Run("DTD default applies when no explicit declaration", func(t *testing.T) {
+		t.Parallel()
+		xml := `<!DOCTYPE r [<!ATTLIST r xmlns CDATA "urn:dtd">]><r/>`
+
+		p := helium.NewParser().DefaultDTDAttributes(true)
+		doc, err := p.Parse(t.Context(), []byte(xml))
+		require.NoError(t, err)
+
+		root := doc.DocumentElement()
+		require.NotNil(t, root)
+		require.Equal(t, "urn:dtd", root.URI())
+	})
+}
+
 func TestGetAttribute(t *testing.T) {
 	t.Parallel()
 

--- a/attr_test.go
+++ b/attr_test.go
@@ -234,6 +234,34 @@ func TestDTDDefaultNamespaceDoesNotOverrideExplicit(t *testing.T) {
 		require.NotNil(t, root)
 		require.Equal(t, "urn:dtd", root.URI())
 	})
+
+	t.Run("explicit reserved xml prefix wins over DTD default", func(t *testing.T) {
+		t.Parallel()
+		// An explicit reserved-prefix declaration (xmlns:xml=...) takes an
+		// early SkipNS shortcut during parsing. The fix records it in
+		// nsDeclared so a conflicting DTD default for the same prefix is
+		// suppressed; otherwise xml:lang would bind to "urn:dtd" instead of
+		// the reserved XML namespace.
+		xml := `<!DOCTYPE r [<!ATTLIST r xmlns:xml CDATA "urn:dtd">]>` +
+			`<r xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en"/>`
+
+		p := helium.NewParser().DefaultDTDAttributes(true)
+		doc, err := p.Parse(t.Context(), []byte(xml))
+		require.NoError(t, err)
+
+		root := doc.DocumentElement()
+		require.NotNil(t, root)
+
+		var lang *helium.Attribute
+		for _, a := range root.Attributes() {
+			if a.Name() == "xml:lang" {
+				lang = a
+				break
+			}
+		}
+		require.NotNil(t, lang)
+		require.Equal(t, "http://www.w3.org/XML/1998/namespace", lang.URI())
+	})
 }
 
 func TestGetAttribute(t *testing.T) {

--- a/parser_element.go
+++ b/parser_element.go
@@ -157,6 +157,40 @@ func (pctx *parserCtx) parseElement(ctx context.Context) error {
 	return nil
 }
 
+// validatePrefixedNamespaceDecl enforces the Namespaces in XML constraints
+// that apply to a prefixed namespace declaration (xmlns:prefix="uri"),
+// regardless of whether the declaration is literal on a start tag or supplied
+// as a DTD attribute default. The reserved xml prefix must map to the XML
+// namespace; the xmlns prefix may not be redeclared; the reserved XMLNS
+// namespace URI may not be reused; the URI may not be empty; and, in pedantic
+// mode, the URI must be absolute. It returns a non-nil namespace error when any
+// constraint is violated.
+func (pctx *parserCtx) validatePrefixedNamespaceDecl(ctx context.Context, prefix, uri string) error {
+	if prefix == lexicon.PrefixXML {
+		if uri != lexicon.NamespaceXML {
+			return pctx.namespaceError(ctx, errors.New("xml namespace prefix mapped to wrong URI"))
+		}
+		return nil
+	}
+	if prefix == lexicon.PrefixXMLNS {
+		return pctx.namespaceError(ctx, errors.New("redefinition of the xmlns prefix forbidden"))
+	}
+	if uri == lexicon.NamespaceXMLNS {
+		return pctx.namespaceError(ctx, errors.New("reuse of the xmlns namespace name if forbidden"))
+	}
+	if uri == "" {
+		return pctx.namespaceError(ctx, fmt.Errorf("xmlns:%s: Empty XML namespace is not allowed", prefix))
+	}
+	u, err := url.Parse(uri)
+	if err != nil {
+		return pctx.namespaceError(ctx, fmt.Errorf("xmlns:%s: '%s' is not a validURI", prefix, uri))
+	}
+	if pctx.pedantic && u.Scheme == "" {
+		return pctx.namespaceError(ctx, fmt.Errorf("xmlns:%s: URI %s is not absolute", prefix, uri))
+	}
+	return nil
+}
+
 func (pctx *parserCtx) parseStartTag(ctx context.Context) error {
 	cur := pctx.getCursor()
 	if cur == nil {
@@ -245,16 +279,16 @@ func (pctx *parserCtx) parseStartTag(ctx context.Context) error {
 			pctx.skipBlanks(ctx)
 			continue
 		} else if aprefix == lexicon.PrefixXMLNS {
-			var u *url.URL
-
 			// <elem xmlns:foo="...">
 			// Namespace URI entity/character references are expanded inline
 			// during attribute value parsing (replaceEntities forced true in
 			// parseAttribute for namespace attrs), so no post-processing needed.
+			// The same validity checks are applied to DTD-defaulted namespace
+			// declarations during attribute defaulting below.
+			if err := pctx.validatePrefixedNamespaceDecl(ctx, attname, attvalue); err != nil {
+				return err
+			}
 			if attname == lexicon.PrefixXML {
-				if attvalue != lexicon.NamespaceXML {
-					return pctx.namespaceError(ctx, errors.New("xml namespace prefix mapped to wrong URI"))
-				}
 				// Record the explicitly-declared reserved prefix before the
 				// SkipNS shortcut so a conflicting DTD-supplied default for the
 				// same prefix (e.g. <!ATTLIST r xmlns:xml CDATA "urn:dtd">) is
@@ -264,25 +298,6 @@ func (pctx *parserCtx) parseStartTag(ctx context.Context) error {
 				// the reserved xml namespace.
 				nsDeclared = append(nsDeclared, attname)
 				goto SkipNS
-			}
-			if attname == lexicon.PrefixXMLNS {
-				return pctx.namespaceError(ctx, errors.New("redefinition of the xmlns prefix forbidden"))
-			}
-
-			if attvalue == lexicon.NamespaceXMLNS {
-				return pctx.namespaceError(ctx, errors.New("reuse of the xmlns namespace name if forbidden"))
-			}
-
-			if attvalue == "" {
-				return pctx.namespaceError(ctx, fmt.Errorf("xmlns:%s: Empty XML namespace is not allowed", attname))
-			}
-
-			u, err = url.Parse(attvalue)
-			if err != nil {
-				return pctx.namespaceError(ctx, fmt.Errorf("xmlns:%s: '%s' is not a validURI", attname, attvalue))
-			}
-			if pctx.pedantic && u.Scheme == "" {
-				return pctx.namespaceError(ctx, fmt.Errorf("xmlns:%s: URI %s is not absolute", attname, attvalue))
 			}
 
 			// A same-element duplicate namespace declaration is a
@@ -374,6 +389,21 @@ func (pctx *parserCtx) parseStartTag(ctx context.Context) error {
 					continue
 				} else if aprefix == lexicon.PrefixXMLNS {
 					if slices.Contains(nsDeclared, attname) {
+						continue
+					}
+					// DTD-defaulted namespace declarations are subject to the
+					// same namespace-validity checks as literal ones: a
+					// wrong-URI xmlns:xml, an xmlns:xmlns redefinition, reuse of
+					// the reserved XMLNS namespace, an empty/invalid URI, etc.
+					// are all rejected before the binding is pushed.
+					if err := pctx.validatePrefixedNamespaceDecl(ctx, attname, attr.Value()); err != nil {
+						return err
+					}
+					// The reserved xml prefix is implicitly bound to the XML
+					// namespace; never let a DTD default push (and thus shadow)
+					// it, even a well-formed one. This mirrors the literal path,
+					// where xmlns:xml takes the SkipNS shortcut without pushing.
+					if attname == lexicon.PrefixXML {
 						continue
 					}
 					pctx.pushNS(attname, attr.Value())

--- a/parser_element.go
+++ b/parser_element.go
@@ -172,6 +172,9 @@ func (pctx *parserCtx) validatePrefixedNamespaceDecl(ctx context.Context, prefix
 		}
 		return nil
 	}
+	if uri == lexicon.NamespaceXML {
+		return pctx.namespaceError(ctx, fmt.Errorf("xmlns:%s: only the xml prefix may be bound to the reserved XML namespace", prefix))
+	}
 	if prefix == lexicon.PrefixXMLNS {
 		return pctx.namespaceError(ctx, errors.New("redefinition of the xmlns prefix forbidden"))
 	}

--- a/parser_element.go
+++ b/parser_element.go
@@ -342,20 +342,32 @@ func (pctx *parserCtx) parseStartTag(ctx context.Context) error {
 
 		defaults, ok := pctx.lookupAttributeDefault(elemName)
 		if ok {
-			// First pass: apply default xmlns="..." (must come before prefixed)
+			// First pass: apply default xmlns="..." (must come before prefixed).
+			// Skip a DTD default whose prefix (the empty string for the default
+			// namespace) was already explicitly declared on this start tag: an
+			// explicit binding must win over a DTD-supplied default. Because
+			// nsStack.Lookup is LIFO, pushing the DTD default afterwards would
+			// otherwise shadow the explicit one.
 			for _, attr := range defaults {
 				if attr.LocalName() == lexicon.PrefixXMLNS && attr.Prefix() == "" {
+					if slices.Contains(nsDeclared, "") {
+						continue
+					}
 					pctx.pushNS("", attr.Value())
 					nbNs++
 				}
 			}
-			// Second pass: apply xmlns:prefix="..." and regular attributes
+			// Second pass: apply xmlns:prefix="..." and regular attributes.
+			// Likewise skip a prefixed DTD default already declared explicitly.
 			for _, attr := range defaults {
 				attname := attr.LocalName()
 				aprefix := attr.Prefix()
 				if attname == lexicon.PrefixXMLNS && aprefix == "" {
 					continue
 				} else if aprefix == lexicon.PrefixXMLNS {
+					if slices.Contains(nsDeclared, attname) {
+						continue
+					}
 					pctx.pushNS(attname, attr.Value())
 					nbNs++
 				} else {

--- a/parser_element.go
+++ b/parser_element.go
@@ -255,6 +255,14 @@ func (pctx *parserCtx) parseStartTag(ctx context.Context) error {
 				if attvalue != lexicon.NamespaceXML {
 					return pctx.namespaceError(ctx, errors.New("xml namespace prefix mapped to wrong URI"))
 				}
+				// Record the explicitly-declared reserved prefix before the
+				// SkipNS shortcut so a conflicting DTD-supplied default for the
+				// same prefix (e.g. <!ATTLIST r xmlns:xml CDATA "urn:dtd">) is
+				// suppressed by the nsDeclared check during attribute
+				// defaulting. Without this, the explicit binding takes the early
+				// goto and is never recorded, letting the DTD default override
+				// the reserved xml namespace.
+				nsDeclared = append(nsDeclared, attname)
 				goto SkipNS
 			}
 			if attname == lexicon.PrefixXMLNS {


### PR DESCRIPTION
- DTD-defaulted xmlns/xmlns:prefix declarations now skip any prefix explicitly declared on the same start tag, so an explicit binding wins over a DTD default
- adds regression test for default and prefixed namespace cases