### PR TITLE
reject UNC file URIs in local-only path conversion

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -20,7 +20,7 @@ c14n           → helium, internal/lexicon, internal/domutil
 xmldsig1       → helium, c14n, internal/lexicon, internal/domutil
 xmlenc1        → helium, internal/domutil
 html           → helium, sax, push, internal/xmlchar
-catalog        → helium, internal/catalog, internal/lexicon, internal/xmlchar
+catalog        → helium, internal/catalog, internal/iofs, internal/lexicon, internal/xmlchar
 stream         → internal/encoding, internal/xmlchar
 sax            → helium, enum
 helium (root)  → sax, enum, internal/encoding, internal/bitset, internal/parser, push, internal/stack, internal/uripath, internal/iofs

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -264,7 +264,7 @@ OASIS XML Catalog resolution for public/system IDs and URIs.
 - Const `MaxCatalogSize`; sentinel `ErrCatalogTooLarge`
 - Catalog chaining via nextCatalog; URN urn:publicid: support
 - Files: `catalog.go`, `load.go`
-- Imports: helium, internal/catalog/, internal/lexicon/
+- Imports: helium, internal/catalog/, internal/iofs/, internal/lexicon/, internal/xmlchar/
 
 ## stream/
 

--- a/catalog/load.go
+++ b/catalog/load.go
@@ -11,6 +11,7 @@ import (
 
 	helium "github.com/lestrrat-go/helium"
 	icatalog "github.com/lestrrat-go/helium/internal/catalog"
+	"github.com/lestrrat-go/helium/internal/iofs"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/xmlchar"
 )
@@ -190,10 +191,12 @@ func catalogFilePath(ref string) (string, bool, error) {
 	}
 
 	// A "file:////server/share" URI parses to an empty host with a path that
-	// begins with "//"; on Windows fileURIPath would turn that into a UNC path
-	// (\\server\share) reaching a remote SMB host, defeating the local-only
-	// policy. Reject the UNC form outright (matching iofs.FileURIToPath).
-	if strings.HasPrefix(u.Path, "//") {
+	// begins with two separators; on Windows fileURIPath would turn that into a
+	// UNC path (\\server\share) reaching a remote SMB host, defeating the
+	// local-only policy. Reject every UNC form outright (shared with
+	// iofs.FileURIToPath via iofs.IsUNCFileURIPath, which also catches
+	// %5C-decoded backslashes).
+	if iofs.IsUNCFileURIPath(u.Path) {
 		return "", false, fmt.Errorf("catalog: UNC file URI %q is not a local path", ref)
 	}
 

--- a/catalog/load.go
+++ b/catalog/load.go
@@ -189,6 +189,14 @@ func catalogFilePath(ref string) (string, bool, error) {
 		return "", false, fmt.Errorf("catalog: invalid file URI %q: no local path", ref)
 	}
 
+	// A "file:////server/share" URI parses to an empty host with a path that
+	// begins with "//"; on Windows fileURIPath would turn that into a UNC path
+	// (\\server\share) reaching a remote SMB host, defeating the local-only
+	// policy. Reject the UNC form outright (matching iofs.FileURIToPath).
+	if strings.HasPrefix(u.Path, "//") {
+		return "", false, fmt.Errorf("catalog: UNC file URI %q is not a local path", ref)
+	}
+
 	return fileURIPath(u.Path), true, nil
 }
 

--- a/catalog/load_internal_test.go
+++ b/catalog/load_internal_test.go
@@ -150,6 +150,14 @@ func TestCatalogFilePathEmptyPathRejected(t *testing.T) {
 	require.Error(t, err)
 }
 
+// catalogFilePath must reject a "file:////server/share" UNC URI. Its path
+// component begins with "//"; on Windows fileURIPath would produce the UNC path
+// \\server\share reaching a remote SMB host, defeating the local-only policy.
+func TestCatalogFilePathUNCRejected(t *testing.T) {
+	_, _, err := catalogFilePath("file:////server/share/catalog.xml")
+	require.Error(t, err)
+}
+
 // catalogFilePath must keep a POSIX "file:///C:/..." path absolute. The
 // drive-letter slash strip is Windows-only; on POSIX "/C:/tmp/..." is a valid
 // absolute path, so this asserts deterministically on the Linux CI host.

--- a/catalog/load_internal_test.go
+++ b/catalog/load_internal_test.go
@@ -158,6 +158,20 @@ func TestCatalogFilePathUNCRejected(t *testing.T) {
 	require.Error(t, err)
 }
 
