### PR TITLE
add DocOrderCache.Reset to clear stale order

### DIFF
--- a/.claude/docs/xpath3-architecture.md
+++ b/.claude/docs/xpath3-architecture.md
@@ -45,6 +45,7 @@ func TraverseAxis(ctx context.Context, axis AxisType, node helium.Node, maxNodes
 type DocOrderCache struct { ... }
 func (c *DocOrderCache) BuildFrom(root helium.Node)
 func (c *DocOrderCache) Position(n helium.Node) int
+func (c *DocOrderCache) Reset() // clear cache; callers MUST call after mutating the document
 func DeduplicateNodes(nodes []helium.Node, cache *DocOrderCache, maxNodes int) ([]helium.Node, error)
 func MergeNodeSets(a, b []helium.Node, cache *DocOrderCache, maxNodes int) ([]helium.Node, error)
 func DocumentRoot(n helium.Node) helium.Node

--- a/internal/xpath/docorder.go
+++ b/internal/xpath/docorder.go
@@ -17,11 +17,29 @@ type docIndex struct {
 //
 // A single DocOrderCache may be shared across concurrent Evaluate calls, so all
 // access to its maps is guarded by mu.
+//
+// The cached positions describe the tree as it was when first indexed. Callers
+// MUST call Reset after mutating any document this cache describes (inserting,
+// removing, or moving nodes), otherwise order results may be stale. Subsequent
+// lookups after Reset recompute order from the current tree.
 type DocOrderCache struct {
 	mu        sync.Mutex
 	documents map[helium.Node]docIndex
 	// rootCache caches DocumentRoot results to avoid repeated parent-chain walks.
 	rootCache map[helium.Node]helium.Node
+}
+
+// Reset clears all cached document-order state so the same cache value can be
+// safely reused after the underlying document(s) are mutated. Subsequent
+// lookups recompute order from the current tree.
+//
+// Callers MUST call Reset after mutating a document this cache describes, or
+// order results may be stale.
+func (c *DocOrderCache) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.documents = nil
+	c.rootCache = nil
 }
 
 // cachedRootLocked returns the DocumentRoot for n, using the rootCache to

--- a/xpath3/context.go
+++ b/xpath3/context.go
@@ -116,6 +116,10 @@ func FnContextNode(ctx context.Context) helium.Node {
 
 // DocOrderCache is a shared document-order cache that can be passed
 // across evaluations to ensure consistent cross-document ordering.
+//
+// The cache describes the tree as it was when first indexed. Callers MUST call
+// Reset after mutating any document the cache describes, or order results may be
+// stale.
 type DocOrderCache = ixpath.DocOrderCache
 
 // NewDocOrderCache creates a new shared document-order cache.

--- a/xpath3/docorder_reset_test.go
+++ b/xpath3/docorder_reset_test.go
@@ -1,0 +1,44 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// A DocOrderCache caches document-order positions when first built. Mutating
+// the underlying document leaves those positions stale because BuildFrom is a
+// no-op once a root is indexed. Reset clears the cache so the same value can be
+// reused after a mutation.
+func TestDocOrderCache_Reset_AfterMutation(t *testing.T) {
+	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	root := doc.CreateElement("root")
+	require.NoError(t, doc.AddChild(root))
+
+	a := doc.CreateElement("a")
+	require.NoError(t, root.AddChild(a))
+	b := doc.CreateElement("b")
+	require.NoError(t, root.AddChild(b))
+
+	cache := xpath3.NewDocOrderCache()
+	cache.BuildFrom(doc)
+
+	// Initial document order: a precedes b.
+	require.True(t, cache.Less(a, b), "a should precede b before mutation")
+
+	// Mutate the document: move a after b, so the true order is now b, a.
+	require.NoError(t, root.AddChild(a))
+
+	// Without Reset, BuildFrom is a no-op (root already indexed) and the cache
+	// still reports the stale pre-mutation order.
+	cache.BuildFrom(doc)
+	require.True(t, cache.Less(a, b), "stale cache still reports pre-mutation order")
+
+	// After Reset, the cache recomputes order from the current tree.
+	cache.Reset()
+	cache.BuildFrom(doc)
+	require.True(t, cache.Less(b, a), "after Reset b should precede a (current order)")
+	require.False(t, cache.Less(a, b), "after Reset a no longer precedes b")
+}


### PR DESCRIPTION
- add exported `DocOrderCache.Reset()` to clear cached document order so the same cache can be reused after the document is mutated
- document the contract: callers MUST call Reset after mutating the described document, or order results may be stale