### PR TITLE
reject bytes >= 0x80 under US-ASCII encoding

### DIFF
--- a/.claude/docs/helium-command.md
+++ b/.claude/docs/helium-command.md
@@ -112,7 +112,7 @@ File output (`--output`/`-o`, not stdout and not `--noout`) is written through a
 ### `--encode ENC`
 
 - Validated at parse time against `internal/encoding.Load`; an unrecognized encoding name is rejected with `--encode: unsupported encoding` and `ExitErr` (no silent fallback).
-- US-ASCII and its aliases (`ascii`, `ANSI_X3.4-1968`, `csASCII`, detected via `internal/encoding.IsASCII`) are rejected with the same `--encode: unsupported encoding` message: `Load` maps them to the UTF-8 encoder, which would emit raw UTF-8 bytes for non-ASCII characters while declaring US-ASCII.
+- US-ASCII and its aliases (`ascii`, `ANSI_X3.4-1968`, `csASCII`, detected via `internal/encoding.IsASCII`) are rejected with the same `--encode: unsupported encoding` message: `Load`'s strict ASCII encoder delegates to UTF-8, which would emit raw UTF-8 bytes for non-ASCII characters while declaring US-ASCII.
 - Cannot be combined with `--xpath`: the XPath path serializes node values without re-encoding, so the combination is rejected at parse time with `--encode cannot be combined with --xpath` and `ExitErr`.
 - Applied to the standard dump path via `doc.SetEncoding`, so the serializer loads the matching encoder and emits the matching encoding declaration.
 - Ignored for C14N modes, which are always UTF-8 per the C14N spec.

--- a/.claude/docs/parser-internals.md
+++ b/.claude/docs/parser-internals.md
@@ -114,6 +114,13 @@ remembered by `UTF8Cursor` as a sticky `Err()` (a clean `Done()` would otherwise
 mask it as EOF); `parseDocument` surfaces it via `cursorDecodeErr()` at the
 document-end gate.
 
+**Strict US-ASCII decode**: US-ASCII is a 7-bit encoding. It is deliberately
+excluded from `IsUTF8`'s direct-byte-cursor fast path and routed through `Load`,
+whose `asciiEncoding` decoder (`ascii.go`) rejects any byte >= 0x80 with
+`ErrInvalidASCII`. A document declaring `encoding="US-ASCII"` that contains a
+byte >= 0x80 (even a valid UTF-8 multibyte sequence) is therefore a fatal decode
+error rather than being silently passed through.
+
 ## File Responsibilities
 
 - `parserctx.go` owns the parser context, input/cursor stack, SAX callback dispatch, location/error reporting, and other shared parser state.

--- a/internal/encoding/ascii.go
+++ b/internal/encoding/ascii.go
@@ -1,0 +1,55 @@
+package encoding
+
+// ascii.go provides a strict US-ASCII decoder. Per the XML specification
+// US-ASCII is a 7-bit encoding: every byte must be <= 0x7F. The base
+// golang.org/x/text library has no dedicated US-ASCII codec, so US-ASCII used
+// to be aliased to UTF-8, which silently accepted multibyte sequences (any
+// byte >= 0x80) in a document declaring US-ASCII. This wrapper rejects any
+// byte >= 0x80 as a fatal decode error instead.
+
+import (
+	"errors"
+
+	enc "golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+)
+
+// ErrInvalidASCII is returned when a document declared as US-ASCII contains a
+// byte outside the 7-bit range (>= 0x80).
+var ErrInvalidASCII = errors.New("encoding: byte outside US-ASCII range (>= 0x80)")
+
+// asciiEncoding is a strict US-ASCII encoding. Its decoder rejects any byte
+// >= 0x80; its encoder delegates to UTF-8 (US-ASCII output is never exercised
+// on the parse path and the serializer handles ASCII output separately).
+type asciiEncoding struct{}
+
+func (asciiEncoding) NewDecoder() *enc.Decoder {
+	return &enc.Decoder{Transformer: asciiDecoder{}}
+}
+
+func (asciiEncoding) NewEncoder() *enc.Encoder {
+	return unicode.UTF8.NewEncoder()
+}
+
+// asciiDecoder copies 7-bit bytes through unchanged and returns
+// ErrInvalidASCII on the first byte >= 0x80.
+type asciiDecoder struct{}
+
+func (asciiDecoder) Reset() {}
+
+func (asciiDecoder) Transform(dst, src []byte, _ bool) (nDst, nSrc int, err error) {
+	for nSrc < len(src) {
+		b := src[nSrc]
+		if b >= 0x80 {
+			return nDst, nSrc, ErrInvalidASCII
+		}
+		if nDst >= len(dst) {
+			return nDst, nSrc, transform.ErrShortDst
+		}
+		dst[nDst] = b
+		nDst++
+		nSrc++
+	}
+	return nDst, nSrc, nil
+}

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -36,7 +36,7 @@ func Load(name string) enc.Encoding {
 	case "utf8", "unicode11utf8", "unicode20utf8", "xunicode20utf8":
 		return unicode.UTF8
 	case "usascii", "ascii", "ansix341968", "csascii":
-		return unicode.UTF8
+		return asciiEncoding{}
 	case "utf16le", "unicodefeff":
 		return withStrictDecode(unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM), 2, orderLE2, false)
 	case "utf16be", "unicodefffe":

--- a/internal/encoding/encoding_test.go
+++ b/internal/encoding/encoding_test.go
@@ -271,3 +271,25 @@ func requireEquivalentEncoding(t *testing.T, canonical, alias string) {
 		require.Equal(t, gotCanonical, gotAlias, "decoded output mismatch: canonical=%q alias=%q sample=%#v", canonical, alias, sample)
 	}
 }
