### PR TITLE
fix xpath3 streamability EQName fn matching

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -38,7 +38,7 @@ internal/uripath → (none)
 internal/xsdregex → (none)
 internal/xsd/value → internal/lexicon
 internal/domutil → helium, internal/lexicon, internal/xmlchar
-internal/xpathstream → xpath3
+internal/xpathstream → xpath3, internal/lexicon
 test           → helium
 ```
 

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -398,7 +398,8 @@ Shared spec vocabulary strings reused across packages.
 - XML vocabulary: common prefixes + attribute/value names such as `xml:base`
 - Catalog vocabulary: OASIS catalog element names, attribute names, `prefer` values
 - XSLT vocabulary: `XSLTElement*` constants for all XSLT element local names
-- Files: `ns.go`, `xml.go`, `catalog.go`, `xslt.go`
+- Streamability helpers: `IsFnNamespacePrefix`, `StreamFnLocalName` (shared by xpath3/xslt3/xpathstream; normalizes EQName `Q{...}local` fn calls)
+- Files: `ns.go`, `xml.go`, `catalog.go`, `xslt.go`, `fn.go`
 - Imports: none
 
 - **Load(name) → encoding.Encoding** — lookup by normalized name

--- a/internal/lexicon/fn.go
+++ b/internal/lexicon/fn.go
@@ -1,0 +1,45 @@
+package lexicon
+
+import "strings"
+
+// IsFnNamespacePrefix reports whether a function-call prefix names the XPath
+// functions namespace (http://www.w3.org/2005/xpath-functions) for the purpose
+// of streamability analysis. For function calls an empty prefix defaults to that
+// namespace, and "fn" is the conventional reserved prefix bound to it, so both
+// lexical forms name the same built-in. Streamability special-cases functions
+// such as position()/last() by (namespace, local-name) and must therefore treat
+// the unprefixed and "fn:"-prefixed spellings identically.
+//
+// This is a deliberately lexical check, not a namespace-resolved one: the
+// analysis runs over the static AST with no access to a prefix->URI map (the map
+// only exists at eval time, via the xpath3 evaluator's namespace bindings). We
+// make the same assumption the xpath3 evaluator's own static-shape recognition
+// already makes (eval_path.go positionCall: Prefix == "" || Prefix == "fn").
+// Edge case: a caller that rebinds "fn" to a custom namespace and then calls
+// fn:position() would have it resolve to a user function at eval time while
+// streamability still treats it as the built-in. Rebinding the reserved "fn"
+// prefix is pathological and unsupported here; consistency with the evaluator is
+// preferred.
+func IsFnNamespacePrefix(prefix string) bool {
+	return prefix == "" || prefix == "fn"
+}
+
+// StreamFnLocalName resolves a function call's lexical (name, prefix) to its
+// local name for streamability analysis, reporting whether the call names the
+// XPath functions namespace.
+//
+// The parser keeps an EQName function call's whole braced spelling in the name
+// (e.g. "Q{http://www.w3.org/2005/xpath-functions}position"), so a bare lexical
+// comparison against "position"/"last" would miss it. This normalizes that form
+// to its local part when the braced URI is the functions namespace. For the
+// lexical (unprefixed or "fn:") forms it defers to IsFnNamespacePrefix and
+// returns name unchanged.
+func StreamFnLocalName(name, prefix string) (string, bool) {
+	if strings.HasPrefix(name, "Q{") {
+		if idx := strings.Index(name, "}"); idx >= 0 {
+			return name[idx+1:], name[2:idx] == NamespaceFn
+		}
+		return name, false
+	}
+	return name, IsFnNamespacePrefix(prefix)
+}

--- a/internal/xpathstream/xpathstream.go
+++ b/internal/xpathstream/xpathstream.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"slices"
 
+	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/xpath3"
 )
 
@@ -336,29 +337,6 @@ func PredicateIsNonMotionlessWithStep(pred xpath3.Expr, step *xpath3.Step) bool 
 	return predicateIsNonMotionlessWithStep(pred, step)
 }
 
-// isFnNamespacePrefix reports whether a FunctionCall prefix names the XPath
-// functions namespace (http://www.w3.org/2005/xpath-functions) for the purpose
-// of streamability analysis. For function calls an empty prefix defaults to
-// that namespace, and "fn" is the conventional reserved prefix bound to it, so
-// both lexical forms name the same built-in. Streamability special-cases
-// functions such as position()/last() by (namespace, local-name) and must
-// therefore treat the unprefixed and "fn:"-prefixed spellings identically.
-//
-// This is a deliberately lexical check, not a namespace-resolved one: this
-// analysis runs over the static AST with no access to a prefix->URI map (the map
-// only exists at eval time, via the xpath3 evaluator's namespace bindings).
-// Resolving "fn" properly would mean threading that map through every xslt3
-// streamability caller. We make the same assumption the xpath3 evaluator's own
-// static-shape recognition already makes (eval_path.go positionCall:
-// Prefix == "" || Prefix == "fn"), keeping the two consistent. Edge case: a
-// caller that rebinds "fn" to a custom namespace and then calls fn:position()
-// would have it resolve to a user function at eval time while streamability still
-// treats it as the built-in. Rebinding the reserved "fn" prefix is pathological
-// and unsupported here; consistency with eval_path.go is preferred.
-func isFnNamespacePrefix(prefix string) bool {
-	return prefix == "" || prefix == "fn"
-}
-
 func predicateIsNonMotionlessWithStep(pred xpath3.Expr, step *xpath3.Step) bool {
 	nonMotionless := false
 	WalkExpr(pred, func(e xpath3.Expr) bool {
@@ -380,12 +358,13 @@ func predicateIsNonMotionlessWithStep(pred xpath3.Expr, step *xpath3.Step) bool 
 				return false
 			}
 		case xpath3.FunctionCall:
-			if isFnNamespacePrefix(v.Prefix) && (v.Name == "last" || v.Name == "position") {
+			local, isFn := lexicon.StreamFnLocalName(v.Name, v.Prefix)
+			if isFn && (local == "last" || local == "position") {
 				nonMotionless = true
 				return false
 			}
-			if isFnNamespacePrefix(v.Prefix) {
-				switch v.Name {
+			if isFn {
+				switch local {
 				case "name", "local-name", "namespace-uri", "node-name",
 					"self", "generate-id", "base-uri", "document-uri",
 					"nilled", "has-children", "string-length", "current":

--- a/internal/xpathstream/xpathstream_test.go
+++ b/internal/xpathstream/xpathstream_test.go
@@ -8,33 +8,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPrefixedFnStreamability verifies that fn:-prefixed calls to the
-// special-cased XPath functions (position, last, ...) are analyzed for
-// streamability identically to their unprefixed forms.
+// fnNS is the XPath functions namespace, used to build EQName spellings.
+const fnNS = "http://www.w3.org/2005/xpath-functions"
+
+// TestPrefixedFnStreamability verifies that fn:-prefixed and EQName-spelled
+// (Q{...}local) calls to the special-cased XPath functions (position, last, ...)
+// are analyzed for streamability identically to their unprefixed forms.
 func TestPrefixedFnStreamability(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
 		uneprefix string
-		prefixed  string
+		other     string
 	}{
-		{name: "position", uneprefix: "a[position() = 1]", prefixed: "a[fn:position() = 1]"},
-		{name: "last", uneprefix: "a[last()]", prefixed: "a[fn:last()]"},
+		{name: "position fn-prefix", uneprefix: "a[position() = 1]", other: "a[fn:position() = 1]"},
+		{name: "last fn-prefix", uneprefix: "a[last()]", other: "a[fn:last()]"},
+		{name: "position eqname", uneprefix: "a[position() = 1]", other: "a[Q{" + fnNS + "}position() = 1]"},
+		{name: "last eqname", uneprefix: "a[last()]", other: "a[Q{" + fnNS + "}last()]"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			plain, err := xpath3.NewCompiler().Compile(tc.uneprefix)
 			require.NoError(t, err, "compile unprefixed")
-			pref, err := xpath3.NewCompiler().Compile(tc.prefixed)
-			require.NoError(t, err, "compile fn-prefixed")
+			other, err := xpath3.NewCompiler().Compile(tc.other)
+			require.NoError(t, err, "compile alternate spelling")
+
+			// Sanity: the unprefixed predicate is non-motionless, so the
+			// equality assertion below is meaningful.
+			require.True(t, xpathstream.ExprTreeHasNonMotionlessPredicate(plain.AST()),
+				"unprefixed %q must be non-motionless", tc.uneprefix)
 
 			require.Equal(t,
 				xpathstream.ExprTreeHasNonMotionlessPredicate(plain.AST()),
-				xpathstream.ExprTreeHasNonMotionlessPredicate(pref.AST()),
-				"non-motionless classification must match for %q vs %q", tc.uneprefix, tc.prefixed)
-
-			require.Equal(t,
-				xpathstream.ExprUsesFunction(plain, tc.name),
-				xpathstream.ExprUsesFunction(pref, tc.name),
-				"ExprUsesFunction must match for %q vs %q", tc.uneprefix, tc.prefixed)
+				xpathstream.ExprTreeHasNonMotionlessPredicate(other.AST()),
+				"non-motionless classification must match for %q vs %q", tc.uneprefix, tc.other)
 		})
 	}
 }

--- a/xpath3/eval_operators.go
+++ b/xpath3/eval_operators.go
@@ -503,10 +503,13 @@ func filterPreservesOrder(e Expr) bool {
 	if !ok {
 		return false
 	}
-	if fc.Prefix != "" {
+	// Normalize the lexical (unprefixed/fn:) and EQName Q{uri}local spellings
+	// to a local name in the XPath functions namespace before matching.
+	local, isFn := lexicon.StreamFnLocalName(fc.Name, fc.Prefix)
+	if !isFn {
 		return false
 	}
-	return fc.Name == "reverse" || fc.Name == "sort"
+	return local == "reverse" || local == "sort"
 }
 
 // evalPathStepExpr evaluates E1/E2 where E2 is a non-axis expression.

--- a/xpath3/eval_operators.go
+++ b/xpath3/eval_operators.go
@@ -440,7 +440,7 @@ func evalPathExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContext, e 
 	// However, when the filter is an ordering function (reverse, sort),
 	// preserve the explicit ordering and only deduplicate.
 	var deduped []helium.Node
-	if filterPreservesOrder(e.Filter) {
+	if filterPreservesOrder(ctx, ec, e.Filter) {
 		deduped, err = ixpath.DeduplicateNodesPreserveOrder(result, ec.maxNodes)
 	} else {
 		deduped, err = ixpath.DeduplicateNodes(result, ec.docOrder, ec.maxNodes)
@@ -479,7 +479,7 @@ func evalVMPathExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContext, 
 		result = append(result, subNodes...)
 	}
 	var deduped []helium.Node
-	if e.PreserveOrder {
+	if filterPreservesOrder(ctx, ec, e.OrderFilter) {
 		deduped, err = ixpath.DeduplicateNodesPreserveOrder(result, ec.maxNodes)
 	} else {
 		deduped, err = ixpath.DeduplicateNodes(result, ec.docOrder, ec.maxNodes)
@@ -494,22 +494,28 @@ func evalVMPathExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContext, 
 	return seq, nil
 }
 
-// filterPreservesOrder returns true if the filter expression is a function
-// call that explicitly controls sequence order (reverse, sort). In these
-// cases, a subsequent path step (/@attr) should preserve the caller's
+// filterPreservesOrder returns true if the filter expression is a call to the
+// built-in fn:reverse or fn:sort, which explicitly control sequence order. In
+// these cases, a subsequent path step (/@attr) should preserve the caller's
 // ordering rather than re-sorting into document order.
-func filterPreservesOrder(e Expr) bool {
+//
+// The decision is made against the runtime function resolver so that a rebound
+// "fn" prefix or a user function overriding the built-in is not mistaken for
+// the order-controlling built-in. (Do not use the lexical streamability helper
+// StreamFnLocalName here — that is a static spelling check, not a binding.)
+func filterPreservesOrder(ctx context.Context, ec *evalContext, e Expr) bool {
 	fc, ok := e.(FunctionCall)
 	if !ok {
 		return false
 	}
-	// Normalize the lexical (unprefixed/fn:) and EQName Q{uri}local spellings
-	// to a local name in the XPath functions namespace before matching.
-	local, isFn := lexicon.StreamFnLocalName(fc.Name, fc.Prefix)
-	if !isFn {
+	r, err := resolveFunctionInfo(ctx, ec, fc.Prefix, fc.Name, len(fc.Args))
+	if err != nil {
 		return false
 	}
-	return local == "reverse" || local == "sort"
+	if !r.isBuiltin || r.uri != NSFn {
+		return false
+	}
+	return r.name == "reverse" || r.name == "sort"
 }
 
 // evalPathStepExpr evaluates E1/E2 where E2 is a non-axis expression.
@@ -558,7 +564,7 @@ func evalPathStepExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContext
 	}
 
 	if hasNodes {
-		if filterPreservesOrder(e.Left) {
+		if filterPreservesOrder(ctx, ec, e.Left) {
 			allNodes, err = ixpath.DeduplicateNodesPreserveOrder(allNodes, ec.maxNodes)
 		} else {
 			allNodes, err = ixpath.DeduplicateNodes(allNodes, ec.docOrder, ec.maxNodes)

--- a/xpath3/eval_path.go
+++ b/xpath3/eval_path.go
@@ -978,12 +978,14 @@ func vmPositionFromLiteral(expr LiteralExpr) (int, bool) {
 func positionCall(expr Expr) bool {
 	switch e := expr.(type) {
 	case FunctionCall:
-		return len(e.Args) == 0 && e.Name == "position" && (e.Prefix == "" || e.Prefix == "fn")
+		local, isFn := lexicon.StreamFnLocalName(e.Name, e.Prefix)
+		return len(e.Args) == 0 && isFn && local == "position"
 	case *FunctionCall:
 		if e == nil {
 			return false
 		}
-		return len(e.Args) == 0 && e.Name == "position" && (e.Prefix == "" || e.Prefix == "fn")
+		local, isFn := lexicon.StreamFnLocalName(e.Name, e.Prefix)
+		return len(e.Args) == 0 && isFn && local == "position"
 	default:
 		return false
 	}

--- a/xpath3/eval_path_order_test.go
+++ b/xpath3/eval_path_order_test.go
@@ -1,0 +1,65 @@
+package xpath3_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// customReverseFn returns its node-sequence argument in reverse order. It stands
+// in for a user function that shadows fn:reverse when the "fn" prefix is rebound.
+type customReverseFn struct{}
+
+func (customReverseFn) MinArity() int { return 1 }
+func (customReverseFn) MaxArity() int { return 1 }
+
+func (customReverseFn) Call(_ context.Context, args []xpath3.Sequence) (xpath3.Sequence, error) {
+	nodes, _ := xpath3.NodesFrom(args[0])
+	out := make(xpath3.ItemSlice, 0, len(nodes))
+	for _, n := range slices.Backward(nodes) {
+		out = append(out, xpath3.NodeItem{Node: n})
+	}
+	return out, nil
+}
+
+// TestFilterPreservesOrderRuntimeBinding guards against treating a path filter
+// as the order-controlling built-in fn:reverse/fn:sort based on its lexical
+// spelling. The order-preservation decision must consult the runtime function
+// binding: when the "fn" prefix is rebound (or a user function overrides the
+// built-in), normal document-order deduplication must apply to the path result.
+func TestFilterPreservesOrderRuntimeBinding(t *testing.T) {
+	doc := mustParseXML(t, `<root><item id="a"/><item id="b"/><item id="c"/></root>`)
+
+	ids := func(seq xpath3.Sequence) []string {
+		t.Helper()
+		nodes, ok := xpath3.NodesFrom(seq)
+		require.True(t, ok)
+		out := make([]string, 0, len(nodes))
+		for _, n := range nodes {
+			el, ok := n.(*helium.Element)
+			require.True(t, ok)
+			v, _ := el.GetAttribute("id")
+			out = append(out, v)
+		}
+		return out
+	}
+
+	t.Run("genuine fn:reverse preserves caller order", func(t *testing.T) {
+		seq := evalExpr(t, doc, `fn:reverse(//item)/self::item`)
+		require.Equal(t, []string{"c", "b", "a"}, ids(seq))
+	})
+
+	t.Run("rebound fn prefix with user reverse uses document order", func(t *testing.T) {
+		eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+			Namespaces(map[string]string{"fn": "urn:custom"}).
+			Functions(nil, map[xpath3.QualifiedName]xpath3.Function{
+				{URI: "urn:custom", Name: "reverse"}: customReverseFn{},
+			})
+		seq := evalExprWithEval(t, eval, doc, `fn:reverse(//item)/self::item`)
+		require.Equal(t, []string{"a", "b", "c"}, ids(seq))
+	})
+}

