### PR TITLE
reject over-depth xi:include before fetch

### DIFF
--- a/xinclude/xinclude.go
+++ b/xinclude/xinclude.go
@@ -287,14 +287,6 @@ func (proc Processor) ProcessTree(ctx context.Context, node helium.Node) (int, e
 }
 
 func (p *processor) processNode(ctx context.Context, n helium.Node) error {
-	maxDepth := p.maxIncludeDepth
-	if maxDepth <= 0 {
-		maxDepth = defaultMaxIncludeDepth
-	}
-	if p.depth > maxDepth {
-		return fmt.Errorf("xi:include: maximum include depth (%d) exceeded", maxDepth)
-	}
-
 	// Repeatedly collect and process xi:include elements at this level.
 	// Fallback processing may insert new xi:include elements as siblings,
 	// so we loop until no more are found.
@@ -334,6 +326,18 @@ func (p *processor) processNode(ctx context.Context, n helium.Node) error {
 }
 
 func (p *processor) processInclude(ctx context.Context, inc *helium.Element) error {
+	// Reject before fetching/splicing the resource so an over-limit include
+	// never retrieves or processes its target. Expanding this include nests its
+	// content one level deeper (p.depth+1), so maxDepth is the actual ceiling on
+	// nesting depth.
+	maxDepth := p.maxIncludeDepth
+	if maxDepth <= 0 {
+		maxDepth = defaultMaxIncludeDepth
+	}
+	if p.depth+1 > maxDepth {
+		return fmt.Errorf("xi:include: maximum include depth (%d) exceeded", maxDepth)
+	}
+
 	if err := validateIncludeChildren(inc); err != nil {
 		return err
 	}

--- a/xinclude/xinclude_test.go
+++ b/xinclude/xinclude_test.go
@@ -857,6 +857,36 @@ func TestXIncludeMaxIncludeDepth(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "maximum include depth (40) exceeded")
 	})
+
+	t.Run("chain exactly at the limit is accepted, one deeper is rejected without fetching", func(t *testing.T) {
+		t.Parallel()
+		// includeChainResolver(n) nests `n+1` levels: root -> level0 -> ... ->
+		// level(n) leaf, so the leaf content sits at nesting depth n+1.
+
+		// Exactly at the limit: maxDepth=3 admits a leaf at depth 3.
+		okCount, err := xinclude.NewProcessor().
+			Resolver(includeChainResolver(2)).
+			MaxIncludeDepth(3).
+			NoXIncludeMarkers().
+			NoBaseFixup().
+			Process(t.Context(), build())
+		require.NoError(t, err)
+		require.Positive(t, okCount)
+
+		// One deeper: the include that would push past the limit must be
+		// rejected before its target is ever resolved/fetched.
+		resolver := &countingResolver{inner: includeChainResolver(3)}
+		_, err = xinclude.NewProcessor().
+			Resolver(resolver).
+			MaxIncludeDepth(3).
+			NoXIncludeMarkers().
+			NoBaseFixup().
+			Process(t.Context(), build())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "maximum include depth (3) exceeded")
+		require.Zero(t, resolver.calls["level3.xml"], "over-limit resource must not be fetched")
+		require.Positive(t, resolver.calls["level2.xml"], "in-limit resources are fetched")
+	})
 }
 
 func TestXIncludeSameURLTwice(t *testing.T) {


### PR DESCRIPTION
- Move the xi:include depth check from `processNode` (post-fetch) into `processInclude` so an over-limit include is rejected before its target is resolved/fetched/spliced.
- Fix the off-by-one: `MaxIncludeDepth(n)` is now the actual nesting ceiling (was n+1).