### PR TITLE
enforce relaxng data except patterns

### DIFF
--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -1769,8 +1769,57 @@ func matchXSDValue(typeName, text, expected string) int {
 	return -1
 }
 
-// matchData checks if text matches a data type pattern.
+// matchData checks if text matches a data type pattern, including any
+// <except> patterns nested under the <data>. The base datatype must match
+// first; then any value excluded by the except patterns is rejected.
 func (v *validator) matchData(pat *pattern, text string) int {
+	if ret := v.matchDataType(pat, text); ret != 0 {
+		return ret
+	}
+	// A <data> may carry an <except> (stored as a patternChoice child by
+	// parseData). The base datatype matched above, so a value that also matches
+	// any except pattern must be rejected.
+	if v.matchesExcept(pat, text) {
+		return -1
+	}
+	return 0
+}
+
+// matchesExcept reports whether text matches any of the <except> patterns
+// stored under a <data> pattern. Each <except> is compiled into a patternChoice
+// child; its alternatives are value/data patterns (optionally combined with
+// nested choice).
+func (v *validator) matchesExcept(pat *pattern, text string) bool {
+	for _, child := range pat.children {
+		if v.matchExceptPattern(child, text) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchExceptPattern reports whether text matches a single pattern appearing
+// inside a <data>'s <except>. Only value, data, and choice patterns are valid
+// there per the RELAX NG schema for except-in-data.
+func (v *validator) matchExceptPattern(ex *pattern, text string) bool {
+	switch ex.kind {
+	case patternData:
+		return v.matchData(ex, text) == 0
+	case patternValue:
+		return v.matchValue(ex, text) == 0
+	case patternChoice:
+		for _, c := range ex.children {
+			if v.matchExceptPattern(c, text) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// matchDataType checks if text matches a data type pattern's base datatype,
+// without considering any <except> patterns.
+func (v *validator) matchDataType(pat *pattern, text string) int {
 	if pat.dataType == nil {
 		return 0
 	}

--- a/relaxng/validate_fixes_test.go
+++ b/relaxng/validate_fixes_test.go
@@ -101,6 +101,62 @@ func TestMatchAttrOneOrMore(t *testing.T) {
 	})
 }
 
+// TestMatchDataExcept covers RNG-001: a <data><except>...</except></data>
+// must reject values matching the except patterns while still accepting the
+// base datatype otherwise.
+func TestMatchDataExcept(t *testing.T) {
+	t.Parallel()
+
+	schema := `<element name="r" xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <data type="integer">
+    <except>
+      <value type="integer">5</value>
+    </except>
+  </data>
+</element>`
+
+	t.Run("excluded value rejected", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<r>5</r>`)
+		require.Error(t, err, `excepted value 5 must be rejected`)
+	})
+
+	t.Run("excluded value rejected via alternate lexical form", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<r>+5</r>`)
+		require.Error(t, err, `excepted value +5 (== 5) must be rejected`)
+	})
+
+	t.Run("non-excluded value accepted", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<r>7</r>`)
+		require.NoError(t, err, `non-excepted integer 7 should match`)
+	})
+
+	t.Run("invalid base datatype still rejected", func(t *testing.T) {
+		t.Parallel()
+		err := validateWith(t, schema, `<r>notanumber</r>`)
+		require.Error(t, err, `non-integer must be rejected by the base datatype`)
+	})
+
+	t.Run("except choice rejects multiple values", func(t *testing.T) {
+		t.Parallel()
+		multi := `<element name="r" xmlns="http://relaxng.org/ns/structure/1.0"
+    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <data type="integer">
+    <except>
+      <value type="integer">5</value>
+      <value type="integer">9</value>
+    </except>
+  </data>
+</element>`
+		require.Error(t, validateWith(t, multi, `<r>5</r>`), `5 must be rejected`)
+		require.Error(t, validateWith(t, multi, `<r>9</r>`), `9 must be rejected`)
+		require.NoError(t, validateWith(t, multi, `<r>7</r>`), `7 should match`)
+	})
+}
+
 // TestValidateWithLengthFacets covers bug 3: minLength/maxLength facets on a
 // <data type="string"> must be enforced.
 func TestValidateWithLengthFacets(t *testing.T) {


### PR DESCRIPTION
- `matchData` now evaluates a `<data>`'s `<except>` choice against the matched value and rejects excluded values; previously parsed but never enforced
- regression test for excluded/non-excluded integer values