### PR TITLE
harden xmlenc1 parsing and multi-key decrypt

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -332,6 +332,7 @@ XML Encryption 1.1 (W3C xmlenc-core1). Encrypt and decrypt XML elements/content.
 - Key transport: RSA-OAEP (1.0 + 1.1 with configurable digest/MGF)
 - Key wrapping: AES-128/256-KeyWrap (RFC 3394)
 - Key sizes are bound to the declared algorithm URI on encrypt and decrypt (incl. after unwrap/key transport); mismatch → `KeySizeError`
+- Multi-recipient: `EncryptedData.EncryptedKeys []*EncryptedKey` holds one EncryptedKey per recipient; decrypt tries each candidate through full block decryption + plaintext validation (a bogus prepended key cannot mask the real one). `EncryptedData.EncryptedKey` is the **deprecated** single-key field — `EncryptedKeys` wins when non-empty, else the single field is treated as a one-element list; parse populates both
 - Files: `xmlenc1.go` (API), `constants.go`, `block.go`, `keytransport.go`, `keywrap.go`, `types.go`, `serialize.go`, `parse.go`, `errors.go`
 - Imports: helium
 

--- a/xmlenc1/block_test.go
+++ b/xmlenc1/block_test.go
@@ -74,9 +74,11 @@ func TestKeySize(t *testing.T) {
 		ed := &xmlenc1.EncryptedData{
 			Type:             xmlenc1.TypeElement,
 			EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256GCM}, // declares 256
-			EncryptedKey: &xmlenc1.EncryptedKey{
-				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES128KeyWrap},
-				CipherValue:      wrapped,
+			EncryptedKeys: []*xmlenc1.EncryptedKey{
+				{
+					EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES128KeyWrap},
+					CipherValue:      wrapped,
+				},
 			},
 			CipherValue: cipher,
 		}

--- a/xmlenc1/keytransport_test.go
+++ b/xmlenc1/keytransport_test.go
@@ -254,9 +254,11 @@ func TestResolveSessionKey(t *testing.T) {
 			ed := &xmlenc1.EncryptedData{
 				Type:             xmlenc1.TypeElement,
 				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256GCM},
-				EncryptedKey: &xmlenc1.EncryptedKey{
-					EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.RSAOAEP},
-					CipherValue:      make([]byte, 256),
+				EncryptedKeys: []*xmlenc1.EncryptedKey{
+					{
+						EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.RSAOAEP},
+						CipherValue:      make([]byte, 256),
+					},
 				},
 				CipherValue: make([]byte, 48),
 			}
@@ -272,9 +274,11 @@ func TestResolveSessionKey(t *testing.T) {
 			ed := &xmlenc1.EncryptedData{
 				Type:             xmlenc1.TypeElement,
 				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256GCM},
-				EncryptedKey: &xmlenc1.EncryptedKey{
-					EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256KeyWrap},
-					CipherValue:      make([]byte, 40),
+				EncryptedKeys: []*xmlenc1.EncryptedKey{
+					{
+						EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256KeyWrap},
+						CipherValue:      make([]byte, 40),
+					},
 				},
 				CipherValue: make([]byte, 48),
 			}
@@ -290,8 +294,10 @@ func TestResolveSessionKey(t *testing.T) {
 			ed := &xmlenc1.EncryptedData{
 				Type:             xmlenc1.TypeElement,
 				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256GCM},
-				EncryptedKey: &xmlenc1.EncryptedKey{
-					CipherValue: make([]byte, 40),
+				EncryptedKeys: []*xmlenc1.EncryptedKey{
+					{
+						CipherValue: make([]byte, 40),
+					},
 				},
 				CipherValue: make([]byte, 48),
 			}
@@ -308,9 +314,11 @@ func TestResolveSessionKey(t *testing.T) {
 		ed := &xmlenc1.EncryptedData{
 			Type:             xmlenc1.TypeElement,
 			EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256GCM},
-			EncryptedKey: &xmlenc1.EncryptedKey{
-				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: "urn:example:not-a-real-algorithm"},
-				CipherValue:      make([]byte, 40),
+			EncryptedKeys: []*xmlenc1.EncryptedKey{
+				{
+					EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: "urn:example:not-a-real-algorithm"},
+					CipherValue:      make([]byte, 40),
+				},
 			},
 			CipherValue: make([]byte, 48),
 		}

--- a/xmlenc1/parse.go
+++ b/xmlenc1/parse.go
@@ -59,6 +59,12 @@ func parseEncryptedData(elem *helium.Element) (*EncryptedData, error) {
 		return nil, fmt.Errorf("%w: missing CipherData/CipherValue", ErrMalformedEncrypted)
 	}
 
+	// Populate the deprecated single EncryptedKey field with the first
+	// candidate so callers reading it keep working.
+	if len(ed.EncryptedKeys) > 0 {
+		ed.EncryptedKey = ed.EncryptedKeys[0]
+	}
+
 	return ed, nil
 }
 