+// url.Parse percent-decodes u.Path, so a "%5C"/"%5c" encoded backslash decodes
+// to "/\server/share" which still becomes the UNC path \\server\share on
+// Windows. catalogFilePath must reject these encoded forms too.
+func TestCatalogFilePathEncodedBackslashUNCRejected(t *testing.T) {
+	for _, ref := range []string{
+		"file:///%5Cserver/share/catalog.xml",
+		"file:///%5cserver/share/catalog.xml",
+		"file:///%5C%5Cserver/share/catalog.xml",
+	} {
+		_, _, err := catalogFilePath(ref)
+		require.Error(t, err, ref)
+	}
+}
+
 // catalogFilePath must keep a POSIX "file:///C:/..." path absolute. The
 // drive-letter slash strip is Windows-only; on POSIX "/C:/tmp/..." is a valid
 // absolute path, so this asserts deterministically on the Linux CI host.

--- a/internal/cli/heliumcmd/safety.go
+++ b/internal/cli/heliumcmd/safety.go
@@ -359,10 +359,11 @@ func localFilePath(uri string) (string, error) {
 	}
 
 	// A "file:////server/share" URI parses to an empty host with a path that
-	// begins with "//"; on Windows that path becomes a UNC path (\\server\share)
-	// reaching a remote SMB host, defeating the local-only policy. Reject the UNC
-	// form outright.
-	if strings.HasPrefix(u.Path, "//") {
+	// begins with two separators; on Windows that path becomes a UNC path
+	// (\\server\share) reaching a remote SMB host, defeating the local-only
+	// policy. Reject every UNC form outright (shared with iofs.FileURIToPath via
+	// iofs.IsUNCFileURIPath, which also catches %5C-decoded backslashes).
+	if iofs.IsUNCFileURIPath(u.Path) {
 		return "", fmt.Errorf("unsupported UNC file URI %q: only local files are allowed", uri)
 	}
 

--- a/internal/cli/heliumcmd/safety.go
+++ b/internal/cli/heliumcmd/safety.go
@@ -358,6 +358,14 @@ func localFilePath(uri string) (string, error) {
 		return "", fmt.Errorf("unsupported file URI host %q: only local files are allowed", u.Host)
 	}
 
+	// A "file:////server/share" URI parses to an empty host with a path that
+	// begins with "//"; on Windows that path becomes a UNC path (\\server\share)
+	// reaching a remote SMB host, defeating the local-only policy. Reject the UNC
+	// form outright.
+	if strings.HasPrefix(u.Path, "//") {
+		return "", fmt.Errorf("unsupported UNC file URI %q: only local files are allowed", uri)
+	}
+
 	// u.Path is already percent-decoded by url.Parse.
 	return fileURIPathToLocal(u.Path, filepath.Separator == '\\'), nil
 }

--- a/internal/cli/heliumcmd/safety_internal_test.go
+++ b/internal/cli/heliumcmd/safety_internal_test.go
@@ -69,6 +69,20 @@ func TestLocalFilePath(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "UNC")
 	})
