### PR TITLE
map iso-8859-1 to true ISO charmap not win-1252

### DIFF
--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -104,7 +104,13 @@ func Load(name string) enc.Encoding {
 		return withC1Fallback(charmap.Windows1250)
 	case "windows1251", "cp1251":
 		return withC1Fallback(charmap.Windows1251)
-	case "iso88591", "iso885911987", "isoir100", "latin1", "l1", "ibm819", "cp819", "csisolatin1", "windows1252", "cp1252", "isolatin1", "xcp1252":
+	case "iso88591", "iso885911987", "isoir100", "latin1", "l1", "ibm819", "cp819", "csisolatin1", "isolatin1":
+		// True ISO-8859-1: bytes 0x80-0x9F map to the C1 controls
+		// U+0080-U+009F, consistent with iso-8859-2..16 above. libxml2's XML
+		// path uses the IANA/ISO codec here, not the Windows-1252 alias the
+		// WHATWG HTML spec mandates (that leniency stays in the html/ package).
+		return withC1Fallback(charmap.ISO8859_1)
+	case "windows1252", "cp1252", "xcp1252":
 		return withC1Fallback(charmap.Windows1252)
 	case "windows1253", "cp1253":
 		return withC1Fallback(charmap.Windows1253)

--- a/internal/encoding/encoding_test.go
+++ b/internal/encoding/encoding_test.go
@@ -21,9 +21,12 @@ func TestISO88591(t *testing.T) {
 		s, err := dec.String(v)
 		require.NoError(t, err)
 
-		if i >= 0x80 && i <= 0x9f {
-			continue
-		}
+		// True ISO-8859-1 is the identity mapping: byte i decodes to U+00xx.
+		// In particular bytes 0x80-0x9F must decode to the C1 controls
+		// U+0080-U+009F, not the Windows-1252 glyphs (e.g. 0x80 must stay
+		// U+0080, not become U+20AC €).
+		require.Equal(t, []rune{rune(i)}, []rune(s))
+
 		v1, err := enc.String(s)
 		require.NoError(t, err)
 		require.Equal(t, v, v1)


### PR DESCRIPTION
- XML parse path mapped `iso-8859-1`/`latin1` to charmap.Windows1252, so bytes 0x80-0x9F decoded to win-1252 glyphs (e.g. 0x80 -> U+20AC) instead of the ISO-8859-1 C1 controls U+0080-U+009F.
- Map iso-8859-1 aliases to charmap.ISO8859_1, consistent with iso-8859-2..16; keep windows-1252/cp1252 on Windows1252. html/ leniency unchanged.