### PR TITLE
reject backslash traversal in fs resolver

### DIFF
--- a/internal/unparsedtext/unparsedtext.go
+++ b/internal/unparsedtext/unparsedtext.go
@@ -714,6 +714,13 @@ func (r *fsResolver) ResolveURI(uri string) (io.ReadCloser, error) {
 	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
 		return nil, fmt.Errorf("path %q escapes the FS root", name)
 	}
+	// path.Clean and fs.ValidPath only recognize '/' as a separator, so a
+	// backslash-based traversal such as "..\\secret" survives the check above
+	// and could escape the root on a filesystem that treats '\' as a separator.
+	// Re-run the containment check with backslashes normalized to slashes.
+	if slashed := path.Clean(strings.ReplaceAll(name, `\`, "/")); slashed == ".." || strings.HasPrefix(slashed, "../") {
+		return nil, fmt.Errorf("path %q escapes the FS root", name)
+	}
 	return r.fsys.Open(cleaned)
 }
 

--- a/internal/unparsedtext/unparsedtext_test.go
+++ b/internal/unparsedtext/unparsedtext_test.go
@@ -706,6 +706,22 @@ func TestNewFileResolver(t *testing.T) {
 	require.Contains(t, err.Error(), "absolute path")
 }
 
+func TestNewFileResolverRejectsBackslashTraversal(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ok.txt"), []byte("via-fs"), 0644))
+
+	r := unparsedtext.NewFileResolver(os.DirFS(dir))
+	cfg := &unparsedtext.Config{URIResolver: r}
+
+	// path.Clean only treats '/' as a separator, so a backslash-based
+	// traversal must still be refused as a containment escape.
+	for _, name := range []string{`..\secret`, `foo\..\..\secret`} {
+		_, err := unparsedtext.ReadURI(t.Context(), cfg, name)
+		require.Error(t, err, "backslash traversal %q must be refused", name)
+		require.Contains(t, err.Error(), "escapes the FS root")
+	}
+}
+
 func TestErrorType(t *testing.T) {
 	err := &unparsedtext.Error{Code: "FOUT1170", Message: "test error"}
 	require.Equal(t, "FOUT1170: test error", err.Error())


### PR DESCRIPTION
- `fsResolver.ResolveURI` only ran path.Clean (forward-slash) containment, letting `..\\` backslash traversal reach the underlying FS.
- Re-run the containment check with backslashes normalized to slashes so such paths are refused as root escapes.