### PR TITLE
fix xsl:result-document serialization AVT preflight gaps

### DIFF
--- a/xslt3/compile.go
+++ b/xslt3/compile.go
@@ -62,6 +62,7 @@ type compiler struct {
 	pendingOverrideTypeChecks []pendingOverrideTypeCheck // deferred XTSE3070 override variable same-type checks
 	usedModes                 map[string]struct{}        // all mode names referenced (for XTSE3085)
 	usedAttrSetRefs           []string                   // all use-attribute-sets names referenced (for XTSE0710)
+	outputAllowDupExplicit    map[string]bool            // per-output-name: allow-duplicate-names explicitly set (compile-time merge bookkeeping, keyed like stylesheet.outputs)
 	localTemplateNames        map[string]struct{}        // pre-scanned named templates in this module (for XTSE3055)
 	localVarNames             map[string]struct{}        // pre-scanned variable names in this module (for XTSE3050)
 	localModeNames            map[string]struct{}        // pre-scanned mode names in this module (for XTSE3050)

--- a/xslt3/compile_formats.go
+++ b/xslt3/compile_formats.go
@@ -483,6 +483,9 @@ func (c *compiler) compileOutput(ctx context.Context, elem *helium.Element) erro
 		if getAttr(elem, paramJSONNodeOutputMethod) == "" {
 			outDef.JSONNodeOutputMethod = existing.JSONNodeOutputMethod
 		}
+		if getAttr(elem, paramAllowDuplicateNames) == "" {
+			outDef.AllowDuplicateNames = existing.AllowDuplicateNames
+		}
 	}
 
 	c.stylesheet.outputs[name] = outDef

--- a/xslt3/compile_formats.go
+++ b/xslt3/compile_formats.go
@@ -626,6 +626,7 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 			if outDef.IndentRaw == "" && val != "" {
 				if b, ok := parseXSDBool(val); ok {
 					outDef.Indent = b
+					outDef.indentSet = true
 				}
 			}
 		case paramOmitXMLDeclaration:
@@ -671,6 +672,7 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 			if val != "" {
 				if b, ok := parseXSDBool(val); ok {
 					outDef.UndeclarePrefixes = b
+					outDef.undeclarePrefixesSet = true
 				}
 			}
 		case paramUseCharacterMaps:
@@ -700,6 +702,7 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 			if !adnExplicit && val != "" {
 				if b, ok := parseXSDBool(val); ok {
 					outDef.AllowDuplicateNames = b
+					outDef.allowDuplicateNamesSet = true
 					adnExplicit = true
 				}
 			}
@@ -711,6 +714,7 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 			if val != "" {
 				if b, ok := parseXSDBool(val); ok {
 					outDef.ByteOrderMark = b
+					outDef.byteOrderMarkSet = true
 				}
 			}
 		case paramEscapeURIAttributes:

--- a/xslt3/compile_formats.go
+++ b/xslt3/compile_formats.go
@@ -398,7 +398,10 @@ func (c *compiler) compileOutput(ctx context.Context, elem *helium.Element) erro
 		outDef.ParameterDocument = v
 		baseURI := stylesheetBaseURI(elem, c.baseURI)
 		var err error
-		if adnExplicit, err = c.loadParameterDocument(ctx, outDef, baseURI, v, adnExplicit); err != nil {
+		// This applies the parameter-document directly onto the xsl:output's
+		// OutputDef (not a delta to be folded later), so the boolean presence
+		// flags are not needed here and are discarded.
+		if adnExplicit, _, err = c.loadParameterDocument(ctx, outDef, baseURI, v, adnExplicit); err != nil {
 			return err
 		}
 	}
@@ -513,7 +516,7 @@ func (c *compiler) compileOutput(ctx context.Context, elem *helium.Element) erro
 // adnExplicit carries the allow-duplicate-names explicitness in and out so the
 // parameter document does not override a value already set on xsl:output and the
 // caller can fold the result into its compile-time merge bookkeeping.
-func (c *compiler) loadParameterDocument(ctx context.Context, outDef *OutputDef, baseURI, href string, adnExplicit bool) (bool, error) {
+func (c *compiler) loadParameterDocument(ctx context.Context, outDef *OutputDef, baseURI, href string, adnExplicit bool) (bool, paramDocPresence, error) {
 	// Compile-time loading is opt-in: a URIResolver must be configured via
 	// Compiler.URIResolver. There is no implicit filesystem access.
 	loadBytes := func(_ context.Context, uri string) ([]byte, error) {
@@ -547,7 +550,15 @@ func (c *compiler) loadParameterDocument(ctx context.Context, outDef *OutputDef,
 // document must not override the value, and the returned value reports whether
 // the parameter document supplied it so the caller can fold it into its own
 // compile-time merge bookkeeping.
-func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser, outDef *OutputDef, baseURI, href string, loadBytes func(context.Context, string) ([]byte, error), runtime bool, adnExplicit bool) (bool, error) {
+//
+// The returned paramDocPresence reports which plain-boolean serialization
+// parameters this parameter-document explicitly supplied. These presence flags
+// are kept off the public OutputDef (a plain bool cannot distinguish "omitted"
+// from "explicit false") and travel alongside the resulting delta so
+// foldParamDocOverrides leaves an inherited xsl:output default intact for any
+// boolean the parameter-document omits.
+func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser, outDef *OutputDef, baseURI, href string, loadBytes func(context.Context, string) ([]byte, error), runtime bool, adnExplicit bool) (bool, paramDocPresence, error) {
+	var presence paramDocPresence
 	// Decide absoluteness with xsd.URIScheme (RFC 3986), not filepath.IsAbs or a
 	// "://" substring check: an absolute-URI href may carry a scheme with no
 	// "//" authority (e.g. "urn:params", "file:/p/p.xml") and must pass through
@@ -579,15 +590,15 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 		// than returning the static wrapper. The cause (e.g. ErrResourceTooLarge)
 		// survives the join either way.
 		if runtime {
-			return adnExplicit, dynamicErrorCause(errCodeFODC0002, err, "cannot read parameter-document %q: %v", href, err)
+			return adnExplicit, presence, dynamicErrorCause(errCodeFODC0002, err, "cannot read parameter-document %q: %v", href, err)
 		}
 		// The compile-time loader already returns an *XSLTError (XTSE0090);
 		// return it as-is rather than wrapping it in a second XTSE0090.
 		var xe *XSLTError
 		if errors.As(err, &xe) {
-			return adnExplicit, err
+			return adnExplicit, presence, err
 		}
-		return adnExplicit, staticErrorCause(errCodeXTSE0090, err, "cannot read parameter-document %q: %v", href, err)
+		return adnExplicit, presence, staticErrorCause(errCodeXTSE0090, err, "cannot read parameter-document %q: %v", href, err)
 	}
 	// Serialization parameter documents have a fixed W3C schema and never use
 	// external entities; parse with the injected base parser (or XXE blocked by
@@ -595,16 +606,16 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 	doc, err := secureXMLParser(injected, "").Parse(ctx, data)
 	if err != nil {
 		if runtime {
-			return adnExplicit, dynamicError(errCodeFODC0002, "cannot parse parameter-document %q: %v", href, err)
+			return adnExplicit, presence, dynamicError(errCodeFODC0002, "cannot parse parameter-document %q: %v", href, err)
 		}
-		return adnExplicit, staticError(errCodeXTSE0090, "cannot parse parameter-document %q: %v", href, err)
+		return adnExplicit, presence, staticError(errCodeXTSE0090, "cannot parse parameter-document %q: %v", href, err)
 	}
 	root := doc.DocumentElement()
 	if root == nil || root.LocalName() != "serialization-parameters" || root.URI() != lexicon.NamespaceSerialization {
 		if runtime {
-			return adnExplicit, dynamicError(errCodeFODC0002, "parameter-document %q: root element must be {%s}serialization-parameters", href, lexicon.NamespaceSerialization)
+			return adnExplicit, presence, dynamicError(errCodeFODC0002, "parameter-document %q: root element must be {%s}serialization-parameters", href, lexicon.NamespaceSerialization)
 		}
-		return adnExplicit, staticError(errCodeXTSE0090, "parameter-document %q: root element must be {%s}serialization-parameters", href, lexicon.NamespaceSerialization)
+		return adnExplicit, presence, staticError(errCodeXTSE0090, "parameter-document %q: root element must be {%s}serialization-parameters", href, lexicon.NamespaceSerialization)
 	}
 
 	for child := range helium.Children(root) {
@@ -626,7 +637,7 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 			if outDef.IndentRaw == "" && val != "" {
 				if b, ok := parseXSDBool(val); ok {
 					outDef.Indent = b
-					outDef.indentSet = true
+					presence.indent = true
 				}
 			}
 		case paramOmitXMLDeclaration:
@@ -672,7 +683,7 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 			if val != "" {
 				if b, ok := parseXSDBool(val); ok {
 					outDef.UndeclarePrefixes = b
-					outDef.undeclarePrefixesSet = true
+					presence.undeclarePrefixes = true
 				}
 			}
 		case paramUseCharacterMaps:
@@ -702,7 +713,7 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 			if !adnExplicit && val != "" {
 				if b, ok := parseXSDBool(val); ok {
 					outDef.AllowDuplicateNames = b
-					outDef.allowDuplicateNamesSet = true
+					presence.allowDuplicateNames = true
 					adnExplicit = true
 				}
 			}
@@ -714,7 +725,7 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 			if val != "" {
 				if b, ok := parseXSDBool(val); ok {
 					outDef.ByteOrderMark = b
-					outDef.byteOrderMarkSet = true
+					presence.byteOrderMark = true
 				}
 			}
 		case paramEscapeURIAttributes:
@@ -753,7 +764,7 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 			}
 		}
 	}
-	return adnExplicit, nil
+	return adnExplicit, presence, nil
 }
 
 func (c *compiler) compileAttributeSet(ctx context.Context, elem *helium.Element) error {

--- a/xslt3/compile_formats.go
+++ b/xslt3/compile_formats.go
@@ -372,7 +372,7 @@ func (c *compiler) compileOutput(ctx context.Context, elem *helium.Element) erro
 		return err
 	} else if present {
 		outDef.AllowDuplicateNames = b
-		outDef.AllowDuplicateNamesExplicit = true
+		outDef.allowDuplicateNamesExplicit = true
 	}
 
 	if v := getAttr(elem, paramSuppressIndentation); v != "" {
@@ -487,10 +487,10 @@ func (c *compiler) compileOutput(ctx context.Context, elem *helium.Element) erro
 		// Preserve the earlier declaration's value only when neither the
 		// attribute nor the parameter document of this declaration supplied
 		// allow-duplicate-names; a parameter-document supplied value sets
-		// AllowDuplicateNamesExplicit and must not be clobbered.
-		if !outDef.AllowDuplicateNamesExplicit {
+		// allowDuplicateNamesExplicit and must not be clobbered.
+		if !outDef.allowDuplicateNamesExplicit {
 			outDef.AllowDuplicateNames = existing.AllowDuplicateNames
-			outDef.AllowDuplicateNamesExplicit = existing.AllowDuplicateNamesExplicit
+			outDef.allowDuplicateNamesExplicit = existing.allowDuplicateNamesExplicit
 		}
 	}
 
@@ -679,10 +679,10 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 				}
 			}
 		case paramAllowDuplicateNames:
-			if !outDef.AllowDuplicateNamesExplicit && val != "" {
+			if !outDef.allowDuplicateNamesExplicit && val != "" {
 				if b, ok := parseXSDBool(val); ok {
 					outDef.AllowDuplicateNames = b
-					outDef.AllowDuplicateNamesExplicit = true
+					outDef.allowDuplicateNamesExplicit = true
 				}
 			}
 		case paramItemSeparator:

--- a/xslt3/compile_formats.go
+++ b/xslt3/compile_formats.go
@@ -368,11 +368,15 @@ func (c *compiler) compileOutput(ctx context.Context, elem *helium.Element) erro
 		outDef.JSONNodeOutputMethod = strings.TrimSpace(v)
 	}
 
