### PR TITLE
fix xsl:evaluate with-params QName key namespace

### DIFF
--- a/xslt3/evaluate_withparams_qname_test.go
+++ b/xslt3/evaluate_withparams_qname_test.go
@@ -1,0 +1,49 @@
+package xslt3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEvaluateWithParamsQNameNamespacedKey verifies that xsl:evaluate's
+// with-params map stores QName keys under their full Clark-name
+// representation, so a namespaced key QName('urn:p','x') is resolvable as
+// $p:x inside the dynamically-evaluated expression (with p->urn:p in scope)
+// and does not collide with a no-namespace variable of the same local name.
+//
+// The xpath attribute is itself an XPath expression whose string value is the
+// dynamically-evaluated expression, hence the string literal '$p:x'.
+func TestEvaluateWithParamsQNameNamespacedKey(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:p="urn:p">
+  <xsl:template match="/">
+    <out><xsl:evaluate xpath="'$p:x'" with-params="map{ QName('urn:p','x') : 42 }"/></out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	result, err := ss.Transform(parseTransformSource(t)).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, result, ">42</out>")
+}
+
+// TestEvaluateWithParamsQNameNoCollision verifies that a namespaced QName key
+// and a no-namespace key with the same local name do not collide: $x resolves
+// to the no-namespace value, $p:x to the namespaced value.
+func TestEvaluateWithParamsQNameNoCollision(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:p="urn:p">
+  <xsl:template match="/">
+    <out><xsl:evaluate xpath="'concat($x, &quot;|&quot;, $p:x)'"
+        with-params="map{ QName('','x') : 'plain', QName('urn:p','x') : 'namespaced' }"/></out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	result, err := ss.Transform(parseTransformSource(t)).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, result, ">plain|namespaced</out>")
+}

--- a/xslt3/execute_misc.go
+++ b/xslt3/execute_misc.go
@@ -830,8 +830,14 @@ func (ec *execContext) execEvaluate(ctx context.Context, inst *evaluateInst) err
 					if key.TypeName != xpath3.TypeQName {
 						return dynamicError(errCodeXTTE3165, "xsl:evaluate: with-params map key must be xs:QName, got %s", key.TypeName)
 					}
-					qn := key.QNameVal()
-					vars[qn.Local] = value
+					// Store under the Clark-name representation used by XPath
+					// variable lookup so namespaced keys (e.g. {urn:p}x) resolve
+					// as $p:x and don't collide with no-namespace variables.
+					clark, clarkErr := paramKeyToClark(key)
+					if clarkErr != nil {
+						return clarkErr
+					}
+					vars[clark] = value
 					return nil
 				})
 				if forEachErr != nil {


### PR DESCRIPTION
- xsl:evaluate with-params now stores QName map keys under their Clark name via paramKeyToClark, so namespaced keys resolve as $p:x and no longer collide with no-namespace variables.