### PR TITLE
bound fn:parse-json/json-to-xml parsing budget

### DIFF
--- a/xpath3/functions_json.go
+++ b/xpath3/functions_json.go
@@ -51,7 +51,7 @@ func fnParseJSON(ctx context.Context, args []Sequence) (Sequence, error) {
 
 	dec := json.NewDecoder(strings.NewReader(s))
 	dec.UseNumber()
-	item, err := parseJSONValue(ctx, dec, opts)
+	item, err := parseJSONValue(ctx, dec, opts, newJSONBudget(ctx), 0)
 	if err != nil {
 		return nil, err
 	}
@@ -167,22 +167,73 @@ func parseJSONOptions(args []Sequence) (jsonOptions, error) {
 	return opts, nil
 }
 
-func parseJSONValue(ctx context.Context, dec *json.Decoder, opts jsonOptions) (Item, error) {
+// jsonBudget threads the evaluator's DoS bounds into the streaming JSON parser
+// shared by fn:parse-json and fn:json-to-xml. Without it, a large or deeply
+// nested JSON string would build an unbounded in-memory map/array structure
+// with no op-limit, node-set, depth, or cancellation accounting, bypassing the
+// engine's evaluation budget. ec may be nil when the functions run outside an
+// evaluation, in which case the package defaults still apply so the constructed
+// structure stays bounded.
+type jsonBudget struct {
+	ec       *evalContext
+	maxNodes int
+	maxDepth int
+}
+
+func newJSONBudget(ctx context.Context) *jsonBudget {
+	ec := getFnContext(ctx)
+	maxDepth := DefaultMaxRecursionDepth
+	if ec != nil && ec.maxRecursionDepth > 0 {
+		maxDepth = ec.maxRecursionDepth
+	}
+	return &jsonBudget{ec: ec, maxNodes: fnMaxNodes(ec), maxDepth: maxDepth}
+}
+
+// enter accounts for one level of object/array nesting and rejects input that
+// nests deeper than the recursion limit, so adversarial JSON cannot exhaust the
+// goroutine stack. It returns the incremented depth for nested calls.
+func (b *jsonBudget) enter(depth int) (int, error) {
+	depth++
+	if b.maxDepth > 0 && depth > b.maxDepth {
+		return depth, ErrRecursionLimit
+	}
+	return depth, nil
+}
+
+// charge accounts for one constructed map entry or array member: it bounds the
+// running member count against maxNodes and charges one op (which also honors
+// context cancellation), so a wide JSON container respects OpLimit and stays
+// cancellable.
+func (b *jsonBudget) charge(ctx context.Context, count int) error {
+	if b.maxNodes > 0 && count+1 > b.maxNodes {
+		return ErrNodeSetLimit
+	}
+	return fnCountOp(ctx, b.ec)
+}
+
+func parseJSONValue(ctx context.Context, dec *json.Decoder, opts jsonOptions, b *jsonBudget, depth int) (Item, error) {
 	tok, err := dec.Token()
 	if err != nil {
 		return nil, &XPathError{Code: errCodeFOJS0001, Message: fmt.Sprintf("invalid JSON: %v", err)}
 	}
-	return parseJSONToken(ctx, tok, dec, opts)
+	return parseJSONToken(ctx, tok, dec, opts, b, depth)
 }
 
-func parseJSONToken(ctx context.Context, tok json.Token, dec *json.Decoder, opts jsonOptions) (Item, error) {
+func parseJSONToken(ctx context.Context, tok json.Token, dec *json.Decoder, opts jsonOptions, b *jsonBudget, depth int) (Item, error) {
 	switch v := tok.(type) {
 	case json.Delim:
 		switch v {
 		case '{':
+			depth, err := b.enter(depth)
+			if err != nil {
+				return nil, err
+			}
 			entries := make([]MapEntry, 0)
 			index := make(map[string]int)
 			for dec.More() {
+				if err := b.charge(ctx, len(entries)); err != nil {
+					return nil, err
+				}
 				keyTok, err := dec.Token()
 				if err != nil {
 					return nil, &XPathError{Code: errCodeFOJS0001, Message: fmt.Sprintf("invalid JSON: %v", err)}
@@ -196,7 +247,7 @@ func parseJSONToken(ctx context.Context, tok json.Token, dec *json.Decoder, opts
 					return nil, err
 				}
 
-				valueItem, err := parseJSONValue(ctx, dec, opts)
+				valueItem, err := parseJSONValue(ctx, dec, opts, b, depth)
 				if err != nil {
 					return nil, err
 				}
@@ -232,9 +283,16 @@ func parseJSONToken(ctx context.Context, tok json.Token, dec *json.Decoder, opts
 			}
 			return NewMap(entries), nil
 		case '[':
+			depth, err := b.enter(depth)
+			if err != nil {
+				return nil, err
+			}
 			members := make([]Sequence, 0)
 			for dec.More() {
-				item, err := parseJSONValue(ctx, dec, opts)
+				if err := b.charge(ctx, len(members)); err != nil {
+					return nil, err
+				}
+				item, err := parseJSONValue(ctx, dec, opts, b, depth)
 				if err != nil {
 					return nil, err
 				}

--- a/xpath3/functions_json_test.go
+++ b/xpath3/functions_json_test.go
@@ -1,8 +1,12 @@
 package xpath3_test
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 
+	"github.com/lestrrat-go/helium/xpath3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,4 +68,63 @@ func TestParseJSON_NestedStructures(t *testing.T) {
 		`xml-to-json(json-to-xml('{"a": [1, true, null, "s"]}'))`)
 	require.NoError(t, err)
 	require.Contains(t, r.StringValue(), "\"a\"")
+}
+
+// fn:parse-json must thread the evaluator's DoS budget into the streaming JSON
+// parser so an oversized or deeply nested JSON string cannot build an unbounded
+// in-memory map/array structure that bypasses the engine's limits. Each case
+// fails (returns a value, no error) before the budget is threaded through
+// parseJSONToken and passes after.
+func TestParseJSON_Bounded(t *testing.T) {
+	// Deeply nested arrays beyond the recursion limit must be rejected rather
+	// than recursing unbounded over the goroutine stack.
+	t.Run("deep nesting", func(t *testing.T) {
+		depth := xpath3.DefaultMaxRecursionDepth + 1
+		nested := strings.Repeat("[", depth) + strings.Repeat("]", depth)
+		expr := `parse-json('` + nested + `')`
+		_, err := evaluate(t.Context(), nil, expr)
+		require.Error(t, err, "deeply nested JSON must be rejected")
+		require.True(t, errors.Is(err, xpath3.ErrRecursionLimit),
+			"expected ErrRecursionLimit, got %v", err)
+	})
+
+	// A wide array exceeding the configured node-set limit must be rejected.
+	t.Run("wide array", func(t *testing.T) {
+		var b strings.Builder
+		b.WriteByte('[')
+		for i := range 50 {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			b.WriteByte('0')
+		}
+		b.WriteByte(']')
+		compiled, err := xpath3.NewCompiler().Compile(`parse-json('` + b.String() + `')`)
+		require.NoError(t, err)
+		eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).MaxNodesForTesting(10)
+		_, err = eval.Evaluate(t.Context(), compiled, nil)
+		require.Error(t, err, "wide JSON array must be rejected")
+		require.True(t, errors.Is(err, xpath3.ErrNodeSetLimit),
+			"expected ErrNodeSetLimit, got %v", err)
+	})
+
+	// Construction must honor context cancellation.
+	t.Run("cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := evaluate(ctx, nil, `parse-json('[1, 2, 3, 4, 5]')`)
+		require.Error(t, err, "cancelled context must abort JSON construction")
+		require.True(t, errors.Is(err, context.Canceled),
+			"expected context.Canceled, got %v", err)
+	})
+}
+
+// fn:json-to-xml shares the same streaming parser and must be bounded too.
+func TestJSONToXML_DeepNestingBounded(t *testing.T) {
+	depth := xpath3.DefaultMaxRecursionDepth + 1
+	nested := strings.Repeat("[", depth) + strings.Repeat("]", depth)
+	_, err := evaluate(t.Context(), nil, `json-to-xml('`+nested+`')`)
+	require.Error(t, err, "deeply nested JSON must be rejected by json-to-xml")
+	require.True(t, errors.Is(err, xpath3.ErrRecursionLimit),
+		"expected ErrRecursionLimit, got %v", err)
 }

--- a/xpath3/functions_json_xml.go
+++ b/xpath3/functions_json_xml.go
@@ -42,7 +42,7 @@ func fnJSONToXML(ctx context.Context, args []Sequence) (Sequence, error) {
 
 	dec := json.NewDecoder(strings.NewReader(s))
 	dec.UseNumber()
-	item, err := parseJSONValue(ctx, dec, opts)
+	item, err := parseJSONValue(ctx, dec, opts, newJSONBudget(ctx), 0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- thread the evaluator budget (maxNodes, op-limit, recursion depth, ctx cancellation) into the shared streaming JSON parser used by fn:parse-json and fn:json-to-xml
- previously a large or deeply nested JSON string built an unbounded in-memory map/array structure, bypassing the engine's DoS limits