### PR TITLE
fix negation-aware attr wildcard restriction subset

### DIFF
--- a/xsd/attr_wildcard_restriction_test.go
+++ b/xsd/attr_wildcard_restriction_test.go
@@ -62,6 +62,6 @@ func TestAttrWildcardRestrictionSubset(t *testing.T) {
   </xs:complexType>
   <xs:element name="root" type="t:Derived"/>
 </xs:schema>`
-		require.NotContains(t, compileFatalErrors(t, schema), notValidSubset)
+		require.Empty(t, compileFatalErrors(t, schema))
 	})
 }

--- a/xsd/attr_wildcard_restriction_test.go
+++ b/xsd/attr_wildcard_restriction_test.go
@@ -1,0 +1,67 @@
+package xsd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAttrWildcardRestrictionSubset (XSD-004) verifies that the
+// derivation-ok-restriction §3.10.6 attribute-wildcard subset check is
+// negation-aware. The earlier helper folded the negation constraints
+// (##other/##not-absent) into empty namespace sets, which both false-accepted a
+// derived ##other against a finite base set and false-rejected a finite derived
+// set against a base ##other.
+func TestAttrWildcardRestrictionSubset(t *testing.T) {
+	t.Parallel()
+
+	const notValidSubset = "is not a valid subset of the wildcard"
+
+	t.Run("rejects derived ##other against base ##local", func(t *testing.T) {
+		t.Parallel()
+		// Base attribute wildcard admits only the absent namespace (##local).
+		// Derived ##other admits infinitely many namespaces — NOT a subset, so
+		// the restriction must be rejected. The buggy helper folded both into
+		// empty sets and wrongly accepted it.
+		schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:t" xmlns:t="urn:t">
+  <xs:complexType name="Base">
+    <xs:sequence/>
+    <xs:anyAttribute namespace="##local" processContents="lax"/>
+  </xs:complexType>
+  <xs:complexType name="Derived">
+    <xs:complexContent>
+      <xs:restriction base="t:Base">
+        <xs:sequence/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="root" type="t:Derived"/>
+</xs:schema>`
+		require.Contains(t, compileFatalErrors(t, schema), notValidSubset)
+	})
+
+	t.Run("accepts finite derived set against base ##other", func(t *testing.T) {
+		t.Parallel()
+		// Base attribute wildcard is ##other (admits every namespace except the
+		// target namespace urn:t and the absent namespace). Derived restricts to
+		// the finite namespace urn:o, which the base admits — a valid subset. The
+		// buggy helper folded ##other into the empty set and wrongly rejected it.
+		schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:t" xmlns:t="urn:t">
+  <xs:complexType name="Base">
+    <xs:sequence/>
+    <xs:anyAttribute namespace="##other" processContents="lax"/>
+  </xs:complexType>
+  <xs:complexType name="Derived">
+    <xs:complexContent>
+      <xs:restriction base="t:Base">
+        <xs:sequence/>
+        <xs:anyAttribute namespace="urn:o" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="root" type="t:Derived"/>
+</xs:schema>`
+		require.NotContains(t, compileFatalErrors(t, schema), notValidSubset)
+	})
+}

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -1106,7 +1106,7 @@ func (c *compiler) checkRestrictionAttrs(ctx context.Context, td *TypeDef) {
 			c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType", component, msg))
 		} else {
 			// 4.2: Derived namespace must be subset of base namespace.
-			if !wildcardNSSubset(td.AnyAttribute, td.BaseType.AnyAttribute) {
+			if !wildcardConstraintSubset(td.AnyAttribute, td.BaseType.AnyAttribute) {
 				msg := fmt.Sprintf("The attribute wildcard is not a valid subset of the wildcard in the base complex type definition %s.", baseQualified)
 				c.schemaError(ctx, schemaComponentError(c.filename, src.line, "complexType", component, msg))
 			}
@@ -1126,28 +1126,6 @@ func (c *compiler) checkRestrictionAttrs(ctx context.Context, td *TypeDef) {
 			}
 		}
 	}
-}
-
-// wildcardNSSubset checks whether the namespace constraint of sub is a subset
-// of the namespace constraint of super, per XSD §3.10.6.
-func wildcardNSSubset(sub, super *Wildcard) bool {
-	// ##any is a superset of everything.
-	if super.Namespace == WildcardNSAny {
-		return true
-	}
-	// If sub is ##any but super is not, sub is not a subset.
-	if sub.Namespace == WildcardNSAny {
-		return false
-	}
-	// Both are specific namespace sets — sub must be contained in super.
-	subSet := wildcardNSSet(sub)
-	superSet := wildcardNSSet(super)
-	for ns := range subSet {
-		if !superSet[ns] {
-			return false
-		}
-	}
-	return true
 }
 
 // wildcardNSSet expands a wildcard's namespace constraint into a set of URIs.


### PR DESCRIPTION
- derivation-ok-restriction attr-wildcard §3.10.6 subset check now calls the negation-aware wildcardConstraintSubset, not the union-oriented helper that folded ##other/##not-absent into empty sets
- fixes false-accept (derived ##other ⊆ base ##local) and false-reject (finite urn:o ⊆ base ##other)