### PR TITLE
fix rng nameclass except vs choice overlap

### DIFF
--- a/relaxng/grammar.go
+++ b/relaxng/grammar.go
@@ -127,6 +127,18 @@ func nameClassesOverlap(a, b *nameClass) bool {
 		return false
 	}
 
+	// ncChoice: overlap if either branch overlaps. Decompose choices before the
+	// anyName handling below so each ncName leaf is tested against the other
+	// class's <except>. Otherwise a choice of names that are all excluded by an
+	// anyName <except> would be wrongly flagged as overlapping, because the
+	// anyName branch short-circuits before reaching the choice decomposition.
+	if a.kind == ncChoice {
+		return nameClassesOverlap(a.left, b) || nameClassesOverlap(a.right, b)
+	}
+	if b.kind == ncChoice {
+		return nameClassesOverlap(a, b.left) || nameClassesOverlap(a, b.right)
+	}
+
 	// anyName: check if except clause excludes the other name class
 	if a.kind == ncAnyName {
 		if a.except != nil && b.kind == ncName {
@@ -143,14 +155,6 @@ func nameClassesOverlap(a, b *nameClass) bool {
 			}
 		}
 		return true
-	}
-
-	// ncChoice: overlap if either branch overlaps
-	if a.kind == ncChoice {
-		return nameClassesOverlap(a.left, b) || nameClassesOverlap(a.right, b)
-	}
-	if b.kind == ncChoice {
-		return nameClassesOverlap(a, b.left) || nameClassesOverlap(a, b.right)
 	}
 
 	// nsName vs nsName

--- a/relaxng/nameclass_overlap_test.go
+++ b/relaxng/nameclass_overlap_test.go
@@ -1,0 +1,69 @@
+package relaxng_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/relaxng"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNameClassOverlapExceptChoice covers the attribute name-class conflict
+// check. An <anyName> with an <except> listing several names does NOT overlap a
+// <choice> of exactly those excluded names, so a grammar pairing them as two
+// attributes must compile cleanly. A choice that includes a name NOT excluded
+// genuinely overlaps and must still be reported.
+func TestNameClassOverlapExceptChoice(t *testing.T) {
+	t.Parallel()
+
+	compile := func(t *testing.T, schema string) string {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schema))
+		require.NoError(t, err)
+
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, err = relaxng.NewCompiler().ErrorHandler(collector).Compile(t.Context(), doc)
+		require.NoError(t, err)
+		_ = collector.Close()
+		_, compileErrors := partitionCompileErrors(collector.Errors())
+		return compileErrors
+	}
+
+	t.Run("disjoint anyName-except vs choice compiles", func(t *testing.T) {
+		const schema = `<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <element name="root">
+      <attribute>
+        <anyName>
+          <except><name>foo</name><name>bar</name></except>
+        </anyName>
+      </attribute>
+      <attribute>
+        <choice><name>foo</name><name>bar</name></choice>
+      </attribute>
+    </element>
+  </start>
+</grammar>`
+		require.Empty(t, compile(t, schema),
+			"anyName-except{foo,bar} and choice(foo,bar) are disjoint and must not conflict")
+	})
+
+	t.Run("genuinely overlapping anyName-except vs choice errors", func(t *testing.T) {
+		const schema = `<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <element name="root">
+      <attribute>
+        <anyName>
+          <except><name>foo</name></except>
+        </anyName>
+      </attribute>
+      <attribute>
+        <choice><name>foo</name><name>bar</name></choice>
+      </attribute>
+    </element>
+  </start>
+</grammar>`
+		require.NotEmpty(t, compile(t, schema),
+			"anyName-except{foo} overlaps choice(foo,bar) on bar and must conflict")
+	})
+}


### PR DESCRIPTION
- decompose ncChoice operands before the anyName except check in nameClassesOverlap
- an anyName-except over names that are all listed in the other class's choice no longer reports a false attribute conflict