--- a/xmlenc1/parse.go
+++ b/xmlenc1/parse.go
@@ -19,6 +19,10 @@ func parseEncryptedData(elem *helium.Element) (*EncryptedData, error) {
 	ed.ID, _ = elem.GetAttribute("Id")
 	ed.Type, _ = elem.GetAttribute("Type")
 
+	// Track CipherData separately: a decoded CipherValue can be a non-nil
+	// empty slice, so a boolean is the reliable duplicate sentinel.
+	var seenCipherData bool
+
 	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
 		e, ok := helium.AsNode[*helium.Element](child)
 		if !ok {
@@ -26,6 +30,9 @@ func parseEncryptedData(elem *helium.Element) (*EncryptedData, error) {
 		}
 		switch {
 		case isXMLEncElem(e, "EncryptionMethod"):
+			if ed.EncryptionMethod != nil {
+				return nil, fmt.Errorf("%w: duplicate EncryptionMethod", ErrMalformedEncrypted)
+			}
 			em, err := parseEncryptionMethod(e)
 			if err != nil {
 				return nil, err
@@ -36,6 +43,10 @@ func parseEncryptedData(elem *helium.Element) (*EncryptedData, error) {
 				return nil, err
 			}
 		case isXMLEncElem(e, "CipherData"):
+			if seenCipherData {
+				return nil, fmt.Errorf("%w: duplicate CipherData", ErrMalformedEncrypted)
+			}
+			seenCipherData = true
 			cv, err := parseCipherData(e)
 			if err != nil {
 				return nil, err
@@ -62,8 +73,7 @@ func parseKeyInfoForEncryption(elem *helium.Element, ed *EncryptedData) error {
 			if err != nil {
 				return err
 			}
-			ed.EncryptedKey = ek
-			return nil
+			ed.EncryptedKeys = append(ed.EncryptedKeys, ek)
 		}
 	}
 	return nil
@@ -79,6 +89,8 @@ func parseEncryptedKey(elem *helium.Element) (*EncryptedKey, error) {
 	ek.ID, _ = elem.GetAttribute("Id")
 	ek.Recipient, _ = elem.GetAttribute("Recipient")
 
+	var seenCipherData bool
+
 	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
 		e, ok := helium.AsNode[*helium.Element](child)
 		if !ok {
@@ -86,12 +98,19 @@ func parseEncryptedKey(elem *helium.Element) (*EncryptedKey, error) {
 		}
 		switch {
 		case isXMLEncElem(e, "EncryptionMethod"):
+			if ek.EncryptionMethod != nil {
+				return nil, fmt.Errorf("%w: duplicate EncryptionMethod", ErrMalformedEncrypted)
+			}
 			em, err := parseEncryptionMethod(e)
 			if err != nil {
 				return nil, err
 			}
 			ek.EncryptionMethod = em
 		case isXMLEncElem(e, "CipherData"):
+			if seenCipherData {
+				return nil, fmt.Errorf("%w: duplicate CipherData", ErrMalformedEncrypted)
+			}
+			seenCipherData = true
 			cv, err := parseCipherData(e)
 			if err != nil {
 				return nil, err

--- a/xmlenc1/parse_test.go
+++ b/xmlenc1/parse_test.go
@@ -157,14 +157,16 @@ func TestMarshalParseRoundTrip(t *testing.T) {
 			MGFAlgorithm: xmlenc1.MGFSHA256,
 			OAEPParams:   []byte("params-bytes"),
 		},
-		EncryptedKey: &xmlenc1.EncryptedKey{
-			ID: "EK-1",
-			EncryptionMethod: &xmlenc1.EncryptionMethod{
-				Algorithm:    xmlenc1.RSAOAEP11,
-				DigestMethod: xmlenc1.DigestSHA256,
-				MGFAlgorithm: xmlenc1.MGFSHA256,
+		EncryptedKeys: []*xmlenc1.EncryptedKey{
+			{
+				ID: "EK-1",
+				EncryptionMethod: &xmlenc1.EncryptionMethod{
+					Algorithm:    xmlenc1.RSAOAEP11,
+					DigestMethod: xmlenc1.DigestSHA256,
+					MGFAlgorithm: xmlenc1.MGFSHA256,
+				},
+				CipherValue: []byte("wrapped-key-bytes"),
 			},
-			CipherValue: []byte("wrapped-key-bytes"),
 		},
 		CipherValue: []byte("cipher-bytes"),
 	}
@@ -186,10 +188,10 @@ func TestMarshalParseRoundTrip(t *testing.T) {
 	require.Equal(t, xmlenc1.MGFSHA256, parsed.EncryptionMethod.MGFAlgorithm)
 	require.Equal(t, []byte("params-bytes"), parsed.EncryptionMethod.OAEPParams)
 
-	require.NotNil(t, parsed.EncryptedKey)
-	require.Equal(t, "EK-1", parsed.EncryptedKey.ID)
-	require.NotNil(t, parsed.EncryptedKey.EncryptionMethod)
-	require.Equal(t, xmlenc1.RSAOAEP11, parsed.EncryptedKey.EncryptionMethod.Algorithm)
-	require.Equal(t, []byte("wrapped-key-bytes"), parsed.EncryptedKey.CipherValue)
+	require.Len(t, parsed.EncryptedKeys, 1)
+	require.Equal(t, "EK-1", parsed.EncryptedKeys[0].ID)
+	require.NotNil(t, parsed.EncryptedKeys[0].EncryptionMethod)
+	require.Equal(t, xmlenc1.RSAOAEP11, parsed.EncryptedKeys[0].EncryptionMethod.Algorithm)
+	require.Equal(t, []byte("wrapped-key-bytes"), parsed.EncryptedKeys[0].CipherValue)
 	require.Equal(t, []byte("cipher-bytes"), parsed.CipherValue)
 }

--- a/xmlenc1/robustness_test.go
+++ b/xmlenc1/robustness_test.go
@@ -1,12 +1,72 @@
 package xmlenc1_test
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
 	"testing"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/xmlenc1"
 	"github.com/stretchr/testify/require"
 )
+
+// TestDecryptBogusFirstKeyTriesNext covers XENC-005: a candidate
+// EncryptedKey that UNWRAPS/transports successfully but wraps the WRONG
+// session key must not short-circuit the search. The decryptor must carry
+// each candidate through block decryption (and plaintext validation),
+// falling through to the next candidate on failure. Otherwise an attacker
+// who prepends a valid RSA-OAEP EncryptedKey (for the recipient's public
+// key) wrapping a random session key denies service to the legitimate key.
+func TestDecryptBogusFirstKeyTriesNext(t *testing.T) {
+	const blockAlg = xmlenc1.AES256GCM
+
+	priv := generateRSAKey(t)
+	pub := &priv.PublicKey
+
+	wrapOAEP := func(t *testing.T, sessionKey []byte) []byte {
+		t.Helper()
+		// RSA-OAEP-MGF1P uses SHA-1 for both digest and MGF1.
+		ct, err := rsa.EncryptOAEP(sha1.New(), rand.Reader, pub, sessionKey, nil)
+		require.NoError(t, err)
+		return ct
+	}
+
+	realSessionKey := randKey(t, 32)
+	cipher, err := xmlenc1.EncryptBytesForTest(blockAlg, realSessionKey, []byte("<x>secret</x>"))
+	require.NoError(t, err)
+
+	// First key is a perfectly valid RSA-OAEP transport of a RANDOM session
+	// key: it unwraps cleanly under priv but cannot decrypt the ciphertext.
+	// Second key transports the real session key.
+	bogusSessionKey := randKey(t, 32)
+
+	doc := mustParseXML(t, `<root/>`)
+	ed := &xmlenc1.EncryptedData{
+		Type:             xmlenc1.TypeElement,
+		EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: blockAlg},
+		EncryptedKeys: []*xmlenc1.EncryptedKey{
+			{
+				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.RSAOAEP},
+				CipherValue:      wrapOAEP(t, bogusSessionKey),
+			},
+			{
+				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.RSAOAEP},
+				CipherValue:      wrapOAEP(t, realSessionKey),
+			},
+		},
+		CipherValue: cipher,
+	}
+	elem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+	require.NoError(t, err)
+
+	nodes, err := xmlenc1.NewDecryptor().PrivateKey(priv).Decrypt(t.Context(), elem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	s, err := helium.WriteString(nodes[0])
+	require.NoError(t, err)
+	require.Contains(t, s, "secret")
+}
 
 // TestMultiRecipientDecrypt covers XENC-002: an EncryptedData may carry
 // several EncryptedKey candidates (one per recipient), and decryption must

--- a/xmlenc1/robustness_test.go
+++ b/xmlenc1/robustness_test.go
@@ -152,6 +152,35 @@ func TestMultiRecipientDecrypt(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, s, "secret")
 	})
+
+	t.Run("applicable failure not masked by later missing key", func(t *testing.T) {
+		sessionKey := randKey(t, 32)
+		cipher, err := xmlenc1.EncryptBytesForTest(algorithm, sessionKey, []byte("<x>secret</x>"))
+		require.NoError(t, err)
+
+		kekMine := randKey(t, 32)
+		wrongSessionKey := randKey(t, 32)
+
+		// First key is APPLICABLE (AES key-wrap, our KEK) but transports the
+		// WRONG session key, so block decryption fails with a real error.
+		// Second key is NON-APPLICABLE (RSA-OAEP, no private key supplied) and
+		// only yields ErrMissingKey. The informative ErrDecryptionFailed must
+		// surface rather than being overwritten by the trailing ErrMissingKey.
+		elem := newEncryptedData(t, []*xmlenc1.EncryptedKey{
+			{
+				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256KeyWrap},
+				CipherValue:      wrap(t, kekMine, wrongSessionKey),
+			},
+			{
+				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.RSAOAEP},
+				CipherValue:      randKey(t, 256),
+			},
+		}, cipher)
+
+		_, err = xmlenc1.NewDecryptor().KeyEncryptionKey(kekMine).Decrypt(t.Context(), elem)
+		require.ErrorIs(t, err, xmlenc1.ErrDecryptionFailed)
+		require.NotErrorIs(t, err, xmlenc1.ErrMissingKey)
+	})
 }
 
 // TestParseRejectsDuplicateCardinality covers XENC-003: XML Encryption
@@ -190,6 +219,18 @@ func TestParseRejectsDuplicateCardinality(t *testing.T) {
 				`<xenc:EncryptionMethod Algorithm="` + xmlenc1.RSAOAEP + `"/>` +
 				`<xenc:EncryptionMethod Algorithm="` + xmlenc1.RSAOAEP11 + `"/>` +
 				`<xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData>` +
+				`</xenc:EncryptedKey></ds:KeyInfo>` +
+				`<xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData>` +
+				`</xenc:EncryptedData>`,
+		},
+		{
+			name: "duplicate CipherData in EncryptedKey",
+			xml: `<xenc:EncryptedData ` + xenc + ` ` + ds + `>` +
+				`<xenc:EncryptionMethod Algorithm="` + xmlenc1.AES256GCM + `"/>` +
+				`<ds:KeyInfo><xenc:EncryptedKey>` +
+				`<xenc:EncryptionMethod Algorithm="` + xmlenc1.RSAOAEP + `"/>` +
+				`<xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData>` +
+				`<xenc:CipherData><xenc:CipherValue>BBBB</xenc:CipherValue></xenc:CipherData>` +
 				`</xenc:EncryptedKey></ds:KeyInfo>` +
 				`<xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData>` +
 				`</xenc:EncryptedData>`,
@@ -242,5 +283,65 @@ func TestDecryptType(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, nodes, 1)
 		require.Equal(t, helium.ElementNode, nodes[0].Type())
+	})
+}
+
+// TestDeprecatedEncryptedKeyField exercises the backward-compatible single
+// EncryptedKey field: a caller that sets only the deprecated field (with
+// EncryptedKeys left nil) must still marshal and decrypt, and parsing a
+// single-EncryptedKey document must populate BOTH EncryptedKey and
+// EncryptedKeys[0] so old and new readers agree.
+func TestDeprecatedEncryptedKeyField(t *testing.T) {
+	const algorithm = xmlenc1.AES256GCM
+
+	t.Run("marshal and decrypt via deprecated field only", func(t *testing.T) {
+		sessionKey := randKey(t, 32)
+		cipher, err := xmlenc1.EncryptBytesForTest(algorithm, sessionKey, []byte("<x>secret</x>"))
+		require.NoError(t, err)
+
+		kek := randKey(t, 32)
+		wrapped, err := xmlenc1.AESKeyWrapForTest(kek, sessionKey)
+		require.NoError(t, err)
+
+		doc := mustParseXML(t, `<root/>`)
+		ed := &xmlenc1.EncryptedData{
+			Type:             xmlenc1.TypeElement,
+			EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: algorithm},
+			// Only the deprecated single field is set; EncryptedKeys is nil.
+			EncryptedKey: &xmlenc1.EncryptedKey{
+				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256KeyWrap},
+				CipherValue:      wrapped,
+			},
+			CipherValue: cipher,
+		}
+		elem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+		require.NoError(t, err)
+
+		nodes, err := xmlenc1.NewDecryptor().KeyEncryptionKey(kek).Decrypt(t.Context(), elem)
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+		s, err := helium.WriteString(nodes[0])
+		require.NoError(t, err)
+		require.Contains(t, s, "secret")
+	})
+
+	t.Run("parse populates both deprecated and slice fields", func(t *testing.T) {
+		const xenc = `xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"`
+		const ds = `xmlns:ds="http://www.w3.org/2000/09/xmldsig#"`
+		xml := `<xenc:EncryptedData ` + xenc + ` ` + ds + `>` +
+			`<xenc:EncryptionMethod Algorithm="` + algorithm + `"/>` +
+			`<ds:KeyInfo><xenc:EncryptedKey>` +
+			`<xenc:EncryptionMethod Algorithm="` + xmlenc1.RSAOAEP + `"/>` +
+			`<xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData>` +
+			`</xenc:EncryptedKey></ds:KeyInfo>` +
+			`<xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData>` +
+			`</xenc:EncryptedData>`
+
+		doc := mustParseXML(t, xml)
+		ed, err := xmlenc1.ParseEncryptedDataForTest(doc.DocumentElement())
+		require.NoError(t, err)
+		require.NotNil(t, ed.EncryptedKey)
+		require.Len(t, ed.EncryptedKeys, 1)
+		require.Same(t, ed.EncryptedKeys[0], ed.EncryptedKey)
 	})
 }

