### PR TITLE
bound html normal-data char-ref name scan

### DIFF
--- a/html/charref_normal_bounds_test.go
+++ b/html/charref_normal_bounds_test.go
@@ -1,0 +1,103 @@
+package html_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium/html"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNormalDataOverCapNamedEntityFails is the regression for the normal
+// character-data char-ref bypass (the sibling of the RCDATA bypass): a `&` in
+// ordinary text followed by a huge alphanumeric run — e.g. `<div>&aaaa...(huge)`
+// — must NOT be buffered whole while deciding whether it names an entity. The
+// normal-data path now shares the bounded char-ref scanner, so a name longer
+// than the longest known entity (31 chars) that matches no legacy prefix is
+// LITERAL text charged against MaxContentSize; once it exceeds the cap before any
+// terminator the parse fails with ErrContentSizeExceeded and no single chunk
+// exceeds the cap. Before the fix the run was collected via an unbounded
+// parseWhile, so peak memory grew with the input.
+func TestNormalDataOverCapNamedEntityFails(t *testing.T) {
+	const limit = 4
+	const runLen = 4096 // far larger than any valid entity name or legacy prefix
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"unknown_no_semicolon", "&" + strings.Repeat("a", runLen)},
+		{"unknown_semicolon", "&" + strings.Repeat("a", runLen) + ";"},
+		// Begins with the legacy "amp" prefix but the long no-';' tail is
+		// ambiguous until the run ends; over the cap it hard-fails too.
+		{"legacy_prefix_long_tail", "&amp" + strings.Repeat("x", runLen)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := "<div>" + tc.body + "</div>"
+
+			maxChunk := 0
+			record := html.CharactersFunc(func(data []byte) error {
+				if len(data) > maxChunk {
+					maxChunk = len(data)
+				}
+				return nil
+			})
+			sax := &html.SAXCallbacks{}
+			sax.SetOnCharacters(record)
+			sax.SetOnCDataBlock(html.CDataBlockFunc(record))
+
+			err := html.NewParser().MaxContentSize(limit).
+				ParseWithSAX(t.Context(), []byte(input), sax)
+			require.ErrorIs(t, err, html.ErrContentSizeExceeded,
+				"over-cap unresolved char-ref in normal character data must fail, not buffer the run")
+			require.LessOrEqual(t, maxChunk, limit+16,
+				"no single Characters chunk may exceed the cap before the abort")
+		})
+	}
+}
+
+// TestNormalDataCharRefResolution pins that ordinary char-ref resolution in
+// normal character data is unchanged after routing through the bounded scanner:
+// a known entity resolves, a legacy (HTML4) entity resolves without ';' and
+// echoes its tail, an unknown name is echoed verbatim, and a numeric reference
+// (including an overflow that normalizes to U+FFFD) resolves. Default cap.
+func TestNormalDataCharRefResolution(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"amp_semicolon", "&amp;", "&"},
+		{"lt_semicolon", "&lt;X", "<X"},
+		{"legacy_amp_no_semicolon_tail", "&ampZ", "&Z"},
+		{"unknown_semicolon", "&qqq;", "&qqq;"},
+		{"numeric_dec", "&#65;", "A"},
+		{"numeric_hex", "&#x41;", "A"},
+		{"numeric_overflow", "&#9999999999;", "�"},
+		// Longer than the longest known entity (31) yet tiny vs the default cap:
+		// must be echoed literally, exactly like the previous unbounded path.
+		{"long_unknown_preserved", "&" + strings.Repeat("a", 40), "&" + strings.Repeat("a", 40)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := "<div>" + tc.body + "</div>"
+
+			var got strings.Builder
+			record := html.CharactersFunc(func(data []byte) error {
+				got.Write(data)
+				return nil
+			})
+			sax := &html.SAXCallbacks{}
+			sax.SetOnCharacters(record)
+			sax.SetOnCDataBlock(html.CDataBlockFunc(record))
+
+			err := html.NewParser().ParseWithSAX(t.Context(), []byte(input), sax)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got.String(),
+				"char-ref in normal character data must resolve like the canonical path")
+		})
+	}
+}

