### PR TITLE
fix dropped external SYSTEM parameter entities

### DIFF
--- a/parser_entity_decl.go
+++ b/parser_entity_decl.go
@@ -372,13 +372,18 @@ func (pctx *parserCtx) parseEntityDecl(ctx context.Context) error {
 				return pctx.error(ctx, err)
 			}
 		} else {
+			// parseExternalID returns (systemURI, publicID). Mirror the external
+			// general-entity path below: guard on the system URI (a SYSTEM
+			// declaration carries no public ID, so guarding on the public ID would
+			// drop every SYSTEM parameter entity), and pass publicID/systemID to
+			// EntityDecl in that order.
 			literal, uri, err = pctx.parseExternalID(ctx)
 			if err != nil {
 				return pctx.error(ctx, ErrValueRequired)
 			}
 
-			if uri != "" {
-				u, err := url.Parse(uri)
+			if literal != "" {
+				u, err := url.Parse(literal)
 				if err != nil {
 					return pctx.error(ctx, err)
 				}
@@ -386,7 +391,7 @@ func (pctx *parserCtx) parseEntityDecl(ctx context.Context) error {
 				if u.Fragment != "" {
 					return pctx.error(ctx, errors.New("err uri fragment"))
 				} else if s := pctx.sax; s != nil {
-					switch err := s.EntityDecl(ctx, name, enum.ExternalParameterEntity, literal, uri, ""); err {
+					switch err := s.EntityDecl(ctx, name, enum.ExternalParameterEntity, uri, literal, ""); err {
 					case nil, sax.ErrHandlerUnspecified:
 					default:
 						return pctx.error(ctx, err)

--- a/parser_entity_test.go
+++ b/parser_entity_test.go
@@ -462,6 +462,70 @@ func TestEntityValueMalformedGeneralRefViaPE(t *testing.T) {
 	})
 }
 
+// TestExternalSystemParameterEntityCaptured proves that an external SYSTEM
+// parameter entity declared in the external subset is registered. parseExternalID
+// returns (systemURI, publicID); the external-PE declaration path must guard on
+// the systemURI and record it. Guarding on the publicID instead drops a SYSTEM PE
+// entirely (a SYSTEM declaration has no public ID), so it would never be stored.
+//
+// A control general entity declared on the line before proves the external subset
+// is loaded; only the SYSTEM external PE was being dropped.
+func TestExternalSystemParameterEntityCaptured(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"d.dtd": {Data: []byte(
+			`<!ENTITY ctrl "control">` + "\n" +
+				`<!ENTITY % pe SYSTEM "pe.ent">`)},
+	}
+	const input = `<?xml version="1.0"?>` + "\n" +
+		`<!DOCTYPE r SYSTEM "d.dtd"><r/>`
+
+	doc, err := helium.NewParser().BlockXXE(false).
+		LoadExternalDTD(true).
+		FS(fsys).
+		Parse(t.Context(), []byte(input))
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+
+	_, ctrlOK := doc.GetEntity("ctrl")
+	require.True(t, ctrlOK, "control general entity must be stored, proving the external subset loaded")
+
+	ent, ok := doc.GetParameterEntity("pe")
+	require.True(t, ok, "external SYSTEM parameter entity must be registered")
+	require.Equal(t, enum.ExternalParameterEntity, ent.EntityType())
+	require.Equal(t, "pe.ent", ent.SystemID(), "the SYSTEM literal must be recorded as the system ID")
+	require.Empty(t, ent.ExternalID(), "a SYSTEM declaration has no public ID")
+}
+
+// TestExternalPublicParameterEntityCaptured proves the PUBLIC external parameter
+// entity path records the public and system IDs in the correct fields rather than
+// swapping them.
+func TestExternalPublicParameterEntityCaptured(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"d.dtd": {Data: []byte(
+			`<!ENTITY ctrl "control">` + "\n" +
+				`<!ENTITY % pe PUBLIC "-//x//pe" "pe.ent">`)},
+	}
+	const input = `<?xml version="1.0"?>` + "\n" +
+		`<!DOCTYPE r SYSTEM "d.dtd"><r/>`
+
+	doc, err := helium.NewParser().BlockXXE(false).
+		LoadExternalDTD(true).
+		FS(fsys).
+		Parse(t.Context(), []byte(input))
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+
+	ent, ok := doc.GetParameterEntity("pe")
+	require.True(t, ok, "external PUBLIC parameter entity must be registered")
+	require.Equal(t, enum.ExternalParameterEntity, ent.EntityType())
+	require.Equal(t, "pe.ent", ent.SystemID(), "the system literal must be the system ID")
+	require.Equal(t, "-//x//pe", ent.ExternalID(), "the public ID must be the external ID")
+}
+
 // TestEntityValueRefValidationIsSideEffectFree proves that the reference
 // validation in parseEntityValue does NOT perturb the entity-amplification
 // accounting. validateEntityValueRefs PE-expands the literal to scan for

--- a/parser_entity_test.go
+++ b/parser_entity_test.go
@@ -445,7 +445,7 @@ func TestEntityValueMalformedGeneralRefViaPE(t *testing.T) {
 		// The malformed per-declaration error in the external subset must now
 		// surface as a top-level parse error rather than being swallowed.
 		fsys := fstest.MapFS{
-			"d.dtd": {Data: []byte(
+			dtdSystemID: {Data: []byte(
 				`<!ENTITY c "control">` + "\n" +
 					`<!ENTITY % amp "&#38;">` + "\n" +
 					`<!ENTITY e "%amp;broken">`)},
@@ -474,7 +474,7 @@ func TestExternalSystemParameterEntityCaptured(t *testing.T) {
 	t.Parallel()
 
 	fsys := fstest.MapFS{
-		"d.dtd": {Data: []byte(
+		dtdSystemID: {Data: []byte(
 			`<!ENTITY ctrl "control">` + "\n" +
 				`<!ENTITY % pe SYSTEM "pe.ent">`)},
 	}
@@ -505,7 +505,7 @@ func TestExternalPublicParameterEntityCaptured(t *testing.T) {
 	t.Parallel()
 
 	fsys := fstest.MapFS{
-		"d.dtd": {Data: []byte(
+		dtdSystemID: {Data: []byte(
 			`<!ENTITY ctrl "control">` + "\n" +
 				`<!ENTITY % pe PUBLIC "-//x//pe" "pe.ent">`)},
 	}
@@ -550,7 +550,7 @@ func TestEntityValueRefValidationIsSideEffectFree(t *testing.T) {
 	dtd := `<!ENTITY c "control">` + "\n" +
 		`<!ENTITY % p "` + big + `">` + "\n" +
 		`<!ENTITY e "%p;">`
-	fsys := fstest.MapFS{"d.dtd": {Data: []byte(dtd)}}
+	fsys := fstest.MapFS{dtdSystemID: {Data: []byte(dtd)}}
 	input := `<?xml version="1.0"?>` + "\n" +
 		`<!DOCTYPE r SYSTEM "d.dtd"><r/>`
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -1071,6 +1071,10 @@ func TestParseExternalDTDUnterminatedIncludeNoHang(t *testing.T) {
 	}
 }
 
+// dtdSystemID is the external-DTD SYSTEM identifier (and MapFS filename) shared
+// by the external-subset parser tests in this package.
+const dtdSystemID = "d.dtd"
+
 func TestParseExternalDTDTrailingWSPreservesPostDoctypeMisc(t *testing.T) {
 	t.Parallel()
 
@@ -1087,7 +1091,7 @@ func TestParseExternalDTDTrailingWSPreservesPostDoctypeMisc(t *testing.T) {
 	// them from the parsed document. Inspecting the floor cursor directly (rather
 	// than via getCursor) stops at the floor instead, so the misc nodes survive.
 	const dtd = "<!ELEMENT r EMPTY>\n"
-	fsys := fstest.MapFS{"d.dtd": &fstest.MapFile{Data: []byte(dtd)}}
+	fsys := fstest.MapFS{dtdSystemID: &fstest.MapFile{Data: []byte(dtd)}}
 
 	p := helium.NewParser().LoadExternalDTD(true).DefaultDTDAttributes(true).FS(fsys)
 	doc, err := p.Parse(t.Context(), []byte(input))


### PR DESCRIPTION
- External-PE decl path used parseExternalID's returns backwards: guarded on the public ID (empty for SYSTEM) so SYSTEM parameter entities were dropped, and swapped publicID/systemID for PUBLIC ones.
- Mirror the working external general-entity path; only affects the opt-in LoadExternalDTD path.