+	// url.Parse percent-decodes u.Path, so a "%5C"/"%5c" encoded backslash
+	// decodes to "/\server/share" which still becomes the UNC path
+	// \\server\share on Windows. These encoded forms must be rejected too.
+	for _, uri := range []string{
+		"file:///%5Cserver/share/mod.xsl",
+		"file:///%5cserver/share/mod.xsl",
+		"file:///%5C%5Cserver/share/mod.xsl",
+	} {
+		t.Run("encoded-backslash UNC rejected: "+uri, func(t *testing.T) {
+			_, err := localFilePath(uri)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "UNC")
+		})
+	}
 	t.Run("file URI drive letter on Windows", func(t *testing.T) {
 		if runtime.GOOS != "windows" {
 			t.Skip("Windows-specific drive-letter handling")

--- a/internal/cli/heliumcmd/safety_internal_test.go
+++ b/internal/cli/heliumcmd/safety_internal_test.go
@@ -60,6 +60,15 @@ func TestLocalFilePath(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "scheme")
 	})
+	// "file:////server/share/x" parses to an empty host with path
+	// "//server/share/x"; on Windows that becomes the UNC path
+	// \\server\share\x, reaching a remote SMB host despite the local-only
+	// policy. It must be rejected on every platform.
+	t.Run("UNC file URI rejected", func(t *testing.T) {
+		_, err := localFilePath("file:////server/share/mod.xsl")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "UNC")
+	})
 	t.Run("file URI drive letter on Windows", func(t *testing.T) {
 		if runtime.GOOS != "windows" {
 			t.Skip("Windows-specific drive-letter handling")

--- a/internal/iofs/iofs.go
+++ b/internal/iofs/iofs.go
@@ -89,14 +89,39 @@ func FileURIToPath(ref string) (string, error) {
 	}
 
 	// A "file:////server/share" URI parses to an empty host with a path that
-	// begins with "//"; on Windows filepath.FromSlash would turn that into a UNC
-	// path (\\server\share) reaching a remote SMB host, defeating the local-only
-	// policy. Reject the UNC form outright.
-	if strings.HasPrefix(u.Path, "//") {
+	// begins with two separators; on Windows filepath.FromSlash would turn that
+	// into a UNC path (\\server\share) reaching a remote SMB host, defeating the
+	// local-only policy. Reject every UNC form outright.
+	if IsUNCFileURIPath(u.Path) {
 		return "", fmt.Errorf("UNC file URI %q is not a local path", ref)
 	}
 
 	return fileURIPathFor(runtime.GOOS, u.Path), nil
+}
+
+// IsUNCFileURIPath reports whether p — the (already percent-decoded) path
+// component of a "file:" URI — denotes a UNC path. A UNC path begins with two
+// path separators ("\\server\share"); on Windows filepath.FromSlash turns such
+// a path into a remote SMB reference, defeating the local-only policy applied by
+// the "file:" URI loaders.
+//
+// url.Parse percent-decodes u.Path, so the two leading separators may appear as
+// any mix of forward slash and backslash: "//" (from "file:////server/share"),
+// "/\" (from "file:///%5Cserver/share", since %5C/%5c decode to a backslash), or
+// "\\" (from doubly-encoded forms). All such forms are detected here so a single
+// encoded backslash cannot smuggle a UNC path past the "//"-only check.
+//
+// This is the single source of truth for the UNC rejection shared by
+// [FileURIToPath], package catalog, and the helium CLI safety helpers.
+func IsUNCFileURIPath(p string) bool {
+	return len(p) >= 2 && isPathSep(p[0]) && isPathSep(p[1])
+}
+
+// isPathSep reports whether c is a path separator in either POSIX ("/") or
+// Windows ("\") form. A decoded "file:" URI path may contain backslashes when
+// the URI percent-encoded them as %5C/%5c.
+func isPathSep(c byte) bool {
+	return c == '/' || c == '\\'
 }
 
 // fileURIPathFor is the OS-parameterized conversion of a "file:" URI path

--- a/internal/iofs/iofs.go
+++ b/internal/iofs/iofs.go
@@ -88,6 +88,14 @@ func FileURIToPath(ref string) (string, error) {
 		return "", fmt.Errorf("invalid file URI %q: no local path", ref)
 	}
 
+	// A "file:////server/share" URI parses to an empty host with a path that
+	// begins with "//"; on Windows filepath.FromSlash would turn that into a UNC
+	// path (\\server\share) reaching a remote SMB host, defeating the local-only
+	// policy. Reject the UNC form outright.
+	if strings.HasPrefix(u.Path, "//") {
+		return "", fmt.Errorf("UNC file URI %q is not a local path", ref)
+	}
+
 	return fileURIPathFor(runtime.GOOS, u.Path), nil
 }
 

--- a/internal/iofs/iofs_test.go
+++ b/internal/iofs/iofs_test.go
@@ -52,4 +52,14 @@ func TestFileURIToPath(t *testing.T) {
 		_, err := iofs.FileURIToPath("http://example.com/inc.xml")
 		require.Error(t, err)
 	})
+
+	// "file:////server/share/x" parses to an empty host with path
+	// "//server/share/x"; on Windows that would become the UNC path
+	// \\server\share\x, reaching a remote SMB host despite the local-only
+	// policy. It must be rejected on every platform.
+	t.Run("UNC file URI rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := iofs.FileURIToPath("file:////server/share/inc.xml")
+		require.Error(t, err)
+	})
 }

--- a/internal/iofs/iofs_test.go
+++ b/internal/iofs/iofs_test.go
@@ -62,4 +62,20 @@ func TestFileURIToPath(t *testing.T) {
 		_, err := iofs.FileURIToPath("file:////server/share/inc.xml")
 		require.Error(t, err)
 	})