+	// adnExplicit tracks whether allow-duplicate-names was supplied by either the
+	// xsl:output attribute or the parameter document. It is compile-time merge
+	// bookkeeping only and is deliberately kept off the public OutputDef type.
+	var adnExplicit bool
 	if b, present, err := outputBoolAttr(elem, paramAllowDuplicateNames); err != nil {
 		return err
 	} else if present {
 		outDef.AllowDuplicateNames = b
-		outDef.allowDuplicateNamesExplicit = true
+		adnExplicit = true
 	}
 
 	if v := getAttr(elem, paramSuppressIndentation); v != "" {
@@ -393,7 +397,8 @@ func (c *compiler) compileOutput(ctx context.Context, elem *helium.Element) erro
 	if v := getAttr(elem, paramParameterDocument); v != "" {
 		outDef.ParameterDocument = v
 		baseURI := stylesheetBaseURI(elem, c.baseURI)
-		if err := c.loadParameterDocument(ctx, outDef, baseURI, v); err != nil {
+		var err error
+		if adnExplicit, err = c.loadParameterDocument(ctx, outDef, baseURI, v, adnExplicit); err != nil {
 			return err
 		}
 	}
@@ -487,21 +492,28 @@ func (c *compiler) compileOutput(ctx context.Context, elem *helium.Element) erro
 		// Preserve the earlier declaration's value only when neither the
 		// attribute nor the parameter document of this declaration supplied
 		// allow-duplicate-names; a parameter-document supplied value sets
-		// allowDuplicateNamesExplicit and must not be clobbered.
-		if !outDef.allowDuplicateNamesExplicit {
+		// adnExplicit and must not be clobbered.
+		if !adnExplicit {
 			outDef.AllowDuplicateNames = existing.AllowDuplicateNames
-			outDef.allowDuplicateNamesExplicit = existing.allowDuplicateNamesExplicit
+			adnExplicit = c.outputAllowDupExplicit[name]
 		}
 	}
 
 	c.stylesheet.outputs[name] = outDef
+	if c.outputAllowDupExplicit == nil {
+		c.outputAllowDupExplicit = make(map[string]bool)
+	}
+	c.outputAllowDupExplicit[name] = adnExplicit
 	return nil
 }
 
 // loadParameterDocument loads a serialization parameter document (XSLT 3.0 §9.2)
 // and applies its settings to the given OutputDef. Parameters explicitly set on
 // the xsl:output element take precedence; the parameter document provides defaults.
-func (c *compiler) loadParameterDocument(ctx context.Context, outDef *OutputDef, baseURI, href string) error {
+// adnExplicit carries the allow-duplicate-names explicitness in and out so the
+// parameter document does not override a value already set on xsl:output and the
+// caller can fold the result into its compile-time merge bookkeeping.
+func (c *compiler) loadParameterDocument(ctx context.Context, outDef *OutputDef, baseURI, href string, adnExplicit bool) (bool, error) {
 	// Compile-time loading is opt-in: a URIResolver must be configured via
 	// Compiler.URIResolver. There is no implicit filesystem access.
 	loadBytes := func(_ context.Context, uri string) ([]byte, error) {
@@ -515,7 +527,7 @@ func (c *compiler) loadParameterDocument(ctx context.Context, outDef *OutputDef,
 		defer func() { _ = rc.Close() }()
 		return readResourceBounded(rc, c.maxResourceBytes)
 	}
-	return loadParameterDocumentFromFile(ctx, c.parser, outDef, baseURI, href, loadBytes, false)
+	return loadParameterDocumentFromFile(ctx, c.parser, outDef, baseURI, href, loadBytes, false, adnExplicit)
 }
 
 // loadParameterDocumentFromFile loads a serialization parameter document and
@@ -529,7 +541,13 @@ func (c *compiler) loadParameterDocument(ctx context.Context, outDef *OutputDef,
 // A runtime failure must NOT also satisfy errors.Is(err, ErrStaticError), so the
 // runtime path never applies the static wrapper. A distinguishable cause such as
 // [ErrResourceTooLarge] survives either way via errors.Join.
-func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser, outDef *OutputDef, baseURI, href string, loadBytes func(context.Context, string) ([]byte, error), runtime bool) error {
+//
+// adnExplicit (allow-duplicate-names explicitness) is threaded in and out rather
+// than stored on the public OutputDef: when already true on input the parameter
+// document must not override the value, and the returned value reports whether
+// the parameter document supplied it so the caller can fold it into its own
+// compile-time merge bookkeeping.
+func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser, outDef *OutputDef, baseURI, href string, loadBytes func(context.Context, string) ([]byte, error), runtime bool, adnExplicit bool) (bool, error) {
 	// Decide absoluteness with xsd.URIScheme (RFC 3986), not filepath.IsAbs or a
 	// "://" substring check: an absolute-URI href may carry a scheme with no
 	// "//" authority (e.g. "urn:params", "file:/p/p.xml") and must pass through
@@ -561,15 +579,15 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 		// than returning the static wrapper. The cause (e.g. ErrResourceTooLarge)
 		// survives the join either way.
 		if runtime {
-			return dynamicErrorCause(errCodeFODC0002, err, "cannot read parameter-document %q: %v", href, err)
+			return adnExplicit, dynamicErrorCause(errCodeFODC0002, err, "cannot read parameter-document %q: %v", href, err)
 		}
 		// The compile-time loader already returns an *XSLTError (XTSE0090);
 		// return it as-is rather than wrapping it in a second XTSE0090.
 		var xe *XSLTError
 		if errors.As(err, &xe) {
-			return err
+			return adnExplicit, err
 		}
-		return staticErrorCause(errCodeXTSE0090, err, "cannot read parameter-document %q: %v", href, err)
+		return adnExplicit, staticErrorCause(errCodeXTSE0090, err, "cannot read parameter-document %q: %v", href, err)
 	}
 	// Serialization parameter documents have a fixed W3C schema and never use
 	// external entities; parse with the injected base parser (or XXE blocked by
@@ -577,16 +595,16 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 	doc, err := secureXMLParser(injected, "").Parse(ctx, data)
 	if err != nil {
 		if runtime {
-			return dynamicError(errCodeFODC0002, "cannot parse parameter-document %q: %v", href, err)
+			return adnExplicit, dynamicError(errCodeFODC0002, "cannot parse parameter-document %q: %v", href, err)
 		}
-		return staticError(errCodeXTSE0090, "cannot parse parameter-document %q: %v", href, err)
+		return adnExplicit, staticError(errCodeXTSE0090, "cannot parse parameter-document %q: %v", href, err)
 	}
 	root := doc.DocumentElement()
 	if root == nil || root.LocalName() != "serialization-parameters" || root.URI() != lexicon.NamespaceSerialization {
 		if runtime {
-			return dynamicError(errCodeFODC0002, "parameter-document %q: root element must be {%s}serialization-parameters", href, lexicon.NamespaceSerialization)
+			return adnExplicit, dynamicError(errCodeFODC0002, "parameter-document %q: root element must be {%s}serialization-parameters", href, lexicon.NamespaceSerialization)
 		}
-		return staticError(errCodeXTSE0090, "parameter-document %q: root element must be {%s}serialization-parameters", href, lexicon.NamespaceSerialization)
+		return adnExplicit, staticError(errCodeXTSE0090, "parameter-document %q: root element must be {%s}serialization-parameters", href, lexicon.NamespaceSerialization)
 	}
 
 	for child := range helium.Children(root) {
@@ -679,10 +697,10 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 				}
 			}
 		case paramAllowDuplicateNames:
-			if !outDef.allowDuplicateNamesExplicit && val != "" {
+			if !adnExplicit && val != "" {
 				if b, ok := parseXSDBool(val); ok {
 					outDef.AllowDuplicateNames = b
-					outDef.allowDuplicateNamesExplicit = true
+					adnExplicit = true
 				}
 			}
 		case paramItemSeparator:
@@ -731,7 +749,7 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 			}
 		}
 	}
-	return nil
+	return adnExplicit, nil
 }
 
 func (c *compiler) compileAttributeSet(ctx context.Context, elem *helium.Element) error {

--- a/xslt3/compile_formats.go
+++ b/xslt3/compile_formats.go
@@ -372,6 +372,7 @@ func (c *compiler) compileOutput(ctx context.Context, elem *helium.Element) erro
 		return err
 	} else if present {
 		outDef.AllowDuplicateNames = b
+		outDef.AllowDuplicateNamesExplicit = true
 	}
 
 	if v := getAttr(elem, paramSuppressIndentation); v != "" {
@@ -483,8 +484,13 @@ func (c *compiler) compileOutput(ctx context.Context, elem *helium.Element) erro
 		if getAttr(elem, paramJSONNodeOutputMethod) == "" {
 			outDef.JSONNodeOutputMethod = existing.JSONNodeOutputMethod
 		}
-		if getAttr(elem, paramAllowDuplicateNames) == "" {
+		// Preserve the earlier declaration's value only when neither the
+		// attribute nor the parameter document of this declaration supplied
+		// allow-duplicate-names; a parameter-document supplied value sets
+		// AllowDuplicateNamesExplicit and must not be clobbered.
+		if !outDef.AllowDuplicateNamesExplicit {
 			outDef.AllowDuplicateNames = existing.AllowDuplicateNames
+			outDef.AllowDuplicateNamesExplicit = existing.AllowDuplicateNamesExplicit
 		}
 	}
 
@@ -673,9 +679,10 @@ func loadParameterDocumentFromFile(ctx context.Context, injected *helium.Parser,
 				}
 			}
 		case paramAllowDuplicateNames:
-			if val != "" {
+			if !outDef.AllowDuplicateNamesExplicit && val != "" {
 				if b, ok := parseXSDBool(val); ok {
 					outDef.AllowDuplicateNames = b
+					outDef.AllowDuplicateNamesExplicit = true
 				}
 			}
 		case paramItemSeparator:

--- a/xslt3/compile_instructions.go
+++ b/xslt3/compile_instructions.go
@@ -713,7 +713,7 @@ func (c *compiler) compileXSLTInstruction(ctx context.Context, elem *helium.Elem
 			}
 		}
 		// Validate boolean output attributes on xsl:result-document.