--- a/xpath3/streamability.go
+++ b/xpath3/streamability.go
@@ -2,6 +2,7 @@ package xpath3
 
 import (
 	"math/big"
+	"strings"
 
 	"github.com/lestrrat-go/helium/internal/lexicon"
 )
@@ -73,8 +74,8 @@ func computeStreamInfo(ast Expr) streamInfo {
 				}
 			}
 		case FunctionCall:
-			if isFnNamespacePrefix(v.Prefix) {
-				si.usedFunctions[v.Name] = true
+			if local, ok := streamFnLocalName(v); ok {
+				si.usedFunctions[local] = true
 			}
 		}
 		return true
@@ -303,6 +304,27 @@ func isFnNamespacePrefix(prefix string) bool {
 	return prefix == "" || prefix == "fn"
 }
 
+// streamFnLocalName resolves a FunctionCall to its local name for streamability
+// purposes, reporting whether the call names the XPath functions namespace.
+//
+// The parser keeps an EQName function call's whole braced spelling in
+// FunctionCall.Name (e.g. "Q{http://www.w3.org/2005/xpath-functions}position"),
+// so a bare lexical-name comparison against "position"/"last" would miss it.
+// This normalizes that form to its local part when the braced URI is the
+// functions namespace. For the lexical (unprefixed or "fn:") forms it defers to
+// isFnNamespacePrefix and returns Name unchanged.
+func streamFnLocalName(fc FunctionCall) (string, bool) {
+	if strings.HasPrefix(fc.Name, "Q{") {
+		if idx := strings.Index(fc.Name, "}"); idx >= 0 {
+			uri := fc.Name[2:idx]
+			local := fc.Name[idx+1:]
+			return local, uri == lexicon.NamespaceFn
+		}
+		return fc.Name, false
+	}
+	return fc.Name, isFnNamespacePrefix(fc.Prefix)
+}
+
 // predicateIsNonMotionless returns true if a predicate expression navigates
 // downward (uses child/descendant axes), uses last(), or uses position() in
 // a non-trivial way.
