### PR TITLE
reject duplicate identity-constraint names

### DIFF
--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -501,6 +501,12 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 	// models must be fully resolved and structurally sound.
 	c.checkElementConsistent(ctx)
 
+	// Identity-constraints (xs:key/xs:unique/xs:keyref) share one symbol space and
+	// must be unique by {targetNamespace}name across the whole schema. Reject any
+	// repeated name before the keyref resolution below, which would otherwise
+	// silently collapse the colliding constraints into one registry entry.
+	c.checkDuplicateIDCs(ctx)
+
 	// Resolve every xs:keyref/@refer against the schema-wide registry of
 	// key/unique constraints. An unresolved refer must be a fatal schema error:
 	// otherwise the keyref is silently skipped at validation time and referential
@@ -579,6 +585,68 @@ func (c *compiler) checkKeyRefRefers(ctx context.Context) {
 		c.schemaError(ctx,
 			schemaParserErrorAttr(source, idc.Line, elemKeyRef, elemKeyRef, attrRefer, msg))
 	}
+}
+
+// checkDuplicateIDCs enforces the XSD constraint that identity-constraint
+// definitions (xs:key, xs:unique, xs:keyref) all share a single symbol space:
+// each {targetNamespace}name must be unique across the entire schema, regardless
+// of which element declaration hosts the constraint. Two constraints sharing one
+// name silently collapsed into a single registry entry before — corrupting
+// keyref resolution and IDC validation — so a collision is now a fatal schema
+// parser error, matching reportDuplicateComponent's style and wording.
+func (c *compiler) checkDuplicateIDCs(ctx context.Context) {
+	if c.filename == "" {
+		return
+	}
+
+	idcs := c.collectAllIDCs()
+
+	// Sort by source location so the reported collision is deterministic (the
+	// later declaration is flagged) regardless of the map-iteration order in
+	// collectAllIDCs.
+	sort.SliceStable(idcs, func(i, j int) bool {
+		if idcs[i].Source != idcs[j].Source {
+			return idcs[i].Source < idcs[j].Source
+		}
+		return idcs[i].Line < idcs[j].Line
+	})
+
+	seen := make(map[QName]struct{}, len(idcs))
+	for _, idc := range idcs {
+		if _, dup := seen[idc.QName]; !dup {
+			seen[idc.QName] = struct{}{}
+			continue
+		}
+		c.reportDuplicateIDC(ctx, idc)
+	}
+}
+
+// reportDuplicateIDC emits the fatal schema-parser error for a redeclared
+// identity-constraint, mirroring reportDuplicateComponent. The XSD element name
+// (key/unique/keyref) is derived from the constraint kind and the constraint's
+// own declaring file/line is used so an imported or included collision cites the
+// declaring document.
+func (c *compiler) reportDuplicateIDC(ctx context.Context, idc *IDConstraint) {
+	xsdElem := elemKey
+	switch idc.Kind {
+	case IDCUnique:
+		xsdElem = elemUnique
+	case IDCKeyRef:
+		xsdElem = elemKeyRef
+	}
+
+	qnDisplay := "'" + idc.QName.NS + "'" + idc.QName.Local
+	if idc.QName.NS != "" {
+		qnDisplay = "'{" + idc.QName.NS + "}" + idc.QName.Local + "'"
+	}
+
+	source := idc.Source
+	if source == "" {
+		source = c.filename
+	}
+
+	c.schemaError(ctx, schemaParserError(source, idc.Line, xsdElem, xsdElem,
+		"An identity-constraint definition "+qnDisplay+" does already exist."))
 }
 
 // collectAllIDCs returns every identity-constraint declared anywhere in the

--- a/xsd/duplicate_idc_test.go
+++ b/xsd/duplicate_idc_test.go
@@ -1,0 +1,109 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDuplicateIDC verifies that identity-constraint definitions (xs:key,
+// xs:unique, xs:keyref) share a single symbol space: two constraints with the
+// same {targetNamespace}name anywhere in the schema are a fatal collision, even
+// when hosted by different element declarations. Distinct names must still
+// compile cleanly.
+func TestDuplicateIDC(t *testing.T) {
+	t.Parallel()
+
+	t.Run("duplicate key across two elements", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="A">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="x" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="k">
+      <xs:selector xpath="x"/>
+      <xs:field xpath="."/>
+    </xs:key>
+  </xs:element>
+  <xs:element name="B">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="y" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="k">
+      <xs:selector xpath="y"/>
+      <xs:field xpath="."/>
+    </xs:key>
+  </xs:element>
+</xs:schema>`
+		require.Contains(t,
+			compileErrorsExact(t, schemaXML),
+			"element key: Schemas parser error : Element '{http://www.w3.org/2001/XMLSchema}key': An identity-constraint definition ''k does already exist.",
+			"duplicate identity-constraint name across element declarations must be rejected")
+	})
+
+	t.Run("key and keyref share symbol space", func(t *testing.T) {
+		t.Parallel()
+		// A keyref colliding with a key on the same name is also a redeclaration:
+		// all three IDC kinds occupy one symbol space.
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="A">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="x" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="k">
+      <xs:selector xpath="x"/>
+      <xs:field xpath="."/>
+    </xs:key>
+    <xs:keyref name="k" refer="k">
+      <xs:selector xpath="x"/>
+      <xs:field xpath="."/>
+    </xs:keyref>
+  </xs:element>
+</xs:schema>`
+		require.Contains(t,
+			compileErrorsExact(t, schemaXML),
+			"An identity-constraint definition ''k does already exist.",
+			"a keyref sharing a key's name must be rejected as a duplicate")
+	})
+
+	t.Run("distinct names compile", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="A">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="x" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="k1">
+      <xs:selector xpath="x"/>
+      <xs:field xpath="."/>
+    </xs:key>
+  </xs:element>
+  <xs:element name="B">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="y" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="k2">
+      <xs:selector xpath="y"/>
+      <xs:field xpath="."/>
+    </xs:key>
+  </xs:element>
+</xs:schema>`
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+		require.NoError(t, err)
+		_, err = xsd.NewCompiler().Label("test.xsd").Compile(t.Context(), doc)
+		require.NoError(t, err, "distinct identity-constraint names must compile cleanly")
+	})
+}


### PR DESCRIPTION
- xs:key/xs:unique/xs:keyref share one symbol space; a repeated {targetNamespace}name across the schema is now a fatal compile error instead of silently collapsing into one registry entry
- adds checkDuplicateIDCs over collectAllIDCs, mirroring reportDuplicateComponent wording