+
+func TestUSASCIIStrictDecode(t *testing.T) {
+	t.Parallel()
+
+	for _, alias := range []string{"US-ASCII", "ascii", "ANSI_X3.4-1968", "csASCII"} {
+		e := xmlenc.Load(alias)
+		require.NotNil(t, e, "alias %q must be loadable", alias)
+
+		// Valid 7-bit input decodes unchanged.
+		got, err := e.NewDecoder().String("hello world")
+		require.NoError(t, err, "alias %q: 7-bit input must decode", alias)
+		require.Equal(t, "hello world", got)
+
+		// A byte >= 0x80 is malformed for US-ASCII and must error, even when
+		// it would form a valid UTF-8 multibyte sequence.
+		_, err = e.NewDecoder().String(string([]byte{0xc3, 0xa9}))
+		require.Error(t, err, "alias %q: high byte must be rejected", alias)
+
+		_, err = e.NewDecoder().String(string([]byte{0x80}))
+		require.Error(t, err, "alias %q: 0x80 must be rejected", alias)
+	}
+}

--- a/internal/encoding/isutf8.go
+++ b/internal/encoding/isutf8.go
@@ -1,19 +1,20 @@
 package encoding
 
-// IsUTF8 returns true if the named encoding is UTF-8 or ASCII (a subset of
-// UTF-8). The parser can use a direct byte cursor for these.
+// IsUTF8 returns true if the named encoding is UTF-8. The parser can use a
+// direct byte cursor for these. US-ASCII is deliberately NOT included: it must
+// route through Load's strict ASCII decoder, which rejects bytes >= 0x80.
 func IsUTF8(name string) bool {
 	switch normalizeEncodingName(name) {
-	case "utf8", "unicode11utf8", "unicode20utf8", "xunicode20utf8",
-		"usascii", "ascii", "ansix341968", "csascii":
+	case "utf8", "unicode11utf8", "unicode20utf8", "xunicode20utf8":
 		return true
 	}
 	return false
 }
 
 // IsASCII returns true if the named encoding is one of the US-ASCII aliases.
-// Load maps these to the UTF-8 encoder, so callers that need byte-valid
-// output for the declared encoding must detect ASCII separately.
+// Load maps these to a strict ASCII encoding whose encoder delegates to UTF-8,
+// so callers that need byte-valid output for the declared encoding must detect
+// ASCII separately.
 func IsASCII(name string) bool {
 	switch normalizeEncodingName(name) {
 	case "usascii", "ascii", "ansix341968", "csascii":

--- a/parser_test.go
+++ b/parser_test.go
@@ -492,6 +492,21 @@ func TestParseExternalEntityMalformedEncoding(t *testing.T) {
 	require.Error(t, err, "malformed UTF-16 external entity must fail rather than inserting U+FFFD")
 }
 
+func TestParseUSASCIIStrict(t *testing.T) {
+	t.Parallel()
+
+	// A document declaring US-ASCII is strictly 7-bit; a byte >= 0x80 is
+	// malformed even when it forms a valid UTF-8 multibyte sequence.
+	highByte := "<?xml version=\"1.0\" encoding=\"US-ASCII\"?><root>\xc3\xa9</root>"
+	_, err := helium.NewParser().Parse(t.Context(), []byte(highByte))
+	require.Error(t, err, "US-ASCII document with a byte >= 0x80 must be rejected")
+
+	// Valid 7-bit US-ASCII still parses.
+	valid := `<?xml version="1.0" encoding="US-ASCII"?><root>hello</root>`
+	_, err = helium.NewParser().Parse(t.Context(), []byte(valid))
+	require.NoError(t, err, "valid 7-bit US-ASCII must parse")
+}
+
 func TestParseExternalDTDSizeLimit(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- US-ASCII now routes through a strict 7-bit decoder that rejects any byte >= 0x80 instead of aliasing to UTF-8
- a document declaring US-ASCII with a high byte (even valid UTF-8 multibyte) is now a fatal decode error