@@ -339,12 +361,13 @@ func predicateIsNonMotionlessWithStep(pred Expr, step *Step) bool {
 				return false
 			}
 		case FunctionCall:
-			if isFnNamespacePrefix(v.Prefix) && (v.Name == "last" || v.Name == lexicon.FnPosition) {
+			local, isFn := streamFnLocalName(v)
+			if isFn && (local == "last" || local == lexicon.FnPosition) {
 				nonMotionless = true
 				return false
 			}
-			if isFnNamespacePrefix(v.Prefix) {
-				switch v.Name {
+			if isFn {
+				switch local {
 				case "name", "local-name", "namespace-uri", "node-name",
 					"self", "generate-id", "base-uri", "document-uri",
 					"nilled", "has-children", "string-length", "current":

--- a/xpath3/streamability.go
+++ b/xpath3/streamability.go
@@ -2,7 +2,6 @@ package xpath3
 
 import (
 	"math/big"
-	"strings"
 
 	"github.com/lestrrat-go/helium/internal/lexicon"
 )
@@ -281,48 +280,11 @@ func walkChildren(expr Expr, fn func(Expr) bool) {
 	}
 }
 
-// isFnNamespacePrefix reports whether a FunctionCall prefix names the XPath
-// functions namespace (http://www.w3.org/2005/xpath-functions) for the purpose
-// of streamability analysis. For function calls an empty prefix defaults to
-// that namespace, and "fn" is the conventional reserved prefix bound to it, so
-// both lexical forms name the same built-in. Streamability special-cases
-// functions such as position()/last() by (namespace, local-name) and must
-// therefore treat the unprefixed and "fn:"-prefixed spellings identically.
-//
-// This is a deliberately lexical check, not a namespace-resolved one: streamability
-// is computed at compile time (computeStreamInfo runs inside the VM compile pass)
-// before any static namespace context is bound — the prefix->URI map only arrives
-// at eval time via evalContext.namespaces. Resolving "fn" properly here would mean
-// threading that map through the whole compile path and every xslt3 caller. We make
-// the same assumption the evaluator's own static-shape recognition already makes
-// (see eval_path.go positionCall: Prefix == "" || Prefix == "fn"), keeping the two
-// consistent. Edge case: a caller that rebinds "fn" to a custom namespace and then
-// calls fn:position() would have it resolve to a user function at eval time while
-// streamability still treats it as the built-in. Rebinding the reserved "fn" prefix
-// is pathological and unsupported here; consistency with eval_path.go is preferred.
-func isFnNamespacePrefix(prefix string) bool {
-	return prefix == "" || prefix == "fn"
-}
-
-// streamFnLocalName resolves a FunctionCall to its local name for streamability
-// purposes, reporting whether the call names the XPath functions namespace.
-//
-// The parser keeps an EQName function call's whole braced spelling in
-// FunctionCall.Name (e.g. "Q{http://www.w3.org/2005/xpath-functions}position"),
-// so a bare lexical-name comparison against "position"/"last" would miss it.
-// This normalizes that form to its local part when the braced URI is the
-// functions namespace. For the lexical (unprefixed or "fn:") forms it defers to
-// isFnNamespacePrefix and returns Name unchanged.
+// streamFnLocalName resolves a FunctionCall to its streamability local name via
+// the shared lexicon.StreamFnLocalName helper, normalizing the EQName
+// (Q{...}local) spelling the parser keeps in FunctionCall.Name.
 func streamFnLocalName(fc FunctionCall) (string, bool) {
-	if strings.HasPrefix(fc.Name, "Q{") {
-		if idx := strings.Index(fc.Name, "}"); idx >= 0 {
-			uri := fc.Name[2:idx]
-			local := fc.Name[idx+1:]
-			return local, uri == lexicon.NamespaceFn
-		}
-		return fc.Name, false
-	}
-	return fc.Name, isFnNamespacePrefix(fc.Prefix)
+	return lexicon.StreamFnLocalName(fc.Name, fc.Prefix)
 }
 
 // predicateIsNonMotionless returns true if a predicate expression navigates

--- a/xpath3/vm.go
+++ b/xpath3/vm.go
@@ -83,9 +83,14 @@ type vmLocationPathExpr struct {
 func (vmLocationPathExpr) exprNode() {}
 
 type vmPathExpr struct {
-	Filter        Expr
-	Path          *vmLocationPathExpr
-	PreserveOrder bool // true when filter is reverse()/sort() — skip doc-order sort
+	Filter Expr
+	Path   *vmLocationPathExpr
+	// OrderFilter holds the original (un-lowered) filter expression so the
+	// order-preservation decision can be made at runtime against the actual
+	// function binding. The lowered Filter becomes an opaque compiledExprRef
+	// that cannot be inspected, so the un-lowered call is retained here for
+	// filterPreservesOrder. Nil when the filter is not a function call.
+	OrderFilter Expr
 }
 
 func (vmPathExpr) exprNode() {}
@@ -591,7 +596,18 @@ func (b *vmBuilder) lowerPathExpr(expr PathExpr) (Expr, error) {
 		}
 		path = &lp
 	}
-	return vmPathExpr{Filter: filter, Path: path, PreserveOrder: filterPreservesOrder(expr.Filter)}, nil
+	return vmPathExpr{Filter: filter, Path: path, OrderFilter: orderFilterFrom(expr.Filter)}, nil
+}
+
+// orderFilterFrom returns the filter expression to retain for runtime
+// order-preservation resolution: the un-lowered function call when the filter is
+// one, otherwise nil. Keeping only function calls avoids holding unrelated
+// subtrees alive.
+func orderFilterFrom(filter Expr) Expr {
+	if _, ok := filter.(FunctionCall); ok {
+		return filter
+	}
+	return nil
 }
 
 func (b *vmBuilder) lowerVMPathExpr(expr vmPathExpr) (Expr, error) {
@@ -611,7 +627,7 @@ func (b *vmBuilder) lowerVMPathExpr(expr vmPathExpr) (Expr, error) {
 		}
 		path = &lp
 	}
-	return vmPathExpr{Filter: filter, Path: path, PreserveOrder: expr.PreserveOrder}, nil
+	return vmPathExpr{Filter: filter, Path: path, OrderFilter: expr.OrderFilter}, nil
 }
 
 func (b *vmBuilder) lowerPathStepExpr(expr PathStepExpr) (Expr, error) {

--- a/xpath3/xpath3_test.go
+++ b/xpath3/xpath3_test.go
@@ -1748,3 +1748,25 @@ func TestExpression_AST_StreamInfo(t *testing.T) {
 	var nilExpr *xpath3.Expression
 	require.Equal(t, xpath3.StreamInfo{}, nilExpr.StreamInfo())
 }
+
+// An EQName-spelled fn:position()/fn:last() in a predicate must classify the
+// same as the unprefixed spelling for streamability (HasNonMotionlessPred) and
+// must be recorded in UsedFunctions under its local name.
+func TestExpression_StreamInfo_EQNameFunction(t *testing.T) {
+	const fnNS = "http://www.w3.org/2005/xpath-functions"
+
+	for _, fn := range []string{"position", "last"} {
+		plain, err := xpath3.NewCompiler().Compile(`a[` + fn + `()=1]`)
+		require.NoError(t, err)
+		eqname, err := xpath3.NewCompiler().Compile(`a[Q{` + fnNS + `}` + fn + `()=1]`)
+		require.NoError(t, err)
+
+		require.True(t, plain.StreamInfo().HasNonMotionlessPred,
+			"plain %s() predicate must be non-motionless", fn)
+		require.Equal(t, plain.StreamInfo().HasNonMotionlessPred,
+			eqname.StreamInfo().HasNonMotionlessPred,
+			"EQName Q{...}%s() must classify same as plain %s()", fn, fn)
+		require.True(t, eqname.StreamInfo().UsedFunctions[fn],
+			"EQName Q{...}%s() must be recorded under local name %q", fn, fn)
+	}
+}

--- a/xslt3/compile_patterns.go
+++ b/xslt3/compile_patterns.go
@@ -197,7 +197,7 @@ func validatePatternExprInner(expr xpath3.Expr, _ bool, nsBindings map[string]st
 		// FilterExpr: a primary expression with predicates.
 		// XSLT 3.0 allows various filter patterns:
 		//   .[pred], (/)[pred], $var[pred], (union)[pred], etc.
-		switch e.Expr.(type) {
+		switch fexpr := e.Expr.(type) {
 		case xpath3.ContextItemExpr:
 			return nil // .[pred]
 		case xpath3.RootExpr:
@@ -209,7 +209,16 @@ func validatePatternExprInner(expr xpath3.Expr, _ bool, nsBindings map[string]st
 		case xpath3.IntersectExceptExpr:
 			return nil // (a except b)[pred]
 		case xpath3.FunctionCall:
-			return nil // fn()[pred] — e.g., root()[self::A]
+			// fn()[pred] — e.g., root()[self::A]. Only the fn-namespace
+			// pattern-start functions (key/id/idref/doc/element-with-id/root)
+			// qualify; a custom-namespace call like c:key('x')[true()] or
+			// Q{urn:custom}key('x')[true()] must be rejected, mirroring the
+			// bare-FunctionCall and path-start checks routed through
+			// isAllowedPatternFunction.
+			if isAllowedPatternFunction(fexpr, nsBindings) {
+				return nil
+			}
+			return fmt.Errorf("function call %s() not allowed in pattern", fexpr.Name)
 		case xpath3.LocationPath:
 			return nil // (path)[pred]
 		case *xpath3.LocationPath:
@@ -336,6 +345,18 @@ func validatePatternPathStepExpr(e xpath3.PathStepExpr, nsBindings map[string]st
 		// variable references are allowed in XSLT 3.0 patterns
 	case xpath3.FunctionCall:
 		return fmt.Errorf("function call %s() not allowed in middle of pattern", r.Name)
+	case xpath3.FilterExpr:
+		// A filtered primary as a non-leading step, e.g. a/key('x')[pred] or
+		// a/c:key('x')[pred]. Pattern-start functions may appear only at the
+		// START of a pattern, so a function-call primary here is rejected just
+		// like the bare mid-pattern function call above — otherwise the
+		// predicate wrapper would smuggle a forbidden/custom function past the
+		// isAllowedPatternFunction gate. Other filtered primaries (a
+		// parenthesized union/path with a predicate such as a/(b|c)[1]) remain
+		// valid and need no further checking here.
+		if fc, ok := r.Expr.(xpath3.FunctionCall); ok {
+			return fmt.Errorf("function call %s() not allowed in middle of pattern", fc.Name)
+		}
 	case xpath3.ArrayConstructorExpr:
 		return fmt.Errorf("array constructor not allowed in pattern")
 	}

--- a/xslt3/compile_patterns.go
+++ b/xslt3/compile_patterns.go
@@ -368,7 +368,10 @@ func isValidPatternStep(expr xpath3.Expr) bool {
 // start of a path pattern. In XSLT 3.0, key(), id(), and doc() are allowed
 // with literal arguments.
 func isAllowedPatternFunction(fc xpath3.FunctionCall) bool {
-	switch fc.Name {
+	// Normalize the EQName spelling Q{uri}local to its local part so the
+	// braced form Q{...}key() is recognized identically to key()/fn:key().
+	local, _ := lexicon.StreamFnLocalName(fc.Name, fc.Prefix)
+	switch local {
 	case "key", "id", "idref", "doc", "element-with-id", "root":
 		// Check that all arguments are literals or variable refs
 		for _, arg := range fc.Args {
@@ -432,6 +435,21 @@ func resolvePatternFunctionNamespace(prefix string, nsBindings map[string]string
 	return ""
 }
 
+// patternFunctionIdentity resolves a function call's (namespace URI, local name)
+// for pattern validation. The xpath3 parser keeps an EQName function call's whole
+// braced spelling in fc.Name (e.g. "Q{http://www.w3.org/2005/xpath-functions}current-group"),
+// so the braced URI must be read directly from the name rather than resolved
+// through fc.Prefix. For the lexical (unprefixed or prefixed) form it falls back
+// to resolvePatternFunctionNamespace so explicit xmlns overrides are honored.
+func patternFunctionIdentity(fc xpath3.FunctionCall, nsBindings map[string]string) (uri, local string) {
+	if strings.HasPrefix(fc.Name, "Q{") {
+		if idx := strings.IndexByte(fc.Name, '}'); idx >= 0 {
+			return fc.Name[2:idx], fc.Name[idx+1:]
+		}
+	}
+	return resolvePatternFunctionNamespace(fc.Prefix, nsBindings), fc.Name
+}
+
 // validatePatternFunctions checks that all function calls in a pattern
 // reference known functions (built-in XPath or declared xsl:function).
 // Unknown functions like f:special() raise XPST0017 at compile time.
@@ -446,13 +464,14 @@ func (c *compiler) validatePatternFunctions(_ context.Context, p *pattern, sourc
 			if !ok {
 				return true
 			}
-			local := fc.Name
 			// An unprefixed function call names the XPath functions namespace,
-			// the same as the prefixed path. Resolve it explicitly so it gets
-			// the identical existence/arity validation below — a nonexistent
-			// no-such-function() or a wrong-arity key() must be rejected, not
-			// silently allowed.
-			nsURI := resolvePatternFunctionNamespace(fc.Prefix, p.nsBindings)
+			// the same as the prefixed path. Resolve identity (URI + local)
+			// explicitly so it gets the identical existence/arity validation
+			// below — a nonexistent no-such-function() or a wrong-arity key()
+			// must be rejected, not silently allowed. patternFunctionIdentity
+			// also normalizes the EQName spelling Q{uri}local so it is matched
+			// against the same registries as the lexical form.
+			nsURI, local := patternFunctionIdentity(fc, p.nsBindings)
 			displayName := local
 			if fc.Prefix != "" {
 				displayName = fc.Prefix + ":" + local
@@ -518,14 +537,17 @@ func checkPatternForbiddenFunctions(ast xpath3.Expr, nsBindings map[string]strin
 			return true
 		}
 		// The forbidden list applies only to the XSLT/XPath functions
-		// namespace. Resolve the prefix the same way function existence is
-		// resolved (explicit bindings first, predeclared as fallback) so an
-		// explicit xmlns:fn override pointing at a custom namespace makes
-		// fn:current-group() a user function, not the forbidden builtin.
-		if resolvePatternFunctionNamespace(fc.Prefix, nsBindings) != lexicon.NamespaceFn {
+		// namespace. Resolve identity the same way function existence is
+		// resolved (braced EQName URI first, then explicit bindings, then
+		// predeclared as fallback) so an explicit xmlns:fn override pointing
+		// at a custom namespace makes fn:current-group() a user function, not
+		// the forbidden builtin, and the EQName spelling
+		// Q{http://www.w3.org/2005/xpath-functions}current-group() is caught.
+		uri, local := patternFunctionIdentity(fc, nsBindings)
+		if uri != lexicon.NamespaceFn {
 			return true
 		}
-		switch fc.Name {
+		switch local {
 		case "current-merge-key":
 			walkErr = staticError(errCodeXTSE3500, "current-merge-key() must not be used within a pattern")
 			return false

--- a/xslt3/compile_patterns.go
+++ b/xslt3/compile_patterns.go
@@ -110,7 +110,7 @@ func compilePattern(s string, elem *helium.Element, xpathDefaultNS string, hasXP
 				}
 			}
 		}
-		if err := validatePatternExpr(ast); err != nil {
+		if err := validatePatternExpr(ast, nsBindings); err != nil {
 			return nil, staticError(errCodeXTSE0340, "invalid match pattern %q: %s", alt, err)
 		}
 		// XTSE3500: current-merge-key() must not be used within a pattern.
@@ -178,11 +178,11 @@ func patternValidateNamespaces(nsBindings map[string]string, xpathDefaultNS stri
 // XSLT match pattern. XSLT patterns are a restricted subset of XPath —
 // certain constructs like variable references, arbitrary function calls,
 // and parenthesized union expressions are not allowed.
-func validatePatternExpr(expr xpath3.Expr) error {
-	return validatePatternExprInner(expr, true)
+func validatePatternExpr(expr xpath3.Expr, nsBindings map[string]string) error {
+	return validatePatternExprInner(expr, true, nsBindings)
 }
 
-func validatePatternExprInner(expr xpath3.Expr, _ bool) error {
+func validatePatternExprInner(expr xpath3.Expr, _ bool, nsBindings map[string]string) error {
 	switch e := expr.(type) {
 	case xpath3.LocationPath, *xpath3.LocationPath:
 		// LocationPath patterns are valid (e.g., a/b/c, //x, /)
@@ -222,16 +222,16 @@ func validatePatternExprInner(expr xpath3.Expr, _ bool) error {
 		return fmt.Errorf("filter expression not allowed in pattern")
 	case xpath3.PathExpr:
 		// PathExpr: filter/step. Check the filter part is valid.
-		return validatePatternPathExpr(e)
+		return validatePatternPathExpr(e, nsBindings)
 	case xpath3.PathStepExpr:
 		// E1/E2 or E1//E2 where E2 is a non-axis expression
-		return validatePatternPathStepExpr(e)
+		return validatePatternPathStepExpr(e, nsBindings)
 	case xpath3.VariableExpr:
 		// variable references are allowed in XSLT 3.0 patterns
 		return nil
 	case xpath3.FunctionCall:
 		// Function calls: key(), id(), doc() with literal args are allowed
-		if isAllowedPatternFunction(e) {
+		if isAllowedPatternFunction(e, nsBindings) {
 			return nil
 		}
 		return fmt.Errorf("function call %s() not allowed in pattern", e.Name)
@@ -241,10 +241,10 @@ func validatePatternExprInner(expr xpath3.Expr, _ bool) error {
 		return nil
 	case xpath3.IntersectExceptExpr:
 		// intersect/except are valid pattern operators in XSLT 3.0
-		if err := validatePatternExprInner(e.Left, false); err != nil {
+		if err := validatePatternExprInner(e.Left, false, nsBindings); err != nil {
 			return err
 		}
-		return validatePatternExprInner(e.Right, false)
+		return validatePatternExprInner(e.Right, false, nsBindings)
 	case xpath3.BinaryExpr:
 		// Binary expressions like "and union or" parse as operator expressions
 		return fmt.Errorf("binary operator not allowed in pattern")
@@ -280,7 +280,7 @@ func validateLocationPathPattern(expr xpath3.Expr) error {
 	return nil
 }
 
-func validatePatternPathExpr(e xpath3.PathExpr) error {
+func validatePatternPathExpr(e xpath3.PathExpr, nsBindings map[string]string) error {
 	// The filter part: only ContextItemExpr, RootExpr, or FunctionCall (key/id/doc)
 	switch f := e.Filter.(type) {
 	case xpath3.ContextItemExpr:
@@ -289,40 +289,40 @@ func validatePatternPathExpr(e xpath3.PathExpr) error {
 		// /steps is valid
 	case xpath3.FunctionCall:
 		// Only certain functions at the start of a path pattern
-		if !isAllowedPatternFunction(f) {
+		if !isAllowedPatternFunction(f, nsBindings) {
 			return fmt.Errorf("function call %s() not allowed at start of path pattern", f.Name)
 		}
 	case xpath3.FilterExpr:
 		// FilterExpr at the start of a path
-		return validatePatternExprInner(f, false)
+		return validatePatternExprInner(f, false, nsBindings)
 	case xpath3.VariableExpr:
 		// variable references are allowed in XSLT 3.0 patterns
 	case xpath3.PathStepExpr:
 		// Nested path step (e.g., x/(a|b)/text())
-		return validatePatternPathStepExpr(f)
+		return validatePatternPathStepExpr(f, nsBindings)
 	case *xpath3.PathStepExpr:
-		return validatePatternPathStepExpr(*f)
+		return validatePatternPathStepExpr(*f, nsBindings)
 	default:
 		return fmt.Errorf("expression type %T not allowed at start of path pattern", e.Filter)
 	}
 	return nil
 }
 
-func validatePatternPathStepExpr(e xpath3.PathStepExpr) error {
+func validatePatternPathStepExpr(e xpath3.PathStepExpr, nsBindings map[string]string) error {
 	// Check left side
 	switch l := e.Left.(type) {
 	case xpath3.VariableExpr:
 		// variable references are allowed in XSLT 3.0 patterns
 	case xpath3.FunctionCall:
-		if !isAllowedPatternFunction(l) {
+		if !isAllowedPatternFunction(l, nsBindings) {
 			return fmt.Errorf("function call %s() not allowed in pattern", l.Name)
 		}
 	case xpath3.PathExpr:
-		if err := validatePatternPathExpr(l); err != nil {
+		if err := validatePatternPathExpr(l, nsBindings); err != nil {
 			return err
 		}
 	case xpath3.PathStepExpr:
-		if err := validatePatternPathStepExpr(l); err != nil {
+		if err := validatePatternPathStepExpr(l, nsBindings); err != nil {
 			return err
 		}
 	}
@@ -366,11 +366,20 @@ func isValidPatternStep(expr xpath3.Expr) bool {
 
 // isAllowedPatternFunction returns true if a function call is allowed at the
 // start of a path pattern. In XSLT 3.0, key(), id(), and doc() are allowed
-// with literal arguments.
-func isAllowedPatternFunction(fc xpath3.FunctionCall) bool {
-	// Normalize the EQName spelling Q{uri}local to its local part so the
-	// braced form Q{...}key() is recognized identically to key()/fn:key().
-	local, _ := lexicon.StreamFnLocalName(fc.Name, fc.Prefix)
+// with literal arguments. Only the built-in functions in the XPath functions
+// namespace qualify: an allowlisted local name in any OTHER namespace (e.g. a
+// user-declared Q{urn:custom}key()) is NOT an allowed pattern-start function,
+// so the namespace URI must be the functions namespace before the local-name
+// switch is consulted.
+func isAllowedPatternFunction(fc xpath3.FunctionCall, nsBindings map[string]string) bool {
+	// Resolve the call's (namespace URI, local name) honoring the EQName braced
+	// form, explicit xmlns bindings, and the predeclared fn: default. A function
+	// outside the functions namespace can never be a built-in pattern function,
+	// regardless of its local name.
+	uri, local := patternFunctionIdentity(fc, nsBindings)
+	if uri != lexicon.NamespaceFn {
+		return false
+	}
 	switch local {
 	case "key", "id", "idref", "doc", "element-with-id", "root":
 		// Check that all arguments are literals or variable refs

--- a/xslt3/pattern_predeclared_ns_test.go
+++ b/xslt3/pattern_predeclared_ns_test.go
@@ -831,6 +831,18 @@ func TestPatternStartFunctionRequiresFnNamespace(t *testing.T) {
 		{name: "unprefixed-key-accepted", match: "key('k', '1')"},
 		{name: "fn-prefixed-key-accepted", match: "fn:key('k', '1')"},
 		{name: "fn-eqname-key-accepted", match: "Q{" + fnNS + "}key('k', '1')"},
+		// FilterExpr (predicate) variants: a predicate after the function call
+		// must not let a non-fn-namespace pattern-start function through the
+		// gate (the FilterExpr pattern-primary case must consult
+		// isAllowedPatternFunction too).
+		{name: "custom-prefixed-key-predicate-rejected", match: "c:key('x')[true()]", wantErr: true},
+		{name: "custom-eqname-key-predicate-rejected", match: "Q{urn:custom}key('x')[true()]", wantErr: true},
+		{name: "fn-eqname-key-predicate-accepted", match: "Q{" + fnNS + "}key('k', '1')[true()]"},
+		{name: "unprefixed-key-predicate-accepted", match: "key('k', '1')[1]"},
+		// A predicate-wrapped function call as a NON-leading path step must also
+		// be rejected — pattern-start functions are only valid at the start, so
+		// the FilterExpr wrapper must not smuggle a custom function mid-path.
+		{name: "custom-key-predicate-mid-path-rejected", match: "*/c:key('x')[true()]", wantErr: true},
 	}
 
 	for _, tc := range tests {

--- a/xslt3/pattern_predeclared_ns_test.go
+++ b/xslt3/pattern_predeclared_ns_test.go
@@ -793,6 +793,66 @@ func TestTypedStrictPatternPredeclaredPrefix(t *testing.T) {
 	})
 }
 
+// TestPatternStartFunctionRequiresFnNamespace verifies that only functions in
+// the XPath functions namespace qualify as built-in pattern-start functions
+// (key/id/idref/doc/element-with-id/root). An allowlisted LOCAL name in any
+// other namespace — e.g. a user-declared Q{urn:custom}key() — must NOT be
+// admitted as a pattern-start function, even when a matching xsl:function
+// exists. Only the fn-namespace spellings key()/fn:key()/Q{fn-ns}key() are
+// accepted.
+func TestPatternStartFunctionRequiresFnNamespace(t *testing.T) {
+	t.Parallel()
+
+	const fnNS = "http://www.w3.org/2005/xpath-functions"
+
+	// A custom Q{urn:custom}key#1 is declared as an xsl:function so that the
+	// downstream function-existence check (validatePatternFunctions) would
+	// happily accept it; the ONLY thing that must reject it is the structural
+	// pattern-start check, which requires the functions namespace.
+	const tmpl = `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:c="urn:custom">
+  <xsl:key name="k" match="a" use="@id"/>
+  <xsl:function name="c:key" as="xs:boolean">
+    <xsl:param name="x"/>
+    <xsl:sequence select="true()"/>
+  </xsl:function>
+  <xsl:template match="%s"><out/></xsl:template>
+</xsl:stylesheet>`
+
+	tests := []struct {
+		name    string
+		match   string
+		wantErr bool
+	}{
+		{name: "custom-prefixed-key-rejected", match: "c:key('x')", wantErr: true},
+		{name: "custom-eqname-key-rejected", match: "Q{urn:custom}key('x')", wantErr: true},
+		{name: "unprefixed-key-accepted", match: "key('k', '1')"},
+		{name: "fn-prefixed-key-accepted", match: "fn:key('k', '1')"},
+		{name: "fn-eqname-key-accepted", match: "Q{" + fnNS + "}key('k', '1')"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			src := strings.Replace(tmpl, "%s", tc.match, 1)
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+			require.NoError(t, err)
+
+			_, err = xslt3.NewCompiler().Compile(t.Context(), doc)
+			if tc.wantErr {
+				require.Error(t, err,
+					"a non-fn-namespace function %q must not be admitted as a pattern-start function", tc.match)
+				return
+			}
+			require.NoError(t, err,
+				"the fn-namespace key() spelling %q must remain an accepted pattern-start function", tc.match)
+		})
+	}
+}
+
 // TestPatternFnCurrentCompiles verifies fn:current() is accepted (not rejected
 // as XPST0017) inside a pattern predicate.
 func TestPatternFnCurrentCompiles(t *testing.T) {

--- a/xslt3/pattern_predeclared_ns_test.go
+++ b/xslt3/pattern_predeclared_ns_test.go
@@ -249,6 +249,36 @@ func TestPatternForbiddenFunctionRespectsExplicitBinding(t *testing.T) {
 	require.Error(t, err, "unprefixed current-group() in a pattern must be forbidden")
 }
 
+// TestPatternForbiddenFunctionEQName verifies that the forbidden-in-pattern
+// check also catches the EQName spelling Q{uri}local. The xpath3 parser keeps
+// an EQName function call's whole braced spelling in the name with an empty
+// prefix, so resolving identity from the prefix alone would miss it. Each of the
+// four forbidden grouping/merge functions written as
+// Q{http://www.w3.org/2005/xpath-functions}fn() in a pattern must be rejected.
+func TestPatternForbiddenFunctionEQName(t *testing.T) {
+	t.Parallel()
+
+	const fnNS = "http://www.w3.org/2005/xpath-functions"
+	for _, fn := range []string{
+		"current-group",
+		"current-grouping-key",
+		"current-merge-key",
+		"current-merge-group",
+	} {
+		t.Run(fn, func(t *testing.T) {
+			t.Parallel()
+			src := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="a[Q{` + fnNS + `}` + fn + `()]"><out/></xsl:template>
+</xsl:stylesheet>`
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+			require.NoError(t, err)
+			_, err = xslt3.NewCompiler().Compile(t.Context(), doc)
+			require.Error(t, err, "EQName Q{...}%s() in a pattern must be forbidden", fn)
+		})
+	}
+}
+
 // TestPatternLexicalNamespaceSnapshot verifies that each match pattern resolves
 // prefixes against its OWN lexical namespace context (the xmlns declarations in
 // scope at the pattern's position), not against a mutable stylesheet-global map.

--- a/xslt3/streamability.go
+++ b/xslt3/streamability.go
@@ -295,8 +295,8 @@ func countParamDownwardRefs(expr *xpath3.Expression, paramName string) int {
 		}
 		// head($param), tail($param), etc. — consuming functions
 		if fc, ok := e.(xpath3.FunctionCall); ok {
-			if isFnNamespacePrefix(fc.Prefix) {
-				switch fc.Name {
+			if local, isFn := lexicon.StreamFnLocalName(fc.Name, fc.Prefix); isFn {
+				switch local {
 				case "head", "tail", fnNameCopyOf, funcSnapshot, "string-join",
 					"serialize", "deep-equal", "sort", "reverse",
 					"empty", "exists", "count", "sum", "avg", "min", "max",
@@ -357,7 +357,7 @@ func exprConsumesParam(expr *xpath3.Expression, params []*param) bool {
 		}
 		// string($param) — string() on a node consumes it
 		if fc, ok := e.(xpath3.FunctionCall); ok {
-			if isFnNamespacePrefix(fc.Prefix) && fc.Name == "string" && len(fc.Args) > 0 {
+			if local, isFn := lexicon.StreamFnLocalName(fc.Name, fc.Prefix); isFn && local == "string" && len(fc.Args) > 0 {
 				if ve, ok := fc.Args[0].(xpath3.VariableExpr); ok {
 					if paramNames[ve.Name] {
 						found = true
@@ -667,7 +667,7 @@ func exprUsesCurrent(expr xpath3.Expr) bool {
 			return false
 		}
 		if fc, ok := e.(xpath3.FunctionCall); ok {
-			if isFnNamespacePrefix(fc.Prefix) && fc.Name == fnNameCurrent {
+			if local, isFn := lexicon.StreamFnLocalName(fc.Name, fc.Prefix); isFn && local == fnNameCurrent {
 				found = true
 				return false
 			}

--- a/xslt3/streamability_currentgroup.go
+++ b/xslt3/streamability_currentgroup.go
@@ -118,8 +118,8 @@ func countCurrentGroupConsumingInExpr(expr xpath3.Expr) int {
 		}
 		count += countCurrentGroupConsumingInExpr(e.Right)
 	case xpath3.FunctionCall:
-		if isFnNamespacePrefix(e.Prefix) {
-			switch e.Name {
+		if local, isFn := lexicon.StreamFnLocalName(e.Name, e.Prefix); isFn {
+			switch local {
 			case lexicon.FnCurrentGroup:
 				// Any reference to current-group() is consuming in streaming
 				return 1
@@ -185,7 +185,11 @@ func countCurrentGroupConsumingInExpr(expr xpath3.Expr) int {
 // isCurrentGroupCall returns true if expr is a call to current-group().
 func isCurrentGroupCall(expr xpath3.Expr) bool {
 	fc, ok := expr.(xpath3.FunctionCall)
-	return ok && isFnNamespacePrefix(fc.Prefix) && fc.Name == lexicon.FnCurrentGroup
+	if !ok {
+		return false
+	}
+	local, isFn := lexicon.StreamFnLocalName(fc.Name, fc.Prefix)
+	return isFn && local == lexicon.FnCurrentGroup
 }
 
 // pathHasDownwardStep returns true if a LocationPath has any child or

--- a/xslt3/streamability_expr.go
+++ b/xslt3/streamability_expr.go
@@ -325,7 +325,7 @@ func exprHasCrawlingGroundingArg(expr *xpath3.Expression) bool {
 			return false
 		}
 		if fc, ok := e.(xpath3.FunctionCall); ok {
-			if isFnNamespacePrefix(fc.Prefix) && (fc.Name == "reverse" || fc.Name == "innermost") {
+			if local, isFn := lexicon.StreamFnLocalName(fc.Name, fc.Prefix); isFn && (local == "reverse" || local == "innermost") {
 				if slices.ContainsFunc(fc.Args, argHasStreamingCrawl) {
 					found = true
 					return false
@@ -353,10 +353,14 @@ func exprHasHigherOrderWithConsumingArg(expr *xpath3.Expression) bool {
 			return false
 		}
 		fc, ok := e.(xpath3.FunctionCall)
-		if !ok || !isFnNamespacePrefix(fc.Prefix) || len(fc.Args) < 2 {
+		if !ok || len(fc.Args) < 2 {
 			return true
 		}
-		switch fc.Name {
+		local, isFn := lexicon.StreamFnLocalName(fc.Name, fc.Prefix)
+		if !isFn {
+			return true
+		}
+		switch local {
 		case lexicon.StreamFilter, "fold-right":
 			if argHasStreamingDownwardUngrounded(fc.Args[0]) {
 				found = true
@@ -591,7 +595,7 @@ func walkExprWithGrounding(expr xpath3.Expr, insideGrounding bool, fn func(xpath
 	// Check if this is a grounding function call
 	newGrounding := insideGrounding
 	if fc, ok := expr.(xpath3.FunctionCall); ok {
-		if isFnNamespacePrefix(fc.Prefix) && isGroundingFuncName(fc.Name) {
+		if local, isFn := lexicon.StreamFnLocalName(fc.Name, fc.Prefix); isFn && isGroundingFuncName(local) {
 			newGrounding = true
 		}
 	}
@@ -692,8 +696,8 @@ func isGroundingExprSS(ss *Stylesheet, expr xpath3.Expr) bool {
 		return true
 	}
 	if fc, ok := expr.(xpath3.FunctionCall); ok {
-		if isFnNamespacePrefix(fc.Prefix) {
-			return isGroundingFuncName(fc.Name)
+		if local, isFn := lexicon.StreamFnLocalName(fc.Name, fc.Prefix); isFn {
+			return isGroundingFuncName(local)
 		}
 		// Check user-defined absorbing/unclassified functions
 		cat := lookupFuncStreamability(ss, fc.Name, len(fc.Args))
@@ -707,8 +711,8 @@ func isGroundingExprSS(ss *Stylesheet, expr xpath3.Expr) bool {
 	// treating arbitrary filtered expressions as grounded.
 	if fe, ok := expr.(xpath3.FilterExpr); ok {
 		if fc, ok2 := derefXPathExpr(fe.Expr).(xpath3.FunctionCall); ok2 {
-			if isFnNamespacePrefix(fc.Prefix) {
-				return isGroundingFuncName(fc.Name)
+			if local, isFn := lexicon.StreamFnLocalName(fc.Name, fc.Prefix); isFn {
+				return isGroundingFuncName(local)
 			}
 		}
 	}
@@ -740,8 +744,8 @@ func exprProducesAtomicResult(expr xpath3.Expr) bool {
 func isAtomicResultExpr(expr xpath3.Expr) bool {
 	expr = derefXPathExpr(expr)
 	if fc, ok := expr.(xpath3.FunctionCall); ok {
-		if isFnNamespacePrefix(fc.Prefix) {
-			switch fc.Name {
+		if local, isFn := lexicon.StreamFnLocalName(fc.Name, fc.Prefix); isFn {
+			switch local {
 			case "tokenize", "string", "data", "number", "boolean",
 				lexicon.FnName, "local-name", "namespace-uri", "string-length",
 				"normalize-space", "count", "sum", "avg", "min", "max",

--- a/xslt3/streamability_expr.go
+++ b/xslt3/streamability_expr.go
@@ -514,7 +514,7 @@ func exprCallsFunction(expr xpath3.Expr, name string) bool {
 			return false
 		}
 		if fc, ok := e.(xpath3.FunctionCall); ok {
-			if isFnNamespacePrefix(fc.Prefix) && fc.Name == name {
+			if local, isFn := lexicon.StreamFnLocalName(fc.Name, fc.Prefix); isFn && local == name {
 				found = true
 				return false
 			}
@@ -773,7 +773,7 @@ func exprUsesLastOutsideGrounding(expr *xpath3.Expression) bool {
 			return true
 		}
 		if fc, ok := e.(xpath3.FunctionCall); ok {
-			if isFnNamespacePrefix(fc.Prefix) && fc.Name == "last" {
+			if local, isFn := lexicon.StreamFnLocalName(fc.Name, fc.Prefix); isFn && local == "last" {
 				found = true
 				return false
 			}
@@ -798,7 +798,7 @@ func exprUsesFunctionOutsideGrounding(expr *xpath3.Expression, name string) bool
 			return true
 		}
 		if fc, ok := e.(xpath3.FunctionCall); ok {
-			if isFnNamespacePrefix(fc.Prefix) && fc.Name == name {
+			if local, isFn := lexicon.StreamFnLocalName(fc.Name, fc.Prefix); isFn && local == name {
 				found = true
 				return false
 			}
@@ -997,19 +997,20 @@ func predicateIsNonMotionlessSS(ss *Stylesheet, pred xpath3.Expr, step *xpath3.S
 				walkPred(lp, underNonContext || filterIsNonContext)
 			}
 		case xpath3.FunctionCall:
-			if isFnNamespacePrefix(v.Prefix) && v.Name == "last" {
+			local, isFn := lexicon.StreamFnLocalName(v.Name, v.Prefix)
+			if isFn && local == "last" {
 				nonMotionless = true
 				return
 			}
 			// current-group() and current-grouping-key() always return
 			// materialized (grounded) data.  Navigation into them (e.g.
 			// current-group()[1]/Date) is motionless w.r.t. the stream.
-			if isFnNamespacePrefix(v.Prefix) && (v.Name == fnNameCurrentGroup || v.Name == fnNameCurrentGroupingKey) {
+			if isFn && (local == fnNameCurrentGroup || local == fnNameCurrentGroupingKey) {
 				return // skip children — result is grounded
 			}
 			// Property-access functions are motionless.
-			if isFnNamespacePrefix(v.Prefix) {
-				switch v.Name {
+			if isFn {
+				switch local {
 				case lexicon.FnName, "local-name", "namespace-uri", "node-name",
 					"self", "generate-id", "base-uri", "document-uri",
 					"nilled", "has-children", "string-length":

--- a/xslt3/streamability_fnprefix_test.go
+++ b/xslt3/streamability_fnprefix_test.go
@@ -87,3 +87,39 @@ func TestPrefixedFnStreamabilityXSLTLayer(t *testing.T) {
 			"fn:current-group() must be forbidden in pattern, same as unprefixed")
 	})
 }
+
+// TestEQNameFnStreamabilityXSLTLayer verifies that EQName-spelled (Q{...}local)
+// calls to special-cased built-ins classify the same as their unprefixed forms.
+// The parser keeps the whole braced spelling in FunctionCall.Name with an empty
+// Prefix, so the XSLT streamability gates must normalize it via the shared
+// lexicon.StreamFnLocalName helper rather than comparing raw names.
+func TestEQNameFnStreamabilityXSLTLayer(t *testing.T) {
+	const fnNS = "http://www.w3.org/2005/xpath-functions"
+	compile := func(t *testing.T, src string) *xpath3.Expression {
+		t.Helper()
+		expr, err := xpath3.NewCompiler().Compile(src)
+		require.NoError(t, err, "compile %q", src)
+		return expr
+	}
+
+	t.Run("last outside grounding", func(t *testing.T) {
+		plain := compile(t, "child::a[last()]")
+		eqname := compile(t, "child::a[Q{"+fnNS+"}last()]")
+		require.True(t, exprUsesLastOutsideGrounding(plain), "unprefixed last() must be detected")
+		require.Equal(t,
+			exprUsesLastOutsideGrounding(plain),
+			exprUsesLastOutsideGrounding(eqname),
+			"EQName Q{...}last() must classify same as unprefixed last()")
+	})
+
+	t.Run("position outside grounding", func(t *testing.T) {
+		plain := compile(t, "child::a[position() = 1]")
+		eqname := compile(t, "child::a[Q{"+fnNS+"}position() = 1]")
+		require.True(t, exprUsesFunctionOutsideGrounding(plain, "position"),
+			"unprefixed position() must be detected")
+		require.Equal(t,
+			exprUsesFunctionOutsideGrounding(plain, "position"),
+			exprUsesFunctionOutsideGrounding(eqname, "position"),
+			"EQName Q{...}position() must classify same as unprefixed position()")
+	})
+}

--- a/xslt3/streamability_fnprefix_test.go
+++ b/xslt3/streamability_fnprefix_test.go
@@ -122,4 +122,59 @@ func TestEQNameFnStreamabilityXSLTLayer(t *testing.T) {
 			exprUsesFunctionOutsideGrounding(eqname, "position"),
 			"EQName Q{...}position() must classify same as unprefixed position()")
 	})
+
+	t.Run("string consuming context item", func(t *testing.T) {
+		plain := compile(t, "string(.)")
+		eqname := compile(t, "Q{"+fnNS+"}string(.)")
+		require.Positive(t, countStreamingDownwardSelections(nil, plain.AST()),
+			"unprefixed string(.) must count as a consuming selection")
+		require.Equal(t,
+			countStreamingDownwardSelections(nil, plain.AST()),
+			countStreamingDownwardSelections(nil, eqname.AST()),
+			"EQName Q{...}string(.) must count same as unprefixed string(.)")
+	})
+
+	t.Run("data consuming context item", func(t *testing.T) {
+		plain := compile(t, "data(.)")
+		eqname := compile(t, "Q{"+fnNS+"}data(.)")
+		require.Positive(t, countStreamingDownwardSelections(nil, plain.AST()),
+			"unprefixed data(.) must count as a consuming selection")
+		require.Equal(t,
+			countStreamingDownwardSelections(nil, plain.AST()),
+			countStreamingDownwardSelections(nil, eqname.AST()),
+			"EQName Q{...}data(.) must count same as unprefixed data(.)")
+	})
+
+	t.Run("current-group consuming", func(t *testing.T) {
+		plain := compile(t, "current-group()/child::b")
+		eqname := compile(t, "Q{"+fnNS+"}current-group()/child::b")
+		require.Positive(t, countCurrentGroupConsumingInExpr(plain.AST()),
+			"unprefixed current-group() must be counted as consuming")
+		require.Equal(t,
+			countCurrentGroupConsumingInExpr(plain.AST()),
+			countCurrentGroupConsumingInExpr(eqname.AST()),
+			"EQName Q{...}current-group() must count same as unprefixed current-group()")
+	})
+
+	t.Run("snapshot grounding", func(t *testing.T) {
+		plain := compile(t, "snapshot(child::a)")
+		eqname := compile(t, "Q{"+fnNS+"}snapshot(child::a)")
+		require.True(t, isGroundingExpr(plain.AST()),
+			"unprefixed snapshot() must be grounding")
+		require.Equal(t,
+			isGroundingExpr(plain.AST()),
+			isGroundingExpr(eqname.AST()),
+			"EQName Q{...}snapshot() must classify same as unprefixed snapshot()")
+	})
+
+	t.Run("copy-of grounding", func(t *testing.T) {
+		plain := compile(t, "copy-of(child::a)")
+		eqname := compile(t, "Q{"+fnNS+"}copy-of(child::a)")
+		require.True(t, isGroundingExpr(plain.AST()),
+			"unprefixed copy-of() must be grounding")
+		require.Equal(t,
+			isGroundingExpr(plain.AST()),
+			isGroundingExpr(eqname.AST()),
+			"EQName Q{...}copy-of() must classify same as unprefixed copy-of()")
+	})
 }

--- a/xslt3/streamability_functions.go
+++ b/xslt3/streamability_functions.go
@@ -290,7 +290,7 @@ func countStreamingDownwardSelectionsInner(ss *Stylesheet, expr xpath3.Expr, gro
 		// The zero-arg form (e.g., string() inside a path like @nr/string())
 		// is NOT counted here because in that case the context is the
 		// navigated-to node, not the streaming context.
-		if isFnNamespacePrefix(e.Prefix) && isConsumingBuiltinFunc(e.Name) && len(e.Args) > 0 && isContextItemArg(e.Args[0]) {
+		if local, isFn := lexicon.StreamFnLocalName(e.Name, e.Prefix); isFn && isConsumingBuiltinFunc(local) && len(e.Args) > 0 && isContextItemArg(e.Args[0]) {
 			count++
 			break
 		}
@@ -422,12 +422,6 @@ func isConsumingBuiltinFunc(name string) bool {
 		return true
 	}
 	return false
-}
-
-// isFnNamespacePrefix delegates to lexicon.IsFnNamespacePrefix, the shared
-// streamability helper used across xpath3, xslt3 and internal/xpathstream.
-func isFnNamespacePrefix(prefix string) bool {
-	return lexicon.IsFnNamespacePrefix(prefix)
 }
 
 // isContextItemArg returns true if the expression is a simple context item

--- a/xslt3/streamability_functions.go
+++ b/xslt3/streamability_functions.go
@@ -424,24 +424,10 @@ func isConsumingBuiltinFunc(name string) bool {
 	return false
 }
 
-// isFnNamespacePrefix reports whether a FunctionCall prefix names the XPath
-// functions namespace (http://www.w3.org/2005/xpath-functions) for the purpose
-// of streamability analysis. For function calls an empty prefix defaults to
-// that namespace, and "fn" is the conventional reserved prefix bound to it, so
-// both lexical forms name the same built-in. Streamability special-cases
-// functions such as last()/position()/current-group() by local-name and must
-// therefore treat the unprefixed and "fn:"-prefixed spellings identically.
-//
-// This is a deliberately lexical check, not a namespace-resolved one: XSLT
-// streamability is computed at compile time before any static namespace context
-// is bound, so resolving "fn" properly would mean threading the prefix->URI map
-// through the whole compile path. We make the same assumption the xpath3
-// evaluator already makes (see xpath3 isFnNamespacePrefix and eval_path.go
-// positionCall: Prefix == "" || Prefix == "fn"), keeping the layers consistent.
-// Rebinding the reserved "fn" prefix to a custom namespace is pathological and
-// unsupported here.
+// isFnNamespacePrefix delegates to lexicon.IsFnNamespacePrefix, the shared
+// streamability helper used across xpath3, xslt3 and internal/xpathstream.
 func isFnNamespacePrefix(prefix string) bool {
-	return prefix == "" || prefix == "fn"
+	return lexicon.IsFnNamespacePrefix(prefix)
 }
 
 // isContextItemArg returns true if the expression is a simple context item

--- a/xslt3/streamability_instructions.go
+++ b/xslt3/streamability_instructions.go
@@ -750,14 +750,15 @@ func exprUsesCurrentGroupConsumingly(expr *xpath3.Expression) bool {
 		e = derefXPathExpr(e)
 		switch v := e.(type) {
 		case xpath3.FunctionCall:
-			if isFnNamespacePrefix(v.Prefix) && v.Name == lexicon.FnCurrentGroup {
+			local, isFn := lexicon.StreamFnLocalName(v.Name, v.Prefix)
+			if isFn && local == lexicon.FnCurrentGroup {
 				if !insideSnapshot {
 					found = true
 				}
 				return
 			}
 			// snapshot() grounds its arguments — current-group() inside is not consuming.
-			if isFnNamespacePrefix(v.Prefix) && v.Name == funcSnapshot {
+			if isFn && local == funcSnapshot {
 				for _, arg := range v.Args {
 					walk(arg, true)
 				}


### PR DESCRIPTION
- Normalize `Q{http://www.w3.org/2005/xpath-functions}position`/`last` to local name in streamability analysis so EQName-spelled calls classify the same as plain/fn: forms.
- `a[Q{...}position()=1]` now flagged non-motionless like `a[position()=1]`; recorded in UsedFunctions under local name.