### PR TITLE
fix html charset prescan quoting and spacing

### DIFF
--- a/html/charset_detect_test.go
+++ b/html/charset_detect_test.go
@@ -24,6 +24,11 @@ func TestCharsetDetect_WHATWGMetaForms(t *testing.T) {
 		{name: "space-around-equals", meta: `<meta charset = utf-8>`},
 		{name: "single-quoted-space", meta: `<meta charset = 'utf-8'>`},
 		{name: "double-quoted-baseline", meta: `<meta charset="utf-8">`},
+		// The charset value sits inside the still-quoted content attribute, so
+		// the byte after "charset=" is 'u', not a quote. The unquoted-value scan
+		// must still stop at the enclosing quote, yielding "utf-8" rather than
+		// "utf-8\"". (Regression: PR #812 / HTML-004.)
+		{name: "http-equiv-content-type", meta: `<meta http-equiv="Content-Type" content="text/html; charset=utf-8">`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/html/charset_detect_test.go
+++ b/html/charset_detect_test.go
@@ -1,0 +1,60 @@
+package html_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium/html"
+	"github.com/stretchr/testify/require"
+)
+
+// The charset prescan must recognize the WHATWG meta-charset value forms beyond
+// the bare double-quoted/unquoted ones: single-quoted values and values with
+// ASCII whitespace around "=". When such a form declares utf-8, an invalid high
+// byte must be replaced with U+FFFD and raise the encoding-error diagnostic,
+// rather than silently falling back to the Latin-1/Windows-1252 decode.
+func TestCharsetDetect_WHATWGMetaForms(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		meta string
+	}{
+		{name: "single-quoted", meta: `<meta charset='utf-8'>`},
+		{name: "space-around-equals", meta: `<meta charset = utf-8>`},
+		{name: "single-quoted-space", meta: `<meta charset = 'utf-8'>`},
+		{name: "double-quoted-baseline", meta: `<meta charset="utf-8">`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// 0xFF is invalid UTF-8. With utf-8 detected it becomes U+FFFD and
+			// raises an encoding error; without detection it would be decoded as
+			// Latin-1 'ÿ' (U+00FF) with no error.
+			input := []byte("<html><head>" + tc.meta + "</head><body>x\xFFy</body></html>")
+
+			var chars strings.Builder
+			var sawEncodingError bool
+			sax := &html.SAXCallbacks{}
+			sax.SetOnCharacters(html.CharactersFunc(func(data []byte) error {
+				chars.Write(data)
+				return nil
+			}))
+			sax.SetOnError(html.ErrorFunc(func(err error) error {
+				if err != nil && err.Error() == "Invalid bytes in character encoding" {
+					sawEncodingError = true
+				}
+				return nil
+			}))
+
+			err := html.NewParser().ParseWithSAX(t.Context(), input, sax)
+			require.NoError(t, err)
+			require.True(t, sawEncodingError,
+				"declared utf-8 must raise the encoding-error diagnostic for the invalid byte")
+			require.Contains(t, chars.String(), "�",
+				"invalid byte under declared utf-8 must become U+FFFD")
+			require.NotContains(t, chars.String(), "ÿ",
+				"invalid byte must not fall through to the Latin-1 decode")
+		})
+	}
+}

--- a/html/charset_extract_test.go
+++ b/html/charset_extract_test.go
@@ -1,0 +1,48 @@
+package html
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// extractDeclaredCharset must yield a clean encoding name even when the charset
+// value sits inside a still-quoted content attribute. The byte after "charset="
+// is then an ordinary letter (not a quote), so the unquoted-value scan must
+// terminate at the enclosing quote rather than swallowing it. (Regression:
+// PR #812 / HTML-004 — previously returned `utf-8"`/`iso-8859-1"`.)
+func TestExtractDeclaredCharset(t *testing.T) {
+	t.Parallel()
+
+	const utf8 = "utf-8"
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "bare-unquoted", in: `<meta charset=utf-8>`, want: utf8},
+		{name: "double-quoted", in: `<meta charset="utf-8">`, want: utf8},
+		{name: "single-quoted", in: `<meta charset='utf-8'>`, want: utf8},
+		{name: "space-around-equals", in: `<meta charset = utf-8>`, want: utf8},
+		{
+			name: "http-equiv-content-type-utf8",
+			in:   `<meta http-equiv="Content-Type" content="text/html; charset=utf-8">`,
+			want: utf8,
+		},
+		{
+			name: "http-equiv-content-type-iso",
+			in:   `<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">`,
+			want: "iso-8859-1",
+		},
+		{
+			name: "http-equiv-content-type-single-quoted",
+			in:   `<meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'>`,
+			want: "iso-8859-1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, extractDeclaredCharset([]byte(tc.in)))
+		})
+	}
+}

--- a/html/parser.go
+++ b/html/parser.go
@@ -421,10 +421,15 @@ func extractDeclaredCharset(data []byte) string {
 			return string(lower[pos : pos+end])
 		}
 		// Unquoted value: runs until ASCII whitespace, ';', tag close '>',
-		// or end. (The crude prescan operates on raw markup, so the tag
-		// terminator must bound a bare value like in <meta charset=utf-8>.)
+		// an enclosing quote, or end. (The crude prescan operates on raw
+		// markup, so the tag terminator must bound a bare value like in
+		// <meta charset=utf-8>. The quote terminators handle a value that
+		// sits inside a still-quoted content attribute, as in
+		// <meta http-equiv="Content-Type" content="text/html; charset=utf-8">,
+		// where the char after "charset=" is not a quote but the value is
+		// nonetheless bounded by the enclosing attribute quote.)
 		start := pos
