### PR TITLE
guard nil PE in entity decode against panic

### DIFF
--- a/parser_entity_decl.go
+++ b/parser_entity_decl.go
@@ -119,6 +119,12 @@ func (pctx *parserCtx) decodeEntitiesInternal(ctx context.Context, s []byte, wha
 				// pctx.valid and returns a nil entity with no error. It is not
 				// expanded. Skip it without dereferencing the nil entity,
 				// mirroring the '&' branch above and expandEntityValueForRefCheck.
+				// Still charge the reference against entity-expansion accounting
+				// (entityCheck tolerates a nil ent) so an unresolved PE ref can't
+				// be used to dodge the amplification/ceiling limits.
+				if err := pctx.entityCheck(ent, width); err != nil {
+					return "", err
+				}
 				s = s[width:]
 				continue
 			}

--- a/parser_entity_decl.go
+++ b/parser_entity_decl.go
@@ -112,6 +112,16 @@ func (pctx *parserCtx) decodeEntitiesInternal(ctx context.Context, s []byte, wha
 			if err != nil {
 				return "", err
 			}
+			if ent == nil {
+				// An undeclared parameter entity in a context with an external
+				// subset (or after a prior PE reference) is a validity error,
+				// not a fatal one: parseStringPEReference has already cleared
+				// pctx.valid and returns a nil entity with no error. It is not
+				// expanded. Skip it without dereferencing the nil entity,
+				// mirroring the '&' branch above and expandEntityValueForRefCheck.
+				s = s[width:]
+				continue
+			}
 			if err := pctx.entityCheck(ent, width); err != nil {
 				return "", err
 			}

--- a/parser_pe_nil_panic_test.go
+++ b/parser_pe_nil_panic_test.go
@@ -58,4 +58,9 @@ func TestDecodeEntitiesUndeclaredPEReturnsEmpty(t *testing.T) {
 	})
 	require.NoError(t, err, "an undeclared PE in an external-subset context is a validity error, not fatal")
 	require.Equal(t, "ab", out, "the undeclared PE must expand to nothing")
+	// The unresolved PE reference must still be charged against entity-expansion
+	// accounting (reference width + per-reference fixed cost), otherwise an
+	// undeclared PE becomes a free way to dodge the amplification/ceiling limits.
+	require.Equal(t, int64(len("%missing;"))+entityFixedCost, pctx.sizeentcopy,
+		"unresolved PE reference must be charged against sizeentcopy")
 }

--- a/parser_pe_nil_panic_test.go
+++ b/parser_pe_nil_panic_test.go
@@ -1,0 +1,61 @@
+package helium
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestUndefinedParameterEntityNoPanic guards against a nil-entity dereference in
+// decodeEntitiesInternal's parameter-entity ('%') branch.
+//
+// For an undeclared parameter entity in a context with an external subset (or
+// after a prior PE reference), parseStringPEReference deliberately returns a nil
+// entity with NO error after clearing pctx.valid — the libxml2-faithful "PE not
+// declared, validity error, keep going" convention that the nilPEHandler models.
+// The '&' (general-entity) branch and expandEntityValueForRefCheck both guard
+// that nil; the '%' branch did not and dereferenced ent.Content(), panicking the
+// whole parse. This test drives the full Parse path with a SAX handler that uses
+// the (nil, nil) convention and asserts no panic.
+func TestUndefinedParameterEntityNoPanic(t *testing.T) {
+	cases := []string{
+		`<!DOCTYPE r SYSTEM "x" [<!ENTITY e "%missing;">]><r/>`,
+		`<!DOCTYPE r SYSTEM "x" [<!ENTITY % p "%missing;">]><r/>`,
+		`<!DOCTYPE r SYSTEM "x" [<!ENTITY e "a%missing;b">]><r/>`,
+	}
+
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			handler := nilPEHandler{TreeBuilder: NewTreeBuilder()}
+			require.NotPanics(t, func() {
+				_, _ = NewParser().SAXHandler(handler).Parse(t.Context(), []byte(input))
+			})
+		})
+	}
+}
+
+// TestDecodeEntitiesUndeclaredPEReturnsEmpty exercises the decode branch
+// directly: an undeclared parameter entity resolved through the (nil, nil)
+// convention must expand to nothing (consistent with expandEntityValueForRefCheck)
+// rather than panic, and must not surface an error.
+func TestDecodeEntitiesUndeclaredPEReturnsEmpty(t *testing.T) {
+	pctx := &parserCtx{}
+	require.NoError(t, pctx.init(nil, bytes.NewReader(nil)))
+	doc := NewDocument("1.0", "", StandaloneImplicitNo)
+	tb := NewTreeBuilder()
+	pctx.doc = doc
+	pctx.sax = nilPEHandler{TreeBuilder: tb}
+	pctx.treeBuilder = tb
+	pctx.hasExternalSubset = true
+
+	ctx := withParserCtx(t.Context(), pctx)
+
+	var out string
+	var err error
+	require.NotPanics(t, func() {
+		out, err = pctx.decodeEntities(ctx, []byte("a%missing;b"), SubstitutePERef)
+	})
+	require.NoError(t, err, "an undeclared PE in an external-subset context is a validity error, not fatal")
+	require.Equal(t, "ab", out, "the undeclared PE must expand to nothing")
+}


### PR DESCRIPTION
- decodeEntitiesInternal's '%' branch dereferenced a nil parameter entity returned by parseStringPEReference for an undeclared PE (the libxml2-faithful (nil,nil) SAX convention, validity error not fatal), panicking the parse.
- now skips the undeclared PE like the '&' branch and expandEntityValueForRefCheck do; reachable via Parse with a custom SAX2 handler (default TreeBuilder masks it by erroring).