### PR TITLE
raise XTTE3170 for non-node xsl:evaluate namespace-context

### DIFF
--- a/xslt3/evaluate_nsctx_test.go
+++ b/xslt3/evaluate_nsctx_test.go
@@ -1,0 +1,40 @@
+package xslt3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// XSLT3-ADV-004: xsl:evaluate's namespace-context attribute must produce a
+// single node. A non-node value (or an empty sequence) is a type error
+// XTTE3170 rather than being silently ignored.
+func TestEvaluateNamespaceContextTypeError(t *testing.T) {
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root/>`))
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name         string
+		namespaceCtx string
+	}{
+		{name: "non-node string", namespaceCtx: "'not-a-node'"},
+		{name: "non-node number", namespaceCtx: "42"},
+		{name: "empty sequence", namespaceCtx: "()"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <out>
+      <xsl:evaluate xpath="'hello'" namespace-context="`+tc.namespaceCtx+`"/>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+			_, err := ss.Transform(doc).Serialize(t.Context())
+			require.Error(t, err)
+			require.ErrorContains(t, err, "XTTE3170")
+		})
+	}
+}

--- a/xslt3/execute_misc.go
+++ b/xslt3/execute_misc.go
@@ -702,37 +702,40 @@ func (ec *execContext) execEvaluate(ctx context.Context, inst *evaluateInst) err
 		if ncSeq != nil {
 			ncLen = sequence.Len(ncSeq)
 		}
-		// XTTE3170: namespace-context must produce a single node.
-		if ncLen > 1 {
+		// XTTE3170: when the namespace-context attribute is supplied, its value
+		// must be a single node. An empty sequence, multiple items, or a non-node
+		// item is a type error rather than being silently ignored.
+		if ncLen != 1 {
 			return dynamicError(errCodeXTTE3170,
 				"xsl:evaluate namespace-context produced %d items; a single node is required", ncLen)
 		}
-		if ncLen > 0 {
-			if ni, nodeOK := ncSeq.Get(0).(xpath3.NodeItem); nodeOK {
-				nsNode := ni.Node
-				// Walk up to find an element
-				for nsNode != nil {
-					if elem, elemOK := nsNode.(*helium.Element); elemOK {
-						// Collect in-scope namespaces walking up
-						seen := make(map[string]struct{})
-						var cur helium.Node = elem
-						for cur != nil {
-							if e, eOK := cur.(*helium.Element); eOK {
-								for _, ns := range e.Namespaces() {
-									prefix := ns.Prefix()
-									if _, exists := seen[prefix]; !exists {
-										seen[prefix] = struct{}{}
-										nsBindings[prefix] = ns.URI()
-									}
-								}
+		ni, nodeOK := ncSeq.Get(0).(xpath3.NodeItem)
+		if !nodeOK {
+			return dynamicError(errCodeXTTE3170,
+				"xsl:evaluate namespace-context must be a single node")
+		}
+		nsNode := ni.Node
+		// Walk up to find an element
+		for nsNode != nil {
+			if elem, elemOK := nsNode.(*helium.Element); elemOK {
+				// Collect in-scope namespaces walking up
+				seen := make(map[string]struct{})
+				var cur helium.Node = elem
+				for cur != nil {
+					if e, eOK := cur.(*helium.Element); eOK {
+						for _, ns := range e.Namespaces() {
+							prefix := ns.Prefix()
+							if _, exists := seen[prefix]; !exists {
+								seen[prefix] = struct{}{}
+								nsBindings[prefix] = ns.URI()
 							}
-							cur = cur.Parent()
 						}
-						break
 					}
-					nsNode = nsNode.Parent()
+					cur = cur.Parent()
 				}
+				break
 			}
+			nsNode = nsNode.Parent()
 		}
 	}
 


### PR DESCRIPTION
- xsl:evaluate now raises XTTE3170 when namespace-context evaluates to a non-node or empty sequence instead of silently ignoring it
- previously only a multi-item result was rejected; a single non-node item was dropped