+
+	// url.Parse percent-decodes u.Path, so a "%5C"/"%5c" encoded backslash after
+	// the leading slash decodes to "/\server/share"; on Windows filepath.FromSlash
+	// turns that into the UNC path \\server\share. The "//"-only check missed
+	// these, so they must be rejected too.
+	for _, ref := range []string{
+		"file:///%5Cserver/share/inc.xml",
+		"file:///%5cserver/share/inc.xml",
+		"file:///%5C%5Cserver/share/inc.xml",
+	} {
+		t.Run("encoded-backslash UNC rejected: "+ref, func(t *testing.T) {
+			t.Parallel()
+			_, err := iofs.FileURIToPath(ref)
+			require.Error(t, err)
+		})
+	}
 }

--- a/xslt3/functions.go
+++ b/xslt3/functions.go
@@ -737,7 +737,12 @@ func (ec *execContext) resolveDocumentURI(uri string, baseDir string) string {
 		if p, err := iofs.FileURIToPath(cleanURI); err == nil {
 			return uripath.ToSlash(p)
 		}
-		return cleanURI[len("file://"):]
+		// On conversion failure (e.g. a "file:////server/share" UNC URI that
+		// FileURIToPath rejects) do NOT strip the "file://" prefix: that would
+		// yield "//server/share/..." which becomes a UNC path on Windows,
+		// bypassing the local-only policy. Return the original file: URI so a
+		// downstream local-path loader rejects it.
+		return cleanURI
 	}
 	// Decide absoluteness with xsd.URIScheme (RFC 3986), not a "://" substring
 	// check or filepath.IsAbs: an absolute-URI ref may carry a scheme with no

--- a/xslt3/resolve_uri_internal_test.go
+++ b/xslt3/resolve_uri_internal_test.go
@@ -161,6 +161,12 @@ func TestResolveDocumentURIAbsolute(t *testing.T) {
 		// "//server/share/x.xml" and reach a remote SMB host on Windows). The
 		// original file: URI is returned unchanged so a local-path loader rejects it.
 		{"file unc rejected not stripped", "file:////server/share/x.xml", testDocsDir, "file:////server/share/x.xml"},
+		// url.Parse percent-decodes u.Path, so a "%5C"/"%5c" encoded backslash
+		// decodes to "/\server/share" — still a UNC path on Windows. FileURIToPath
+		// rejects it, so the fallback must keep the original file: URI verbatim
+		// rather than stripping "file://" into a bare UNC path.
+		{"file unc encoded backslash not stripped", "file:///%5Cserver/share/x.xml", testDocsDir, "file:///%5Cserver/share/x.xml"},
+		{"file unc encoded backslash lower not stripped", "file:///%5cserver/share/x.xml", testDocsDir, "file:///%5cserver/share/x.xml"},
 		// Windows-shaped local base resolves with forward-slash output on any OS
 		// (a plain string here, so the Windows behavior is exercised on Linux).
 		{"windows base relative ref", testChildXML, `C:\docs`, "C:/docs/child.xml"},

--- a/xslt3/resolve_uri_internal_test.go
+++ b/xslt3/resolve_uri_internal_test.go
@@ -156,6 +156,11 @@ func TestResolveDocumentURIAbsolute(t *testing.T) {
 		// GOOS-dependent via FileURIToPath, so it is not asserted in this
 		// cross-OS table.)
 		{"file triple slash", "file:///abs/x.xml", testDocsDir, "/abs/x.xml"},
+		// A "file:////server/share" UNC URI is rejected by FileURIToPath; the
+		// fallback must NOT strip "file://" (which would yield the UNC path
+		// "//server/share/x.xml" and reach a remote SMB host on Windows). The
+		// original file: URI is returned unchanged so a local-path loader rejects it.
+		{"file unc rejected not stripped", "file:////server/share/x.xml", testDocsDir, "file:////server/share/x.xml"},
 		// Windows-shaped local base resolves with forward-slash output on any OS
 		// (a plain string here, so the Windows behavior is exercised on Linux).
 		{"windows base relative ref", testChildXML, `C:\docs`, "C:/docs/child.xml"},


### PR DESCRIPTION
- file:////server/share parses to empty host + path //... which became a UNC remote path on Windows, bypassing the local-only policy
- FileURIToPath and localFilePath now reject empty-host file: URIs whose path begins with //