### PR TITLE
fix tunnel param leak on caught with-param error

### DIFF
--- a/xslt3/execute_apply.go
+++ b/xslt3/execute_apply.go
@@ -402,6 +402,11 @@ func (ec *execContext) execCallTemplate(ctx context.Context, inst *callTemplateI
 	// because the with-param select expressions need the caller's context item.
 	paramOverrides := make(map[string]xpath3.Sequence)
 	savedTunnel := ec.tunnelParams
+	// Register the tunnel restore BEFORE evaluating params: a tunnel
+	// with-param mutates ec.tunnelParams, and a later param's evaluation
+	// may fail and return — without the defer already in place the
+	// mutation would leak (e.g. across a dynamic error caught by xsl:try).
+	defer func() { ec.tunnelParams = savedTunnel }()
 	hasTunnelOverrides := false
 	for _, wp := range inst.Params {
 		val, err := ec.evaluateWithParam(ctx, wp)
@@ -423,7 +428,6 @@ func (ec *execContext) execCallTemplate(ctx context.Context, inst *callTemplateI
 			paramOverrides[wp.Name] = val
 		}
 	}
-	defer func() { ec.tunnelParams = savedTunnel }()
 
 	// xsl:context-item use="absent": make the context item absent within the
 	// called template's body. This means xsl:next-match will fail with
@@ -559,6 +563,11 @@ func (ec *execContext) execNextMatch(ctx context.Context, inst *nextMatchInst) e
 	// Copy tunnel params to avoid mutating the caller's map.
 	var pv map[string]xpath3.Sequence
 	savedTunnel := ec.tunnelParams
+	// Register the tunnel restore BEFORE evaluating params: a tunnel
+	// with-param mutates ec.tunnelParams below, and a later param's
+	// evaluation may fail and return — without the defer already in place
+	// the mutation would leak (e.g. across a dynamic error caught by xsl:try).
+	defer func() { ec.tunnelParams = savedTunnel }()
 	if len(inst.Params) > 0 {
 		hasTunnel := false
 		for _, wp := range inst.Params {
@@ -587,7 +596,6 @@ func (ec *execContext) execNextMatch(ctx context.Context, inst *nextMatchInst) e
 			}
 		}
 	}
