### PR TITLE
reject duplicate xmldsig SignedInfo/Reference children

### DIFF
--- a/xmldsig1/transforms_internal_test.go
+++ b/xmldsig1/transforms_internal_test.go
@@ -40,6 +40,20 @@ func buildExcC14NReference(t *testing.T, doc *helium.Document, incPx, incNS, pre
 	require.NoError(t, inc.SetLiteralAttribute("PrefixList", prefixList))
 	require.NoError(t, transform.AddChild(inc))
 
+	// DigestMethod/DigestValue are mandatory under Reference's content model, so
+	// include them: parseReferenceElement now rejects a Reference missing either,
+	// and this helper exercises the transform/InclusiveNamespaces parsing of an
+	// otherwise complete Reference.
+	digestMethod := doc.CreateElement("DigestMethod")
+	require.NoError(t, digestMethod.SetActiveNamespace(nsPrefix, NamespaceDSig))
+	require.NoError(t, digestMethod.SetLiteralAttribute("Algorithm", DigestSHA256))
+	require.NoError(t, ref.AddChild(digestMethod))
+
+	digestValue := doc.CreateElement("DigestValue")
+	require.NoError(t, digestValue.SetActiveNamespace(nsPrefix, NamespaceDSig))
+	require.NoError(t, digestValue.AddChild(doc.CreateText([]byte("AA=="))))
+	require.NoError(t, ref.AddChild(digestValue))
+
 	return ref
 }
 

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -262,6 +262,14 @@ func parseSignatureElement(sigElem *helium.Element) (*parsedSignature, error) {
 }
 
 func parseSignedInfo(elem *helium.Element, parsed *parsedSignature) error {
+	// The XML-Signature schema fixes SignedInfo's content model as
+	// (CanonicalizationMethod, SignatureMethod, Reference+) with exactly one
+	// CanonicalizationMethod and exactly one SignatureMethod. Enforce that
+	// cardinality rather than accepting duplicates last-one-wins: a crafted
+	// SignedInfo carrying two SignatureMethod (or CanonicalizationMethod)
+	// children is schema-invalid and ambiguous about which algorithm the
+	// signature actually commits to, so a conforming verifier must reject it.
+	var c14nSeen, sigMethodSeen bool
 	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
 		e, ok := helium.AsNode[*helium.Element](child)
 		if !ok {
@@ -277,12 +285,20 @@ func parseSignedInfo(elem *helium.Element, parsed *parsedSignature) error {
 		}
 		switch domutil.LocalName(e) {
 		case "CanonicalizationMethod":
+			if c14nSeen {
+				return fmt.Errorf("%w: multiple CanonicalizationMethod elements", ErrInvalidSignature)
+			}
+			c14nSeen = true
 			alg, ok := e.GetAttribute("Algorithm")
 			if !ok {
 				return fmt.Errorf("%w: CanonicalizationMethod missing Algorithm", ErrInvalidSignature)
 			}
 			parsed.c14nMethod = alg
 		case "SignatureMethod":
+			if sigMethodSeen {
+				return fmt.Errorf("%w: multiple SignatureMethod elements", ErrInvalidSignature)
+			}
+			sigMethodSeen = true
 			alg, ok := e.GetAttribute("Algorithm")
 			if !ok {
 				return fmt.Errorf("%w: SignatureMethod missing Algorithm", ErrInvalidSignature)
@@ -310,6 +326,14 @@ func parseReferenceElement(elem *helium.Element) (parsedReference, error) {
 	ref := parsedReference{}
 	ref.uri, _ = elem.GetAttribute("URI")
 
+	// The XML-Signature schema fixes Reference's content model as
+	// (Transforms?, DigestMethod, DigestValue) with at most one Transforms and
+	// exactly one DigestMethod and one DigestValue. Enforce that cardinality
+	// rather than accepting duplicates last-one-wins: a crafted Reference with
+	// two DigestValue children (the second crafted to match the recomputed
+	// digest) is schema-invalid and ambiguous about which digest the signature
+	// commits to, so a conforming verifier must reject it.
+	var transformsSeen, digestMethodSeen, digestValueSeen bool
 	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
 		e, ok := helium.AsNode[*helium.Element](child)
 		if !ok {
@@ -324,6 +348,10 @@ func parseReferenceElement(elem *helium.Element) (parsedReference, error) {
 		}
 		switch domutil.LocalName(e) {
 		case "Transforms":
+			if transformsSeen {
+				return ref, fmt.Errorf("%w: multiple Transforms elements", ErrInvalidSignature)
+			}
+			transformsSeen = true
 			for tc := e.FirstChild(); tc != nil; tc = tc.NextSibling() {
 				te, ok := helium.AsNode[*helium.Element](tc)
 				if !ok {
@@ -369,12 +397,20 @@ func parseReferenceElement(elem *helium.Element) (parsedReference, error) {
 				ref.transforms = append(ref.transforms, t)
 			}
 		case "DigestMethod":
+			if digestMethodSeen {
+				return ref, fmt.Errorf("%w: multiple DigestMethod elements", ErrInvalidSignature)
+			}
+			digestMethodSeen = true
 			alg, ok := e.GetAttribute("Algorithm")
 			if !ok {
 				return ref, fmt.Errorf("%w: DigestMethod missing Algorithm", ErrInvalidSignature)
 			}
 			ref.digestAlgorithm = alg
 		case "DigestValue":
+			if digestValueSeen {
+				return ref, fmt.Errorf("%w: multiple DigestValue elements", ErrInvalidSignature)
+			}
+			digestValueSeen = true
 			decoded, err := xmlbase64.DecodeString(domutil.TextContent(e))
 			if err != nil {
 				return ref, fmt.Errorf("%w: invalid DigestValue base64: %v", ErrInvalidSignature, err)

--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -313,6 +313,20 @@ func parseSignedInfo(elem *helium.Element, parsed *parsedSignature) error {
 		}
 	}
 
+	// SignedInfo's content model fixes CanonicalizationMethod and
+	// SignatureMethod at exactly one each, not merely at most one. Enforcing
+	// only "at most one" lets a SignedInfo missing either element parse OK and
+	// fail much later — as an unsupported-algorithm error, sometimes only after
+	// key resolution — instead of as a clean ErrInvalidSignature. Reject the
+	// absence here so a structurally invalid SignedInfo never reaches
+	// canonicalization or key resolution.
+	if !c14nSeen {
+		return fmt.Errorf("%w: missing CanonicalizationMethod", ErrInvalidSignature)
+	}
+	if !sigMethodSeen {
+		return fmt.Errorf("%w: missing SignatureMethod", ErrInvalidSignature)
+	}
+
 	// XML-Signature requires at least one Reference. A SignatureValue computed
 	// over a reference-free SignedInfo verifies cryptographically yet covers no
 	// document content, so accepting it would attest to nothing. Reject it.
@@ -417,6 +431,19 @@ func parseReferenceElement(elem *helium.Element) (parsedReference, error) {
 			}
 			ref.digestValue = decoded
 		}
+	}
+
+	// Reference's content model fixes DigestMethod and DigestValue at exactly
+	// one each, not merely at most one. Enforcing only "at most one" lets a
+	// Reference missing either element parse OK and fail much later — a missing
+	// DigestMethod surfaces as an unsupported-digest error and a missing
+	// DigestValue as a digest mismatch (the empty digest never matches) —
+	// instead of as a clean ErrInvalidSignature. Reject the absence here.
+	if !digestMethodSeen {
+		return ref, fmt.Errorf("%w: missing DigestMethod", ErrInvalidSignature)
+	}
+	if !digestValueSeen {
+		return ref, fmt.Errorf("%w: missing DigestValue", ErrInvalidSignature)
 	}
 	return ref, nil
 }

--- a/xmldsig1/verify_internal_test.go
+++ b/xmldsig1/verify_internal_test.go
@@ -15,6 +15,10 @@ import (
 
 const dsigNS = NamespaceDSig
 
+// payloadURI is the same-document Reference URI used by the signer-driven tests
+// below, all of which sign a <data Id="payload"> element.
+const payloadURI = "#payload"
+
 // findChild returns the first child element of parent with the given local
 // name, failing the test if none is found.
 func findChild(t *testing.T, parent *helium.Element, name string) *helium.Element {
@@ -168,6 +172,42 @@ func TestParseSignedInfo(t *testing.T) {
 		require.ErrorIs(t, err, ErrInvalidSignature)
 		require.Contains(t, err.Error(), "no Reference")
 	})
+
+	// A second CanonicalizationMethod makes the c14n algorithm ambiguous; the
+	// schema fixes its cardinality at one, so it must be rejected rather than
+	// accepted last-one-wins.
+	t.Run("duplicate CanonicalizationMethod", func(t *testing.T) {
+		si := `<ds:SignedInfo xmlns:ds="` + dsigNS + `">` +
+			`<ds:CanonicalizationMethod xmlns:ds="` + dsigNS + `" Algorithm="` + ExcC14N10 + `"/>` +
+			`<ds:CanonicalizationMethod xmlns:ds="` + dsigNS + `" Algorithm="` + C14N10 + `"/>` +
+			`<ds:SignatureMethod xmlns:ds="` + dsigNS + `" Algorithm="` + AlgRSASHA256 + `"/>` +
+			`<ds:Reference xmlns:ds="` + dsigNS + `" URI="">` +
+			`<ds:DigestMethod xmlns:ds="` + dsigNS + `" Algorithm="` + DigestSHA256 + `"/>` +
+			`<ds:DigestValue xmlns:ds="` + dsigNS + `">AA==</ds:DigestValue>` +
+			`</ds:Reference></ds:SignedInfo>`
+		doc := mustParse(t, si)
+		var parsed parsedSignature
+		err := parseSignedInfo(doc.DocumentElement(), &parsed)
+		require.ErrorIs(t, err, ErrInvalidSignature)
+		require.Contains(t, err.Error(), "multiple CanonicalizationMethod")
+	})
+
+	// A second SignatureMethod makes the signature algorithm ambiguous.
+	t.Run("duplicate SignatureMethod", func(t *testing.T) {
+		si := `<ds:SignedInfo xmlns:ds="` + dsigNS + `">` +
+			`<ds:CanonicalizationMethod xmlns:ds="` + dsigNS + `" Algorithm="` + ExcC14N10 + `"/>` +
+			`<ds:SignatureMethod xmlns:ds="` + dsigNS + `" Algorithm="` + AlgRSASHA256 + `"/>` +
+			`<ds:SignatureMethod xmlns:ds="` + dsigNS + `" Algorithm="` + AlgECDSASHA256 + `"/>` +
+			`<ds:Reference xmlns:ds="` + dsigNS + `" URI="">` +
+			`<ds:DigestMethod xmlns:ds="` + dsigNS + `" Algorithm="` + DigestSHA256 + `"/>` +
+			`<ds:DigestValue xmlns:ds="` + dsigNS + `">AA==</ds:DigestValue>` +
+			`</ds:Reference></ds:SignedInfo>`
+		doc := mustParse(t, si)
+		var parsed parsedSignature
+		err := parseSignedInfo(doc.DocumentElement(), &parsed)
+		require.ErrorIs(t, err, ErrInvalidSignature)
+		require.Contains(t, err.Error(), "multiple SignatureMethod")
+	})
 }
 
 func TestParseReferenceElement(t *testing.T) {
@@ -207,6 +247,53 @@ func TestParseReferenceElement(t *testing.T) {
 		require.Len(t, ref.transforms, 1)
 		require.Equal(t, []string{"a", "b"}, ref.transforms[0].prefixes)
 	})
+
+	// A second DigestMethod makes the digest algorithm ambiguous.
+	t.Run("duplicate DigestMethod", func(t *testing.T) {
+		r := `<ds:Reference xmlns:ds="` + dsigNS + `" URI="">` +
+			`<ds:DigestMethod xmlns:ds="` + dsigNS + `" Algorithm="` + DigestSHA256 + `"/>` +
+			`<ds:DigestMethod xmlns:ds="` + dsigNS + `" Algorithm="` + DigestSHA512 + `"/>` +
+			`<ds:DigestValue xmlns:ds="` + dsigNS + `">AA==</ds:DigestValue>` +
+			`</ds:Reference>`
+		doc := mustParse(t, r)
+		_, err := parseReferenceElement(doc.DocumentElement())
+		require.ErrorIs(t, err, ErrInvalidSignature)
+		require.Contains(t, err.Error(), "multiple DigestMethod")
+	})
+
+	// Two DigestValue children (the core of DSIG-004): even when the second
+	// matches the recomputed digest, the ambiguous schema-invalid Reference
+	// must be rejected rather than accepted last-one-wins.
+	t.Run("duplicate DigestValue", func(t *testing.T) {
+		r := `<ds:Reference xmlns:ds="` + dsigNS + `" URI="">` +
+			`<ds:DigestMethod xmlns:ds="` + dsigNS + `" Algorithm="` + DigestSHA256 + `"/>` +
+			`<ds:DigestValue xmlns:ds="` + dsigNS + `">AA==</ds:DigestValue>` +
+			`<ds:DigestValue xmlns:ds="` + dsigNS + `">BB==</ds:DigestValue>` +
+			`</ds:Reference>`
+		doc := mustParse(t, r)
+		_, err := parseReferenceElement(doc.DocumentElement())
+		require.ErrorIs(t, err, ErrInvalidSignature)
+		require.Contains(t, err.Error(), "multiple DigestValue")
+	})
+
+	// At most one Transforms element is permitted; two would let extra
+	// transforms accumulate and silently change the canonical input.
+	t.Run("duplicate Transforms", func(t *testing.T) {
+		r := `<ds:Reference xmlns:ds="` + dsigNS + `" URI="">` +
+			`<ds:Transforms xmlns:ds="` + dsigNS + `">` +
+			`<ds:Transform xmlns:ds="` + dsigNS + `" Algorithm="` + ExcC14N10 + `"/>` +
+			`</ds:Transforms>` +
+			`<ds:Transforms xmlns:ds="` + dsigNS + `">` +
+			`<ds:Transform xmlns:ds="` + dsigNS + `" Algorithm="` + C14N10 + `"/>` +
+			`</ds:Transforms>` +
+			`<ds:DigestMethod xmlns:ds="` + dsigNS + `" Algorithm="` + DigestSHA256 + `"/>` +
+			`<ds:DigestValue xmlns:ds="` + dsigNS + `">AA==</ds:DigestValue>` +
+			`</ds:Reference>`
+		doc := mustParse(t, r)
+		_, err := parseReferenceElement(doc.DocumentElement())
+		require.ErrorIs(t, err, ErrInvalidSignature)
+		require.Contains(t, err.Error(), "multiple Transforms")
+	})
 }
 
 // TestEmptyReferencesRejected guards against a SignedInfo that carries zero
@@ -230,7 +317,7 @@ func TestEmptyReferencesRejected(t *testing.T) {
 	sigElem, err := NewSigner().
 		SignatureAlgorithm(AlgRSASHA256).
 		Reference(ReferenceConfig{
-			URI:             "#payload",
+			URI:             payloadURI,
 			DigestAlgorithm: DigestSHA256,
 			Transforms:      []Transform{ExcC14NTransform()},
 		}).
@@ -270,6 +357,62 @@ func TestEmptyReferencesRejected(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidSignature)
 	require.True(t, strings.Contains(err.Error(), "Reference"),
 		"error should mention the missing Reference: %v", err)
+}
+
+// TestDuplicateDigestValueRejected is the end-to-end form of DSIG-004: a
+// SignedInfo whose Reference carries two DigestValue children must be rejected
+// even when the document is otherwise a perfectly valid signature. The attack
+// is built with full key control: sign normally, append a second (matching)
+// DigestValue to the Reference, then recompute a valid SignatureValue over the
+// now-ambiguous SignedInfo. Last-one-wins parsing would accept it; a conforming
+// verifier must reject the schema-invalid duplicate.
+func TestDuplicateDigestValueRejected(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(`<root><data Id="payload">secret</data></root>`))
+	require.NoError(t, err)
+
+	sigElem, err := NewSigner().
+		SignatureAlgorithm(AlgRSASHA256).
+		Reference(ReferenceConfig{
+			URI:             payloadURI,
+			DigestAlgorithm: DigestSHA256,
+			Transforms:      []Transform{ExcC14NTransform()},
+		}).
+		SignDetached(context.Background(), doc, key)
+	require.NoError(t, err)
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	// Sanity: the freshly produced signature verifies before tampering.
+	_, err = NewVerifier(StaticKey(&key.PublicKey)).Verify(context.Background(), doc)
+	require.NoError(t, err)
+
+	signedInfo := findChild(t, sigElem, "SignedInfo")
+	reference := findChild(t, signedInfo, "Reference")
+	digestValue := findChild(t, reference, "DigestValue")
+
+	// Append an identical second DigestValue so the Reference now has two.
+	dup, err := helium.CopyNode(digestValue, doc)
+	require.NoError(t, err)
+	dupElem, ok := helium.AsNode[*helium.Element](dup)
+	require.True(t, ok)
+	require.NoError(t, reference.AddChild(dupElem))
+	require.Equal(t, 2, countChildren(reference, "DigestValue"))
+
+	// Recompute a valid SignatureValue over the now-ambiguous SignedInfo.
+	canonical, err := canonicalizeSubtree(ExcC14N10, signedInfo, nil)
+	require.NoError(t, err)
+	sigBytes, err := signBytes(AlgRSASHA256, key, canonical, false)
+	require.NoError(t, err)
+
+	sigValueElem := findChild(t, sigElem, "SignatureValue")
+	setText(t, sigValueElem, base64.StdEncoding.EncodeToString(sigBytes))
+
+	_, err = NewVerifier(StaticKey(&key.PublicKey)).Verify(context.Background(), doc)
+	require.Error(t, err, "signature with duplicate DigestValue must be rejected")
+	require.ErrorIs(t, err, ErrInvalidSignature)
+	require.Contains(t, err.Error(), "multiple DigestValue")
 }
 
 // TestVerifyLineWrappedDigestValue ensures a DigestValue carrying embedded
@@ -336,7 +479,7 @@ func TestReferenceNamespace(t *testing.T) {
 		sigElem, err := NewSigner().
 			SignatureAlgorithm(AlgRSASHA256).
 			Reference(ReferenceConfig{
-				URI:             "#payload",
+				URI:             payloadURI,
 				DigestAlgorithm: DigestSHA256,
 				Transforms:      []Transform{ExcC14NTransform()},
 			}).
@@ -396,7 +539,7 @@ func TestReferenceNamespace(t *testing.T) {
 		sigElem, err := NewSigner().
 			SignatureAlgorithm(AlgRSASHA256).
 			Reference(ReferenceConfig{
-				URI:             "#payload",
+				URI:             payloadURI,
 				DigestAlgorithm: DigestSHA256,
 				Transforms:      []Transform{ExcC14NTransform()},
 			}).
@@ -452,7 +595,7 @@ func TestReferenceNamespace(t *testing.T) {
 		sigElem, err := NewSigner().
 			SignatureAlgorithm(AlgRSASHA256).
 			Reference(ReferenceConfig{
-				URI:             "#payload",
+				URI:             payloadURI,
 				DigestAlgorithm: DigestSHA256,
 				Transforms:      []Transform{ExcC14NTransform()},
 			}).

--- a/xmldsig1/verify_internal_test.go
+++ b/xmldsig1/verify_internal_test.go
@@ -127,6 +127,8 @@ func TestParseSignatureElement(t *testing.T) {
 
 	t.Run("bad SignatureValue base64", func(t *testing.T) {
 		si := `<ds:SignedInfo xmlns:ds="` + dsigNS + `">` +
+			`<ds:CanonicalizationMethod xmlns:ds="` + dsigNS + `" Algorithm="` + ExcC14N10 + `"/>` +
+			`<ds:SignatureMethod xmlns:ds="` + dsigNS + `" Algorithm="` + AlgRSASHA256 + `"/>` +
 			`<ds:Reference xmlns:ds="` + dsigNS + `" URI="">` +
 			`<ds:DigestMethod xmlns:ds="` + dsigNS + `" Algorithm="` + DigestSHA256 + `"/>` +
 			`<ds:DigestValue xmlns:ds="` + dsigNS + `">AA==</ds:DigestValue>` +
@@ -159,6 +161,40 @@ func TestParseSignedInfo(t *testing.T) {
 		err := parseSignedInfo(doc.DocumentElement(), &parsed)
 		require.ErrorIs(t, err, ErrInvalidSignature)
 		require.Contains(t, err.Error(), "SignatureMethod missing Algorithm")
+	})
+
+	// A SignedInfo with no CanonicalizationMethod is structurally invalid and
+	// must be rejected up front rather than parsing OK and failing later as an
+	// unsupported-algorithm error during canonicalization.
+	t.Run("missing CanonicalizationMethod", func(t *testing.T) {
+		si := `<ds:SignedInfo xmlns:ds="` + dsigNS + `">` +
+			`<ds:SignatureMethod xmlns:ds="` + dsigNS + `" Algorithm="` + AlgRSASHA256 + `"/>` +
+			`<ds:Reference xmlns:ds="` + dsigNS + `" URI="">` +
+			`<ds:DigestMethod xmlns:ds="` + dsigNS + `" Algorithm="` + DigestSHA256 + `"/>` +
+			`<ds:DigestValue xmlns:ds="` + dsigNS + `">AA==</ds:DigestValue>` +
+			`</ds:Reference></ds:SignedInfo>`
+		doc := mustParse(t, si)
+		var parsed parsedSignature
+		err := parseSignedInfo(doc.DocumentElement(), &parsed)
+		require.ErrorIs(t, err, ErrInvalidSignature)
+		require.Contains(t, err.Error(), "missing CanonicalizationMethod")
+	})
+
+	// A SignedInfo with no SignatureMethod is structurally invalid and must be
+	// rejected up front rather than parsing OK and failing later (possibly only
+	// after key resolution) as an unsupported-algorithm error.
+	t.Run("missing SignatureMethod", func(t *testing.T) {
+		si := `<ds:SignedInfo xmlns:ds="` + dsigNS + `">` +
+			`<ds:CanonicalizationMethod xmlns:ds="` + dsigNS + `" Algorithm="` + ExcC14N10 + `"/>` +
+			`<ds:Reference xmlns:ds="` + dsigNS + `" URI="">` +
+			`<ds:DigestMethod xmlns:ds="` + dsigNS + `" Algorithm="` + DigestSHA256 + `"/>` +
+			`<ds:DigestValue xmlns:ds="` + dsigNS + `">AA==</ds:DigestValue>` +
+			`</ds:Reference></ds:SignedInfo>`
+		doc := mustParse(t, si)
+		var parsed parsedSignature
+		err := parseSignedInfo(doc.DocumentElement(), &parsed)
+		require.ErrorIs(t, err, ErrInvalidSignature)
+		require.Contains(t, err.Error(), "missing SignatureMethod")
 	})
 
 	t.Run("no Reference", func(t *testing.T) {
@@ -229,6 +265,32 @@ func TestParseReferenceElement(t *testing.T) {
 		doc := mustParse(t, r)
 		_, err := parseReferenceElement(doc.DocumentElement())
 		require.ErrorIs(t, err, ErrInvalidSignature)
+	})
+
+	// A Reference with no DigestMethod is structurally invalid and must be
+	// rejected up front rather than parsing OK and failing later as an
+	// unsupported-digest error.
+	t.Run("missing DigestMethod", func(t *testing.T) {
+		r := `<ds:Reference xmlns:ds="` + dsigNS + `" URI="">` +
+			`<ds:DigestValue xmlns:ds="` + dsigNS + `">AA==</ds:DigestValue>` +
+			`</ds:Reference>`
+		doc := mustParse(t, r)
+		_, err := parseReferenceElement(doc.DocumentElement())
+		require.ErrorIs(t, err, ErrInvalidSignature)
+		require.Contains(t, err.Error(), "missing DigestMethod")
+	})
+
+	// A Reference with no DigestValue is structurally invalid and must be
+	// rejected up front rather than parsing OK and failing later as a digest
+	// mismatch (the empty digest never matches the recomputed one).
+	t.Run("missing DigestValue", func(t *testing.T) {
+		r := `<ds:Reference xmlns:ds="` + dsigNS + `" URI="">` +
+			`<ds:DigestMethod xmlns:ds="` + dsigNS + `" Algorithm="` + DigestSHA256 + `"/>` +
+			`</ds:Reference>`
+		doc := mustParse(t, r)
+		_, err := parseReferenceElement(doc.DocumentElement())
+		require.ErrorIs(t, err, ErrInvalidSignature)
+		require.Contains(t, err.Error(), "missing DigestValue")
 	})
 
 	t.Run("with InclusiveNamespaces", func(t *testing.T) {


### PR DESCRIPTION
- enforce XMLDSig child cardinality in parseSignedInfo / parseReferenceElement: duplicate CanonicalizationMethod, SignatureMethod, Transforms, DigestMethod, DigestValue now rejected instead of last-one-wins
- closes DSIG-004: a crafted Reference with two DigestValue children (second matching) was wrongly accepted as a valid, ambiguous signature
- adds unit + end-to-end regression tests