--- a/xmlenc1/robustness_test.go
+++ b/xmlenc1/robustness_test.go
@@ -1,0 +1,186 @@
+package xmlenc1_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xmlenc1"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMultiRecipientDecrypt covers XENC-002: an EncryptedData may carry
+// several EncryptedKey candidates (one per recipient), and decryption must
+// try each rather than committing to the first. This also makes a bogus
+// EncryptedKey prepended to a legitimate one a non-issue instead of a DoS.
+func TestMultiRecipientDecrypt(t *testing.T) {
+	const algorithm = xmlenc1.AES256GCM
+
+	newEncryptedData := func(t *testing.T, keys []*xmlenc1.EncryptedKey, cipher []byte) *helium.Element {
+		t.Helper()
+		doc := mustParseXML(t, `<root/>`)
+		ed := &xmlenc1.EncryptedData{
+			Type:             xmlenc1.TypeElement,
+			EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: algorithm},
+			EncryptedKeys:    keys,
+			CipherValue:      cipher,
+		}
+		elem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+		require.NoError(t, err)
+		return elem
+	}
+
+	wrap := func(t *testing.T, kek, sessionKey []byte) []byte {
+		t.Helper()
+		wrapped, err := xmlenc1.AESKeyWrapForTest(kek, sessionKey)
+		require.NoError(t, err)
+		return wrapped
+	}
+
+	t.Run("second recipient matches", func(t *testing.T) {
+		sessionKey := randKey(t, 32)
+		cipher, err := xmlenc1.EncryptBytesForTest(algorithm, sessionKey, []byte("<x>secret</x>"))
+		require.NoError(t, err)
+
+		kekOther := randKey(t, 32)
+		kekMine := randKey(t, 32)
+
+		// Two legitimate recipients; only the second one's KEK is ours.
+		elem := newEncryptedData(t, []*xmlenc1.EncryptedKey{
+			{
+				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256KeyWrap},
+				CipherValue:      wrap(t, kekOther, sessionKey),
+			},
+			{
+				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256KeyWrap},
+				CipherValue:      wrap(t, kekMine, sessionKey),
+			},
+		}, cipher)
+
+		nodes, err := xmlenc1.NewDecryptor().KeyEncryptionKey(kekMine).Decrypt(t.Context(), elem)
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+		s, err := helium.WriteString(nodes[0])
+		require.NoError(t, err)
+		require.Contains(t, s, "secret")
+	})
+
+	t.Run("bogus first key tolerated", func(t *testing.T) {
+		sessionKey := randKey(t, 32)
+		cipher, err := xmlenc1.EncryptBytesForTest(algorithm, sessionKey, []byte("<x>secret</x>"))
+		require.NoError(t, err)
+
+		kekMine := randKey(t, 32)
+
+		// A junk EncryptedKey is prepended ahead of the legitimate one.
+		// Under the old "first key only" behavior this denied service to
+		// the real recipient.
+		elem := newEncryptedData(t, []*xmlenc1.EncryptedKey{
+			{
+				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256KeyWrap},
+				CipherValue:      randKey(t, 40), // not a valid AES-wrap of any key
+			},
+			{
+				EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256KeyWrap},
+				CipherValue:      wrap(t, kekMine, sessionKey),
+			},
+		}, cipher)
+
+		nodes, err := xmlenc1.NewDecryptor().KeyEncryptionKey(kekMine).Decrypt(t.Context(), elem)
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+		s, err := helium.WriteString(nodes[0])
+		require.NoError(t, err)
+		require.Contains(t, s, "secret")
+	})
+}
+
+// TestParseRejectsDuplicateCardinality covers XENC-003: XML Encryption
+// allows at most one EncryptionMethod and one CipherData per EncryptedData
+// (and per EncryptedKey). Duplicates were previously accepted last-one-wins;
+// they must now be rejected during parse.
+func TestParseRejectsDuplicateCardinality(t *testing.T) {
+	const xenc = `xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"`
+	const ds = `xmlns:ds="http://www.w3.org/2000/09/xmldsig#"`
+
+	for _, tc := range []struct {
+		name string
+		xml  string
+	}{
+		{
+			name: "duplicate EncryptionMethod in EncryptedData",
+			xml: `<xenc:EncryptedData ` + xenc + `>` +
+				`<xenc:EncryptionMethod Algorithm="` + xmlenc1.AES256GCM + `"/>` +
+				`<xenc:EncryptionMethod Algorithm="` + xmlenc1.AES128GCM + `"/>` +
+				`<xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData>` +
+				`</xenc:EncryptedData>`,
+		},
+		{
+			name: "duplicate CipherData in EncryptedData",
+			xml: `<xenc:EncryptedData ` + xenc + `>` +
+				`<xenc:EncryptionMethod Algorithm="` + xmlenc1.AES256GCM + `"/>` +
+				`<xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData>` +
+				`<xenc:CipherData><xenc:CipherValue>BBBB</xenc:CipherValue></xenc:CipherData>` +
+				`</xenc:EncryptedData>`,
+		},
+		{
+			name: "duplicate EncryptionMethod in EncryptedKey",
+			xml: `<xenc:EncryptedData ` + xenc + ` ` + ds + `>` +
+				`<xenc:EncryptionMethod Algorithm="` + xmlenc1.AES256GCM + `"/>` +
+				`<ds:KeyInfo><xenc:EncryptedKey>` +
+				`<xenc:EncryptionMethod Algorithm="` + xmlenc1.RSAOAEP + `"/>` +
+				`<xenc:EncryptionMethod Algorithm="` + xmlenc1.RSAOAEP11 + `"/>` +
+				`<xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData>` +
+				`</xenc:EncryptedKey></ds:KeyInfo>` +
+				`<xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData>` +
+				`</xenc:EncryptedData>`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := mustParseXML(t, tc.xml)
+			_, err := xmlenc1.ParseEncryptedDataForTest(doc.DocumentElement())
+			require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+		})
+	}
+}
+
+// TestDecryptType covers XENC-004: a non-empty Type other than Element or
+// Content (including unknown URIs) must be rejected rather than silently
+// treated as Element. An omitted Type keeps the historical Element default.
+func TestDecryptType(t *testing.T) {
+	const algorithm = xmlenc1.AES256GCM
+
+	build := func(t *testing.T, typeURI string, cipher []byte) *helium.Element {
+		t.Helper()
+		doc := mustParseXML(t, `<root/>`)
+		ed := &xmlenc1.EncryptedData{
+			Type:             typeURI,
+			EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: algorithm},
+			CipherValue:      cipher,
+		}
+		elem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+		require.NoError(t, err)
+		return elem
+	}
+
+	t.Run("unknown Type rejected", func(t *testing.T) {
+		sessionKey := randKey(t, 32)
+		cipher, err := xmlenc1.EncryptBytesForTest(algorithm, sessionKey, []byte("<x>secret</x>"))
+		require.NoError(t, err)
+
+		elem := build(t, "urn:example:bogus-type", cipher)
+		_, err = xmlenc1.NewDecryptor().SessionKey(sessionKey).Decrypt(t.Context(), elem)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+
+	t.Run("omitted Type defaults to Element", func(t *testing.T) {
+		sessionKey := randKey(t, 32)
+		cipher, err := xmlenc1.EncryptBytesForTest(algorithm, sessionKey, []byte("<x>secret</x>"))
+		require.NoError(t, err)
+
+		elem := build(t, "", cipher)
+		nodes, err := xmlenc1.NewDecryptor().SessionKey(sessionKey).Decrypt(t.Context(), elem)
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+		require.Equal(t, helium.ElementNode, nodes[0].Type())
+	})
+}

--- a/xmlenc1/serialize.go
+++ b/xmlenc1/serialize.go
@@ -37,8 +37,10 @@ func marshalEncryptedData(doc *helium.Document, ed *EncryptedData) (*helium.Elem
 		}
 	}
 
