### PR TITLE
bound xpath3 sequence concat by maxNodes

### DIFF
--- a/.claude/docs/xpath3-eval.md
+++ b/.claude/docs/xpath3-eval.md
@@ -54,7 +54,7 @@ Lowering is structural for non-trivial nodes: recursive children usually become 
 ## Evaluation Rules by Expr Type
 
 ### SequenceExpr (comma)
-Evaluate each item, concatenate sequences.
+Evaluate each item, concatenate sequences through `appendBoundedSeq` so the aggregate honors `maxNodes` / OpLimit / cancellation (each operand is individually capped, but the concatenation must be bounded too).
 
 ### LocationPath
 1. Start: root node (absolute) or context node (relative)

--- a/xpath3/eval_path.go
+++ b/xpath3/eval_path.go
@@ -105,7 +105,15 @@ func evalSequenceExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContext
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, seqMaterialize(seq)...)
+		// Concatenate through appendBoundedSeq so maxNodes / OpLimit /
+		// cancellation fire across the aggregate. Each operand is itself capped,
+		// but the concatenation is not, so a sequence of K capped range operands
+		// (1 to N, 1 to N, ...) would otherwise materialize K*N items past the
+		// configured limit.
+		result, err = appendBoundedSeq(ctx, ec, result, seq, ec.maxNodes)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return result, nil
 }

--- a/xpath3/functions_hof_bounds_test.go
+++ b/xpath3/functions_hof_bounds_test.go
@@ -1128,3 +1128,44 @@ func TestMapFindDeepNesting(t *testing.T) {
 		require.Equal(t, 1, res.Sequence().Len())
 	})
 }
+
+// TestSequenceConcatHonorsNodeSetLimit proves that evalSequenceExpr concatenates
+// its operands through appendBoundedSeq: each range operand is individually
+// capped, but the aggregate must still trip ErrNodeSetLimit. Before the fix the
+// concatenation used a raw append that bypassed maxNodes, so K capped operands
+// could materialize K*N items past the configured limit.
+func TestSequenceConcatHonorsNodeSetLimit(t *testing.T) {
+	t.Parallel()
+
+	const limit = 1000
+	// Each operand (1 to 600) is under the limit; two of them exceed it.
+	compiled, err := xpath3.NewCompiler().Compile(`(1 to 600, 1 to 600)`)
+	require.NoError(t, err)
+
+	var evalErr error
+	require.NotPanics(t, func() {
+		_, evalErr = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+			MaxNodesForTesting(limit).
+			Evaluate(t.Context(), compiled, nil)
+	})
+	require.ErrorIs(t, evalErr, xpath3.ErrNodeSetLimit)
+}
+
+// TestSequenceConcatHonorsOpLimit proves that the concatenation in
+// evalSequenceExpr charges an op per appended item, so a sequence of operands
+// whose total length exceeds OpLimit aborts with ErrOpLimit (and, by extension,
+// honors context cancellation) rather than running unbounded.
+func TestSequenceConcatHonorsOpLimit(t *testing.T) {
+	t.Parallel()
+
+	compiled, err := xpath3.NewCompiler().Compile(`(1 to 600, 1 to 600)`)
+	require.NoError(t, err)
+
+	var evalErr error
+	require.NotPanics(t, func() {
+		_, evalErr = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+			OpLimit(1000).
+			Evaluate(t.Context(), compiled, nil)
+	})
+	require.ErrorIs(t, evalErr, xpath3.ErrOpLimit)
+}


### PR DESCRIPTION
- evalSequenceExpr concatenated operands with a raw append that bypassed maxNodes/OpLimit/cancellation; switch to appendBoundedSeq so (1 to N, 1 to N, ...) can't materialize K*N items past the cap
- add regression tests for the node-set and op-limit bounds