### PR TITLE
fix relaxng multi-flexible group backtracking

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -389,6 +389,17 @@ When mandatory group child fails:
      yield (e.g. `group(zeroOrMore(x), zeroOrMore(x), x)`)
    - Keep highest successful count (maximizes consumption — libxml2 semantics)
 
+The recursive retry would be exponential (`O(M^N)` for `N` flexible members over
+`M` elements) without memoization, since the cascading reductions re-explore
+overlapping subproblems. `validateGroupChildren`/`validateGroupSeq` therefore
+cache each call in `validator.groupMemo`, keyed by the inputs that fully determine
+the result (child-range start pattern + length, owning element, first remaining
+node + sequence length, packed `attrUsed`, `suppressDepth>0`, content-vs-naive
+discriminator). A hit reproduces the original call's effect exactly — resulting
+position, attribute usage, appended errors, return value — so memoization is sound
+(no valid document rejected) while collapsing the fan-out to polynomial. Regression
+guard: `TestMultiFlexibleGroupBacktrackingNotExponential`.
+
 Two parallel implementations share this strategy. `validateGroupContent` +
 `backtrackGroupFlexible` runs inside element bodies (threads attrs/attrUsed and
 emits content-failure diagnostics). `validateGroup` + `backtrackGroupNaive` runs

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -383,7 +383,10 @@ When mandatory group child fails:
 1. Check if element was consumed (structural vs content error)
 2. For each previous flexible child (zeroOrMore/oneOrMore/optional) from nearest to furthest:
    - Try iteration counts from minimum upward to greedy count
-   - Re-validate remaining children at each count
+   - Re-validate remaining children via the group routine (`validateGroupChildren` /
+     `validateGroupSeq`) so flexible members in the retry range can themselves
+     backtrack — this recovers groups with 2+ flexible members that must each
+     yield (e.g. `group(zeroOrMore(x), zeroOrMore(x), x)`)
    - Keep highest successful count (maximizes consumption — libxml2 semantics)
 
 Two parallel implementations share this strategy. `validateGroupContent` +

--- a/relaxng/group_backtrack_test.go
+++ b/relaxng/group_backtrack_test.go
@@ -1,7 +1,9 @@
 package relaxng_test
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/relaxng"
@@ -185,4 +187,41 @@ func TestMultiFlexibleGroupBacktracking(t *testing.T) {
 			require.Error(t, verr, "%s should be rejected", tc.name)
 		})
 	}
+}
+
+// TestMultiFlexibleGroupBacktrackingNotExponential guards against a re-introduced
+// algorithmic-complexity DoS: a group of N greedy zeroOrMore members followed by
+// a mandatory member, matched against M elements, drove the cascading backtracker
+// to O(M^N) before group-result memoization was added (N=9/M=25 took ~45s). With
+// memoization each distinct (child-range, input-position) subproblem is computed
+// once, so the same input validates near-instantly.
+func TestMultiFlexibleGroupBacktrackingNotExponential(t *testing.T) {
+	t.Parallel()
+
+	const N, M = 10, 30
+	a := `<element name="a"><empty/></element>`
+	var schema strings.Builder
+	schema.WriteString(`<grammar xmlns="http://relaxng.org/ns/structure/1.0"><start><element name="root"><group>`)
+	for range N {
+		schema.WriteString(`<zeroOrMore>` + a + `</zeroOrMore>`)
+	}
+	schema.WriteString(a + `</group></element></start></grammar>`)
+
+	var docStr strings.Builder
+	docStr.WriteString(`<root>`)
+	for range M {
+		docStr.WriteString(`<a/>`)
+	}
+	docStr.WriteString(`</root>`)
+
+	grammar := compileGrammar(t, schema.String())
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(docStr.String()))
+	require.NoError(t, err)
+
+	start := time.Now()
+	verr := relaxng.NewValidator(grammar).Validate(t.Context(), doc)
+	elapsed := time.Since(start)
+
+	require.NoError(t, verr, "group(zeroOrMore(a) x%d, a) over %d elements should validate", N, M)
+	require.Less(t, elapsed, 5*time.Second, "validation must not be exponential (took %s)", elapsed)
 }

--- a/relaxng/group_backtrack_test.go
+++ b/relaxng/group_backtrack_test.go
@@ -129,3 +129,60 @@ func TestNaiveGroupBacktrackingFlexKinds(t *testing.T) {
 		})
 	}
 }
