### PR TITLE
fix relaxng interleave repeatable member-group

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -370,7 +370,7 @@ Pattern-matching engine with backtracking:
    - **Attribute**: match against instance attrs
    - **Group**: sequential with backtracking
    - **Choice**: try alternatives, prefer branches making progress
-   - **Interleave**: unordered member-by-member matching
+   - **Interleave**: unordered member-by-member matching; a repeatable member-group (zeroOrMore/oneOrMore of group) restarts its members each iteration so a sibling branch can consume elements between group members across iterations
    - **ZeroOrMore/OneOrMore/Optional**: repetition with suppressed errors
    - **Ref/ParentRef**: follow the compile-time-resolved `pattern.resolved` scoped pointer and recurse (no by-name lookup)
    - **Data/Value**: type checking

--- a/relaxng/interleave_repeat_test.go
+++ b/relaxng/interleave_repeat_test.go
@@ -1,0 +1,103 @@
+package relaxng_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/relaxng"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInterleaveRepeatableMemberGroup covers an <interleave> whose repeatable
+// member (zeroOrMore/oneOrMore) wraps a multi-element group. Another interleave
+// branch may consume elements between the group members, across iterations.
+// Before the fix the round-robin matcher could not split a repeatable group's
+// expansion around an interleaved sibling and wrongly rejected valid content.
+func TestInterleaveRepeatableMemberGroup(t *testing.T) {
+	t.Parallel()
+
+	content := func(members string) string {
+		return `<grammar xmlns="http://relaxng.org/ns/structure/1.0"><start>` +
+			`<element name="root"><interleave>` + members + `</interleave></element></start></grammar>`
+	}
+	a := `<element name="a"><empty/></element>`
+	b := `<element name="b"><empty/></element>`
+	c := `<element name="c"><empty/></element>`
+	z := func(p string) string { return `<zeroOrMore>` + p + `</zeroOrMore>` }
+	o := func(p string) string { return `<oneOrMore>` + p + `</oneOrMore>` }
+	grp := func(p ...string) string { return `<group>` + strings.Join(p, "") + `</group>` }
+
+	cases := []struct {
+		name   string
+		schema string
+		doc    string
+		valid  bool
+	}{
+		// Repeatable group(a,b) with c interleaved between/around members.
+		{"zz group(a,b) + zz c", content(z(grp(a, b)) + z(c)), `<root><a/><c/><b/><a/><c/><b/></root>`, true},
+		// c may not appear at all; pure paired groups.
+		{"zz group(a,b) no c", content(z(grp(a, b)) + z(c)), `<root><a/><b/><a/><b/></root>`, true},
+		// oneOrMore group requires at least one complete pair.
+		{"oo group(a,b) + zz c", content(o(grp(a, b)) + z(c)), `<root><a/><c/><b/><a/><b/></root>`, true},
+		// Empty content: zeroOrMore group + zeroOrMore c accepts nothing.
+		{"zz group(a,b) empty ok", content(z(grp(a, b)) + z(c)), `<root></root>`, true},
+		// oneOrMore group requires one pair: empty must be rejected.
+		{"oo group(a,b) empty rejects", content(o(grp(a, b)) + z(c)), `<root><c/></root>`, false},
+		// Dangling unpaired trailing 'a' (missing its 'b') must be rejected.
+		{"zz group(a,b) dangling a rejects", content(z(grp(a, b)) + z(c)), `<root><a/><b/><a/></root>`, false},
+		// Dangling partial group with c interleaved must still be rejected.
+		{"zz group(a,b) dangling a + c rejects", content(z(grp(a, b)) + z(c)), `<root><a/><c/><b/><c/><a/></root>`, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			grammar := compileGrammar(t, tc.schema)
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(tc.doc))
+			require.NoError(t, err)
+			verr := relaxng.NewValidator(grammar).Validate(t.Context(), doc)
+			if tc.valid {
+				require.NoError(t, verr, "%s should validate", tc.name)
+				return
+			}
+			require.Error(t, verr, "%s should be rejected", tc.name)
+		})
+	}
+}
+
+// TestInterleaveRepeatableMemberGroupNotExponential guards against algorithmic
+// blowup: a long document of interleaved group(a,b) pairs and c elements must
+// validate in linear-ish time, not exponentially. The matcher is greedy and
+// round-bounded by content length, so this stays well under a second.
+func TestInterleaveRepeatableMemberGroupNotExponential(t *testing.T) {
+	t.Parallel()
+
+	const N = 2000
+	schema := `<grammar xmlns="http://relaxng.org/ns/structure/1.0"><start>` +
+		`<element name="root"><interleave>` +
+		`<zeroOrMore><group>` +
+		`<element name="a"><empty/></element><element name="b"><empty/></element>` +
+		`</group></zeroOrMore>` +
+		`<zeroOrMore><element name="c"><empty/></element></zeroOrMore>` +
+		`</interleave></element></start></grammar>`
+
+	var docStr strings.Builder
+	docStr.WriteString(`<root>`)
+	for range N {
+		docStr.WriteString(`<a/><c/><b/>`)
+	}
+	docStr.WriteString(`</root>`)
+
+	grammar := compileGrammar(t, schema)
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(docStr.String()))
+	require.NoError(t, err)
+
+	start := time.Now()
+	verr := relaxng.NewValidator(grammar).Validate(t.Context(), doc)
+	elapsed := time.Since(start)
+
+	require.NoError(t, verr, "interleave of %d group(a,b) pairs with c must validate", N)
+	require.Less(t, elapsed, 5*time.Second, "validation must not be exponential (took %s)", elapsed)
+}

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -558,15 +558,27 @@ func (v *validator) validateContentPat(pat *pattern, elem *helium.Element,
 
 		// For children that resolve to groups, track per-member progress.
 		// This allows group members to be matched one-by-one with other
-		// interleave children consuming elements between them.
+		// interleave children consuming elements between them. A repeatable
+		// child wrapping a group (zeroOrMore/oneOrMore of group(a,b)) is tracked
+		// the same way, with repeat=true so a completed iteration restarts at the
+		// first member — letting another interleave branch consume between group
+		// members across iterations.
 		type groupState struct {
-			members []*pattern
-			pos     int
+			members      []*pattern
+			pos          int
+			repeat       bool // member-group wrapped in zeroOrMore/oneOrMore
+			iterConsumed bool // current iteration consumed at least one item
 		}
 		groupStates := make([]*groupState, len(pat.children))
 		for i, child := range pat.children {
 			if grp := v.resolveToGroup(child); grp != nil {
 				groupStates[i] = &groupState{members: grp.children, pos: 0}
+				continue
+			}
+			if child.kind == patternZeroOrMore || child.kind == patternOneOrMore {
+				if grp := v.resolveToGroup(wrapChildren(child.children)); grp != nil {
+					groupStates[i] = &groupState{members: grp.children, pos: 0, repeat: true}
+				}
 			}
 		}
 
@@ -608,42 +620,57 @@ func (v *validator) validateContentPat(pat *pattern, elem *helium.Element,
 				}
 
 				// Group children: match member-by-member so other interleave
-				// children can consume elements between group members.
+				// children can consume elements between group members. For a
+				// repeatable member-group, a completed iteration that consumed
+				// something restarts at the first member (a fresh group iteration).
 				if gs := groupStates[i]; gs != nil {
-					for gs.pos < len(gs.members) {
-						member := gs.members[gs.pos]
-						savedState := state.clone()
-						savedAttrUsed := make([]bool, len(attrUsed))
-						copy(savedAttrUsed, attrUsed)
-						savedLen := len(v.pendingErrors)
-						savedValid := v.valid
-						v.suppressDepth++
-						ret := v.validateContentPat(member, elem, attrs, attrUsed, state)
-						v.suppressDepth--
-						if ret == 0 && (!seqEqual(state.seq, savedState.seq) || !boolSliceEqual(attrUsed, savedAttrUsed)) {
-							// Member consumed something — advance.
-							consumed[i] = true
-							progress = true
-							gs.pos++
-							v.pendingErrors = v.pendingErrors[:savedLen]
-							v.valid = savedValid
-							// Continue trying next members in same round
-							// (they might also match immediately).
-						} else {
-							// Member didn't consume. If nullable, skip it
-							// and try the next member.
-							*state = *savedState
-							copy(attrUsed, savedAttrUsed)
-							v.pendingErrors = v.pendingErrors[:savedLen]
-							v.valid = savedValid
-							if v.isNullable(member) {
+					for {
+						gs.iterConsumed = false
+						blocked := false
+						for gs.pos < len(gs.members) {
+							member := gs.members[gs.pos]
+							savedState := state.clone()
+							savedAttrUsed := make([]bool, len(attrUsed))
+							copy(savedAttrUsed, attrUsed)
+							savedLen := len(v.pendingErrors)
+							savedValid := v.valid
+							v.suppressDepth++
+							ret := v.validateContentPat(member, elem, attrs, attrUsed, state)
+							v.suppressDepth--
+							if ret == 0 && (!seqEqual(state.seq, savedState.seq) || !boolSliceEqual(attrUsed, savedAttrUsed)) {
+								// Member consumed something — advance.
+								consumed[i] = true
+								progress = true
+								gs.iterConsumed = true
 								gs.pos++
-								continue
+								v.pendingErrors = v.pendingErrors[:savedLen]
+								v.valid = savedValid
+								// Continue trying next members in same round
+								// (they might also match immediately).
+							} else {
+								// Member didn't consume. If nullable, skip it
+								// and try the next member.
+								*state = *savedState
+								copy(attrUsed, savedAttrUsed)
+								v.pendingErrors = v.pendingErrors[:savedLen]
+								v.valid = savedValid
+								if v.isNullable(member) {
+									gs.pos++
+									continue
+								}
+								// Not nullable — stop trying this group for now.
+								// Other interleave children may consume first.
+								blocked = true
+								break
 							}
-							// Not nullable — stop trying this group for now.
-							// Other interleave children may consume first.
-							break
 						}
+						// Restart a repeatable member-group only after a full
+						// iteration that consumed something; otherwise stop.
+						if gs.repeat && !blocked && gs.pos >= len(gs.members) && gs.iterConsumed {
+							gs.pos = 0
+							continue
+						}
+						break
 					}
 					if gs.pos >= len(gs.members) {
 						if !isRepeatable[i] {
@@ -713,6 +740,22 @@ func (v *validator) validateContentPat(pat *pattern, elem *helium.Element,
 					v.addError(elem, fmt.Sprintf("Element %s failed to validate content", elem.LocalName()))
 				}
 				return -1
+			}
+		}
+		// A repeatable member-group that ends mid-iteration with a non-nullable
+		// remaining member has a dangling partial group (e.g. zeroOrMore(group(a,b))
+		// fed an unpaired trailing a): that is incomplete content.
+		for i := range pat.children {
+			gs := groupStates[i]
+			if gs == nil || !gs.repeat || gs.pos <= 0 || gs.pos >= len(gs.members) {
+				continue
+			}
+			for j := gs.pos; j < len(gs.members); j++ {
+				if !v.isNullable(gs.members[j]) {
+					v.addError(elem, "Invalid sequence in interleave")
+					v.addError(elem, fmt.Sprintf("Element %s failed to validate content", elem.LocalName()))
+					return -1
+				}
 			}
 		}
 		return 0


### PR DESCRIPTION
- Repeatable interleave members (zeroOrMore/oneOrMore wrapping a multi-element group) now restart their group members each iteration, so a sibling branch can consume elements between group members across iterations.
- Dangling partial group (unpaired trailing member) in a repeatable member-group is now correctly rejected.
- Greedy and round-bounded by content length, so it stays non-exponential.