-	defer func() { ec.tunnelParams = savedTunnel }()
 
 	// Handle atomic context items (e.g., xsl:next-match when processing integers)
 	if ec.contextItem != nil {
@@ -671,6 +679,11 @@ func (ec *execContext) execApplyImports(ctx context.Context, inst *applyImportsI
 	// Copy tunnel params to avoid mutating the caller's map.
 	var pv map[string]xpath3.Sequence
 	savedTunnel := ec.tunnelParams
+	// Register the tunnel restore BEFORE evaluating params: a tunnel
+	// with-param mutates ec.tunnelParams below, and a later param's
+	// evaluation may fail and return — without the defer already in place
+	// the mutation would leak (e.g. across a dynamic error caught by xsl:try).
+	defer func() { ec.tunnelParams = savedTunnel }()
 	if len(inst.Params) > 0 {
 		hasTunnel := false
 		for _, wp := range inst.Params {
@@ -699,7 +712,6 @@ func (ec *execContext) execApplyImports(ctx context.Context, inst *applyImportsI
 			}
 		}
 	}
-	defer func() { ec.tunnelParams = savedTunnel }()
 
 	// xsl:apply-imports searches only within the current module's import
 	// tree. MinImportPrec marks the lowest precedence among the module's

--- a/xslt3/execute_apply.go
+++ b/xslt3/execute_apply.go
@@ -400,27 +400,25 @@ func (ec *execContext) execCallTemplate(ctx context.Context, inst *callTemplateI
 
 	// Evaluate with-param values BEFORE clearing the context for use="absent",
 	// because the with-param select expressions need the caller's context item.
+	//
+	// Two-phase param evaluation (mirrors xsl:apply-templates): evaluate ALL
+	// with-param values into LOCAL maps first, THEN merge tunnel params into
+	// ec.tunnelParams. This prevents a later with-param body that invokes
+	// another template (e.g. via an error caught by xsl:try/xsl:catch) from
+	// observing a tentative tunnel override before control has actually been
+	// transferred to the called template.
 	paramOverrides := make(map[string]xpath3.Sequence)
-	savedTunnel := ec.tunnelParams
-	// Register the tunnel restore BEFORE evaluating params: a tunnel
-	// with-param mutates ec.tunnelParams, and a later param's evaluation
-	// may fail and return — without the defer already in place the
-	// mutation would leak (e.g. across a dynamic error caught by xsl:try).
-	defer func() { ec.tunnelParams = savedTunnel }()
-	hasTunnelOverrides := false
+	var newTunnelParams map[string]xpath3.Sequence
 	for _, wp := range inst.Params {
 		val, err := ec.evaluateWithParam(ctx, wp)
 		if err != nil {
 			return err
 		}
 		if wp.Tunnel {
-			if !hasTunnelOverrides {
-				merged := make(map[string]xpath3.Sequence)
-				maps.Copy(merged, ec.tunnelParams)
-				ec.tunnelParams = merged
-				hasTunnelOverrides = true
+			if newTunnelParams == nil {
+				newTunnelParams = make(map[string]xpath3.Sequence)
 			}
-			ec.tunnelParams[wp.Name] = val
+			newTunnelParams[wp.Name] = val
 		} else {
 			if _, dup := paramOverrides[wp.Name]; dup {
 				return dynamicError(errCodeXTDE0410, "duplicate parameter %q in xsl:call-template", wp.Name)
@@ -428,6 +426,17 @@ func (ec *execContext) execCallTemplate(ctx context.Context, inst *callTemplateI
 			paramOverrides[wp.Name] = val
 		}
 	}
+
+	// Merge tunnel params and register the restore only after every with-param
+	// value has been computed.
+	savedTunnel := ec.tunnelParams
+	if newTunnelParams != nil {
+		merged := make(map[string]xpath3.Sequence)
+		maps.Copy(merged, ec.tunnelParams)
+		maps.Copy(merged, newTunnelParams)
+		ec.tunnelParams = merged
+	}
+	defer func() { ec.tunnelParams = savedTunnel }()
 
 	// xsl:context-item use="absent": make the context item absent within the
 	// called template's body. This means xsl:next-match will fail with
@@ -560,42 +569,41 @@ func (ec *execContext) execNextMatch(ctx context.Context, inst *nextMatchInst) e
 	mode := ec.currentMode
 
 	// Process with-param (tunnel and regular).
-	// Copy tunnel params to avoid mutating the caller's map.
+	//
+	// Two-phase param evaluation (mirrors xsl:apply-templates): evaluate ALL
+	// with-param values into LOCAL maps first, THEN merge tunnel params into
+	// ec.tunnelParams. This prevents a later with-param body that invokes
+	// another template (e.g. via an error caught by xsl:try/xsl:catch) from
+	// observing a tentative tunnel override before control has actually been
+	// transferred to the next-match template.
 	var pv map[string]xpath3.Sequence
-	savedTunnel := ec.tunnelParams
-	// Register the tunnel restore BEFORE evaluating params: a tunnel
-	// with-param mutates ec.tunnelParams below, and a later param's
-	// evaluation may fail and return — without the defer already in place
-	// the mutation would leak (e.g. across a dynamic error caught by xsl:try).
-	defer func() { ec.tunnelParams = savedTunnel }()
-	if len(inst.Params) > 0 {
-		hasTunnel := false
-		for _, wp := range inst.Params {
-			if wp.Tunnel {
-				hasTunnel = true
-				break
-			}
+	var newTunnelParams map[string]xpath3.Sequence
+	for _, wp := range inst.Params {
+		val, err := ec.evaluateWithParam(ctx, wp)
+		if err != nil {
+			return err
 		}
-		if hasTunnel {
-			newTunnel := make(map[string]xpath3.Sequence, len(ec.tunnelParams)+len(inst.Params))
-			maps.Copy(newTunnel, ec.tunnelParams)
-			ec.tunnelParams = newTunnel
-		}
-		for _, wp := range inst.Params {
-			val, err := ec.evaluateWithParam(ctx, wp)
-			if err != nil {
-				return err
+		if wp.Tunnel {
+			if newTunnelParams == nil {
+				newTunnelParams = make(map[string]xpath3.Sequence)
 			}
-			if wp.Tunnel {
-				ec.tunnelParams[wp.Name] = val
-			} else {
-				if pv == nil {
-					pv = make(map[string]xpath3.Sequence)
-				}
-				pv[wp.Name] = val
+			newTunnelParams[wp.Name] = val
+		} else {
+			if pv == nil {
+				pv = make(map[string]xpath3.Sequence)
 			}
+			pv[wp.Name] = val
 		}
 	}
+
+	savedTunnel := ec.tunnelParams
+	if newTunnelParams != nil {
+		merged := make(map[string]xpath3.Sequence, len(ec.tunnelParams)+len(newTunnelParams))
+		maps.Copy(merged, ec.tunnelParams)
+		maps.Copy(merged, newTunnelParams)
+		ec.tunnelParams = merged
+	}
+	defer func() { ec.tunnelParams = savedTunnel }()
 
 	// Handle atomic context items (e.g., xsl:next-match when processing integers)
 	if ec.contextItem != nil {
@@ -676,42 +684,41 @@ func (ec *execContext) execApplyImports(ctx context.Context, inst *applyImportsI
 	maxPrec := ec.currentTemplate.ImportPrec
 
 	// Process with-param (tunnel and regular).
-	// Copy tunnel params to avoid mutating the caller's map.
+	//
+	// Two-phase param evaluation (mirrors xsl:apply-templates): evaluate ALL
+	// with-param values into LOCAL maps first, THEN merge tunnel params into
+	// ec.tunnelParams. This prevents a later with-param body that invokes
+	// another template (e.g. via an error caught by xsl:try/xsl:catch) from
+	// observing a tentative tunnel override before control has actually been
+	// transferred to the imported template.
 	var pv map[string]xpath3.Sequence
-	savedTunnel := ec.tunnelParams
-	// Register the tunnel restore BEFORE evaluating params: a tunnel
-	// with-param mutates ec.tunnelParams below, and a later param's
-	// evaluation may fail and return — without the defer already in place
-	// the mutation would leak (e.g. across a dynamic error caught by xsl:try).
-	defer func() { ec.tunnelParams = savedTunnel }()
-	if len(inst.Params) > 0 {
-		hasTunnel := false
-		for _, wp := range inst.Params {
-			if wp.Tunnel {
-				hasTunnel = true
-				break
-			}
+	var newTunnelParams map[string]xpath3.Sequence
+	for _, wp := range inst.Params {
+		val, err := ec.evaluateWithParam(ctx, wp)
+		if err != nil {
+			return err
 		}
-		if hasTunnel {
-			newTunnel := make(map[string]xpath3.Sequence, len(ec.tunnelParams)+len(inst.Params))
-			maps.Copy(newTunnel, ec.tunnelParams)
-			ec.tunnelParams = newTunnel
-		}
-		for _, wp := range inst.Params {
-			val, err := ec.evaluateWithParam(ctx, wp)
-			if err != nil {
-				return err
+		if wp.Tunnel {
+			if newTunnelParams == nil {
+				newTunnelParams = make(map[string]xpath3.Sequence)
 			}
-			if wp.Tunnel {
-				ec.tunnelParams[wp.Name] = val
-			} else {
-				if pv == nil {
-					pv = make(map[string]xpath3.Sequence)
-				}
-				pv[wp.Name] = val
+			newTunnelParams[wp.Name] = val
+		} else {
+			if pv == nil {
+				pv = make(map[string]xpath3.Sequence)
 			}
+			pv[wp.Name] = val
 		}
 	}
+
+	savedTunnel := ec.tunnelParams
+	if newTunnelParams != nil {
+		merged := make(map[string]xpath3.Sequence, len(ec.tunnelParams)+len(newTunnelParams))
+		maps.Copy(merged, ec.tunnelParams)
+		maps.Copy(merged, newTunnelParams)
+		ec.tunnelParams = merged
+	}
+	defer func() { ec.tunnelParams = savedTunnel }()
 
 	// xsl:apply-imports searches only within the current module's import
 	// tree. MinImportPrec marks the lowest precedence among the module's

--- a/xslt3/trycatch_test.go
+++ b/xslt3/trycatch_test.go
@@ -3,6 +3,8 @@ package xslt3_test
 import (
 	"testing"
 
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xslt3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -98,4 +100,154 @@ func TestCallTemplateTunnelParamDoesNotLeakAcrossCaughtError(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, result, "NOLEAK")
 	require.NotContains(t, result, "LEAKED")
+}
+
+// A tunnel parameter must not become observable to a template invoked from a
+// LATER sibling with-param's BODY before control is actually transferred to the
+// target template. Here the first with-param sets the tunnel param, and a later
+// with-param body contains an xsl:try whose error is caught; the xsl:catch calls
+// another template that reads the same tunnel param. Because the value is still
+// being assembled (the call/next-match/apply-imports has not yet handed control
+// to its target), the called template must see the tunnel param as ABSENT.
+// This is the two-phase guarantee that xsl:apply-templates already provides.
+func TestTunnelParamNotObservedByLaterWithParamBody(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "call-template",
+			src: `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:call-template name="consume">
+        <xsl:with-param name="tp" select="'LEAKED'" tunnel="yes"/>
+        <xsl:with-param name="probe">
+          <xsl:try>
+            <xsl:sequence select="xs:integer('not-a-number')"/>
+            <xsl:catch>
+              <xsl:call-template name="check"/>
+            </xsl:catch>
+          </xsl:try>
+        </xsl:with-param>
+      </xsl:call-template>
+    </out>
+  </xsl:template>
+
+  <xsl:template name="consume">
+    <xsl:param name="tp" tunnel="yes"/>
+    <xsl:param name="probe"/>
+    <xsl:copy-of select="$probe"/>
+  </xsl:template>
+
+  <xsl:template name="check">
+    <xsl:param name="tp" select="'NOLEAK'" tunnel="yes"/>
+    <xsl:value-of select="$tp"/>
+  </xsl:template>
+</xsl:stylesheet>`,
+		},
+		{
+			name: "next-match",
+			src: `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="root" priority="2">
+    <out>
+      <xsl:next-match>
+        <xsl:with-param name="tp" select="'LEAKED'" tunnel="yes"/>
+        <xsl:with-param name="probe">
+          <xsl:try>
+            <xsl:sequence select="xs:integer('not-a-number')"/>
+            <xsl:catch>
+              <xsl:call-template name="check"/>
+            </xsl:catch>
+          </xsl:try>
+        </xsl:with-param>
+      </xsl:next-match>
+    </out>
+  </xsl:template>
+
+  <xsl:template match="root" priority="1">
+    <xsl:param name="tp" tunnel="yes"/>
+    <xsl:param name="probe"/>
+    <xsl:copy-of select="$probe"/>
+  </xsl:template>
+
+  <xsl:template name="check">
+    <xsl:param name="tp" select="'NOLEAK'" tunnel="yes"/>
+    <xsl:value-of select="$tp"/>
+  </xsl:template>
+</xsl:stylesheet>`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ss := compileStylesheetString(t, tc.src)
+			result, err := ss.Transform(parseTransformSource(t)).Serialize(t.Context())
+			require.NoError(t, err)
+			require.Contains(t, result, "NOLEAK")
+			require.NotContains(t, result, "LEAKED")
+		})
+	}
+}
+
+// Same two-phase guarantee for xsl:apply-imports: a tunnel with-param set by an
+// earlier sibling must not be visible to a template invoked from a later
+// with-param body whose inner error is caught, before control is transferred to
+// the imported template.
+func TestApplyImportsTunnelParamNotObservedByLaterWithParamBody(t *testing.T) {
+	const importedURI = "mem:/imported-tunnel.xsl"
+
+	imported := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="root">
+    <xsl:param name="tp" tunnel="yes"/>
+    <xsl:param name="probe"/>
+    <xsl:copy-of select="$probe"/>
+  </xsl:template>
+</xsl:stylesheet>`
+
+	main := `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:import href="` + importedURI + `"/>
+  <xsl:output method="xml" omit-xml-declaration="yes"/>
+  <xsl:template match="root">
+    <out>
+      <xsl:apply-imports>
+        <xsl:with-param name="tp" select="'LEAKED'" tunnel="yes"/>
+        <xsl:with-param name="probe">
+          <xsl:try>
+            <xsl:sequence select="xs:integer('not-a-number')"/>
+            <xsl:catch>
+              <xsl:call-template name="check"/>
+            </xsl:catch>
+          </xsl:try>
+        </xsl:with-param>
+      </xsl:apply-imports>
+    </out>
+  </xsl:template>
+
+  <xsl:template name="check">
+    <xsl:param name="tp" select="'NOLEAK'" tunnel="yes"/>
+    <xsl:value-of select="$tp"/>
+  </xsl:template>
+</xsl:stylesheet>`
+
+	resolver := &memResolver{files: map[string]string{importedURI: imported}}
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(main))
+	require.NoError(t, err)
+
+	ss, err := xslt3.NewCompiler().
+		BaseURI("mem:/main.xsl").
+		URIResolver(resolver).
+		Compile(t.Context(), doc)
+	require.NoError(t, err)
+
+	source, err := helium.NewParser().Parse(t.Context(), []byte("<root/>"))
+	require.NoError(t, err)
+
+	out, err := xslt3.TransformString(t.Context(), source, ss)
+	require.NoError(t, err)
+	require.Contains(t, out, "NOLEAK")
+	require.NotContains(t, out, "LEAKED")
 }

--- a/xslt3/trycatch_test.go
+++ b/xslt3/trycatch_test.go
@@ -60,3 +60,42 @@ func TestTryDoesNotLeakVariables(t *testing.T) {
 		})
 	}
 }
+
+// A tunnel parameter set by an xsl:call-template whose with-param evaluation
+// later fails must not leak into templates invoked from the surrounding
+// xsl:catch. The tunnel param is evaluated (mutating the active tunnel map)
+// before a sibling with-param raises a dynamic error; the error is caught, and
+// a second template called from xsl:catch must see the tunnel param as absent.
+func TestCallTemplateTunnelParamDoesNotLeakAcrossCaughtError(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:try>
+        <xsl:call-template name="consume">
+          <xsl:with-param name="tp" select="'LEAKED'" tunnel="yes"/>
+          <xsl:with-param name="bad" select="xs:integer('not-a-number')"/>
+        </xsl:call-template>
+        <xsl:catch>
+          <xsl:call-template name="check"/>
+        </xsl:catch>
+      </xsl:try>
+    </out>
+  </xsl:template>
+
+  <xsl:template name="consume">
+    <xsl:param name="tp" tunnel="yes"/>
+    <xsl:param name="bad"/>
+  </xsl:template>
+
+  <xsl:template name="check">
+    <xsl:param name="tp" select="'NOLEAK'" tunnel="yes"/>
+    <xsl:value-of select="$tp"/>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	result, err := ss.Transform(parseTransformSource(t)).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, result, "NOLEAK")
+	require.NotContains(t, result, "LEAKED")
+}


### PR DESCRIPTION
- Register the tunnel-param restore defer before evaluating with-param values in xsl:call-template, xsl:next-match, and xsl:apply-imports, so a later param's failing evaluation can't leak a mutated tunnel map across a caught dynamic error.
- Add a regression test exercising the xsl:try/xsl:catch leak path.