+
+// TestMultiFlexibleGroupBacktracking covers groups with two or more flexible
+// members (zeroOrMore/oneOrMore/optional) that must each yield content. The
+// backtracker must cascade reductions recursively so a second flexible member
+// does not re-grab content a later mandatory member needs. This exercises both
+// the naive-group path (backtrackGroupNaive) and the element-content path
+// (backtrackGroupFlexible).
+func TestMultiFlexibleGroupBacktracking(t *testing.T) {
+	t.Parallel()
+
+	naive := func(members string) string {
+		return `<grammar xmlns="http://relaxng.org/ns/structure/1.0"><start><group>` +
+			members + `</group></start></grammar>`
+	}
+	content := func(members string) string {
+		return `<grammar xmlns="http://relaxng.org/ns/structure/1.0"><start>` +
+			`<element name="root"><group>` + members + `</group></element></start></grammar>`
+	}
+	root := `<element name="root"><empty/></element>`
+	a := `<element name="a"><empty/></element>`
+	z := func(p string) string { return `<zeroOrMore>` + p + `</zeroOrMore>` }
+	o := func(p string) string { return `<optional>` + p + `</optional>` }
+
+	cases := []struct {
+		name   string
+		schema string
+		doc    string
+		valid  bool
+	}{
+		// Naive path: two zeroOrMore both yield 0 so the mandatory member matches.
+		{"naive zz+m", naive(z(root) + z(root) + root), `<root/>`, true},
+		// Naive path: optional + zeroOrMore both yield 0 for the mandatory member.
+		{"naive oz+m", naive(o(root) + z(root) + root), `<root/>`, true},
+		// Element-content path: two zeroOrMore yield 0 so the mandatory a matches.
+		{"content zz+m", content(z(a) + z(a) + a), `<root><a/></root>`, true},
+		// Element-content path: with more content, the flexible members can still
+		// consume while leaving exactly one a for the mandatory member.
+		{"content zz+m many", content(z(a) + z(a) + a), `<root><a/><a/><a/></root>`, true},
+		// Guard against false-accept: no element for the mandatory member.
+		{"content zz+m empty rejects", content(z(a) + z(a) + a), `<root></root>`, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			grammar := compileGrammar(t, tc.schema)
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(tc.doc))
+			require.NoError(t, err)
+			verr := relaxng.NewValidator(grammar).Validate(t.Context(), doc)
+			if tc.valid {
+				require.NoError(t, verr, "%s should validate", tc.name)
+				return
+			}
+			require.Error(t, verr, "%s should be rejected", tc.name)
+		})
+	}
+}

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -27,6 +27,84 @@ type validator struct {
 	valid         bool
 	suppressDepth int // when > 0, errors are suppressed (inside choice branches)
 	depth         int // recursion depth guard
+
+	// groupMemo caches results of validateGroupChildren/validateGroupSeq so the
+	// recursive group backtracker (backtrackGroupFlexible/backtrackGroupNaive)
+	// does not re-explore overlapping (child-range, input-position) subproblems.
+	// Without it the cascading retry is exponential in the number of flexible
+	// members. Keyed by the full input that determines the result; a hit
+	// reproduces the original call's effect byte-for-byte.
+	groupMemo map[groupMemoKey]*groupMemoEntry
+}
+
+// groupMemoKey identifies a group-validation subproblem. Two calls with an equal
+// key are guaranteed to produce identical results and side effects.
+type groupMemoKey struct {
+	first *pattern        // children[0] — uniquely identifies the child sub-range start
+	n     int             // len(children) — sub-range length
+	elem  *helium.Element // owning element (content path); pins the element's attrs,
+	// which group content may consult even when the child sequence is empty
+	pos      helium.Node // first remaining node (nil when the input sequence is empty)
+	seqLen   int         // len(state.seq); with pos, fully identifies the sibling run
+	attrKey  string      // packed attrUsed bits ("" for the naive path)
+	suppress bool        // v.suppressDepth > 0 (governs whether errors are emitted)
+	content  bool        // element-content path vs naive path discriminator
+}
+
+// groupMemoEntry records the full effect of a memoized group-validation call so a
+// cache hit can reproduce it exactly: the resulting input position, attribute
+// usage, any errors the call appended, and its return value.
+type groupMemoEntry struct {
+	result   int
+	seq      []helium.Node
+	attrUsed []bool
+	errs     []error
+}
+
+func (e *groupMemoEntry) apply(state *validState, attrUsed []bool, v *validator) int {
+	state.seq = append([]helium.Node(nil), e.seq...)
+	if attrUsed != nil {
+		copy(attrUsed, e.attrUsed)
+	}
+	if len(e.errs) > 0 {
+		v.pendingErrors = append(v.pendingErrors, e.errs...)
+		v.valid = false
+	}
+	return e.result
+}
+
+// groupMemoLookupKey builds the cache key for a group-validation call, or reports
+// false when the sub-range is empty (trivially handled by the callers).
+func (v *validator) groupMemoLookupKey(children []*pattern, elem *helium.Element, attrUsed []bool, state *validState, content bool) (groupMemoKey, bool) {
+	if len(children) == 0 {
+		return groupMemoKey{}, false
+	}
+	var pos helium.Node
+	if len(state.seq) > 0 {
+		pos = state.seq[0]
+	}
+	var attrKey string
+	if len(attrUsed) > 0 {
+		buf := make([]byte, len(attrUsed))
+		for i, used := range attrUsed {
+			if used {
+				buf[i] = '1'
+			} else {
+				buf[i] = '0'
+			}
+		}
+		attrKey = string(buf)
+	}
+	return groupMemoKey{
+		first:    children[0],
+		n:        len(children),
+		elem:     elem,
+		pos:      pos,
+		seqLen:   len(state.seq),
+		attrKey:  attrKey,
+		suppress: v.suppressDepth > 0,
+		content:  content,
+	}, true
 }
 
 const maxValidationDepth = 500
