### PR TITLE
bound shim prolog scanner buffer size

### DIFF
--- a/shim/directive.go
+++ b/shim/directive.go
@@ -5,8 +5,21 @@ import (
 	stdxml "encoding/xml"
 	"io"
 
+	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 )
+
+// maxPrologSize bounds the number of bytes the prolog scanner will buffer
+// before reaching the first element start tag. Without it, a document with a
+// huge prolog (megabytes of comments or a giant internal DTD subset) ahead of
+// the root element forces unbounded buffering — a memory-amplification DoS on
+// untrusted input. The cap mirrors helium.MaxExternalDTDSize (10 MiB), the
+// parser's existing content-size bound.
+const maxPrologSize = helium.MaxExternalDTDSize
+
+// errPrologTooLarge is returned when the prolog exceeds maxPrologSize before
+// the first element start tag is reached.
+var errPrologTooLarge = &stdxml.SyntaxError{Msg: "prolog exceeds maximum size before root element"}
 
 // scanProlog reads from r until the first element start tag, tokenizing
 // the XML prolog. It extracts CharData (whitespace), ProcInst, Comment,
@@ -22,6 +35,13 @@ import (
 func scanProlog(r io.Reader) ([]Token, io.Reader, bool, error) {
 	s := &prologScanner{r: r}
 	tokens, err := s.scan()
+
+	// A prolog-size overflow is reported via s.sizeErr regardless of how the
+	// inner sub-scanners (PI/comment/directive) rewrote the read error, so
+	// surface it first.
+	if s.sizeErr != nil {
+		return nil, nil, false, s.sizeErr
+	}
 
 	if err != nil && err != io.EOF {
 		// Syntax error from prolog validation
@@ -51,6 +71,7 @@ type prologScanner struct {
 	peek         []byte       // ungotten bytes
 	xmlDeclStart int          // byte offset of '<' in <?xml ...?>
 	xmlDeclEnd   int          // byte offset after '>' in <?xml ...?>
+	sizeErr      error        // set when the prolog exceeds maxPrologSize
 }
 
 func (s *prologScanner) readByte() (byte, error) {
@@ -66,6 +87,10 @@ func (s *prologScanner) readByte() (byte, error) {
 		return 0, err
 	}
 	s.buf.WriteByte(tmp[0])
+	if s.buf.Len() > maxPrologSize {
+		s.sizeErr = errPrologTooLarge
+		return 0, errPrologTooLarge
+	}
 	return tmp[0], nil
 }
 

--- a/shim/directive_internal_test.go
+++ b/shim/directive_internal_test.go
@@ -1,0 +1,58 @@
+package shim
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestScanPrologSizeBound verifies that a prolog larger than maxPrologSize
+// (here, an oversized comment ahead of the root element) is rejected with
+// errPrologTooLarge instead of being buffered unboundedly.
+func TestScanPrologSizeBound(t *testing.T) {
+	t.Run("oversized prolog comment fails", func(t *testing.T) {
+		var b bytes.Buffer
+		b.WriteString("<!--")
+		b.Write(bytes.Repeat([]byte("a"), maxPrologSize+16))
+		b.WriteString("--><root/>")
+
+		_, _, _, err := scanProlog(bytes.NewReader(b.Bytes()))
+		if !errors.Is(err, errPrologTooLarge) {
+			t.Fatalf("expected errPrologTooLarge, got %v", err)
+		}
+	})
+
+	t.Run("small prolog succeeds", func(t *testing.T) {
+		in := "<!-- hello --><root/>"
+		_, _, _, err := scanProlog(strings.NewReader(in))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("decoder surfaces size error", func(t *testing.T) {
+		var b bytes.Buffer
+		b.WriteString("<!--")
+		b.Write(bytes.Repeat([]byte("a"), maxPrologSize+16))
+		b.WriteString("--><root/>")
+
+		dec := NewDecoder(context.Background(), bytes.NewReader(b.Bytes()))
+		var lastErr error
+		for {
+			_, err := dec.Token()
+			if err != nil {
+				lastErr = err
+				break
+			}
+		}
+		if !errors.Is(lastErr, errPrologTooLarge) {
+			t.Fatalf("expected errPrologTooLarge from Decoder, got %v", lastErr)
+		}
+		if lastErr == io.EOF {
+			t.Fatal("decoder reached EOF without reporting size error")
+		}
+	})
+}


### PR DESCRIPTION
- shim/directive.go scanProlog buffered all pre-root bytes (XML decl, DTD, comments, PIs) with no cap, a memory-amplification DoS on untrusted input
- cap prolog buffering at maxPrologSize (mirrors helium.MaxExternalDTDSize, 10 MiB); reject oversized prologs with errPrologTooLarge