-		for pos < len(lower) && !isASCIIWhitespace(lower[pos]) && lower[pos] != ';' && lower[pos] != '>' {
+		for pos < len(lower) && !isASCIIWhitespace(lower[pos]) && lower[pos] != ';' && lower[pos] != '>' && lower[pos] != '"' && lower[pos] != '\'' {
 			pos++
 		}
 		return string(lower[start:pos])

--- a/html/parser.go
+++ b/html/parser.go
@@ -360,29 +360,88 @@ func replaceInvalidUTF8(data []byte, info *invalidByteInfo) ([]byte, bool) {
 	return buf.Bytes(), found
 }
 
-// declaredCharsetIsUTF8 scans the raw (possibly invalid) input bytes for a
-// <meta charset="utf-8"> declaration, returning true if found.
-func declaredCharsetIsUTF8(data []byte) bool {
-	// Case-insensitive search for charset="utf-8" or charset=utf-8
+// isASCIIWhitespace reports whether b is one of the WHATWG ASCII whitespace
+// characters (tab, LF, FF, CR, space).
+func isASCIIWhitespace(b byte) bool {
+	switch b {
+	case '\t', '\n', '\f', '\r', ' ':
+		return true
+	default:
+		return false
+	}
+}
+
+// extractDeclaredCharset scans the raw (possibly invalid) input bytes for a
+// charset declaration (as found in <meta charset=...> or in a <meta
+// http-equiv="content-type" content="...; charset=..."> attribute) and returns
+// the declared encoding name, lowercased, or "" if none is found.
+//
+// The value syntax mirrors the WHATWG "extracting a character encoding from a
+// meta element" algorithm: ASCII whitespace may surround the "=", and the value
+// may be wrapped in single or double quotes, or left unquoted (terminated by
+// whitespace or ";").
+func extractDeclaredCharset(data []byte) string {
 	lower := bytes.ToLower(data)
-	// Limit scan to the first 1024 bytes (charset should appear early)
+	// Limit scan to the first 1024 bytes (charset should appear early).
 	if len(lower) > 1024 {
 		lower = lower[:1024]
 	}
-	return bytes.Contains(lower, []byte("charset=\"utf-8\"")) ||
-		bytes.Contains(lower, []byte("charset=utf-8"))
+	const key = "charset"
+	from := 0
+	for {
+		idx := bytes.Index(lower[from:], []byte(key))
+		if idx < 0 {
+			return ""
+		}
+		pos := from + idx + len(key)
+		from = pos
+		// Skip ASCII whitespace before '='.
+		for pos < len(lower) && isASCIIWhitespace(lower[pos]) {
+			pos++
+		}
+		// Require '='.
+		if pos >= len(lower) || lower[pos] != '=' {
+			continue
+		}
+		pos++
+		// Skip ASCII whitespace after '='.
+		for pos < len(lower) && isASCIIWhitespace(lower[pos]) {
+			pos++
+		}
+		if pos >= len(lower) {
+			return ""
+		}
+		// Quoted value: read up to the matching quote.
+		if q := lower[pos]; q == '"' || q == '\'' {
+			pos++
+			end := bytes.IndexByte(lower[pos:], q)
+			if end < 0 {
+				return ""
+			}
+			return string(lower[pos : pos+end])
+		}
+		// Unquoted value: runs until ASCII whitespace, ';', tag close '>',
+		// or end. (The crude prescan operates on raw markup, so the tag
+		// terminator must bound a bare value like in <meta charset=utf-8>.)
+		start := pos
+		for pos < len(lower) && !isASCIIWhitespace(lower[pos]) && lower[pos] != ';' && lower[pos] != '>' {
+			pos++
+		}
+		return string(lower[start:pos])
+	}
+}
+
+// declaredCharsetIsUTF8 scans the raw (possibly invalid) input bytes for a
+// <meta charset="utf-8"> declaration, returning true if found.
+func declaredCharsetIsUTF8(data []byte) bool {
+	return extractDeclaredCharset(data) == "utf-8"
 }
 
 // declaredCharsetIsLatin1 scans the raw input bytes for an explicit
 // charset=iso-8859-1 declaration. This distinguishes documents that
 // declare ISO-8859-1 from those that are just auto-detected as non-UTF-8.
 func declaredCharsetIsLatin1(data []byte) bool {
-	lower := bytes.ToLower(data)
-	if len(lower) > 1024 {
-		lower = lower[:1024]
-	}
-	return bytes.Contains(lower, []byte("charset=iso-8859-1")) ||
-		bytes.Contains(lower, []byte("charset=\"iso-8859-1\""))
+	return extractDeclaredCharset(data) == "iso-8859-1"
 }
 
 // hasPrefixFold checks if the current input starts with the given prefix


### PR DESCRIPTION
- HTML charset prescan now recognizes single-quoted values and ASCII whitespace around `=` per the WHATWG meta-charset value syntax, not just bare double-quoted/unquoted forms.
- Documents declaring `charset='utf-8'` or `charset = utf-8` are detected as utf-8 (invalid bytes -> U+FFFD + encoding error) instead of falling back to the Latin-1 decode.