-	// KeyInfo with one EncryptedKey per recipient.
-	if len(ed.EncryptedKeys) > 0 {
+	// KeyInfo with one EncryptedKey per recipient. EncryptedKeys takes
+	// precedence over the deprecated single EncryptedKey field.
+	encKeys := ed.effectiveEncryptedKeys()
+	if len(encKeys) > 0 {
 		keyInfo := doc.CreateElement("KeyInfo")
 		if err := keyInfo.DeclareNamespace(nsPrefixDSig, NamespaceDSig); err != nil {
 			return nil, err
@@ -47,7 +49,7 @@ func marshalEncryptedData(doc *helium.Document, ed *EncryptedData) (*helium.Elem
 			return nil, err
 		}
 
-		for _, k := range ed.EncryptedKeys {
+		for _, k := range encKeys {
 			ek, err := marshalEncryptedKey(doc, k)
 			if err != nil {
 				return nil, err

--- a/xmlenc1/serialize.go
+++ b/xmlenc1/serialize.go
@@ -37,8 +37,8 @@ func marshalEncryptedData(doc *helium.Document, ed *EncryptedData) (*helium.Elem
 		}
 	}
 
-	// KeyInfo with EncryptedKey
-	if ed.EncryptedKey != nil {
+	// KeyInfo with one EncryptedKey per recipient.
+	if len(ed.EncryptedKeys) > 0 {
 		keyInfo := doc.CreateElement("KeyInfo")
 		if err := keyInfo.DeclareNamespace(nsPrefixDSig, NamespaceDSig); err != nil {
 			return nil, err
@@ -47,12 +47,14 @@ func marshalEncryptedData(doc *helium.Document, ed *EncryptedData) (*helium.Elem
 			return nil, err
 		}
 
-		ek, err := marshalEncryptedKey(doc, ed.EncryptedKey)
-		if err != nil {
-			return nil, err
-		}
-		if err := keyInfo.AddChild(ek); err != nil {
-			return nil, err
+		for _, k := range ed.EncryptedKeys {
+			ek, err := marshalEncryptedKey(doc, k)
+			if err != nil {
+				return nil, err
+			}
+			if err := keyInfo.AddChild(ek); err != nil {
+				return nil, err
+			}
 		}
 		if err := root.AddChild(keyInfo); err != nil {
 			return nil, err

--- a/xmlenc1/types.go
+++ b/xmlenc1/types.go
@@ -13,12 +13,33 @@ type EncryptedData struct {
 	ID               string
 	Type             string // TypeElement or TypeContent
 	EncryptionMethod *EncryptionMethod
+	// EncryptedKey is the first EncryptedKey candidate, kept for backward
+	// compatibility with callers written against the old single-key field.
+	//
+	// Deprecated: use EncryptedKeys. When both are set, EncryptedKeys takes
+	// precedence and this field is ignored; when only this field is set it
+	// is treated as a single-element EncryptedKeys.
+	EncryptedKey *EncryptedKey
 	// EncryptedKeys holds every EncryptedKey candidate found in KeyInfo
 	// (one per recipient). Decryption tries each in turn, so a
 	// multi-recipient document, or one with a bogus EncryptedKey
 	// prepended to a legitimate one, still resolves.
 	EncryptedKeys []*EncryptedKey
 	CipherValue   []byte // base64-decoded cipher bytes
+}
+
+// effectiveEncryptedKeys returns the EncryptedKey candidates to use,
+// reconciling the EncryptedKeys slice with the deprecated single
+// EncryptedKey field: EncryptedKeys wins when non-empty; otherwise the
+// deprecated field, if set, is treated as a single-element list.
+func (ed *EncryptedData) effectiveEncryptedKeys() []*EncryptedKey {
+	if len(ed.EncryptedKeys) > 0 {
+		return ed.EncryptedKeys
+	}
+	if ed.EncryptedKey != nil {
+		return []*EncryptedKey{ed.EncryptedKey}
+	}
+	return nil
 }
 
 // EncryptedKey represents the <EncryptedKey> element.

--- a/xmlenc1/types.go
+++ b/xmlenc1/types.go
@@ -13,8 +13,12 @@ type EncryptedData struct {
 	ID               string
 	Type             string // TypeElement or TypeContent
 	EncryptionMethod *EncryptionMethod
-	EncryptedKey     *EncryptedKey // from KeyInfo
-	CipherValue      []byte        // base64-decoded cipher bytes
+	// EncryptedKeys holds every EncryptedKey candidate found in KeyInfo
+	// (one per recipient). Decryption tries each in turn, so a
+	// multi-recipient document, or one with a bogus EncryptedKey
+	// prepended to a legitimate one, still resolves.
+	EncryptedKeys []*EncryptedKey
+	CipherValue   []byte // base64-decoded cipher bytes
 }
 
 // EncryptedKey represents the <EncryptedKey> element.

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -429,17 +429,34 @@ func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Elemen
 	for _, ek := range keys {
 		sessionKey, err := resolveSessionKeyFromEncryptedKey(cfg, ek)
 		if err != nil {
-			lastErr = err
+			lastErr = preferInformativeErr(lastErr, err)
 			continue
 		}
 		nodes, err := finishDecrypt(ctx, ed, elem, alg, isContent, sessionKey)
 		if err != nil {
-			lastErr = err
+			lastErr = preferInformativeErr(lastErr, err)
 			continue
 		}
 		return nodes, nil
 	}
 	return nil, lastErr
+}
+
+// preferInformativeErr keeps the most informative error across EncryptedKey
+// candidates. A non-applicable candidate (one whose algorithm needs a key the
+// caller did not supply) yields ErrMissingKey, which carries no signal about
+// why decryption truly failed. A real failure from an applicable candidate
+// (bad unwrap, wrong session key, malformed plaintext) must not be masked by
+// a later ErrMissingKey. So: the first non-ErrMissingKey error wins and is
+// never overwritten by a subsequent ErrMissingKey.
+func preferInformativeErr(existing, candidate error) error {
+	if existing == nil {
+		return candidate
+	}
+	if errors.Is(existing, ErrMissingKey) && !errors.Is(candidate, ErrMissingKey) {
+		return candidate
+	}
+	return existing
 }
 
 // finishDecrypt block-decrypts the CipherValue under a candidate session

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -393,17 +393,12 @@ func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Elemen
 		return nil, fmt.Errorf("%w: unsupported EncryptedData Type %q", ErrMalformedEncrypted, ed.Type)
 	}
 
-	// Obtain session key.
-	sessionKey, err := resolveSessionKey(cfg, ed)
-	if err != nil {
-		return nil, err
-	}
-
-	// Block decrypt.
+	// Validate the EncryptionMethod and CBC opt-in once, up front: these
+	// describe the block cipher and are independent of which session-key
+	// candidate ultimately succeeds.
 	if ed.EncryptionMethod == nil {
 		return nil, fmt.Errorf("%w: missing EncryptionMethod", ErrMalformedEncrypted)
 	}
-
 	alg := ed.EncryptionMethod.Algorithm
 	switch alg {
 	case AES128CBC, AES256CBC:
@@ -412,6 +407,47 @@ func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Elemen
 		}
 	}
 
+	// A pre-shared session key, when configured, is the sole candidate.
+	if len(cfg.sessionKey) > 0 {
+		return finishDecrypt(ctx, ed, elem, alg, isContent, cfg.sessionKey)
+	}
+
+	keys := ed.effectiveEncryptedKeys()
+	if len(keys) == 0 {
+		return nil, ErrMissingKey
+	}
+
+	// A document may carry several EncryptedKey candidates (one per
+	// recipient), and an attacker can prepend a junk EncryptedKey that
+	// unwraps cleanly under the recipient's key while wrapping the WRONG
+	// session key. Carry each candidate all the way through block
+	// decryption AND plaintext parse/shape validation, accepting only a
+	// candidate that fully succeeds — never stop at one that merely
+	// unwraps/transports. This supports multi-recipient documents and
+	// stops a bogus-but-valid EncryptedKey from masking the real one.
+	var lastErr error
+	for _, ek := range keys {
+		sessionKey, err := resolveSessionKeyFromEncryptedKey(cfg, ek)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		nodes, err := finishDecrypt(ctx, ed, elem, alg, isContent, sessionKey)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return nodes, nil
+	}
+	return nil, lastErr
+}
+
+// finishDecrypt block-decrypts the CipherValue under a candidate session
+// key, parses the recovered plaintext through a hardened parser, and
+// validates its shape. It returns the decrypted nodes only when the entire
+// pipeline succeeds, so a caller iterating session-key candidates can
+// safely fall through to the next candidate on any error.
+func finishDecrypt(ctx context.Context, ed *EncryptedData, elem *helium.Element, alg string, isContent bool, sessionKey []byte) ([]helium.Node, error) {
 	plaintext, err := blockDecrypt(alg, sessionKey, ed.CipherValue)
 	if err != nil {
 		// Squash all decryption errors to the same sentinel — and
@@ -503,33 +539,6 @@ func newHardenedInnerParser() helium.Parser {
 		BlockXXE(true).
 		LoadExternalDTD(false).
 		AllowNetwork(false)
-}
-
-func resolveSessionKey(cfg *decryptConfig, ed *EncryptedData) ([]byte, error) {
-	if len(cfg.sessionKey) > 0 {
-		return cfg.sessionKey, nil
-	}
-
-	if len(ed.EncryptedKeys) == 0 {
-		return nil, ErrMissingKey
-	}
-
-	// A document may carry several EncryptedKey candidates (one per
-	// recipient), and an attacker can prepend a junk EncryptedKey to a
-	// legitimate one. Try every candidate and accept the first that
-	// yields a session key, instead of committing to the first element.
-	// This both supports multi-recipient documents and stops a single
-	// bogus key from denying service to the legitimate recipient.
-	var lastErr error
-	for _, ek := range ed.EncryptedKeys {
-		key, err := resolveSessionKeyFromEncryptedKey(cfg, ek)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		return key, nil
-	}
-	return nil, lastErr
 }
 
 func resolveSessionKeyFromEncryptedKey(cfg *decryptConfig, ek *EncryptedKey) ([]byte, error) {

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -246,10 +246,14 @@ func encrypt(_ context.Context, cfg *encryptConfig, elem *helium.Element, encTyp
 	}
 
 	// Build EncryptedData.
+	var encKeys []*EncryptedKey
+	if encKey != nil {
+		encKeys = []*EncryptedKey{encKey}
+	}
 	ed := &EncryptedData{
 		Type:             encType,
 		EncryptionMethod: &EncryptionMethod{Algorithm: blockAlgorithm},
-		EncryptedKey:     encKey,
+		EncryptedKeys:    encKeys,
 		CipherValue:      cipherValue,
 	}
 
@@ -375,6 +379,20 @@ func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Elemen
 		return nil, err
 	}
 
+	// Validate the declared content Type up front. An omitted Type defaults
+	// to Element (preserving prior behavior); any other non-empty value,
+	// including unknown URIs, is rejected rather than silently treated as
+	// Element.
+	var isContent bool
+	switch ed.Type {
+	case "", TypeElement:
+		isContent = false
+	case TypeContent:
+		isContent = true
+	default:
+		return nil, fmt.Errorf("%w: unsupported EncryptedData Type %q", ErrMalformedEncrypted, ed.Type)
+	}
+
 	// Obtain session key.
 	sessionKey, err := resolveSessionKey(cfg, ed)
 	if err != nil {
@@ -413,7 +431,6 @@ func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Elemen
 	// the recipient's key) and must not be allowed to fetch external
 	// resources.
 	parser := newHardenedInnerParser()
-	isContent := ed.Type == TypeContent
 
 	// Both Element and Content replace EncryptedData at its position in the
 	// tree, so the decrypted fragment must be parsed in the in-scope-namespace
@@ -493,11 +510,29 @@ func resolveSessionKey(cfg *decryptConfig, ed *EncryptedData) ([]byte, error) {
 		return cfg.sessionKey, nil
 	}
 
-	if ed.EncryptedKey == nil {
+	if len(ed.EncryptedKeys) == 0 {
 		return nil, ErrMissingKey
 	}
 
-	ek := ed.EncryptedKey
+	// A document may carry several EncryptedKey candidates (one per
+	// recipient), and an attacker can prepend a junk EncryptedKey to a
+	// legitimate one. Try every candidate and accept the first that
+	// yields a session key, instead of committing to the first element.
+	// This both supports multi-recipient documents and stops a single
+	// bogus key from denying service to the legitimate recipient.
+	var lastErr error
+	for _, ek := range ed.EncryptedKeys {
+		key, err := resolveSessionKeyFromEncryptedKey(cfg, ek)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return key, nil
+	}
+	return nil, lastErr
+}
+
+func resolveSessionKeyFromEncryptedKey(cfg *decryptConfig, ek *EncryptedKey) ([]byte, error) {
 	if ek.EncryptionMethod == nil {
 		return nil, fmt.Errorf("%w: EncryptedKey missing EncryptionMethod", ErrMalformedEncrypted)
 	}


### PR DESCRIPTION
- try all EncryptedKey candidates on decrypt so multi-recipient docs work and a bogus prepended key no longer denies service (XENC-002)
- reject duplicate EncryptionMethod/CipherData during parse (XENC-003)
- reject EncryptedData Type values other than Element/Content; omitted Type still defaults to Element (XENC-004)