--- a/html/html.go
+++ b/html/html.go
@@ -98,8 +98,9 @@ func (p Parser) Strict(v bool) Parser {
 // section, which still parses successfully. A chunk may slightly exceed the cap
 // because an indivisible token is never split: a whole multi-byte UTF-8 rune (or
 // a resolved character reference) is always emitted intact, so a single rune
-// larger than the cap is emitted whole. An unresolved RCDATA named-reference
-// literal hard-fails with [ErrContentSizeExceeded] when the bytes it would emit
+// larger than the cap is emitted whole. An unresolved named-reference literal — in
+// RCDATA or in ordinary character data, which share one bounded char-ref scanner —
+// hard-fails with [ErrContentSizeExceeded] when the bytes it would emit
 // ("&" + name + optional ";") exceed the cap — this applies to ANY unresolved
 // literal, whether short, semicolon-terminated, or unbounded. A known-entity
 // (';'-terminated) reference is exempt: it is resolved within a fixed lookahead

--- a/html/parser.go
+++ b/html/parser.go
@@ -542,7 +542,7 @@ func (p *parser) parse(ctx context.Context) error {
 				_ = p.cur.Advance(1)
 			}
 		} else {
-			p.parseCharacters()
+			p.parseCharacters(ctx)
 		}
 	}
 
@@ -882,7 +882,7 @@ func (p *parser) parseDoctype() {
 }
 
 // parseCharacters parses character data (text content).
