### PR TITLE
reject out-of-subset xsd idc selector/field xpath

### DIFF
--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -2,6 +2,7 @@ package xsd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -761,7 +762,7 @@ func (c *compiler) parseIDConstraint(ctx context.Context, elem *helium.Element, 
 	// run), so an invalid schema must fail to compile rather than validate
 	// documents as if no constraint were present.
 	if idc.Selector != "" {
-		compiled, err := xpath1.Compile(idc.Selector)
+		compiled, err := compileIDCXPath(idc.Selector, false)
 		if err != nil {
 			c.reportIDCXPathError(ctx, elemSelector, selectorLine, idc.Selector, err)
 		} else {
@@ -775,7 +776,7 @@ func (c *compiler) parseIDConstraint(ctx context.Context, elem *helium.Element, 
 	// constraint.
 	idc.FieldExprs = make([]*xpath1.Expression, len(idc.Fields))
 	for i, f := range idc.Fields {
-		compiled, err := xpath1.Compile(f)
+		compiled, err := compileIDCXPath(f, true)
 		if err != nil {
 			line := 0
 			if i < len(fieldLines) {
@@ -835,4 +836,92 @@ func (c *compiler) reportIDCXPathError(ctx context.Context, kind string, line in
 	msg := fmt.Sprintf("The %s XPath '%s' is not a valid %s expression: %s.", noun, xpath, noun, cause)
 	c.schemaError(ctx,
 		schemaParserErrorAttr(c.filename, line, kind, kind, attrXPath, msg))
+}
+
+// compileIDCXPath compiles an identity-constraint selector/field XPath and
+// additionally verifies it conforms to the restricted XPath subset that XSD
+// (Structures 3.11.6) permits for selectors and fields. The full XPath 1.0
+// grammar accepted by xpath1.Compile is broader than that subset, so a syntax
+// check alone would wrongly accept expressions such as string/number literal
+// steps, function calls, variable references, operators, or predicates that the
+// subset forbids. allowAttribute is true for <field> (which may end in an
+// attribute step) and false for <selector> (where the attribute axis is not
+// permitted).
+func compileIDCXPath(expr string, allowAttribute bool) (*xpath1.Expression, error) {
+	compiled, err := xpath1.Compile(expr)
+	if err != nil {
+		return nil, err
+	}
+	// Re-parse to inspect the AST; the expression already compiled, so this
+	// cannot fail. The subset gate only runs at schema-compile time.
+	ast, err := xpath1.Parse(expr)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateIDCXPathSubset(ast, allowAttribute); err != nil {
+		return nil, err
+	}
+	return compiled, nil
+}
+
+// validateIDCXPathSubset reports an error if expr falls outside the XSD
+// identity-constraint XPath subset. The subset is a union ('|') of relative
+// location paths whose steps use only the child axis (with a name test), the
+// self axis (the abbreviated '.'), the descendant-or-self step of the './/'
+// prefix, and — for fields only — a trailing attribute step. Anything else
+// (literals, function calls, variables, arithmetic/boolean operators, filter
+// expressions, predicates, absolute paths) is rejected.
+func validateIDCXPathSubset(expr xpath1.Expr, allowAttribute bool) error {
+	switch e := expr.(type) {
+	case xpath1.UnionExpr:
+		if err := validateIDCXPathSubset(e.Left, allowAttribute); err != nil {
+			return err
+		}
+		return validateIDCXPathSubset(e.Right, allowAttribute)
+	case *xpath1.LocationPath:
+		return validateIDCLocationPath(e, allowAttribute)
+	case xpath1.LocationPath:
+		return validateIDCLocationPath(&e, allowAttribute)
+	default:
+		return errors.New("the expression is outside the identity-constraint XPath subset")
+	}
+}
+
+// validateIDCLocationPath checks a single location path against the IDC subset.
+func validateIDCLocationPath(lp *xpath1.LocationPath, allowAttribute bool) error {
+	if lp.Absolute {
+		return errors.New("absolute location paths are not permitted")
+	}
+	last := len(lp.Steps) - 1
+	for i, step := range lp.Steps {
+		if len(step.Predicates) > 0 {
+			return errors.New("predicates are not permitted")
+		}
+		switch step.Axis {
+		case xpath1.AxisSelf, xpath1.AxisDescendantOrSelf:
+			// Only the abbreviated '.' and './/' steps (axis::node()) are
+			// allowed; a name or other node-type test on these axes is not.
+			tt, ok := step.NodeTest.(xpath1.TypeTest)
+			if !ok || tt.Type != xpath1.NodeTestNode {
+				return fmt.Errorf("the %s axis is only permitted as the abbreviated '.' or './/' step", step.Axis)
+			}
+		case xpath1.AxisChild:
+			if _, ok := step.NodeTest.(xpath1.NameTest); !ok {
+				return errors.New("only name tests are permitted on the child axis")
+			}
+		case xpath1.AxisAttribute:
+			if !allowAttribute {
+				return errors.New("the attribute axis is not permitted in a selector")
+			}
+			if i != last {
+				return errors.New("the attribute axis is only permitted in the final step")
+			}
+			if _, ok := step.NodeTest.(xpath1.NameTest); !ok {
+				return errors.New("only name tests are permitted on the attribute axis")
+			}
+		default:
+			return fmt.Errorf("the %s axis is not permitted", step.Axis)
+		}
+	}
+	return nil
 }

--- a/xsd/validate_idc_errors_test.go
+++ b/xsd/validate_idc_errors_test.go
@@ -94,6 +94,90 @@ func TestIDCMalformedXPath(t *testing.T) {
 	})
 }
 
+// TestIDCXPathSubset verifies that identity-constraint selector/field XPath
+// expressions are gated against the restricted XPath subset XSD permits
+// (Structures 3.11.6). The full XPath 1.0 grammar is broader than that subset,
+// so syntactically valid but out-of-subset constructs (string/number literals,
+// function calls, variable references, operators, predicates, the attribute
+// axis in a selector) must be rejected at schema-compile time, while genuine
+// subset expressions still compile clean.
+func TestIDCXPathSubset(t *testing.T) {
+	t.Parallel()
+
+	const (
+		okSelector = "item" // a valid in-subset selector
+		okField    = "@id"  // a valid in-subset field
+	)
+
+	schema := func(selector, field string) string {
+		return `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="id" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="itemKey">
+      <xs:selector xpath="` + selector + `"/>
+      <xs:field xpath="` + field + `"/>
+    </xs:unique>
+  </xs:element>
+</xs:schema>`
+	}
+
+	t.Run("selector rejected", func(t *testing.T) {
+		t.Parallel()
+		// String/number literals, function calls, predicates, the attribute
+		// axis, absolute paths and operators are all outside the subset.
+		for _, sel := range []string{"'literal'", "42", "foo()", "item[@id='x']", "@id", "/item", "item + 1"} {
+			t.Run(sel, func(t *testing.T) {
+				t.Parallel()
+				_, errs := compileXSD(t, schema(sel, okField))
+				require.NotEmpty(t, errs, "out-of-subset selector must be rejected")
+				require.Contains(t, errs, "is not a valid selector")
+			})
+		}
+	})
+
+	t.Run("field rejected", func(t *testing.T) {
+		t.Parallel()
+		// Like selectors, plus a non-final attribute step is out of subset.
+		for _, f := range []string{"'literal'", "string(@id)", "$x", "@id[1]", "@id/item"} {
+			t.Run(f, func(t *testing.T) {
+				t.Parallel()
+				_, errs := compileXSD(t, schema(okSelector, f))
+				require.NotEmpty(t, errs, "out-of-subset field must be rejected")
+				require.Contains(t, errs, "is not a valid field")
+			})
+		}
+	})
+
+	t.Run("accepted", func(t *testing.T) {
+		t.Parallel()
+		for name, tc := range map[string]struct {
+			selector, field string
+		}{
+			"child name test":    {okSelector, okField},
+			"self step":          {".", okField},
+			"descendant-or-self": {".//item", okField},
+			"wildcard name test": {"*", okField},
+			"union of paths":     {".//item | item", okField},
+			"field self":         {okSelector, "."},
+			"multi-step child":   {"item/item", okField},
+		} {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				_, errs := compileXSD(t, schema(tc.selector, tc.field))
+				require.Empty(t, errs, "valid subset XPath must compile clean")
+			})
+		}
+	})
+}
+
 // TestIDCKeyRefUnresolvedRefer covers an xs:keyref whose @refer names a
 // key/unique constraint that does not exist. Previously such a keyref was
 // silently skipped at validation time, so referential integrity was not

--- a/xsd/validate_idc_keyref_scope_test.go
+++ b/xsd/validate_idc_keyref_scope_test.go
@@ -24,16 +24,15 @@ func compileXSD(t *testing.T, schemaXML string) (xsd.Validator, string) {
 	return xsd.NewValidator(s), ""
 }
 
-// TestIDCFieldXPathEvalError covers a field XPath that COMPILES but fails at
-// evaluation (e.g. an unknown function). Previously the evaluation error was
-// swallowed — the field was treated as absent and the selected node silently
-// dropped from the constraint, so a unique/keyref could miss a violation. The
-// failure must now surface as a validity error.
-func TestIDCFieldXPathEvalError(t *testing.T) {
+// TestIDCFieldXPathFunctionRejected covers a field XPath that uses a function
+// call. Such an expression is outside the XSD identity-constraint XPath subset
+// (selectors/fields are restricted location paths), so it must be a fatal schema
+// compilation error. Previously it compiled and the field's evaluation error was
+// swallowed, silently disabling the constraint so a unique/keyref could miss a
+// violation; now the out-of-subset XPath is rejected up front.
+func TestIDCFieldXPathFunctionRejected(t *testing.T) {
 	t.Parallel()
 
-	// "bogusfn(.)" parses and compiles in xpath1 but errors at Evaluate with
-	// ErrUnknownFunction. The selector still selects the two <item> nodes.
 	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="root">
     <xs:complexType>
@@ -52,17 +51,9 @@ func TestIDCFieldXPathEvalError(t *testing.T) {
   </xs:element>
 </xs:schema>`
 
-	v, compileErrs := compileXSD(t, schemaXML)
-	require.Empty(t, compileErrs, "schema should compile clean; the failure is at evaluation")
-
-	doc, err := helium.NewParser().Parse(t.Context(),
-		[]byte(`<root><item id="a"/><item id="b"/></root>`))
-	require.NoError(t, err)
-
-	var errs string
-	err = validateWithOutput(t, v, doc, &errs)
-	require.Error(t, err, "a failing field XPath must surface as a validation error, not be swallowed")
-	require.Contains(t, errs, "itemKey")
+	_, compileErrs := compileXSD(t, schemaXML)
+	require.NotEmpty(t, compileErrs, "an out-of-subset field XPath must be a fatal schema error")
+	require.Contains(t, compileErrs, "is not a valid field")
 }
 
 // TestIDCCrossElementKeyRefOutOfScope verifies the XSD identity-constraint scope

--- a/xsd/validate_nil_guard_test.go
+++ b/xsd/validate_nil_guard_test.go
@@ -48,7 +48,7 @@ func TestValidateNilDocument(t *testing.T) {
 }
 
 // TestValidateNilContext asserts that Validate normalizes a nil context.Context
-// rather than panicking through IDC XPath function evaluation.
+// rather than panicking while evaluating an identity-constraint XPath.
 func TestValidateNilContext(t *testing.T) {
 	const schemaSrc = `<?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
@@ -63,7 +63,7 @@ func TestValidateNilContext(t *testing.T) {
       </xs:sequence>
     </xs:complexType>
     <xs:unique name="itemKey">
-      <xs:selector xpath="item[normalize-space(@n)]"/>
+      <xs:selector xpath="item"/>
       <xs:field xpath="@n"/>
     </xs:unique>
   </xs:element>


### PR DESCRIPTION
- Gate xs:unique/key/keyref selector and field XPath against the restricted subset XSD permits (Structures 3.11.6); literals, function calls, variables, operators, predicates, absolute paths, and a selector/non-final attribute axis are now fatal schema-compile errors instead of silently accepted.
- Two prior tests that exploited the over-acceptance (a predicate-with-function selector; a bogus-function field) updated to valid-subset equivalents.