@@ -697,8 +775,33 @@ func (v *validator) validateGroupContent(pat *pattern, elem *helium.Element,
 // validateGroupChildren validates a sequence of group children with backtracking
 // support. It is shared by validateGroupContent and by the recursive retry inside
 // backtrackGroupFlexible, so a backtracked sub-range that contains its own
-// flexible members can itself backtrack.
+// flexible members can itself backtrack. Results are memoized so the cascading
+// retry stays polynomial instead of exponential in the flexible-member count.
 func (v *validator) validateGroupChildren(children []*pattern, elem *helium.Element,
+	attrs []*helium.Attribute, attrUsed []bool, state *validState) int {
+	key, ok := v.groupMemoLookupKey(children, elem, attrUsed, state, true)
+	if ok {
+		if e, hit := v.groupMemo[key]; hit {
+			return e.apply(state, attrUsed, v)
+		}
+	}
+	errBase := len(v.pendingErrors)
+	result := v.validateGroupChildrenUncached(children, elem, attrs, attrUsed, state)
+	if ok {
+		if v.groupMemo == nil {
+			v.groupMemo = make(map[groupMemoKey]*groupMemoEntry)
+		}
+		v.groupMemo[key] = &groupMemoEntry{
+			result:   result,
+			seq:      append([]helium.Node(nil), state.seq...),
+			attrUsed: append([]bool(nil), attrUsed...),
+			errs:     append([]error(nil), v.pendingErrors[errBase:]...),
+		}
+	}
+	return result
+}
+
+func (v *validator) validateGroupChildrenUncached(children []*pattern, elem *helium.Element,
 	attrs []*helium.Attribute, attrUsed []bool, state *validState) int {
 	if len(children) == 0 {
 		return 0
@@ -1362,8 +1465,31 @@ func (v *validator) validateGroup(pat *pattern, state *validState) int {
 // validateGroupSeq validates a sequence of naive-group children with
 // backtracking support. It is shared by validateGroup and by the recursive
 // retry inside backtrackGroupNaive, so a backtracked sub-range with its own
-// flexible members can itself backtrack.
+// flexible members can itself backtrack. Results are memoized (see
+// validateGroupChildren) to keep the cascading retry polynomial.
 func (v *validator) validateGroupSeq(children []*pattern, state *validState) int {
+	key, ok := v.groupMemoLookupKey(children, nil, nil, state, false)
+	if ok {
+		if e, hit := v.groupMemo[key]; hit {
+			return e.apply(state, nil, v)
+		}
+	}
+	errBase := len(v.pendingErrors)
+	result := v.validateGroupSeqUncached(children, state)
+	if ok {
+		if v.groupMemo == nil {
+			v.groupMemo = make(map[groupMemoKey]*groupMemoEntry)
+		}
+		v.groupMemo[key] = &groupMemoEntry{
+			result: result,
+			seq:    append([]helium.Node(nil), state.seq...),
+			errs:   append([]error(nil), v.pendingErrors[errBase:]...),
+		}
+	}
+	return result
+}
+
+func (v *validator) validateGroupSeqUncached(children []*pattern, state *validState) int {
 	if len(children) == 0 {
 		return 0
 	}

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -691,7 +691,15 @@ func (b *groupBound) restore(state *validState, attrUsed []bool, v *validator) {
 // we try reducing the flexible child's consumption.
 func (v *validator) validateGroupContent(pat *pattern, elem *helium.Element,
 	attrs []*helium.Attribute, attrUsed []bool, state *validState) int {
-	children := pat.children
+	return v.validateGroupChildren(pat.children, elem, attrs, attrUsed, state)
+}
+
+// validateGroupChildren validates a sequence of group children with backtracking
+// support. It is shared by validateGroupContent and by the recursive retry inside
+// backtrackGroupFlexible, so a backtracked sub-range that contains its own
+// flexible members can itself backtrack.
+func (v *validator) validateGroupChildren(children []*pattern, elem *helium.Element,
+	attrs []*helium.Attribute, attrUsed []bool, state *validState) int {
 	if len(children) == 0 {
 		return 0
 	}
@@ -829,13 +837,11 @@ func (v *validator) backtrackGroupFlexible(children []*pattern, failIdx int,
 			// Save error state so failed retries don't leave stale errors.
 			retryLen := len(v.pendingErrors)
 			retryValid := v.valid
-			allOK := true
-			for k := j + 1; k <= failIdx; k++ {
-				if v.validateContentPat(children[k], elem, attrs, attrUsed, state) != 0 {
-					allOK = false
-					break
-				}
-			}
+			// Validate the remaining children as a group so that any flexible
+			// members in [j+1..failIdx] can themselves backtrack. A flat greedy
+			// retry would let a second flexible member re-grab content that a
+			// later mandatory member needs.
+			allOK := v.validateGroupChildren(children[j+1:failIdx+1], elem, attrs, attrUsed, state) == 0
 			if allOK {
 				best = &btSuccess{
 					state:    state.clone(),
@@ -1350,7 +1356,14 @@ func sortDescending(counts []int) {
 }
 
 func (v *validator) validateGroup(pat *pattern, state *validState) int {
-	children := pat.children
+	return v.validateGroupSeq(pat.children, state)
+}
+
+// validateGroupSeq validates a sequence of naive-group children with
+// backtracking support. It is shared by validateGroup and by the recursive
+// retry inside backtrackGroupNaive, so a backtracked sub-range with its own
+// flexible members can itself backtrack.
+func (v *validator) validateGroupSeq(children []*pattern, state *validState) int {
 	if len(children) == 0 {
 		return 0
 	}
@@ -1388,12 +1401,11 @@ func (v *validator) validateGroup(pat *pattern, state *validState) int {
 //     validateGroupContent. So `bounds[failIdx]` is always the freshly-appended
 //     boundary and there is no multi-node cascade across separate backtrack calls
 //     that could observe a stale intermediate `bounds` entry.
-//   - Recovery reduces exactly one flexible child and greedily re-validates the
-//     rest; it does not cascade yields across several competing flexible members.
-//     A group with two or more flexible members that must each yield (e.g.
-//     group(zeroOrMore(x), zeroOrMore(x), x)) is therefore not fully recovered.
-//     This is a deliberate, pre-existing limitation shared with the element-
-//     content path (backtrackGroupFlexible), not specific to this function.
+//   - Recovery reduces one flexible child and re-validates the rest via
+//     validateGroupSeq, which itself backtracks. So a group with two or more
+//     flexible members that must each yield (e.g. group(zeroOrMore(x),
+//     zeroOrMore(x), x)) is recovered by cascading the reductions recursively.
+//     The element-content path (backtrackGroupFlexible) mirrors this.
 func (v *validator) backtrackGroupNaive(children []*pattern, failIdx int,
 	state *validState, bounds []groupBound) bool {
 	for j := failIdx - 1; j >= 0; j-- {
@@ -1445,13 +1457,11 @@ func (v *validator) backtrackGroupNaive(children []*pattern, failIdx int,
 
 			retryLen := len(v.pendingErrors)
 			retryValid := v.valid
-			allOK := true
-			for k := j + 1; k <= failIdx; k++ {
-				if v.validatePattern(children[k], state) != 0 {
-					allOK = false
-					break
-				}
-			}
+			// Validate the remaining children as a group so that any flexible
+			// members in [j+1..failIdx] can themselves backtrack. A flat greedy
+			// retry would let a second flexible member re-grab content that a
+			// later mandatory member needs.
+			allOK := v.validateGroupSeq(children[j+1:failIdx+1], state) == 0
 			if allOK {
 				bestState = state.clone()
 				bestErrLen = len(v.pendingErrors)


### PR DESCRIPTION
- Group backtracking now recovers groups with 2+ flexible members that must each yield (e.g. group(zeroOrMore(x), zeroOrMore(x), x)) by re-validating the retry range through the group routine so inner flexible members can themselves backtrack.
- Applies to both the element-content path (backtrackGroupFlexible) and the naive-group path (backtrackGroupNaive).