### PR TITLE
fix schematron value-of node-set string-value

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -14,7 +14,7 @@ xpath3         → helium, internal/xpath, internal/lexicon, internal/icu, inter
 xslt3          → helium, xpath3, xsd, html, internal/iofs, internal/lexicon, internal/sequence, internal/uripath, internal/xpathstream, internal/domutil, xslt3/internal/elements
 xsd            → helium, xpath1, internal/lexicon, internal/xsd/value, internal/xsdregex, internal/uripath, internal/iofs
 relaxng        → helium, internal/lexicon, internal/iofs, internal/xsd/value, internal/xmlchar, internal/uripath
-schematron     → helium, xpath1
+schematron     → helium, xpath1, internal/xpath
 xpointer       → helium, xpath1, internal/xmlchar
 c14n           → helium, internal/lexicon, internal/domutil
 xmldsig1       → helium, c14n, internal/lexicon, internal/domutil
@@ -55,7 +55,7 @@ c14n, xpath1, xpath3, html, catalog, relaxng, stream, xmlenc1
 xmldsig1 (root + c14n + internal/lexicon)
 
 ## Composition layer (depends on processing)
-xsd (root + xpath1 + internal/lexicon), xpointer (root + xpath1 + internal/xmlchar), schematron (root + xpath1), xinclude (root + xpointer + internal/encoding + internal/iofs + internal/lexicon), xslt3 (root + xpath3 + xsd + html + internal/elements), shim (root + stream)
+xsd (root + xpath1 + internal/lexicon), xpointer (root + xpath1 + internal/xmlchar), schematron (root + xpath1 + internal/xpath), xinclude (root + xpointer + internal/encoding + internal/iofs + internal/lexicon), xslt3 (root + xpath3 + xsd + html + internal/elements), shim (root + stream)
 
 ## Application layer
 internal/cli/heliumcmd (CLI implementation)

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -248,7 +248,7 @@ Schematron schema compilation and validation.
 - Supports: schema, pattern, rule, assert, report, let, name, value-of
 - Variable bindings via `<let>` and `<param>`
 - Files: `schematron.go` (API + config), `schema.go` (data model), `parse.go` (compilation), `validate.go` (validation), `errors.go` (error types + formatting)
-- Imports: helium, xpath1/
+- Imports: helium, internal/xpath, xpath1/
 
 ## catalog/
 

--- a/schematron/schematron_test.go
+++ b/schematron/schematron_test.go
@@ -738,7 +738,7 @@ func TestValueOfInterpolation(t *testing.T) {
 		require.Contains(t, collected[0].Message, "result is False")
 	})
 
-	t.Run("nodeset names", func(t *testing.T) {
+	t.Run("nodeset string-value", func(t *testing.T) {
 		t.Parallel()
 		schema, errs := compileTestSchema(t, `<schema xmlns="http://purl.oclc.org/dsdl/schematron">
 			<pattern><rule context="root">
@@ -747,12 +747,14 @@ func TestValueOfInterpolation(t *testing.T) {
 		</schema>`)
 		require.Equal(t, "", errs)
 
-		doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root><a/><b/><c/></root>`))
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root><a>X</a><b>Y</b><c>Z</c></root>`))
 		require.NoError(t, err)
 
 		collected, err := validateAndCollect(t, schema, doc)
 		require.ErrorIs(t, err, schematron.ErrValidationFailed)
-		require.Contains(t, collected[0].Message, "children: a b c")
+		// XPath 1.0: a node-set converts to the string-value of the node
+		// first in document order, i.e. the text of <a>, not the names.
+		require.Contains(t, collected[0].Message, "children: X")
 	})
 
 	t.Run("empty nodeset", func(t *testing.T) {

--- a/schematron/validate.go
+++ b/schematron/validate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	helium "github.com/lestrrat-go/helium"
+	ixpath "github.com/lestrrat-go/helium/internal/xpath"
 	"github.com/lestrrat-go/helium/xpath1"
 )
 
@@ -240,14 +241,9 @@ func xpathResultToString(r *xpath1.Result) string {
 		if len(r.NodeSet) == 0 {
 			return ""
 		}
-		var sb strings.Builder
-		for i, n := range r.NodeSet {
-			if i > 0 {
-				sb.WriteByte(' ')
-			}
-			sb.WriteString(n.Name())
-		}
-		return sb.String()
+		// XPath 1.0: a node-set converts to the string-value of the node
+		// first in document order.
+		return ixpath.StringValue(r.NodeSet[0])
 	}
 	return ""
 }

--- a/schematron/value_of_test.go
+++ b/schematron/value_of_test.go
@@ -1,0 +1,45 @@
+package schematron_test
+
+import (
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/schematron"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValueOfNodeSetStringValue verifies that a <value-of> over a node-set
+// emits the XPath 1.0 string-value (the text content of the first node in
+// document order) rather than the node's element name.
+func TestValueOfNodeSetStringValue(t *testing.T) {
+	const schemaSrc = `<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://purl.oclc.org/dsdl/schematron">
+  <pattern>
+    <rule context="/root">
+      <report test="child">found <value-of select="child"/></report>
+    </rule>
+  </pattern>
+</schema>`
+
+	const instanceSrc = `<?xml version="1.0" encoding="UTF-8"?><root><child>TEXT</child></root>`
+
+	ctx := t.Context()
+
+	schemaDoc, err := helium.NewParser().Parse(ctx, []byte(schemaSrc))
+	require.NoError(t, err, "parse schema")
+
+	schema, err := schematron.NewCompiler().Compile(ctx, schemaDoc)
+	require.NoError(t, err, "compile schema")
+
+	instDoc, err := helium.NewParser().Parse(ctx, []byte(instanceSrc))
+	require.NoError(t, err, "parse instance")
+
+	var captured []string
+	handler := captureHandler{out: &captured}
+	_ = schematron.NewValidator(schema).ErrorHandler(handler).Validate(ctx, instDoc)
+
+	joined := strings.Join(captured, "\n")
+	require.Contains(t, joined, "found TEXT", "value-of must emit the node string-value (TEXT), not the element name (child)")
+	require.NotContains(t, joined, "found child", "value-of must not emit the element name")
+}


### PR DESCRIPTION
- `<value-of>` over a node-set now emits the XPath 1.0 string-value (text of the first node in document order) instead of node names.
- reuse internal/xpath.StringValue in schematron/validate.go; add regression test.