-func (p *parser) parseCharacters() {
+func (p *parser) parseCharacters(ctx context.Context) {
 	// Collect text up to the next '<' or '&'.
 	// We need to split at whitespace→non-whitespace boundaries when inside
 	// <head> so that whitespace is emitted in <head> and non-whitespace
@@ -956,9 +956,14 @@ func (p *parser) parseCharacters() {
 		return
 	}
 
-	// Handle entity references in character data
+	// Handle entity references in character data. Use the bounded char-ref
+	// scanner (shared with RCDATA) so a runaway alphanumeric run after '&' — e.g.
+	// `<p>&` + a huge alphanumeric run — is decided within a fixed
+	// maxEntityNameLen lookahead and drained/charged against MaxContentSize
+	// rather than buffered whole. For ordinary documents (default 16 MiB cap) the
+	// observable result is identical to resolving the name in one shot.
 	if !p.cur.Done() && p.cur.Peek() == '&' {
-		p.parseCharRef()
+		p.parseCharRefBounded(ctx, p.cfg.contentLimit())
 	}
 }
 
@@ -1078,44 +1083,6 @@ func (p *parser) scanNumericCharRef() (codepoint int, haveDigits bool) {
 	return codepoint, haveDigits
 }
 
-// parseCharRef handles entity references (&name; or &#num; or &#xhex;).
-// Emits the resolved value as a Characters SAX event (entity splitting behavior).
-func (p *parser) parseCharRef() {
-	// Entity content is non-whitespace — ensure implied elements
-	p.htmlStartCharData()
-
-	_ = p.cur.Advance(1) // skip '&'
-
-	if p.cur.Peek() == '#' {
-		codepoint, haveDigits := p.scanNumericCharRef()
-		p.emitNumericCharRef(codepoint, haveDigits)
-		return
-	}
-
-	// Named entity
-	name := p.parseWhile(isAlphanumeric)
-	hasSemicolon := false
-	if p.cur.Peek() == ';' {
-		hasSemicolon = true
-		_ = p.cur.Advance(1)
-	}
-
-	if val, remainder, ok := resolveNamedEntity(name, hasSemicolon); ok {
-		_ = p.emitCharacters([]byte(val))
-		if remainder != "" {
-			_ = p.emitCharacters([]byte(remainder))
-		}
-		return
-	}
-
-	// Unknown entity — emit as literal text
-	text := "&" + name
-	if hasSemicolon {
-		text += ";"
-	}
-	_ = p.emitCharacters([]byte(text))
-}
-
 // maxEntityNameLen is one past the length of the longest named HTML entity
 // ("CounterClockwiseContourIntegral", 31 chars). An alphanumeric run reaching
 // this length cannot match any known entity, so the char-ref scan can stop and
@@ -1128,12 +1095,16 @@ const maxEntityNameLen = 32
 // and over-cap checks, independent of (and never larger than) MaxContentSize.
 const saturatedCharRefChunk = 4096
 
-// parseCharRefBounded handles an entity reference inside cap-aware content
-// (RCDATA: title/textarea) where the surrounding text is flushed to SAX in
-// chunks no larger than limit. It makes the SAME entity-resolution decisions as
-// parseCharRef — numeric references (including overlong/leading-zero/overflow
-// runs) normalize to their HTML5 output (U+FFFD on overflow/invalid), and named
-// references resolve identically including legacy-prefix matching.
+// parseCharRefBounded handles an entity reference in cap-aware content. It is the
+// single char-ref handler for both normal character data and RCDATA
+// (title/textarea); the surrounding text is flushed to SAX in chunks no larger
+// than limit. It makes the canonical (whole-run) HTML char-ref decisions —
+// numeric references (including overlong/leading-zero/overflow runs) normalize to
+// their HTML5 output (U+FFFD on overflow/invalid), and named references resolve
+// including legacy-prefix matching — without ever buffering an arbitrarily long
+// run: a runaway alphanumeric run after '&' is decided within the fixed
+// maxEntityNameLen lookahead and drained/charged against MaxContentSize rather
+// than collected whole.
 //
 // Memory AND bytes-read work are kept bounded by two independent budgets:
 //
@@ -1218,8 +1189,8 @@ func (p *parser) parseCharRefBounded(ctx context.Context, limit int) {
 	}
 
 	// The lookahead SATURATES when the alphanumeric run reaches the fixed window
-	// AND keeps going. parseCharRef scans the WHOLE run before deciding, so its
-	// resolveNamedEntity sees the full (over-long) name; a long ';'-terminated
+	// AND keeps going. The canonical (whole-run) decision sees the full (over-long)
+	// name before resolving, so resolveNamedEntity gets it intact; a long ';'-terminated
 	// name is NOT legacy-prefix-resolved (that loop is gated on !hasSemicolon),
 	// and an over-long no-semicolon name resolves only its longest legacy prefix.
 	// Resolving from the truncated 32-byte window here — before knowing whether a
@@ -1305,7 +1276,7 @@ func (p *parser) parseCharRefBounded(ctx context.Context, limit int) {
 // overflowed the fixed maxEntityNameLen lookahead window: head holds the first
 // maxEntityNameLen bytes already CONSUMED and the run is known to continue. Such
 // a run can never match a KNOWN entity (the longest is 31 chars), so the only
-// resolution parseCharRef could ever apply to it is a legacy-prefix match — and
+// resolution that could ever apply to it is a legacy-prefix match — and
 // that applies ONLY when the run is NOT ';'-terminated (resolveNamedEntity gates
 // its prefix loop on !hasSemicolon). The two interpretations differ:
 //
@@ -1313,7 +1284,7 @@ func (p *parser) parseCharRefBounded(ctx context.Context, limit int) {
 //     within head, ≤6 chars) and emit the unmatched remainder (rest of head plus
 //     the alphanumeric tail) as ordinary text. If head has no legacy prefix the
 //     whole run is an unresolved literal (see below).
-//   - ';'-terminated: an over-long UNKNOWN name. parseCharRef does NOT
+//   - ';'-terminated: an over-long UNKNOWN name. The canonical decision does NOT
 //     legacy-resolve it; the WHOLE run plus ';' is an unresolved literal.
 //
 // Because the two interpretations EMIT DIFFERENT bytes, nothing may be emitted
@@ -1400,7 +1371,7 @@ func (p *parser) parseSaturatedCharRefLiteral(ctx context.Context, head string, 
 		_ = p.cur.Advance(1)
 	}
 
-	// No ';' and head legacy-resolves: mirror parseCharRef's no-semicolon
+	// No ';' and head legacy-resolves: take the canonical no-semicolon
 	// legacy-prefix path. The run fit the cap, so emit the resolution + head's
 	// leftover + the spooled tail as ordinary text. Only now, with ';' ruled out,
 	// does emission begin, so nothing was emitted prematurely.


### PR DESCRIPTION
- Route normal character-data char-refs through the bounded scanner (parseWhileMaxErr + saturated-literal handling) shared with RCDATA, so `<p>&`+ a huge alphanumeric run is decided within a fixed lookahead and charged against MaxContentSize instead of being buffered whole via the unbounded parseWhile.
- Delete the now-redundant unbounded parseCharRef; update MaxContentSize doc.