### PR TITLE
cap nextCatalog load fan-out per resolution

### DIFF
--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -14,6 +14,11 @@ const (
 
 	// MaxDelegates is the maximum number of delegate catalogs per resolution.
 	MaxDelegates = 50
+
+	// MaxNextCatalogs is the maximum number of nextCatalog targets actually
+	// loaded per resolution. It bounds the sibling fan-out so a catalog with
+	// many unique nextCatalog entries cannot trigger an unbounded load.
+	MaxNextCatalogs = 50
 )
 
 // Prefer controls whether public or system identifiers take precedence

--- a/internal/catalog/resolve.go
+++ b/internal/catalog/resolve.go
@@ -52,6 +52,11 @@ type resolveState struct {
 	// catalog with many UNIQUE delegate entries cannot trigger an unbounded
 	// load fan-out (CAT-005).
 	delegates int
+	// nextCatalogs counts how many nextCatalog targets have actually been
+	// loaded and followed during this resolution. It bounds I/O at
+	// MaxNextCatalogs so a catalog with many UNIQUE nextCatalog entries cannot
+	// trigger an unbounded sibling load fan-out at one depth level (CAT-001).
+	nextCatalogs int
 }
 
 // checkVisited returns true if the (url, id1, id2) combination has already
@@ -421,6 +426,13 @@ func (c *Catalog) resolveNextCatalogs(ctx context.Context, st *resolveState, pub
 		if e.Type != EntryNextCatalog {
 			continue
 		}
+		// Bound the number of nextCatalog targets actually loaded across the
+		// whole resolution, not just by recursion depth, so a wide sibling
+		// fan-out cannot trigger an unbounded load (CAT-001).
+		if st.nextCatalogs >= MaxNextCatalogs {
+			break
+		}
+		st.nextCatalogs++
 		sub, err := c.lazyLoad(ctx, e)
 		if err != nil {
 			continue
@@ -446,6 +458,13 @@ func (c *Catalog) resolveNextCatalogsURI(ctx context.Context, st *resolveState, 
 		if e.Type != EntryNextCatalog {
 			continue
 		}
+		// Bound the number of nextCatalog targets actually loaded across the
+		// whole resolution, not just by recursion depth, so a wide sibling
+		// fan-out cannot trigger an unbounded load (CAT-001).
+		if st.nextCatalogs >= MaxNextCatalogs {
+			break
+		}
+		st.nextCatalogs++
 		sub, err := c.lazyLoad(ctx, e)
 		if err != nil {
 			continue

--- a/internal/catalog/resolve_test.go
+++ b/internal/catalog/resolve_test.go
@@ -370,6 +370,46 @@ func TestDelegateLoadCountBounded(t *testing.T) {
 	})
 }
 
+// A catalog with more than MaxNextCatalogs UNIQUE nextCatalog entries must load
+// at most MaxNextCatalogs of them during a single resolution. The sibling
+// fan-out is bounded by a total-load cap, not only by recursion depth (CAT-001).
+func TestNextCatalogLoadCountBounded(t *testing.T) {
+	t.Parallel()
+
+	mkEntries := func() []catalog.Entry {
+		n := catalog.MaxNextCatalogs + 10
+		entries := make([]catalog.Entry, 0, n)
+		for i := range n {
+			// Distinct URL per entry so the visited-set dedup never applies.
+			entries = append(entries, catalog.Entry{
+				Type: catalog.EntryNextCatalog,
+				URL:  "next-" + strconv.Itoa(i) + ".xml",
+			})
+		}
+		return entries
+	}
+
+	t.Run("Resolve", func(t *testing.T) {
+		t.Parallel()
+		loader := &totalLoader{}
+		root := &catalog.Catalog{Entries: mkEntries(), Loader: loader}
+		got := root.Resolve(t.Context(), "", "http://example.com/notfound.dtd")
+		require.Equal(t, "", got)
+		require.LessOrEqual(t, int(loader.calls.Load()), catalog.MaxNextCatalogs,
+			"loaded more nextCatalog targets than MaxNextCatalogs")
+	})
+
+	t.Run("ResolveURI", func(t *testing.T) {
+		t.Parallel()
+		loader := &totalLoader{}
+		root := &catalog.Catalog{Entries: mkEntries(), Loader: loader}
+		got := root.ResolveURI(t.Context(), "http://example.com/notfound")
+		require.Equal(t, "", got)
+		require.LessOrEqual(t, int(loader.calls.Load()), catalog.MaxNextCatalogs,
+			"loaded more nextCatalog targets than MaxNextCatalogs")
+	})
+}
+
 // Per the OASIS XML Catalogs spec, matching delegate entries must be tried
 // most-specific-first: the entry with the longest matching start-string is
 // followed before shorter ones. Here the longer prefix points at a catalog


### PR DESCRIPTION
- Bound nextCatalog sibling fan-out with a per-resolution MaxNextCatalogs load cap, mirroring the MaxDelegates cap; previously only recursion depth limited it (CAT-001).
- Add regression test that an oversized unique nextCatalog set loads at most MaxNextCatalogs targets.