-		for _, boolAttr := range []string{paramByteOrderMark, paramEscapeURIAttributes,
+		for _, boolAttr := range []string{paramAllowDuplicateNames, paramByteOrderMark, paramEscapeURIAttributes,
 			paramIncludeContentType, paramIndent, paramOmitXMLDeclaration, paramUndeclarePrefixes} {
 			if v := getAttr(elem, boolAttr); v != "" {
 				if !strings.ContainsAny(v, "{}") {

--- a/xslt3/compile_instructions.go
+++ b/xslt3/compile_instructions.go
@@ -823,10 +823,12 @@ func (c *compiler) compileXSLTInstruction(ctx context.Context, elem *helium.Elem
 				// Static parameter-document: load at compile time
 				outDef := &OutputDef{}
 				baseURI := stylesheetBaseURI(elem, c.baseURI)
-				if _, err := c.loadParameterDocument(ctx, outDef, baseURI, pd, false); err != nil {
+				_, presence, err := c.loadParameterDocument(ctx, outDef, baseURI, pd, false)
+				if err != nil {
 					return nil, err
 				}
 				inst.ParameterDocOutputDef = outDef
+				inst.ParameterDocPresence = presence
 				// If the parameter-document sets the method, use it as the
 				// compile-time method so isItemOutputMethod works.
 				if outDef.Method != "" && inst.Method == "" {

--- a/xslt3/compile_instructions.go
+++ b/xslt3/compile_instructions.go
@@ -822,7 +822,7 @@ func (c *compiler) compileXSLTInstruction(ctx context.Context, elem *helium.Elem
 				// Static parameter-document: load at compile time
 				outDef := &OutputDef{}
 				baseURI := stylesheetBaseURI(elem, c.baseURI)
-				if err := c.loadParameterDocument(ctx, outDef, baseURI, pd); err != nil {
+				if _, err := c.loadParameterDocument(ctx, outDef, baseURI, pd, false); err != nil {
 					return nil, err
 				}
 				inst.ParameterDocOutputDef = outDef

--- a/xslt3/compile_instructions.go
+++ b/xslt3/compile_instructions.go
@@ -713,7 +713,7 @@ func (c *compiler) compileXSLTInstruction(ctx context.Context, elem *helium.Elem
 			}
 		}
 		// Validate boolean output attributes on xsl:result-document.
-		for _, boolAttr := range []string{paramAllowDuplicateNames, paramByteOrderMark, paramEscapeURIAttributes,
+		for _, boolAttr := range []string{paramAllowDuplicateNames, paramBuildTree, paramByteOrderMark, paramEscapeURIAttributes,
 			paramIncludeContentType, paramIndent, paramOmitXMLDeclaration, paramUndeclarePrefixes} {
 			if v := getAttr(elem, boolAttr); v != "" {
 				if !strings.ContainsAny(v, "{}") {
@@ -794,6 +794,7 @@ func (c *compiler) compileXSLTInstruction(ctx context.Context, elem *helium.Elem
 			{paramEscapeURIAttributes, &inst.EscapeURIAttributes},
 			{paramJSONNodeOutputMethod, &inst.JSONNodeOutputMethodAVT},
 			{paramNormalizationForm, &inst.NormalizationForm},
+			{paramBuildTree, &inst.BuildTree},
 		} {
 			if v := getAttr(elem, sp.attr); v != "" {
 				avt, err := compileAVT(v, c.nsBindings)
@@ -840,11 +841,6 @@ func (c *compiler) compileXSLTInstruction(ctx context.Context, elem *helium.Elem
 				resolved[i] = resolveQName(n, c.nsBindings)
 			}
 			inst.SuppressIndentation = resolved
-		}
-		if v := getAttr(elem, paramBuildTree); v != "" {
-			if b, ok := parseXSDBool(v); ok {
-				inst.BuildTree = &b
-			}
 		}
 		body, err := c.compileChildren(ctx, elem)
 		if err != nil {

--- a/xslt3/compile_instructions.go
+++ b/xslt3/compile_instructions.go
@@ -790,6 +790,7 @@ func (c *compiler) compileXSLTInstruction(ctx context.Context, elem *helium.Elem
 			{paramHTMLVersion, &inst.HTMLVersion},
 			{paramIncludeContentType, &inst.IncludeContentType},
 			{paramAllowDuplicateNames, &inst.AllowDuplicateNames},
+			{paramUndeclarePrefixes, &inst.UndeclarePrefixes},
 			{paramEscapeURIAttributes, &inst.EscapeURIAttributes},
 			{paramJSONNodeOutputMethod, &inst.JSONNodeOutputMethodAVT},
 			{paramNormalizationForm, &inst.NormalizationForm},

--- a/xslt3/execute.go
+++ b/xslt3/execute.go
@@ -105,20 +105,21 @@ type execContext struct {
 	atomicTextNodes              map[helium.Node]struct{}      // text nodes created from atomic item serialization
 	nodeMemoIDs                  map[helium.Node]uint64        // stable per-transform node identities for function caching
 	nextNodeMemoID               uint64
-	paramDocOutputDefs           map[*resultDocumentInst]*OutputDef // per-invocation cache for parameter-document output defs
-	primaryCharacterMaps         []string                           // character map names from xsl:result-document targeting primary output
-	primaryResolvedCharMap       map[rune]string                    // resolved character map from parameter-document for primary output
-	primaryOutputOverrides       *OutputDef                         // serialization param overrides from primary xsl:result-document
-	rawResultSequence            xpath3.Sequence                    // raw XDM result sequence (set when initial template has as="...")
-	nsFixupAllowed               map[*helium.Element]struct{}       // elements whose prefix NS was auto-generated (fixup eligible)
-	overridingTemplate           *template                          // currently executing overriding template (for xsl:original)
-	overridingVarDef             *variable                          // currently evaluating overriding variable (for $xsl:original)
-	originalFunc                 xpath3.Function                    // current xsl:original function (set during overriding function call)
-	currentAttrSetOriginal       *attributeSetDef                   // original attribute-set for use-attribute-sets="xsl:original"
-	docOrderCache                *xpath3.DocOrderCache              // shared document-order cache for consistent cross-document ordering
-	packageVarCache              map[*variable]xpath3.Sequence      // cache for package-scoped variable evaluations
-	globalContextAbsent          bool                               // true when global context item is absent (select evaluated to empty)
-	traceWriter                  io.Writer                          // destination for fn:trace output (nil = os.Stderr)
+	paramDocOutputDefs           map[*resultDocumentInst]*OutputDef       // per-invocation cache for parameter-document output defs
+	paramDocPresences            map[*resultDocumentInst]paramDocPresence // per-invocation cache for parameter-document plain-boolean presence flags
+	primaryCharacterMaps         []string                                 // character map names from xsl:result-document targeting primary output
+	primaryResolvedCharMap       map[rune]string                          // resolved character map from parameter-document for primary output
+	primaryOutputOverrides       *OutputDef                               // serialization param overrides from primary xsl:result-document
+	rawResultSequence            xpath3.Sequence                          // raw XDM result sequence (set when initial template has as="...")
+	nsFixupAllowed               map[*helium.Element]struct{}             // elements whose prefix NS was auto-generated (fixup eligible)
+	overridingTemplate           *template                                // currently executing overriding template (for xsl:original)
+	overridingVarDef             *variable                                // currently evaluating overriding variable (for $xsl:original)
+	originalFunc                 xpath3.Function                          // current xsl:original function (set during overriding function call)
+	currentAttrSetOriginal       *attributeSetDef                         // original attribute-set for use-attribute-sets="xsl:original"
+	docOrderCache                *xpath3.DocOrderCache                    // shared document-order cache for consistent cross-document ordering
+	packageVarCache              map[*variable]xpath3.Sequence            // cache for package-scoped variable evaluations
+	globalContextAbsent          bool                                     // true when global context item is absent (select evaluated to empty)
+	traceWriter                  io.Writer                                // destination for fn:trace output (nil = os.Stderr)
 
 	// cached base XPath evaluator — rebuilt when invalidation keys change
 	cachedBaseEval                  xpath3.Evaluator

--- a/xslt3/execute_resultdoc.go
+++ b/xslt3/execute_resultdoc.go
@@ -914,6 +914,19 @@ func (ec *execContext) execResultDocument(ctx context.Context, inst *resultDocum
 		}
 	}
 
+	// SERE0022: a SECONDARY (href) JSON result document must reject duplicate
+	// keys unless allow-duplicate-names="yes", exactly like the primary path. The
+	// final SerializeItems pass in execute_transform.go does NOT re-validate
+	// staged secondary items, so without this check a secondary
+	// method="json" build-tree="no" result document would silently accept
+	// map{1:'a','1':'b'}. Validate against the preflighted output definition
+	// before committing so a thrown SERE0022 leaves no per-href side effect.
+	if effectiveMethod == methodJSON && stagedItems != nil && !stagedOutDef.AllowDuplicateNames {
+		if err := validateJSONItems(stagedItems); err != nil {
+			return err
+		}
+	}
+
 	// COMMIT POINT: body and every post-body validation step succeeded. Publish
 	// all staged per-href state atomically, then mark the transaction committed
 	// so the deferred rollback leaves the usedResultURIs reservation in place.
@@ -926,6 +939,27 @@ func (ec *execContext) execResultDocument(ctx context.Context, inst *resultDocum
 	ec.resultDocuments[href] = tmpDoc
 	committed = true
 	return nil
+}
+
+// evalBoolSerializationAVT evaluates a boolean serialization-parameter AVT on
+// xsl:result-document and returns its xs:boolean value. A non-empty value that
+// is not a valid xs:boolean lexical form raises SEPM0016 instead of being
+// silently coerced to false. This is the SINGLE chokepoint that EVERY boolean
+// serialization parameter (indent, omit-xml-declaration, byte-order-mark,
+// escape-uri-attributes, include-content-type, allow-duplicate-names) must route
+// through, so the invalid-value validation can never drift parameter-by-parameter
+// again. (standalone is a tri-state yes/no/omit value and is handled separately.)
+func (ec *execContext) evalBoolSerializationAVT(ctx context.Context, a *avt, paramName string) (bool, error) {
+	v, err := a.evaluate(ctx, ec.contextNode)
+	if err != nil {
+		return false, err
+	}
+	b, ok := parseXSDBool(strings.TrimSpace(v))
+	if !ok {
+		return false, dynamicError(errCodeSEPM0016,
+			"%q is not a valid value for xsl:result-document/@%s", v, paramName)
+	}
+	return b, nil
 }
 
 // evalResultDocOutputDef evaluates serialization parameter AVTs on
@@ -997,19 +1031,17 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 		base.Standalone = v
 	}
 	if inst.Indent != nil {
-		v, err := evalAVT(inst.Indent)
+		b, err := ec.evalBoolSerializationAVT(ctx, inst.Indent, paramIndent)
 		if err != nil {
 			return nil, err
 		}
-		b, _ := parseXSDBool(strings.TrimSpace(v))
 		base.Indent = b
 	}
 	if inst.OmitXMLDeclaration != nil {
-		v, err := evalAVT(inst.OmitXMLDeclaration)
+		b, err := ec.evalBoolSerializationAVT(ctx, inst.OmitXMLDeclaration, paramOmitXMLDeclaration)
 		if err != nil {
 			return nil, err
 		}
-		b, _ := parseXSDBool(strings.TrimSpace(v))
 		base.OmitDeclaration = b
 	}
 	if inst.DoctypeSystem != nil {
@@ -1041,13 +1073,11 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 		base.Version = strings.TrimSpace(v)
 	}
 	if inst.ByteOrderMark != nil {
-		v, err := evalAVT(inst.ByteOrderMark)
+		b, err := ec.evalBoolSerializationAVT(ctx, inst.ByteOrderMark, paramByteOrderMark)
 		if err != nil {
 			return nil, err
 		}
-		if b, ok := parseXSDBool(strings.TrimSpace(v)); ok {
-			base.ByteOrderMark = b
-		}
+		base.ByteOrderMark = b
 	}
 	if inst.CDATASectionElements != nil {
 		v, err := evalAVT(inst.CDATASectionElements)
@@ -1083,33 +1113,25 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 		base.HTMLVersion = strings.TrimSpace(v)
 	}
 	if inst.IncludeContentType != nil {
-		v, err := evalAVT(inst.IncludeContentType)
+		b, err := ec.evalBoolSerializationAVT(ctx, inst.IncludeContentType, paramIncludeContentType)
 		if err != nil {
 			return nil, err
 		}
-		b, _ := parseXSDBool(strings.TrimSpace(v))
 		base.IncludeContentType = &b
 	}
 	if inst.AllowDuplicateNames != nil {
-		v, err := evalAVT(inst.AllowDuplicateNames)
+		b, err := ec.evalBoolSerializationAVT(ctx, inst.AllowDuplicateNames, paramAllowDuplicateNames)
 		if err != nil {
 			return nil, err
-		}
-		b, ok := parseXSDBool(strings.TrimSpace(v))
-		if !ok {
-			return nil, dynamicError(errCodeSEPM0016,
-				"%q is not a valid value for xsl:result-document/@%s", v, paramAllowDuplicateNames)
 		}
 		base.AllowDuplicateNames = b
 	}
 	if inst.EscapeURIAttributes != nil {
-		v, err := evalAVT(inst.EscapeURIAttributes)
+		b, err := ec.evalBoolSerializationAVT(ctx, inst.EscapeURIAttributes, paramEscapeURIAttributes)
 		if err != nil {
 			return nil, err
 		}
-		if b, ok := parseXSDBool(strings.TrimSpace(v)); ok {
-			base.EscapeURIAttributes = &b
-		}
+		base.EscapeURIAttributes = &b
 	}
 	if inst.JSONNodeOutputMethodAVT != nil {
 		v, err := evalAVT(inst.JSONNodeOutputMethodAVT)

--- a/xslt3/execute_resultdoc.go
+++ b/xslt3/execute_resultdoc.go
@@ -663,6 +663,25 @@ func (ec *execContext) execResultDocument(ctx context.Context, inst *resultDocum
 			ec.outputStack = ec.outputStack[:len(ec.outputStack)-1]
 
 			out := ec.outputStack[0]
+			// SERE0022: validate JSON duplicate keys when allow-duplicate-names
+			// is not "yes". This branch selects JSON purely from the
+			// result-document's effective method, so currentResultDocMethod has
+			// already been restored by the time the final primary validation runs
+			// in execute_transform.go; validate here against the preflighted
+			// overrides instead. Mirrors the buffered direct-write path.
+			if effectiveMethod == methodJSON {
+				allowDupes := false
+				if primaryOverrides != nil {
+					allowDupes = primaryOverrides.AllowDuplicateNames
+				} else if defDef, ok := ec.effectiveOutputs()[""]; ok {
+					allowDupes = defDef.AllowDuplicateNames
+				}
+				if !allowDupes {
+					if err := validateJSONItems(frame.pendingItems); err != nil {
+						return err
+					}
+				}
+			}
 			out.pendingItems = append(out.pendingItems, frame.pendingItems...)
 
 			ec.commitPrimaryOutputState(inst, effectiveFormat, primaryOverrides)

--- a/xslt3/execute_resultdoc.go
+++ b/xslt3/execute_resultdoc.go
@@ -49,6 +49,20 @@ func canonicalResultURIKey(href, base string) string {
 	return baseURL.ResolveReference(ref).String()
 }
 
+// paramDocPresence records which plain-boolean serialization parameters a
+// parameter-document explicitly supplied. These flags are deliberately kept off
+// the public OutputDef: a plain bool cannot distinguish "omitted" from "explicit
+// false", and foldParamDocOverrides consults them so an omitted parameter-document
+// value leaves an inherited xsl:output default intact instead of clobbering it
+// with the Go zero value. They travel alongside the parameter-document delta
+// OutputDef (on the compiled instruction or the per-invocation cache).
+type paramDocPresence struct {
+	indent              bool
+	byteOrderMark       bool
+	allowDuplicateNames bool
+	undeclarePrefixes   bool
+}
+
 // getParamDocOutputDef returns the effective parameter-document OutputDef for
 // a result-document instruction, checking the per-invocation cache on
 // execContext first, then falling back to the compiled instruction's field.
@@ -57,6 +71,17 @@ func (ec *execContext) getParamDocOutputDef(inst *resultDocumentInst) *OutputDef
 		return od
 	}
 	return inst.ParameterDocOutputDef
+}
+
+// getParamDocPresence returns the plain-boolean presence flags that accompany
+// the effective parameter-document delta, mirroring getParamDocOutputDef's
+// cache-then-instruction lookup so the runtime AVT and compile-time static
+// parameter-document paths stay in sync.
+func (ec *execContext) getParamDocPresence(inst *resultDocumentInst) paramDocPresence {
+	if p, ok := ec.paramDocPresences[inst]; ok {
+		return p
+	}
+	return inst.ParameterDocPresence
 }
 
 // validateDocumentStructure checks that a document node has exactly one element
@@ -492,13 +517,18 @@ func (ec *execContext) execResultDocument(ctx context.Context, inst *resultDocum
 				// callers can observe it, and an over-cap read keeps
 				// [ErrResourceTooLarge] in the chain (matched via errors.Is)
 				// while errors.Is(err, ErrStaticError) stays false.
-				if _, loadErr := loadParameterDocumentFromFile(ctx, ec.injectedParser(), outDef, baseURI, pdHref, ec.retrieveDocumentBytes, true, false); loadErr != nil {
+				_, presence, loadErr := loadParameterDocumentFromFile(ctx, ec.injectedParser(), outDef, baseURI, pdHref, ec.retrieveDocumentBytes, true, false)
+				if loadErr != nil {
 					return loadErr
 				}
 				if ec.paramDocOutputDefs == nil {
 					ec.paramDocOutputDefs = make(map[*resultDocumentInst]*OutputDef)
 				}
 				ec.paramDocOutputDefs[inst] = outDef
+				if ec.paramDocPresences == nil {
+					ec.paramDocPresences = make(map[*resultDocumentInst]paramDocPresence)
+				}
+				ec.paramDocPresences[inst] = presence
 			}
 		}
 	}
@@ -974,9 +1004,9 @@ func (ec *execContext) evalBoolSerializationAVT(ctx context.Context, a *avt, par
 // unnamed-default xsl:output values. A parameter-document outranks the format it
 // layers on, so any value it specifies wins; values it OMITS leave base intact.
 // String/pointer/slice fields are absent when zero/nil/empty; the plain-boolean
-// parameters carry explicit *Set companion flags because a false bool cannot
-// otherwise be distinguished from an omitted one.
-func foldParamDocOverrides(base, pd *OutputDef) {
+// parameters rely on the companion paramDocPresence flags because a false bool
+// cannot otherwise be distinguished from an omitted one.
+func foldParamDocOverrides(base, pd *OutputDef, pres paramDocPresence) {
 	if pd.Method != "" {
 		base.Method = pd.Method
 		base.MethodExplicit = pd.MethodExplicit
@@ -1038,16 +1068,16 @@ func foldParamDocOverrides(base, pd *OutputDef) {
 		base.OmitDeclaration = pd.OmitDeclaration
 		base.OmitDeclarationExplicit = true
 	}
-	if pd.indentSet {
+	if pres.indent {
 		base.Indent = pd.Indent
 	}
-	if pd.byteOrderMarkSet {
+	if pres.byteOrderMark {
 		base.ByteOrderMark = pd.ByteOrderMark
 	}
-	if pd.allowDuplicateNamesSet {
+	if pres.allowDuplicateNames {
 		base.AllowDuplicateNames = pd.AllowDuplicateNames
 	}
-	if pd.undeclarePrefixesSet {
+	if pres.undeclarePrefixes {
 		base.UndeclarePrefixes = pd.UndeclarePrefixes
 	}
 }
@@ -1097,7 +1127,7 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 		base = *cloneOutputDef(defDef)
 	}
 	if paramDocOD != nil {
-		foldParamDocOverrides(&base, paramDocOD)
+		foldParamDocOverrides(&base, paramDocOD, ec.getParamDocPresence(inst))
 	}
 
 	evalAVT := func(avt *avt) (string, error) {
@@ -1309,7 +1339,7 @@ func (ec *execContext) buildEffectiveOutputDef(ctx context.Context, inst *result
 		base = *cloneOutputDef(defDef)
 	}
 	if paramDocOD != nil {
-		foldParamDocOverrides(&base, paramDocOD)
+		foldParamDocOverrides(&base, paramDocOD, ec.getParamDocPresence(inst))
 	}
 	if base.Method == "" && method != "" {
 		base.Method = method

--- a/xslt3/execute_resultdoc.go
+++ b/xslt3/execute_resultdoc.go
@@ -1076,9 +1076,12 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 		if err != nil {
 			return nil, err
 		}
-		if b, ok := parseXSDBool(strings.TrimSpace(v)); ok {
-			base.AllowDuplicateNames = b
+		b, ok := parseXSDBool(strings.TrimSpace(v))
+		if !ok {
+			return nil, dynamicError(errCodeSEPM0016,
+				"%q is not a valid value for xsl:result-document/@%s", v, paramAllowDuplicateNames)
 		}
+		base.AllowDuplicateNames = b
 	}
 	if inst.EscapeURIAttributes != nil {
 		v, err := evalAVT(inst.EscapeURIAttributes)

--- a/xslt3/execute_resultdoc.go
+++ b/xslt3/execute_resultdoc.go
@@ -722,15 +722,14 @@ func (ec *execContext) execResultDocument(ctx context.Context, inst *resultDocum
 		}
 		// Validate JSON duplicate keys (SERE0022) when allow-duplicate-names is not "yes".
 		if effectiveMethod == methodJSON {
-			allowDupes := false // default: allow-duplicate-names=no per XSLT 3.0 §20
-			if inst.AllowDuplicateNames != nil {
-				adnVal, adnErr := inst.AllowDuplicateNames.evaluate(ctx, ec.contextNode)
-				if adnErr == nil {
-					adnVal = strings.TrimSpace(adnVal)
-					if adnVal == lexicon.ValueYes || adnVal == lexicon.ValueTrue || adnVal == "1" {
-						allowDupes = true
-					}
-				}
+			// allow-duplicate-names defaults to "no" per XSLT 3.0 §20. The value
+			// (including the result-document AVT and any named-format/default
+			// xsl:output base) was already evaluated up front in the preflight via
+			// evalResultDocOutputDef; reuse it so a failing AVT was surfaced there
+			// rather than silently swallowed here.
+			allowDupes := false
+			if primaryOverrides != nil {
+				allowDupes = primaryOverrides.AllowDuplicateNames
 			}
 			if !allowDupes {
 				if err := validateJSONItems(bufFrame.pendingItems); err != nil {
@@ -910,6 +909,8 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 		inst.OmitXMLDeclaration != nil || inst.DoctypeSystem != nil || inst.DoctypePublic != nil ||
 		inst.CDATASectionElements != nil || inst.Encoding != nil || inst.OutputVersion != nil ||
 		inst.ByteOrderMark != nil || inst.EscapeURIAttributes != nil ||
+		inst.MediaType != nil || inst.HTMLVersion != nil || inst.IncludeContentType != nil ||
+		inst.AllowDuplicateNames != nil ||
 		inst.JSONNodeOutputMethodAVT != nil || inst.NormalizationForm != nil ||
 		ec.getParamDocOutputDef(inst) != nil ||
 		inst.ItemSeparatorSet || inst.BuildTree != nil
@@ -1005,6 +1006,13 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 		}
 		base.Encoding = strings.TrimSpace(v)
 	}
+	if inst.OutputVersion != nil {
+		v, err := evalAVT(inst.OutputVersion)
+		if err != nil {
+			return nil, err
+		}
+		base.Version = strings.TrimSpace(v)
+	}
 	if inst.ByteOrderMark != nil {
 		v, err := evalAVT(inst.ByteOrderMark)
 		if err != nil {
@@ -1054,6 +1062,15 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 		}
 		b, _ := parseXSDBool(strings.TrimSpace(v))
 		base.IncludeContentType = &b
+	}
+	if inst.AllowDuplicateNames != nil {
+		v, err := evalAVT(inst.AllowDuplicateNames)
+		if err != nil {
+			return nil, err
+		}
+		if b, ok := parseXSDBool(strings.TrimSpace(v)); ok {
+			base.AllowDuplicateNames = b
+		}
 	}
 	if inst.EscapeURIAttributes != nil {
 		v, err := evalAVT(inst.EscapeURIAttributes)

--- a/xslt3/execute_resultdoc.go
+++ b/xslt3/execute_resultdoc.go
@@ -629,7 +629,13 @@ func (ec *execContext) execResultDocument(ctx context.Context, inst *resultDocum
 			return nil
 		}
 		effectiveMethod := ec.resolveResultDocMethod(ctx, inst)
-		buildTreeNo := inst.BuildTree != nil && !*inst.BuildTree
+		// Drive build-tree from the EVALUATED effective output def (primaryOverrides),
+		// not a static compile-time bool: build-tree may be an AVT (e.g.
+		// build-tree="{false()}") and may also be inherited from the named format or
+		// parameter-document folded into the overrides. primaryOverrides is nil only
+		// when no serialization params (build-tree included) were set, in which case
+		// build-tree defaults to true.
+		buildTreeNo := primaryOverrides != nil && primaryOverrides.BuildTree != nil && !*primaryOverrides.BuildTree
 
 		// When build-tree="no", execute into a temporary document,
 		// then extract children and pending items as a raw sequence
@@ -974,7 +980,8 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 		inst.AllowDuplicateNames != nil || inst.UndeclarePrefixes != nil ||
 		inst.JSONNodeOutputMethodAVT != nil || inst.NormalizationForm != nil ||
 		ec.getParamDocOutputDef(inst) != nil ||
-		inst.ItemSeparatorSet || inst.BuildTree != nil
+		inst.ItemSeparatorSet || inst.BuildTree != nil ||
+		len(inst.SuppressIndentation) > 0
 	effectiveFormat, fmtErr := ec.resolveResultDocFormat(ctx, inst)
 	if fmtErr != nil {
 		return nil, fmtErr
@@ -1172,10 +1179,11 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 		}
 	}
 	if inst.BuildTree != nil {
-		// Copy the pointee so a derived/handler-delivered OutputDef cannot mutate
-		// the compiled instruction's BuildTree value.
-		v := *inst.BuildTree
-		base.BuildTree = &v
+		b, err := ec.evalBoolSerializationAVT(ctx, inst.BuildTree, paramBuildTree)
+		if err != nil {
+			return nil, err
+		}
+		base.BuildTree = &b
 	}
 	return &base, nil
 }

--- a/xslt3/execute_resultdoc.go
+++ b/xslt3/execute_resultdoc.go
@@ -492,7 +492,7 @@ func (ec *execContext) execResultDocument(ctx context.Context, inst *resultDocum
 				// callers can observe it, and an over-cap read keeps
 				// [ErrResourceTooLarge] in the chain (matched via errors.Is)
 				// while errors.Is(err, ErrStaticError) stays false.
-				if loadErr := loadParameterDocumentFromFile(ctx, ec.injectedParser(), outDef, baseURI, pdHref, ec.retrieveDocumentBytes, true); loadErr != nil {
+				if _, loadErr := loadParameterDocumentFromFile(ctx, ec.injectedParser(), outDef, baseURI, pdHref, ec.retrieveDocumentBytes, true, false); loadErr != nil {
 					return loadErr
 				}
 				if ec.paramDocOutputDefs == nil {

--- a/xslt3/execute_resultdoc.go
+++ b/xslt3/execute_resultdoc.go
@@ -968,6 +968,90 @@ func (ec *execContext) evalBoolSerializationAVT(ctx context.Context, a *avt, par
 	return b, nil
 }
 
+// foldParamDocOverrides overlays the serialization parameters supplied by a
+// result-document's parameter-document (pd, loaded as a delta from an empty
+// OutputDef) onto base, which already holds the inherited named-format or
+// unnamed-default xsl:output values. A parameter-document outranks the format it
+// layers on, so any value it specifies wins; values it OMITS leave base intact.
+// String/pointer/slice fields are absent when zero/nil/empty; the plain-boolean
+// parameters carry explicit *Set companion flags because a false bool cannot
+// otherwise be distinguished from an omitted one.
+func foldParamDocOverrides(base, pd *OutputDef) {
+	if pd.Method != "" {
+		base.Method = pd.Method
+		base.MethodExplicit = pd.MethodExplicit
+	}
+	if pd.Encoding != "" {
+		base.Encoding = pd.Encoding
+	}
+	if pd.Standalone != "" {
+		base.Standalone = pd.Standalone
+	}
+	if len(pd.CDATASections) > 0 {
+		base.CDATASections = append([]string(nil), pd.CDATASections...)
+	}
+	if pd.DoctypePublic != "" {
+		base.DoctypePublic = pd.DoctypePublic
+	}
+	if pd.DoctypeSystem != "" {
+		base.DoctypeSystem = pd.DoctypeSystem
+	}
+	if pd.MediaType != "" {
+		base.MediaType = pd.MediaType
+	}
+	if pd.Version != "" {
+		base.Version = pd.Version
+	}
+	if pd.NormalizationForm != "" {
+		base.NormalizationForm = pd.NormalizationForm
+	}
+	if pd.HTMLVersion != "" {
+		base.HTMLVersion = pd.HTMLVersion
+	}
+	if pd.JSONNodeOutputMethod != "" {
+		base.JSONNodeOutputMethod = pd.JSONNodeOutputMethod
+	}
+	if len(pd.SuppressIndentation) > 0 {
+		base.SuppressIndentation = append([]string(nil), pd.SuppressIndentation...)
+	}
+	if pd.IncludeContentType != nil {
+		v := *pd.IncludeContentType
+		base.IncludeContentType = &v
+	}
+	if pd.EscapeURIAttributes != nil {
+		v := *pd.EscapeURIAttributes
+		base.EscapeURIAttributes = &v
+	}
+	if pd.BuildTree != nil {
+		v := *pd.BuildTree
+		base.BuildTree = &v
+	}
+	if pd.ItemSeparator != nil {
+		v := *pd.ItemSeparator
+		base.ItemSeparator = &v
+	}
+	if len(pd.ResolvedCharMap) > 0 {
+		base.ResolvedCharMap = make(map[rune]string, len(pd.ResolvedCharMap))
+		maps.Copy(base.ResolvedCharMap, pd.ResolvedCharMap)
+	}
+	if pd.OmitDeclarationExplicit {
+		base.OmitDeclaration = pd.OmitDeclaration
+		base.OmitDeclarationExplicit = true
+	}
+	if pd.indentSet {
+		base.Indent = pd.Indent
+	}
+	if pd.byteOrderMarkSet {
+		base.ByteOrderMark = pd.ByteOrderMark
+	}
+	if pd.allowDuplicateNamesSet {
+		base.AllowDuplicateNames = pd.AllowDuplicateNames
+	}
+	if pd.undeclarePrefixesSet {
+		base.UndeclarePrefixes = pd.UndeclarePrefixes
+	}
+}
+
 // evalResultDocOutputDef evaluates serialization parameter AVTs on
 // xsl:result-document and returns an OutputDef with the overrides.
 // Returns nil if no serialization parameters are specified.
@@ -990,21 +1074,30 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 		return nil, nil //nolint:nilnil
 	}
 
-	// Start with parameter-document defaults (lowest priority).
+	// Build the effective base in serialization-parameter priority order
+	// (low -> high): the named format (or the unnamed default xsl:output when no
+	// format), then the parameter-document. A parameter-document has HIGHER
+	// priority than the format it layers on, so its values win; values it omits
+	// must leave the inherited format/default intact. The earlier implementation
+	// took the parameter-document OutputDef as the whole base, which dropped the
+	// unnamed-default xsl:output entirely: a parameter-document that omitted a
+	// plain boolean (indent, byte-order-mark, allow-duplicate-names,
+	// undeclare-prefixes) then overwrote an inherited true with the Go zero value
+	// (wrongly disabling inherited indent/BOM, or rejecting duplicate JSON keys a
+	// default allow-duplicate-names="yes" permits). Folding the default base first
+	// and overlaying only the parameter-document's set values fixes that and keeps
+	// the primary-output direct-assign in execute_transform.go correct.
 	var base OutputDef
 	paramDocOD := ec.getParamDocOutputDef(inst)
-	if paramDocOD != nil {
-		base = *cloneOutputDef(paramDocOD)
-	}
-	// Named format overrides parameter-document.
 	if effectiveFormat != "" {
 		if fmtDef, ok := ec.effectiveOutputs()[effectiveFormat]; ok {
 			base = *cloneOutputDef(fmtDef)
 		}
-	} else if paramDocOD == nil {
-		if defDef, ok := ec.effectiveOutputs()[""]; ok {
-			base = *cloneOutputDef(defDef)
-		}
+	} else if defDef, ok := ec.effectiveOutputs()[""]; ok {
+		base = *cloneOutputDef(defDef)
+	}
+	if paramDocOD != nil {
+		foldParamDocOverrides(&base, paramDocOD)
 	}
 
 	evalAVT := func(avt *avt) (string, error) {
@@ -1194,31 +1287,29 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 // buildEffectiveOutputDef builds the effective output definition for a secondary
 // result document, combining the named format with result-document overrides.
 func (ec *execContext) buildEffectiveOutputDef(ctx context.Context, inst *resultDocumentInst, formatName, method string) (*OutputDef, error) {
+	// Build the base in priority order (low -> high): named format (or the
+	// unnamed default xsl:output when no format), then the parameter-document.
+	// This mirrors evalResultDocOutputDef's default-folding; without the default
+	// fold a secondary result-document with no local serialization attributes
+	// would not inherit stylesheet defaults (e.g. method="json"
+	// allow-duplicate-names="yes"), and the SERE0022 dup-key check below would see
+	// a hard-false allow-duplicate-names and wrongly reject duplicate JSON keys
+	// the default output permits. When evalResultDocOutputDef returns a non-nil
+	// overrides def (hasAny or a named format), it already folded the default and
+	// the parameter-document in and base is replaced below; this construction only
+	// matters when overrides is nil (no serialization params and no
+	// parameter-document, hence paramDocOD is nil here too).
 	var base OutputDef
-	// Start with parameter-document defaults (lowest priority).
 	paramDocOD := ec.getParamDocOutputDef(inst)
-	if paramDocOD != nil {
-		base = *cloneOutputDef(paramDocOD)
-	}
-	// Named format overrides parameter-document.
 	if formatName != "" {
 		if fmtDef, ok := ec.effectiveOutputs()[formatName]; ok {
 			base = *cloneOutputDef(fmtDef)
 		}
-	} else if paramDocOD == nil {
-		// No named format and no parameter-document: fold in the unnamed default
-		// xsl:output so a secondary result-document with no local serialization
-		// attributes still inherits the stylesheet defaults (e.g.
-		// method="json" allow-duplicate-names="yes"). This mirrors
-		// evalResultDocOutputDef's default-folding; without it the SERE0022
-		// dup-key check below would see a hard-false allow-duplicate-names and
-		// wrongly reject duplicate JSON keys the default output permits. When
-		// evalResultDocOutputDef returns a non-nil overrides def (hasAny or a
-		// named format), it already folded the default in and base is replaced
-		// below; this branch only matters when overrides is nil.
-		if defDef, ok := ec.effectiveOutputs()[""]; ok {
-			base = *cloneOutputDef(defDef)
-		}
+	} else if defDef, ok := ec.effectiveOutputs()[""]; ok {
+		base = *cloneOutputDef(defDef)
+	}
+	if paramDocOD != nil {
+		foldParamDocOverrides(&base, paramDocOD)
 	}
 	if base.Method == "" && method != "" {
 		base.Method = method

--- a/xslt3/execute_resultdoc.go
+++ b/xslt3/execute_resultdoc.go
@@ -971,7 +971,7 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 		inst.CDATASectionElements != nil || inst.Encoding != nil || inst.OutputVersion != nil ||
 		inst.ByteOrderMark != nil || inst.EscapeURIAttributes != nil ||
 		inst.MediaType != nil || inst.HTMLVersion != nil || inst.IncludeContentType != nil ||
-		inst.AllowDuplicateNames != nil ||
+		inst.AllowDuplicateNames != nil || inst.UndeclarePrefixes != nil ||
 		inst.JSONNodeOutputMethodAVT != nil || inst.NormalizationForm != nil ||
 		ec.getParamDocOutputDef(inst) != nil ||
 		inst.ItemSeparatorSet || inst.BuildTree != nil
@@ -1126,6 +1126,13 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 		}
 		base.AllowDuplicateNames = b
 	}
+	if inst.UndeclarePrefixes != nil {
+		b, err := ec.evalBoolSerializationAVT(ctx, inst.UndeclarePrefixes, paramUndeclarePrefixes)
+		if err != nil {
+			return nil, err
+		}
+		base.UndeclarePrefixes = b
+	}
 	if inst.EscapeURIAttributes != nil {
 		b, err := ec.evalBoolSerializationAVT(ctx, inst.EscapeURIAttributes, paramEscapeURIAttributes)
 		if err != nil {
@@ -1178,13 +1185,28 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 func (ec *execContext) buildEffectiveOutputDef(ctx context.Context, inst *resultDocumentInst, formatName, method string) (*OutputDef, error) {
 	var base OutputDef
 	// Start with parameter-document defaults (lowest priority).
-	if pd := ec.getParamDocOutputDef(inst); pd != nil {
-		base = *cloneOutputDef(pd)
+	paramDocOD := ec.getParamDocOutputDef(inst)
+	if paramDocOD != nil {
+		base = *cloneOutputDef(paramDocOD)
 	}
 	// Named format overrides parameter-document.
 	if formatName != "" {
 		if fmtDef, ok := ec.effectiveOutputs()[formatName]; ok {
 			base = *cloneOutputDef(fmtDef)
+		}
+	} else if paramDocOD == nil {
+		// No named format and no parameter-document: fold in the unnamed default
+		// xsl:output so a secondary result-document with no local serialization
+		// attributes still inherits the stylesheet defaults (e.g.
+		// method="json" allow-duplicate-names="yes"). This mirrors
+		// evalResultDocOutputDef's default-folding; without it the SERE0022
+		// dup-key check below would see a hard-false allow-duplicate-names and
+		// wrongly reject duplicate JSON keys the default output permits. When
+		// evalResultDocOutputDef returns a non-nil overrides def (hasAny or a
+		// named format), it already folded the default in and base is replaced
+		// below; this branch only matters when overrides is nil.
+		if defDef, ok := ec.effectiveOutputs()[""]; ok {
+			base = *cloneOutputDef(defDef)
 		}
 	}
 	if base.Method == "" && method != "" {

--- a/xslt3/execute_resultdoc.go
+++ b/xslt3/execute_resultdoc.go
@@ -1050,6 +1050,9 @@ func (ec *execContext) evalResultDocOutputDef(ctx context.Context, inst *resultD
 			return nil, err
 		}
 		base.OmitDeclaration = b
+		// The result-document explicitly specified omit-xml-declaration, so the
+		// xhtml/html5 serializer must not flip it back to "yes" by default.
+		base.OmitDeclarationExplicit = true
 	}
 	if inst.DoctypeSystem != nil {
 		v, err := evalAVT(inst.DoctypeSystem)

--- a/xslt3/execute_resultdoc.go
+++ b/xslt3/execute_resultdoc.go
@@ -727,9 +727,17 @@ func (ec *execContext) execResultDocument(ctx context.Context, inst *resultDocum
 			// xsl:output base) was already evaluated up front in the preflight via
 			// evalResultDocOutputDef; reuse it so a failing AVT was surfaced there
 			// rather than silently swallowed here.
+			// When the primary result-document declares no serialization
+			// attributes of its own, primaryOverrides is nil. In that case the
+			// effective allow-duplicate-names comes from the resolved default
+			// output definition (e.g. a stylesheet-level
+			// <xsl:output method="json" allow-duplicate-names="yes"/>), not a
+			// hard-coded "no".
 			allowDupes := false
 			if primaryOverrides != nil {
 				allowDupes = primaryOverrides.AllowDuplicateNames
+			} else if defDef, ok := ec.effectiveOutputs()[""]; ok {
+				allowDupes = defDef.AllowDuplicateNames
 			}
 			if !allowDupes {
 				if err := validateJSONItems(bufFrame.pendingItems); err != nil {

--- a/xslt3/execute_transform.go
+++ b/xslt3/execute_transform.go
@@ -831,6 +831,9 @@ func executeTransform(ctx context.Context, source *helium.Document, ss *Styleshe
 		// ov folds in the default xsl:output base via evalResultDocOutputDef, so
 		// this is the effective allow-duplicate-names for the primary output.
 		outDef.AllowDuplicateNames = ov.AllowDuplicateNames
+		// Likewise, ov folds in the default xsl:output base, so this is the
+		// effective undeclare-prefixes for the primary output.
+		outDef.UndeclarePrefixes = ov.UndeclarePrefixes
 	}
 
 	if cfg != nil {

--- a/xslt3/execute_transform.go
+++ b/xslt3/execute_transform.go
@@ -790,6 +790,10 @@ func executeTransform(ctx context.Context, source *helium.Document, ss *Styleshe
 		// true. OR-ing would wrongly keep the inherited true on.
 		outDef.Indent = ov.Indent
 		outDef.OmitDeclaration = ov.OmitDeclaration
+		// Carry the omit-xml-declaration explicitness so the xhtml/html5
+		// serializer respects an explicit value rather than defaulting it to
+		// "yes" (output_html.go keys on OmitDeclarationExplicit).
+		outDef.OmitDeclarationExplicit = ov.OmitDeclarationExplicit
 		if ov.DoctypeSystem != "" {
 			outDef.DoctypeSystem = ov.DoctypeSystem
 		}

--- a/xslt3/execute_transform.go
+++ b/xslt3/execute_transform.go
@@ -770,7 +770,12 @@ func executeTransform(ctx context.Context, source *helium.Document, ss *Styleshe
 		ov := cloneOutputDef(ec.primaryOutputOverrides)
 		if ov.Method != "" {
 			outDef.Method = ov.Method
-			outDef.MethodExplicit = true
+			// Carry the override's explicitness rather than forcing it true:
+			// an override built solely from AVT-only attributes (media-type,
+			// html-version, etc.) inherits the base method without making it
+			// explicit, so forcing MethodExplicit=true here would wrongly
+			// disable html/xhtml auto-detection in serializeResult.
+			outDef.MethodExplicit = ov.MethodExplicit
 		}
 		if ov.Standalone != "" {
 			outDef.Standalone = ov.Standalone

--- a/xslt3/execute_transform.go
+++ b/xslt3/execute_transform.go
@@ -783,8 +783,13 @@ func executeTransform(ctx context.Context, source *helium.Document, ss *Styleshe
 		if ov.Encoding != "" {
 			outDef.Encoding = ov.Encoding
 		}
-		outDef.Indent = ov.Indent || outDef.Indent
-		outDef.OmitDeclaration = ov.OmitDeclaration || outDef.OmitDeclaration
+		// ov folds in the default xsl:output base via evalResultDocOutputDef, so
+		// it is the effective output definition. Assign the boolean serialization
+		// fields directly rather than OR-ing with outDef: an explicit false on
+		// the result-document (e.g. indent="{false()}") must override an inherited
+		// true. OR-ing would wrongly keep the inherited true on.
+		outDef.Indent = ov.Indent
+		outDef.OmitDeclaration = ov.OmitDeclaration
 		if ov.DoctypeSystem != "" {
 			outDef.DoctypeSystem = ov.DoctypeSystem
 		}
@@ -797,12 +802,10 @@ func executeTransform(ctx context.Context, source *helium.Document, ss *Styleshe
 		if ov.HTMLVersion != "" {
 			outDef.HTMLVersion = ov.HTMLVersion
 		}
-		if ov.IncludeContentType != nil {
-			outDef.IncludeContentType = ov.IncludeContentType
-		}
-		if ov.ByteOrderMark {
-			outDef.ByteOrderMark = true
-		}
+		// Effective (base-folded) values; assign directly so an explicit false
+		// overrides an inherited true.
+		outDef.IncludeContentType = ov.IncludeContentType
+		outDef.ByteOrderMark = ov.ByteOrderMark
 		if len(ov.CDATASections) > 0 {
 			outDef.CDATASections = ov.CDATASections
 		}
@@ -812,9 +815,7 @@ func executeTransform(ctx context.Context, source *helium.Document, ss *Styleshe
 		if ov.Version != "" {
 			outDef.Version = ov.Version
 		}
-		if ov.EscapeURIAttributes != nil {
-			outDef.EscapeURIAttributes = ov.EscapeURIAttributes
-		}
+		outDef.EscapeURIAttributes = ov.EscapeURIAttributes
 		if len(ov.SuppressIndentation) > 0 {
 			outDef.SuppressIndentation = ov.SuppressIndentation
 		}

--- a/xslt3/execute_transform.go
+++ b/xslt3/execute_transform.go
@@ -701,9 +701,16 @@ func executeTransform(ctx context.Context, source *helium.Document, ss *Styleshe
 			// for the primary output method.
 			primaryMethod := ec.currentResultDocMethod
 			if primaryMethod == methodJSON {
+				// Derive allow-duplicate-names from the effective primary output
+				// definition: the default xsl:output, overridden by any primary
+				// xsl:result-document serialization params (which already fold in
+				// the default base via evalResultDocOutputDef).
 				allowDupes := false
 				if defOut := ss.outputs[""]; defOut != nil {
 					allowDupes = defOut.AllowDuplicateNames
+				}
+				if ec.primaryOutputOverrides != nil {
+					allowDupes = ec.primaryOutputOverrides.AllowDuplicateNames
 				}
 				if !allowDupes {
 					if err := validateJSONItems(out.pendingItems); err != nil {
@@ -821,6 +828,9 @@ func executeTransform(ctx context.Context, source *helium.Document, ss *Styleshe
 		if ov.BuildTree != nil {
 			outDef.BuildTree = ov.BuildTree
 		}
+		// ov folds in the default xsl:output base via evalResultDocOutputDef, so
+		// this is the effective allow-duplicate-names for the primary output.
+		outDef.AllowDuplicateNames = ov.AllowDuplicateNames
 	}
 
 	if cfg != nil {

--- a/xslt3/instruction.go
+++ b/xslt3/instruction.go
@@ -368,6 +368,7 @@ type resultDocumentInst struct {
 	HTMLVersion             *avt
 	IncludeContentType      *avt
 	AllowDuplicateNames     *avt
+	UndeclarePrefixes       *avt
 	EscapeURIAttributes     *avt
 	JSONNodeOutputMethodAVT *avt       // json-node-output-method avt
 	NormalizationForm       *avt       // normalization-form avt

--- a/xslt3/instruction.go
+++ b/xslt3/instruction.go
@@ -375,7 +375,7 @@ type resultDocumentInst struct {
 	SuppressIndentation     []string   // suppress-indentation element names
 	ParameterDocAVT         *avt       // parameter-document avt
 	ParameterDocOutputDef   *OutputDef // resolved output def from parameter-document (compile-time)
-	BuildTree               *bool      // build-tree: nil=default(true), true/false
+	BuildTree               *avt       // build-tree avt: nil=default(true); evaluated as xs:boolean
 }
 
 func (*resultDocumentInst) instructionTag() {}

--- a/xslt3/instruction.go
+++ b/xslt3/instruction.go
@@ -370,12 +370,13 @@ type resultDocumentInst struct {
 	AllowDuplicateNames     *avt
 	UndeclarePrefixes       *avt
 	EscapeURIAttributes     *avt
-	JSONNodeOutputMethodAVT *avt       // json-node-output-method avt
-	NormalizationForm       *avt       // normalization-form avt
-	SuppressIndentation     []string   // suppress-indentation element names
-	ParameterDocAVT         *avt       // parameter-document avt
-	ParameterDocOutputDef   *OutputDef // resolved output def from parameter-document (compile-time)
-	BuildTree               *avt       // build-tree avt: nil=default(true); evaluated as xs:boolean
+	JSONNodeOutputMethodAVT *avt             // json-node-output-method avt
+	NormalizationForm       *avt             // normalization-form avt
+	SuppressIndentation     []string         // suppress-indentation element names
+	ParameterDocAVT         *avt             // parameter-document avt
+	ParameterDocOutputDef   *OutputDef       // resolved output def from parameter-document (compile-time)
+	ParameterDocPresence    paramDocPresence // plain-boolean presence flags for the compile-time parameter-document delta
+	BuildTree               *avt             // build-tree avt: nil=default(true); evaluated as xs:boolean
 }
 
 func (*resultDocumentInst) instructionTag() {}

--- a/xslt3/internal/elements/data.go
+++ b/xslt3/internal/elements/data.go
@@ -214,6 +214,9 @@ func elementDefs() map[string]ElementInfo {
 				"include-content-type", "normalization-form",
 				"undeclare-prefixes", "use-character-maps",
 				"output-version", "type", "validation",
+				"allow-duplicate-names", "item-separator",
+				"json-node-output-method", "parameter-document",
+				"build-tree", "html-version", "suppress-indentation",
 			),
 		},
 		lexicon.XSLTElementWherePopulated: {

--- a/xslt3/output_fixes_test.go
+++ b/xslt3/output_fixes_test.go
@@ -203,6 +203,66 @@ func TestPrimaryResultDocumentResolvedOutputDefIsIsolated(t *testing.T) {
 	require.Equal(t, ";", *second.ItemSeparator, "compiled/override state must be unaffected across runs")
 }
 
+// A primary xsl:result-document with an explicit false boolean serialization
+// AVT must override an inherited true from xsl:output. Before the fix the merge
+// OR-ed the override with the inherited value, so an explicit false could never
+// turn an inherited true back off.
+func TestPrimaryResultDocBooleanFalseOverridesInheritedTrue(t *testing.T) {
+	resolve := func(t *testing.T, output, resultDocAttrs string) *xslt3.OutputDef {
+		t.Helper()
+		ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  `+output+`
+  <xsl:template match="/">
+    <xsl:result-document `+resultDocAttrs+`><out/></xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+		inv := ss.Transform(parseTransformSource(t))
+		_, err := inv.Do(t.Context())
+		require.NoError(t, err)
+		r := inv.ResolvedOutputDef()
+		require.NotNil(t, r)
+		return r
+	}
+
+	t.Run("indent false overrides inherited yes", func(t *testing.T) {
+		r := resolve(t, `<xsl:output method="xml" indent="yes"/>`, `indent="{false()}"`)
+		require.False(t, r.Indent, "explicit indent=false must override inherited indent=yes")
+	})
+
+	t.Run("indent inherited yes stays on when not overridden", func(t *testing.T) {
+		r := resolve(t, `<xsl:output method="xml" indent="yes"/>`, `method="xml"`)
+		require.True(t, r.Indent, "inherited indent=yes must remain on when not overridden")
+	})
+
+	t.Run("omit-xml-declaration false overrides inherited yes", func(t *testing.T) {
+		r := resolve(t, `<xsl:output method="xml" omit-xml-declaration="yes"/>`, `omit-xml-declaration="{false()}"`)
+		require.False(t, r.OmitDeclaration, "explicit omit-xml-declaration=false must override inherited yes")
+	})
+
+	t.Run("byte-order-mark false overrides inherited yes", func(t *testing.T) {
+		r := resolve(t, `<xsl:output method="xml" byte-order-mark="yes"/>`, `byte-order-mark="{false()}"`)
+		require.False(t, r.ByteOrderMark, "explicit byte-order-mark=false must override inherited yes")
+	})
+
+	t.Run("escape-uri-attributes false overrides inherited yes", func(t *testing.T) {
+		r := resolve(t, `<xsl:output method="html" escape-uri-attributes="yes"/>`, `escape-uri-attributes="{false()}"`)
+		require.NotNil(t, r.EscapeURIAttributes)
+		require.False(t, *r.EscapeURIAttributes, "explicit escape-uri-attributes=false must override inherited yes")
+	})
+
+	t.Run("include-content-type false overrides inherited yes", func(t *testing.T) {
+		r := resolve(t, `<xsl:output method="html" include-content-type="yes"/>`, `include-content-type="{false()}"`)
+		require.NotNil(t, r.IncludeContentType)
+		require.False(t, *r.IncludeContentType, "explicit include-content-type=false must override inherited yes")
+	})
+
+	t.Run("undeclare-prefixes false overrides inherited yes", func(t *testing.T) {
+		r := resolve(t, `<xsl:output method="xml" version="1.1" undeclare-prefixes="yes"/>`, `undeclare-prefixes="{false()}"`)
+		require.False(t, r.UndeclarePrefixes, "explicit undeclare-prefixes=false must override inherited yes")
+	})
+}
+
 // A-006 race: concurrent Serialize/ResolvedOutputDef on the SAME Invocation
 // value must be safe. Run under -race to catch data races on the shared config.
 func TestConcurrentSerializeAndResolvedOutputDef(t *testing.T) {

--- a/xslt3/resolve_uri_internal_test.go
+++ b/xslt3/resolve_uri_internal_test.go
@@ -91,7 +91,7 @@ func TestLoadParameterDocumentURIAbsolute(t *testing.T) {
 				// care which URI the loader was asked for.
 				return nil, errStopAfterResolve
 			}
-			_ = loadParameterDocumentFromFile(context.Background(), nil, &OutputDef{}, tc.base, tc.href, loadBytes, false)
+			_, _ = loadParameterDocumentFromFile(context.Background(), nil, &OutputDef{}, tc.base, tc.href, loadBytes, false, false)
 			require.Equal(t, tc.want, seen)
 		})
 	}

--- a/xslt3/resolve_uri_internal_test.go
+++ b/xslt3/resolve_uri_internal_test.go
@@ -91,7 +91,7 @@ func TestLoadParameterDocumentURIAbsolute(t *testing.T) {
 				// care which URI the loader was asked for.
 				return nil, errStopAfterResolve
 			}
-			_, _ = loadParameterDocumentFromFile(context.Background(), nil, &OutputDef{}, tc.base, tc.href, loadBytes, false, false)
+			_, _, _ = loadParameterDocumentFromFile(context.Background(), nil, &OutputDef{}, tc.base, tc.href, loadBytes, false, false)
 			require.Equal(t, tc.want, seen)
 		})
 	}

--- a/xslt3/resultdoc_avt_validation_test.go
+++ b/xslt3/resultdoc_avt_validation_test.go
@@ -155,3 +155,26 @@ func TestResultDocumentSoleSuppressIndentationHonored(t *testing.T) {
 	require.Contains(t, out, "<p><b>x</b><i>y</i></p>",
 		"sole suppress-indentation override must be honored (p children not indented)")
 }
+
+// XHTML/HTML5 serialization defaults omit-xml-declaration to "yes" only when the
+// value was NOT explicitly set. A primary xsl:result-document that evaluates
+// omit-xml-declaration="{false()}" explicitly specifies it, so the XML
+// declaration must be emitted. Before the fix the OmitDeclarationExplicit flag
+// was dropped on the result-document AVT path and the html5 serializer flipped
+// the declaration back off.
+func TestResultDocumentXHTMLOmitDeclarationFalseExplicit(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xhtml" html-version="5"/>
+  <xsl:template match="/">
+    <xsl:result-document omit-xml-declaration="{false()}">
+      <html xmlns="http://www.w3.org/1999/xhtml"><body><p>x</p></body></html>
+    </xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	out, err := ss.Transform(parseTransformSource(t)).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, out, "<?xml",
+		"explicit omit-xml-declaration=false on the result-document must keep the XML declaration in XHTML/HTML5 output")
+}

--- a/xslt3/resultdoc_avt_validation_test.go
+++ b/xslt3/resultdoc_avt_validation_test.go
@@ -69,6 +69,7 @@ func TestResultDocumentInvalidBooleanAVTRaisesSEPM0016(t *testing.T) {
 		{name: "include-content-type", attr: `include-content-type="{'bogus'}"`},
 		{name: "escape-uri-attributes", attr: `escape-uri-attributes="{'bogus'}"`},
 		{name: "omit-xml-declaration", attr: `omit-xml-declaration="{'bogus'}"`},
+		{name: "undeclare-prefixes", attr: `undeclare-prefixes="{'bogus'}"`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ss := compileStylesheetString(t, `

--- a/xslt3/resultdoc_avt_validation_test.go
+++ b/xslt3/resultdoc_avt_validation_test.go
@@ -55,6 +55,29 @@ func TestResultDocumentSecondaryJSONDuplicateKeyAllowed(t *testing.T) {
 		"allow-duplicate-names=yes must permit duplicate JSON keys in a secondary result document")
 }
 
+// A primary xsl:result-document that carries only AVT-only serialization
+// attributes (media-type, html-version, include-content-type, etc.) must NOT
+// force the output method to become explicit. When the base xsl:output did not
+// explicitly set a method, html/xhtml auto-detection has to keep working: a
+// result tree rooted at <html> in no namespace serializes with the HTML method
+// (void elements like <br> are not self-closed).
+func TestResultDocumentPrimaryAVTOnlyKeepsHTMLAutoDetect(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output encoding="UTF-8"/>
+  <xsl:template match="/">
+    <xsl:result-document media-type="{'text/html'}"><html><body><br/></body></html></xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	out, err := ss.Transform(parseTransformSource(t)).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, out, "<br>",
+		"AVT-only primary result-document must keep html auto-detection (void br not self-closed)")
+	require.NotContains(t, out, "<br/>",
+		"forcing MethodExplicit must not disable html auto-detection back to XML serialization")
+}
+
 // An invalid AVT value for ANY boolean serialization parameter on
 // xsl:result-document must raise SEPM0016 rather than being silently coerced to
 // false. All boolean serialization-param AVTs route through one shared helper,

--- a/xslt3/resultdoc_avt_validation_test.go
+++ b/xslt3/resultdoc_avt_validation_test.go
@@ -93,6 +93,7 @@ func TestResultDocumentInvalidBooleanAVTRaisesSEPM0016(t *testing.T) {
 		{name: "escape-uri-attributes", attr: `escape-uri-attributes="{'bogus'}"`},
 		{name: "omit-xml-declaration", attr: `omit-xml-declaration="{'bogus'}"`},
 		{name: "undeclare-prefixes", attr: `undeclare-prefixes="{'bogus'}"`},
+		{name: "build-tree", attr: `build-tree="{'bogus'}"`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ss := compileStylesheetString(t, `
@@ -110,4 +111,47 @@ func TestResultDocumentInvalidBooleanAVTRaisesSEPM0016(t *testing.T) {
 			require.ErrorContains(t, err, "SEPM0016")
 		})
 	}
+}
+
+// build-tree is an AVT, not a static compile-time bool. A build-tree AVT whose
+// evaluation raises a dynamic error must surface that error instead of being
+// silently ignored (which is what happened when build-tree was parsed only with
+// parseXSDBool at compile time and dropped on a non-constant value).
+func TestResultDocumentBuildTreeAVTEvaluated(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:result-document build-tree="{1 idiv 0}">
+      <out/>
+    </xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	_, err := ss.Transform(parseTransformSource(t)).Do(t.Context())
+	require.Error(t, err,
+		"a build-tree AVT that raises a dynamic error must not be silently ignored")
+	require.ErrorContains(t, err, "FOAR0001")
+}
+
+// A primary xsl:result-document whose ONLY serialization attribute is
+// suppress-indentation must still contribute that override. Before the fix the
+// hasAny preflight gate omitted suppress-indentation, so evalResultDocOutputDef
+// returned nil overrides and the attribute was silently dropped. With the base
+// xsl:output indenting, suppress-indentation must keep the named element's
+// children on a single line.
+func TestResultDocumentSoleSuppressIndentationHonored(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output indent="yes"/>
+  <xsl:template match="/">
+    <xsl:result-document suppress-indentation="p">
+      <doc><p><b>x</b><i>y</i></p></doc>
+    </xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	out, err := ss.Transform(parseTransformSource(t)).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, out, "<p><b>x</b><i>y</i></p>",
+		"sole suppress-indentation override must be honored (p children not indented)")
 }

--- a/xslt3/resultdoc_avt_validation_test.go
+++ b/xslt3/resultdoc_avt_validation_test.go
@@ -1,0 +1,89 @@
+package xslt3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// A secondary (href) JSON result document must reject duplicate keys
+// (SERE0022) when allow-duplicate-names is not "yes", exactly like the primary
+// path. The final SerializeItems pass swallows serialization errors, so the
+// duplicate-key check has to happen at the result-document commit point.
+func TestResultDocumentSecondaryJSONDuplicateKeyRejected(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:map="http://www.w3.org/2005/xpath-functions/map">
+  <xsl:output name="j" method="json" build-tree="no"/>
+  <xsl:template match="/">
+    <xsl:result-document href="out.json" format="j">
+      <xsl:sequence select="map{1:'a','1':'b'}"/>
+    </xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	collector := &resultDocCollect{docs: map[string]*helium.Document{}}
+	_, err := ss.Transform(parseTransformSource(t)).
+		ResultDocumentHandler(collector).
+		Do(t.Context())
+	require.Error(t, err, "a secondary JSON result document with duplicate keys must fail")
+	require.ErrorContains(t, err, "SERE0022")
+}
+
+// With allow-duplicate-names="yes" the same secondary JSON result document is
+// accepted, confirming the new check honors the serialization parameter.
+func TestResultDocumentSecondaryJSONDuplicateKeyAllowed(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:map="http://www.w3.org/2005/xpath-functions/map">
+  <xsl:output name="j" method="json" build-tree="no"/>
+  <xsl:template match="/">
+    <xsl:result-document href="out.json" format="j" allow-duplicate-names="yes">
+      <xsl:sequence select="map{1:'a','1':'b'}"/>
+    </xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	collector := &resultDocCollect{docs: map[string]*helium.Document{}}
+	_, err := ss.Transform(parseTransformSource(t)).
+		ResultDocumentHandler(collector).
+		Do(t.Context())
+	require.NoError(t, err,
+		"allow-duplicate-names=yes must permit duplicate JSON keys in a secondary result document")
+}
+
+// An invalid AVT value for ANY boolean serialization parameter on
+// xsl:result-document must raise SEPM0016 rather than being silently coerced to
+// false. All boolean serialization-param AVTs route through one shared helper,
+// so a single invalid value is enough to fail each one.
+func TestResultDocumentInvalidBooleanAVTRaisesSEPM0016(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		attr string
+	}{
+		{name: "indent", attr: `indent="{'bogus'}"`},
+		{name: "byte-order-mark", attr: `byte-order-mark="{'bogus'}"`},
+		{name: "include-content-type", attr: `include-content-type="{'bogus'}"`},
+		{name: "escape-uri-attributes", attr: `escape-uri-attributes="{'bogus'}"`},
+		{name: "omit-xml-declaration", attr: `omit-xml-declaration="{'bogus'}"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:result-document `+tc.attr+`>
+      <out/>
+    </xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+			_, err := ss.Transform(parseTransformSource(t)).Do(t.Context())
+			require.Error(t, err,
+				"an invalid AVT value for a boolean serialization parameter must fail")
+			require.ErrorContains(t, err, "SEPM0016")
+		})
+	}
+}

--- a/xslt3/resultdoc_paramdoc_inherit_test.go
+++ b/xslt3/resultdoc_paramdoc_inherit_test.go
@@ -1,0 +1,79 @@
+package xslt3_test
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A primary xsl:result-document whose parameter-document OMITS a serialization
+// parameter must inherit that parameter's value from the unnamed default
+// xsl:output, not silently reset it to the Go zero value. Before the fix
+// evalResultDocOutputDef took the parameter-document OutputDef as the WHOLE base
+// when a parameter-document was present, dropping the default xsl:output: an
+// omitted plain boolean (indent, byte-order-mark, allow-duplicate-names,
+// undeclare-prefixes) then overwrote an inherited true with false.
+func TestResultDocParamDocInheritsDefaultOutput(t *testing.T) {
+	const paramDocURI = "http://example.invalid/params.xml"
+
+	// Serialization parameter document that deliberately OMITS indent and
+	// allow-duplicate-names; it only sets an unrelated parameter (encoding).
+	const paramDoc = `<serialization-parameters xmlns="http://www.w3.org/2010/xslt-xquery-serialization">` +
+		`<encoding value="utf-8"/>` +
+		`</serialization-parameters>`
+
+	resolver := httpResolverFunc(func(uri string) (io.ReadCloser, error) {
+		if uri != paramDocURI {
+			return nil, errors.New("not found: " + uri)
+		}
+		return io.NopCloser(strings.NewReader(paramDoc)), nil
+	})
+
+	t.Run("indent inherited", func(t *testing.T) {
+		ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output indent="yes"/>
+  <xsl:template match="/">
+    <xsl:result-document parameter-document="{'`+paramDocURI+`'}">
+      <root><child>x</child></root>
+    </xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+		out, err := ss.Transform(parseTransformSource(t)).
+			URIResolver(resolver).
+			Serialize(t.Context())
+		require.NoError(t, err)
+		// indent="yes" inherited from the default xsl:output must still pretty-print
+		// the nested element across lines ("<root>\n  <child>..."); a clobbered
+		// indent=false would emit "<root><child>x</child></root>" on one line.
+		require.Contains(t, out, "<root>\n", "inherited indent=yes must survive a parameter-document that omits indent")
+	})
+
+	t.Run("allow-duplicate-names inherited", func(t *testing.T) {
+		ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="json" allow-duplicate-names="yes"/>
+  <xsl:template match="/">
+    <xsl:result-document parameter-document="{'`+paramDocURI+`'}">
+      <xsl:sequence select="map{1:'a','1':'b'}"/>
+    </xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+		// The map's integer key 1 and string key "1" both become the JSON name
+		// "1": a duplicate name that SERE0022 rejects unless allow-duplicate-names
+		// ="yes". That value is set only on the default xsl:output and OMITTED by
+		// the parameter-document, so it must be inherited rather than reset to false.
+		inv := ss.Transform(parseTransformSource(t)).URIResolver(resolver)
+		_, err := inv.Do(t.Context())
+		require.NoError(t, err, "inherited allow-duplicate-names=yes must survive a parameter-document that omits it (no SERE0022)")
+		od := inv.ResolvedOutputDef()
+		require.NotNil(t, od)
+		require.True(t, od.AllowDuplicateNames,
+			"the default xsl:output allow-duplicate-names=yes must survive a parameter-document that omits it")
+	})
+}

--- a/xslt3/resultdoc_uri_test.go
+++ b/xslt3/resultdoc_uri_test.go
@@ -340,3 +340,92 @@ func TestResultDocumentNestedDuplicateRelativeVsAbsoluteFileURI(t *testing.T) {
 	require.Error(t, err, "nested relative and absolute file: hrefs denoting the same file must collide")
 	require.Contains(t, err.Error(), "XTDE1490")
 }
+
+// XSLT3-ADV-001: every error-prone serialization AVT on xsl:result-document must
+// be evaluated in the preflight, even when it is the ONLY serialization attribute
+// present. Previously media-type, html-version, include-content-type,
+// allow-duplicate-names and output-version were absent from the preflight
+// `hasAny` gate (or never evaluated), so when one of them was the sole
+// serialization attribute the gate short-circuited and a failing AVT (e.g.
+// {1 idiv 0}) was silently swallowed: the body emitted output with err=nil.
+func TestResultDocumentSerializationAVTErrorPropagates(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		attr string
+	}{
+		{"media-type", `media-type="{1 idiv 0}"`},
+		{"output-version", `output-version="{1 idiv 0}"`},
+		{"html-version", `html-version="{1 idiv 0}"`},
+		{"include-content-type", `include-content-type="{1 idiv 0}"`},
+		{"allow-duplicate-names", `allow-duplicate-names="{1 idiv 0}"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:result-document `+tc.attr+`><a/></xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+			_, err := ss.Transform(parseTransformSource(t)).Do(t.Context())
+			require.Error(t, err, "a dynamic error in the %s AVT must not be swallowed", tc.name)
+			require.True(t, strings.Contains(err.Error(), "idiv") || strings.Contains(err.Error(), "FOAR0001") ||
+				strings.Contains(err.Error(), "division") || strings.Contains(err.Error(), "zero"),
+				"error should reflect the division-by-zero dynamic error, got: %v", err)
+		})
+	}
+}
+
+// XSLT3-ADV-001: a primary xsl:result-document whose serialization AVT raises a
+// dynamic error must fail in the preflight, BEFORE any primary output is emitted,
+// so an enclosing xsl:catch can write the sole primary result document with no
+// partial <a/> left behind. This must hold for the AVTs that were previously
+// missing from the preflight gate (media-type / output-version shown here).
+func TestResultDocumentSerializationAVTErrorObservableInTryCatch(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		attr string
+	}{
+		{"media-type", `media-type="{1 idiv 0}"`},
+		{"output-version", `output-version="{1 idiv 0}"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:try>
+      <xsl:result-document `+tc.attr+`><a/></xsl:result-document>
+      <xsl:catch>
+        <xsl:result-document><b/></xsl:result-document>
+      </xsl:catch>
+    </xsl:try>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+			out, err := ss.Transform(parseTransformSource(t)).Serialize(t.Context())
+			require.NoError(t, err, "the caught primary result-document must succeed without a spurious conflict")
+			require.Contains(t, out, "<b/>", "the catch's primary result document must be emitted")
+			require.NotContains(t, out, "<a/>", "the failed primary result document must not leave partial output behind")
+		})
+	}
+}
+
+// XSLT3-ADV-001: output-version supplied as a valid AVT on a primary
+// xsl:result-document must reach the effective output definition. Pre-fix the
+// output-version AVT was never evaluated/applied, so the override was dropped.
+func TestResultDocumentPrimaryOutputVersionAVTApplied(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:result-document method="xml" output-version="{concat('1','.','1')}"><a/></xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	inv := ss.Transform(parseTransformSource(t))
+	_, err := inv.Do(t.Context())
+	require.NoError(t, err)
+	od := inv.ResolvedOutputDef()
+	require.NotNil(t, od, "resolved output def must be populated after Do")
+	require.Equal(t, "1.1", od.Version,
+		"the primary result-document's output-version AVT override must reach the effective output def")
+}

--- a/xslt3/resultdoc_uri_test.go
+++ b/xslt3/resultdoc_uri_test.go
@@ -456,3 +456,26 @@ func TestResultDocumentPrimaryJSONAllowDuplicateNamesAVT(t *testing.T) {
 	require.True(t, od.AllowDuplicateNames,
 		"the primary result-document allow-duplicate-names override must reach the effective output def")
 }
+
+// A bare primary <xsl:result-document> (no serialization attributes of its own)
+// must still honor a stylesheet-level
+// <xsl:output method="json" allow-duplicate-names="yes"/>. Pre-fix the JSON
+// dup-key check hard-coded allowDupes=false whenever the result-document carried
+// no overrides (primaryOverrides==nil), so duplicate keys were wrongly rejected
+// even though the default output definition permitted them.
+func TestResultDocumentPrimaryJSONAllowDuplicateNamesDefaultOutput(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="json" allow-duplicate-names="yes"/>
+  <xsl:template match="/">
+    <xsl:result-document>
+      <xsl:sequence select="map{1:'a','1':'b'}"/>
+    </xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	inv := ss.Transform(parseTransformSource(t))
+	_, err := inv.Do(t.Context())
+	require.NoError(t, err,
+		"duplicate JSON keys must be accepted when the default xsl:output sets allow-duplicate-names=yes, even for a bare result-document")
+}

--- a/xslt3/resultdoc_uri_test.go
+++ b/xslt3/resultdoc_uri_test.go
@@ -480,6 +480,59 @@ func TestResultDocumentPrimaryJSONAllowDuplicateNamesDefaultOutput(t *testing.T)
 		"duplicate JSON keys must be accepted when the default xsl:output sets allow-duplicate-names=yes, even for a bare result-document")
 }
 
+// Secondary equivalent of TestResultDocumentPrimaryJSONAllowDuplicateNamesDefaultOutput:
+// a bare SECONDARY xsl:result-document (href, no format, no serialization
+// attributes of its own) must still honor a stylesheet-level
+// <xsl:output method="json" allow-duplicate-names="yes"/>. Pre-fix
+// buildEffectiveOutputDef left base empty when there was no named format and no
+// parameter-document, so the SERE0022 dup-key check saw allow-duplicate-names=false
+// and wrongly rejected duplicate keys the default output permitted.
+func TestResultDocumentSecondaryJSONAllowDuplicateNamesDefaultOutput(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:map="http://www.w3.org/2005/xpath-functions/map">
+  <xsl:output method="json" allow-duplicate-names="yes"/>
+  <xsl:template match="/">
+    <xsl:result-document href="out.json">
+      <xsl:sequence select="map{1:'a','1':'b'}"/>
+    </xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	collector := &resultDocCollect{docs: map[string]*helium.Document{}}
+	_, err := ss.Transform(parseTransformSource(t)).
+		ResultDocumentHandler(collector).
+		Do(t.Context())
+	require.NoError(t, err,
+		"duplicate JSON keys must be accepted when the default xsl:output sets allow-duplicate-names=yes, even for a bare secondary result-document")
+}
+
+// A primary xsl:result-document undeclare-prefixes="{...}" AVT that resolves to
+// true must reach the effective output definition. Pre-fix undeclare-prefixes was
+// validated as a boolean serialization attribute at compile time but never
+// compiled into an AVT, never evaluated, and never copied into the merged output
+// def, so a dynamic value was silently ignored.
+func TestResultDocumentPrimaryUndeclarePrefixesAVT(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:result-document undeclare-prefixes="{true()}">
+      <out/>
+    </xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	inv := ss.Transform(parseTransformSource(t))
+	_, err := inv.Do(t.Context())
+	require.NoError(t, err,
+		"a primary result-document undeclare-prefixes AVT resolving to true must not fail")
+	od := inv.ResolvedOutputDef()
+	require.NotNil(t, od)
+	require.True(t, od.UndeclarePrefixes,
+		"the primary result-document undeclare-prefixes override must reach the effective output def")
+}
+
 // An xsl:result-document with a CONSTANT (non-AVT) invalid allow-duplicate-names
 // value must be rejected at compile time with SEPM0016, like every other boolean
 // serialization attribute. (Regression: allow-duplicate-names was missing from

--- a/xslt3/resultdoc_uri_test.go
+++ b/xslt3/resultdoc_uri_test.go
@@ -429,3 +429,30 @@ func TestResultDocumentPrimaryOutputVersionAVTApplied(t *testing.T) {
 	require.Equal(t, "1.1", od.Version,
 		"the primary result-document's output-version AVT override must reach the effective output def")
 }
+
+// XSLT3-ADV-001: with a default method="json" output, a primary
+// xsl:result-document allow-duplicate-names="{...}" AVT that resolves to true
+// must reach the transform-level SERE0022 dup-key validation. Pre-fix the
+// final validation read ss.outputs[""] (default, no) and the override merge
+// never copied AllowDuplicateNames, so duplicate JSON keys were wrongly
+// rejected even though the result-document permitted them.
+func TestResultDocumentPrimaryJSONAllowDuplicateNamesAVT(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="json"/>
+  <xsl:template match="/">
+    <xsl:result-document allow-duplicate-names="{true()}">
+      <xsl:sequence select="map{1:'a','1':'b'}"/>
+    </xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	inv := ss.Transform(parseTransformSource(t))
+	_, err := inv.Do(t.Context())
+	require.NoError(t, err,
+		"duplicate JSON keys must be accepted when the primary result-document's allow-duplicate-names AVT resolves to true")
+	od := inv.ResolvedOutputDef()
+	require.NotNil(t, od)
+	require.True(t, od.AllowDuplicateNames,
+		"the primary result-document allow-duplicate-names override must reach the effective output def")
+}

--- a/xslt3/resultdoc_uri_test.go
+++ b/xslt3/resultdoc_uri_test.go
@@ -479,3 +479,43 @@ func TestResultDocumentPrimaryJSONAllowDuplicateNamesDefaultOutput(t *testing.T)
 	require.NoError(t, err,
 		"duplicate JSON keys must be accepted when the default xsl:output sets allow-duplicate-names=yes, even for a bare result-document")
 }
+
+// An xsl:result-document with a CONSTANT (non-AVT) invalid allow-duplicate-names
+// value must be rejected at compile time with SEPM0016, like every other boolean
+// serialization attribute. (Regression: allow-duplicate-names was missing from
+// the compile-time boolean-validation list, so "bogus" compiled cleanly.)
+func TestResultDocumentAllowDuplicateNamesInvalidConstantCompileError(t *testing.T) {
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:result-document allow-duplicate-names="bogus"><a/></xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`))
+	require.NoError(t, err)
+
+	_, err = xslt3.CompileStylesheet(t.Context(), doc)
+	require.Error(t, err, "an invalid constant allow-duplicate-names must fail compilation")
+	require.Contains(t, err.Error(), "SEPM0016")
+}
+
+// An xsl:result-document whose allow-duplicate-names AVT resolves to an invalid
+// xs:boolean lexical form must raise a dynamic SEPM0016 error, NOT silently fall
+// back to an inherited value. (Regression: an invalid AVT result was dropped on
+// the floor, leaving an inherited allow-duplicate-names="yes" wrongly in force
+// and permitting duplicate JSON keys.)
+func TestResultDocumentAllowDuplicateNamesInvalidAVTDynamicError(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="json" allow-duplicate-names="yes"/>
+  <xsl:template match="/">
+    <xsl:result-document allow-duplicate-names="{'bogus'}">
+      <xsl:sequence select="map{1:'a','1':'b'}"/>
+    </xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	_, err := ss.Transform(parseTransformSource(t)).Do(t.Context())
+	require.Error(t, err,
+		"an invalid allow-duplicate-names AVT must raise a dynamic error, not fall back to the inherited value")
+	require.Contains(t, err.Error(), "SEPM0016")
+}

--- a/xslt3/stylesheet.go
+++ b/xslt3/stylesheet.go
@@ -352,26 +352,22 @@ type OutputDef struct {
 	// Version is the version emitted in the XML or HTML declaration.
 	Version string
 	// UndeclarePrefixes enables namespace-undeclaration in XML 1.1 output.
-	UndeclarePrefixes   bool
-	IncludeContentType  *bool           // include-content-type: nil=default(yes), true/false
-	ItemSeparator       *string         // item-separator serialization parameter; nil = not set
-	ItemSeparatorAbsent bool            // true when item-separator="#absent" was explicitly set
-	HTMLVersion         string          // html-version: "5", "4.0", etc.
-	NormalizationForm   string          // "NFC", "NFD", "NFKC", "NFKD", "fully-normalized", "none"
-	ByteOrderMark       bool            // byte-order-mark: emit BOM at start of output
-	EscapeURIAttributes *bool           // escape-uri-attributes: nil=default(true), true/false
-	UseCharacterMaps    []string        // names of character maps to use
-	ResolvedCharMap     map[rune]string // resolved character map (populated at runtime)
-	AllowDuplicateNames bool            // allow-duplicate-names for JSON output
-	// allowDuplicateNamesExplicit is true when allow-duplicate-names was
-	// supplied by either the xsl:output attribute or the parameter document.
-	// Internal merge bookkeeping; not part of the public API.
-	allowDuplicateNamesExplicit bool
-	JSONNodeOutputMethod        string   // json-node-output-method: "xml", "html", "xhtml", "text"
-	SuppressIndentation         []string // suppress-indentation element names
-	ParameterDocument           string   // parameter-document URI
-	BuildTree                   *bool    // build-tree: nil=default(true), true/false
-	ImportPrec                  int      // import precedence for XTSE1560 conflict detection
+	UndeclarePrefixes    bool
+	IncludeContentType   *bool           // include-content-type: nil=default(yes), true/false
+	ItemSeparator        *string         // item-separator serialization parameter; nil = not set
+	ItemSeparatorAbsent  bool            // true when item-separator="#absent" was explicitly set
+	HTMLVersion          string          // html-version: "5", "4.0", etc.
+	NormalizationForm    string          // "NFC", "NFD", "NFKC", "NFKD", "fully-normalized", "none"
+	ByteOrderMark        bool            // byte-order-mark: emit BOM at start of output
+	EscapeURIAttributes  *bool           // escape-uri-attributes: nil=default(true), true/false
+	UseCharacterMaps     []string        // names of character maps to use
+	ResolvedCharMap      map[rune]string // resolved character map (populated at runtime)
+	AllowDuplicateNames  bool            // allow-duplicate-names for JSON output
+	JSONNodeOutputMethod string          // json-node-output-method: "xml", "html", "xhtml", "text"
+	SuppressIndentation  []string        // suppress-indentation element names
+	ParameterDocument    string          // parameter-document URI
+	BuildTree            *bool           // build-tree: nil=default(true), true/false
+	ImportPrec           int             // import precedence for XTSE1560 conflict detection
 	// Raw attribute values for XTSE1560 conflict detection
 	MethodRaw     string
 	IndentRaw     string

--- a/xslt3/stylesheet.go
+++ b/xslt3/stylesheet.go
@@ -352,22 +352,25 @@ type OutputDef struct {
 	// Version is the version emitted in the XML or HTML declaration.
 	Version string
 	// UndeclarePrefixes enables namespace-undeclaration in XML 1.1 output.
-	UndeclarePrefixes    bool
-	IncludeContentType   *bool           // include-content-type: nil=default(yes), true/false
-	ItemSeparator        *string         // item-separator serialization parameter; nil = not set
-	ItemSeparatorAbsent  bool            // true when item-separator="#absent" was explicitly set
-	HTMLVersion          string          // html-version: "5", "4.0", etc.
-	NormalizationForm    string          // "NFC", "NFD", "NFKC", "NFKD", "fully-normalized", "none"
-	ByteOrderMark        bool            // byte-order-mark: emit BOM at start of output
-	EscapeURIAttributes  *bool           // escape-uri-attributes: nil=default(true), true/false
-	UseCharacterMaps     []string        // names of character maps to use
-	ResolvedCharMap      map[rune]string // resolved character map (populated at runtime)
-	AllowDuplicateNames  bool            // allow-duplicate-names for JSON output
-	JSONNodeOutputMethod string          // json-node-output-method: "xml", "html", "xhtml", "text"
-	SuppressIndentation  []string        // suppress-indentation element names
-	ParameterDocument    string          // parameter-document URI
-	BuildTree            *bool           // build-tree: nil=default(true), true/false
-	ImportPrec           int             // import precedence for XTSE1560 conflict detection
+	UndeclarePrefixes   bool
+	IncludeContentType  *bool           // include-content-type: nil=default(yes), true/false
+	ItemSeparator       *string         // item-separator serialization parameter; nil = not set
+	ItemSeparatorAbsent bool            // true when item-separator="#absent" was explicitly set
+	HTMLVersion         string          // html-version: "5", "4.0", etc.
+	NormalizationForm   string          // "NFC", "NFD", "NFKC", "NFKD", "fully-normalized", "none"
+	ByteOrderMark       bool            // byte-order-mark: emit BOM at start of output
+	EscapeURIAttributes *bool           // escape-uri-attributes: nil=default(true), true/false
+	UseCharacterMaps    []string        // names of character maps to use
+	ResolvedCharMap     map[rune]string // resolved character map (populated at runtime)
+	AllowDuplicateNames bool            // allow-duplicate-names for JSON output
+	// AllowDuplicateNamesExplicit is true when allow-duplicate-names was
+	// supplied by either the xsl:output attribute or the parameter document.
+	AllowDuplicateNamesExplicit bool
+	JSONNodeOutputMethod        string   // json-node-output-method: "xml", "html", "xhtml", "text"
+	SuppressIndentation         []string // suppress-indentation element names
+	ParameterDocument           string   // parameter-document URI
+	BuildTree                   *bool    // build-tree: nil=default(true), true/false
+	ImportPrec                  int      // import precedence for XTSE1560 conflict detection
 	// Raw attribute values for XTSE1560 conflict detection
 	MethodRaw     string
 	IndentRaw     string

--- a/xslt3/stylesheet.go
+++ b/xslt3/stylesheet.go
@@ -363,9 +363,10 @@ type OutputDef struct {
 	UseCharacterMaps    []string        // names of character maps to use
 	ResolvedCharMap     map[rune]string // resolved character map (populated at runtime)
 	AllowDuplicateNames bool            // allow-duplicate-names for JSON output
-	// AllowDuplicateNamesExplicit is true when allow-duplicate-names was
+	// allowDuplicateNamesExplicit is true when allow-duplicate-names was
 	// supplied by either the xsl:output attribute or the parameter document.
-	AllowDuplicateNamesExplicit bool
+	// Internal merge bookkeeping; not part of the public API.
+	allowDuplicateNamesExplicit bool
 	JSONNodeOutputMethod        string   // json-node-output-method: "xml", "html", "xhtml", "text"
 	SuppressIndentation         []string // suppress-indentation element names
 	ParameterDocument           string   // parameter-document URI

--- a/xslt3/stylesheet.go
+++ b/xslt3/stylesheet.go
@@ -374,6 +374,18 @@ type OutputDef struct {
 	EncodingRaw   string
 	VersionRaw    string
 	StandaloneRaw string
+
+	// Explicit-presence flags for the plain-boolean serialization parameters,
+	// set only when a parameter-document supplies the corresponding value. A
+	// plain bool cannot otherwise distinguish "omitted" from "explicit false",
+	// which foldParamDocOverrides needs so an omitted parameter-document value
+	// leaves an inherited xsl:output default intact instead of clobbering it with
+	// the Go zero value. (The tri-state pointer params already encode this via
+	// nil, and method/omit-xml-declaration via their *Explicit fields.)
+	indentSet              bool
+	byteOrderMarkSet       bool
+	allowDuplicateNamesSet bool
+	undeclarePrefixesSet   bool
 }
 
 // GetUseCharacterMaps returns the use-character-maps list, nil-safe.

--- a/xslt3/stylesheet.go
+++ b/xslt3/stylesheet.go
@@ -374,18 +374,6 @@ type OutputDef struct {
 	EncodingRaw   string
 	VersionRaw    string
 	StandaloneRaw string
-
-	// Explicit-presence flags for the plain-boolean serialization parameters,
-	// set only when a parameter-document supplies the corresponding value. A
-	// plain bool cannot otherwise distinguish "omitted" from "explicit false",
-	// which foldParamDocOverrides needs so an omitted parameter-document value
-	// leaves an inherited xsl:output default intact instead of clobbering it with
-	// the Go zero value. (The tri-state pointer params already encode this via
-	// nil, and method/omit-xml-declaration via their *Explicit fields.)
-	indentSet              bool
-	byteOrderMarkSet       bool
-	allowDuplicateNamesSet bool
-	undeclarePrefixesSet   bool
 }
 
 // GetUseCharacterMaps returns the use-character-maps list, nil-safe.


### PR DESCRIPTION
- Add media-type, html-version, include-content-type, allow-duplicate-names to the result-document serialization-AVT preflight gate so a failing AVT (e.g. {1 idiv 0}) is no longer swallowed when it is the sole serialization attribute
- Evaluate and apply output-version into the effective output definition
- Stop discarding the allow-duplicate-names AVT error in the primary JSON path; reuse the preflighted override