### PR TITLE
validate xsl:sort data-type attribute value

### DIFF
--- a/xslt3/execute_control.go
+++ b/xslt3/execute_control.go
@@ -120,6 +120,13 @@ func (ec *execContext) execForEach(ctx context.Context, inst *forEachInst) error
 				return err
 			}
 		} else {
+			// Validate sort key attributes even when the selection is empty
+			// (XTDE0030); sortNodes does this internally, sortItems does not.
+			for _, sk := range inst.Sort {
+				if err := validateSortKeyAttrs(ctx, ec, sk); err != nil {
+					return err
+				}
+			}
 			seq, err = sortItems(ctx, ec, seq, inst.Sort)
 			if err != nil {
 				return err

--- a/xslt3/sort.go
+++ b/xslt3/sort.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/sequence"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
 	"github.com/lestrrat-go/helium/xpath3"
 )
 
@@ -247,11 +248,22 @@ func buildImplicitCollationURI(ctx context.Context, ec *execContext, sk *sortKey
 	return "http://www.w3.org/2013/collation/UCA?" + strings.Join(params, ";"), nil
 }
 
-// validateSortKeyAttrs validates sort key attribute values (order, case-order,
-// lang, collation, stable) regardless of whether there are nodes to sort.
+// validateSortKeyAttrs validates sort key attribute values (order, data-type,
+// case-order, lang, collation, stable) regardless of whether there are nodes
+// to sort.
 func validateSortKeyAttrs(ctx context.Context, ec *execContext, sk *sortKey) error {
 	if _, err := resolveSortOrder(ctx, ec, sk); err != nil {
 		return err
+	}
+	if sk.DataType != nil {
+		dt, err := sk.DataType.evaluate(ctx, ec.contextNode)
+		if err != nil {
+			return err
+		}
+		if !isValidSortDataType(dt) {
+			return dynamicError(errCodeXTDE0030,
+				"invalid data-type %q in xsl:sort; must be \"text\", \"number\", or a QName", dt)
+		}
 	}
 	if sk.CaseOrder != nil {
 		co, err := sk.CaseOrder.evaluate(ctx, ec.contextNode)
@@ -350,6 +362,26 @@ func checkSortKeyTypeConsistency[T interface{ keyType() string }](entries []T) e
 		}
 	}
 	return nil
+}
+
+// isValidSortDataType reports whether s is a permitted xsl:sort data-type
+// value: "text", "number", or a QName denoting a non-absent namespace
+// (a prefixed lexical QName or an EQName Q{uri}local). The effect of a QName
+// data-type is implementation-defined; helium treats it as "text".
+func isValidSortDataType(s string) bool {
+	switch s {
+	case "text", lexicon.TypeNumber:
+		return true
+	}
+	if isValidEQName(s) {
+		return true
+	}
+	// A bare NCName has an absent namespace and is not permitted; require a
+	// prefix so the QName denotes a non-absent namespace.
+	if strings.IndexByte(s, ':') > 0 && xmlchar.IsValidQName(s) {
+		return true
+	}
+	return false
 }
 
 // isValidLanguageTag checks if s is a plausible BCP47 language tag.

--- a/xslt3/sort_validate_test.go
+++ b/xslt3/sort_validate_test.go
@@ -119,3 +119,49 @@ func TestPerformSortEmptyValidatesCollation(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "XTDE1035")
 }
+
+// XSLT3-ADV-003: an xsl:sort data-type that is neither "text"/"number" nor a
+// valid QName must raise XTDE0030 even when the input sequence is empty (the
+// validation must not be skipped just because there is nothing to sort).
+func TestSortInvalidDataTypeEmptyRaisesXTDE0030(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <out>
+      <xsl:perform-sort select="()">
+        <xsl:sort select="." data-type="bogus"/>
+      </xsl:perform-sort>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root/>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(doc).Serialize(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "XTDE0030")
+}
+
+// XSLT3-ADV-003: an invalid evaluated data-type with non-empty input must also
+// raise XTDE0030 rather than silently falling back to text sorting.
+func TestSortInvalidDataTypeRaisesXTDE0030(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="." data-type="{'bogus'}"/>
+        <xsl:value-of select="."/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root><item>b</item><item>a</item></root>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(doc).Serialize(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "XTDE0030")
+}

--- a/xslt3/sort_validate_test.go
+++ b/xslt3/sort_validate_test.go
@@ -98,6 +98,30 @@ func TestSortInvalidStableRaisesXTDE0030(t *testing.T) {
 	require.ErrorContains(t, err, "XTDE0030")
 }
 
+// XSLT3-ADV-003: a NON-EMPTY atomic xsl:for-each (atomic-sequence sort path)
+// must validate its sort-key data-type and raise XTDE0030, not silently sort
+// the atomic items as text.
+func TestForEachAtomicInvalidDataTypeRaisesXTDE0030(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="('b','a','c')">
+        <xsl:sort select="." data-type="bogus"/>
+        <xsl:value-of select="."/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root/>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(doc).Serialize(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "XTDE0030")
+}
+
 // ENG-004: xsl:perform-sort over an EMPTY sequence must still validate its
 // sort keys, so an invalid collation raises XTDE1035 even with no input.
 func TestPerformSortEmptyValidatesCollation(t *testing.T) {


### PR DESCRIPTION
- xsl:sort `data-type` is now validated (text/number/QName); an invalid value raises XTDE0030.
- Validation runs even when the input sequence is empty, so the error is no longer skipped.