### PR TITLE
fix rng anyName-except containment vs nsName

### DIFF
--- a/relaxng/grammar.go
+++ b/relaxng/grammar.go
@@ -204,28 +204,46 @@ func nameClassContains(outer, inner *nameClass) bool {
 	case ncName:
 		return nameClassMatches(outer, inner.name, inner.ns)
 	case ncNsName:
-		return nameClassCoversNS(outer, inner.ns)
+		// inner = nsName(inner.ns) minus inner.except, so outer need only cover
+		// the names inner actually matches — namespace inner.ns with inner.except
+		// removed — NOT all of inner.ns. Threading inner.except lets an outer
+		// nsName/anyName carrying its OWN finite except still contain inner.
+		return nameClassCoversNSExcept(outer, inner.ns, inner.except)
 	case ncAnyName:
 		return nameClassCoversAll(outer)
 	}
 	return false
 }
 
-// nameClassCoversNS reports whether outer certainly matches every name in
-// namespace ns. A finite set of ncName leaves can never cover an infinite
-// namespace, so only an except-free anyName, a matching except-free nsName, or
-// a choice containing one of those qualifies.
-func nameClassCoversNS(outer *nameClass, ns string) bool {
+// nameClassCoversNSExcept reports whether outer certainly matches every name in
+// namespace ns that is NOT matched by innerExcept (i.e. outer ⊇ nsName(ns)
+// except innerExcept). A finite set of ncName leaves can never cover an
+// (infinite) namespace, so only an anyName/nsName whose own except is itself
+// contained by innerExcept, or a choice containing one of those, qualifies.
+// When innerExcept is nil this reduces to "outer covers every name in ns".
+func nameClassCoversNSExcept(outer *nameClass, ns string, innerExcept *nameClass) bool {
 	if outer == nil {
 		return false
 	}
 	switch outer.kind {
 	case ncAnyName:
-		return outer.except == nil
+		// anyName except outer.except covers (ns \ innerExcept) iff every name
+		// outer.except removes is already removed by innerExcept.
+		if outer.except == nil {
+			return true
+		}
+		return nameClassContains(innerExcept, outer.except)
 	case ncNsName:
-		return outer.ns == ns && outer.except == nil
+		if outer.ns != ns {
+			return false
+		}
+		if outer.except == nil {
+			return true
+		}
+		return nameClassContains(innerExcept, outer.except)
 	case ncChoice:
-		return nameClassCoversNS(outer.left, ns) || nameClassCoversNS(outer.right, ns)
+		return nameClassCoversNSExcept(outer.left, ns, innerExcept) ||
+			nameClassCoversNSExcept(outer.right, ns, innerExcept)
 	}
 	return false
 }

--- a/relaxng/grammar.go
+++ b/relaxng/grammar.go
@@ -242,10 +242,109 @@ func nameClassCoversNSExcept(outer *nameClass, ns string, innerExcept *nameClass
 		}
 		return nameClassContains(innerExcept, outer.except)
 	case ncChoice:
-		return nameClassCoversNSExcept(outer.left, ns, innerExcept) ||
-			nameClassCoversNSExcept(outer.right, ns, innerExcept)
+		// A single branch may cover ns\innerExcept on its own...
+		if nameClassCoversNSExcept(outer.left, ns, innerExcept) ||
+			nameClassCoversNSExcept(outer.right, ns, innerExcept) {
+			return true
+		}
+		// ...or the branches may cover it only by UNION. e.g.
+		// (nsName(X) except foo) | name(foo) covers all of nsName(X): the
+		// nsName branch matches everything in X but foo, and a sibling branch
+		// fills the foo gap.
+		return choiceCoversNSByUnion(outer, ns, innerExcept)
 	}
 	return false
+}
+
+// choiceCoversNSByUnion reports whether the UNION of a choice's branches
+// certainly matches every name in namespace ns that innerExcept does not
+// remove. It handles the disjoint-union case nameClassCoversNSExcept's
+// branch-by-branch test misses: one branch is nsName(ns) minus a FINITE set of
+// names, and sibling branches match each of those removed names. Soundness
+// rests on the gap being finitely enumerable — if the nsName branch's own
+// except is not a finite set of ncName leaves, no claim is made.
+func choiceCoversNSByUnion(choice *nameClass, ns string, innerExcept *nameClass) bool {
+	for _, branch := range flattenChoiceBranches(choice) {
+		if branch.kind != ncNsName || branch.ns != ns {
+			continue
+		}
+		if branch.except == nil {
+			return true
+		}
+		gap, ok := collectFiniteNames(branch.except)
+		if !ok {
+			// The branch removes an infinite/unknown set; the gap cannot be
+			// enumerated, so coverage cannot be claimed soundly.
+			continue
+		}
+		covered := true
+		for _, n := range gap {
+			if n.ns != ns {
+				// A name outside ns the branch excludes is irrelevant: the
+				// nsName branch never matched it within ns anyway.
+				continue
+			}
+			if innerExcept != nil && nameClassMatches(innerExcept, n.name, n.ns) {
+				// innerExcept already removes this name, so it need not be
+				// covered.
+				continue
+			}
+			// Some OTHER branch must match the gap name; the nsName branch
+			// itself excludes it by construction.
+			if !nameClassMatches(choice, n.name, n.ns) {
+				covered = false
+				break
+			}
+		}
+		if covered {
+			return true
+		}
+	}
+	return false
+}
+
+// ncQName is a fully-qualified name (local + namespace) used when enumerating a
+// finite name set out of a name class.
+type ncQName struct {
+	name string
+	ns   string
+}
+
+// collectFiniteNames returns the finite set of names a name class matches, or
+// ok=false when the class is not a finite union of ncName leaves (i.e. it
+// contains an nsName/anyName/ncNoMatch and so matches an infinite or
+// indeterminate set).
+func collectFiniteNames(nc *nameClass) ([]ncQName, bool) {
+	if nc == nil {
+		return nil, true
+	}
+	switch nc.kind {
+	case ncName:
+		return []ncQName{{name: nc.name, ns: nc.ns}}, true
+	case ncChoice:
+		left, ok := collectFiniteNames(nc.left)
+		if !ok {
+			return nil, false
+		}
+		right, ok := collectFiniteNames(nc.right)
+		if !ok {
+			return nil, false
+		}
+		return append(left, right...), true
+	}
+	return nil, false
+}
+
+// flattenChoiceBranches collapses a (possibly nested) ncChoice tree into its
+// leaf branches.
+func flattenChoiceBranches(nc *nameClass) []*nameClass {
+	if nc == nil {
+		return nil
+	}
+	if nc.kind != ncChoice {
+		return []*nameClass{nc}
+	}
+	return append(flattenChoiceBranches(nc.left), flattenChoiceBranches(nc.right)...)
 }
 
 // nameClassCoversAll reports whether outer certainly matches every possible

--- a/relaxng/grammar.go
+++ b/relaxng/grammar.go
@@ -139,20 +139,19 @@ func nameClassesOverlap(a, b *nameClass) bool {
 		return nameClassesOverlap(a, b.left) || nameClassesOverlap(a, b.right)
 	}
 
-	// anyName: check if except clause excludes the other name class
+	// anyName: anyName-except-E matches every name NOT in E, so it is disjoint
+	// from the other class b exactly when E fully CONTAINS b (every name b can
+	// match is excluded). This generalises the single-ncName case to nsName and
+	// choice — e.g. anyName except nsName(X) does not overlap nsName(X).
 	if a.kind == ncAnyName {
-		if a.except != nil && b.kind == ncName {
-			if nameClassMatches(a.except, b.name, b.ns) {
-				return false
-			}
+		if a.except != nil && nameClassContains(a.except, b) {
+			return false
 		}
 		return true
 	}
 	if b.kind == ncAnyName {
-		if b.except != nil && a.kind == ncName {
-			if nameClassMatches(b.except, a.name, a.ns) {
-				return false
-			}
+		if b.except != nil && nameClassContains(b.except, a) {
+			return false
 		}
 		return true
 	}
@@ -187,6 +186,62 @@ func nameClassesOverlap(a, b *nameClass) bool {
 		return a.name == b.name && a.ns == b.ns
 	}
 
+	return false
+}
+
+// nameClassContains reports whether outer definitely matches every name that
+// inner can match (outer ⊇ inner). It is CONSERVATIVE: it returns true only
+// when containment is certain, so a caller subtracting an <except> never
+// concludes "disjoint" for a pair that might actually overlap. Any inner
+// <except> only shrinks inner, so it is safe to ignore for containment.
+func nameClassContains(outer, inner *nameClass) bool {
+	if outer == nil || inner == nil {
+		return false
+	}
+	switch inner.kind {
+	case ncChoice:
+		return nameClassContains(outer, inner.left) && nameClassContains(outer, inner.right)
+	case ncName:
+		return nameClassMatches(outer, inner.name, inner.ns)
+	case ncNsName:
+		return nameClassCoversNS(outer, inner.ns)
+	case ncAnyName:
+		return nameClassCoversAll(outer)
+	}
+	return false
+}
+
+// nameClassCoversNS reports whether outer certainly matches every name in
+// namespace ns. A finite set of ncName leaves can never cover an infinite
+// namespace, so only an except-free anyName, a matching except-free nsName, or
+// a choice containing one of those qualifies.
+func nameClassCoversNS(outer *nameClass, ns string) bool {
+	if outer == nil {
+		return false
+	}
+	switch outer.kind {
+	case ncAnyName:
+		return outer.except == nil
+	case ncNsName:
+		return outer.ns == ns && outer.except == nil
+	case ncChoice:
+		return nameClassCoversNS(outer.left, ns) || nameClassCoversNS(outer.right, ns)
+	}
+	return false
+}
+
+// nameClassCoversAll reports whether outer certainly matches every possible
+// name (only an except-free anyName, or a choice containing one).
+func nameClassCoversAll(outer *nameClass) bool {
+	if outer == nil {
+		return false
+	}
+	switch outer.kind {
+	case ncAnyName:
+		return outer.except == nil
+	case ncChoice:
+		return nameClassCoversAll(outer.left) || nameClassCoversAll(outer.right)
+	}
 	return false
 }
 

--- a/relaxng/grammar.go
+++ b/relaxng/grammar.go
@@ -218,9 +218,10 @@ func nameClassContains(outer, inner *nameClass) bool {
 // nameClassCoversNSExcept reports whether outer certainly matches every name in
 // namespace ns that is NOT matched by innerExcept (i.e. outer ⊇ nsName(ns)
 // except innerExcept). A finite set of ncName leaves can never cover an
-// (infinite) namespace, so only an anyName/nsName whose own except is itself
-// contained by innerExcept, or a choice containing one of those, qualifies.
-// When innerExcept is nil this reduces to "outer covers every name in ns".
+// (infinite) namespace, so only an anyName/nsName whose own except removes
+// nothing from ns that innerExcept does not already remove, or a choice
+// containing one of those, qualifies. When innerExcept is nil this reduces to
+// "outer covers every name in ns".
 func nameClassCoversNSExcept(outer *nameClass, ns string, innerExcept *nameClass) bool {
 	if outer == nil {
 		return false
@@ -228,11 +229,13 @@ func nameClassCoversNSExcept(outer *nameClass, ns string, innerExcept *nameClass
 	switch outer.kind {
 	case ncAnyName:
 		// anyName except outer.except covers (ns \ innerExcept) iff every name
-		// outer.except removes is already removed by innerExcept.
+		// IN ns that outer.except removes is already removed by innerExcept.
+		// Names outer.except removes OUTSIDE ns are irrelevant — outer never
+		// needed to match them within ns — so only outer.except ∩ ns matters.
 		if outer.except == nil {
 			return true
 		}
-		return nameClassContains(innerExcept, outer.except)
+		return nameClassCoversWithinNS(innerExcept, outer.except, ns)
 	case ncNsName:
 		if outer.ns != ns {
 			return false
@@ -240,7 +243,7 @@ func nameClassCoversNSExcept(outer *nameClass, ns string, innerExcept *nameClass
 		if outer.except == nil {
 			return true
 		}
-		return nameClassContains(innerExcept, outer.except)
+		return nameClassCoversWithinNS(innerExcept, outer.except, ns)
 	case ncChoice:
 		// A single branch may cover ns\innerExcept on its own...
 		if nameClassCoversNSExcept(outer.left, ns, innerExcept) ||
@@ -252,6 +255,44 @@ func nameClassCoversNSExcept(outer *nameClass, ns string, innerExcept *nameClass
 		// nsName branch matches everything in X but foo, and a sibling branch
 		// fills the foo gap.
 		return choiceCoversNSByUnion(outer, ns, innerExcept)
+	}
+	return false
+}
+
+// nameClassCoversWithinNS reports whether cover certainly matches every name in
+// namespace ns that sub matches — i.e. cover ⊇ (sub ∩ ns). Names sub matches
+// OUTSIDE ns are ignored: when establishing that an outer class covers
+// nsName(ns) minus some except, an excluded name in a DIFFERENT namespace can
+// never have been in ns to begin with, so it does not need to be re-covered.
+// This is what makes e.g. anyName except (nsName(X) except name(Y:foo)) cover
+// nsName(X): within X, the inner except removes nothing (Y:foo ∉ X), so the
+// excluded class is all of X and the anyName matches no name in X. Conservative:
+// returns true only when coverage within ns is certain.
+func nameClassCoversWithinNS(cover, sub *nameClass, ns string) bool {
+	if sub == nil {
+		// sub matches nothing, so there is nothing in ns to cover.
+		return true
+	}
+	switch sub.kind {
+	case ncChoice:
+		return nameClassCoversWithinNS(cover, sub.left, ns) &&
+			nameClassCoversWithinNS(cover, sub.right, ns)
+	case ncName:
+		if sub.ns != ns {
+			// A single name outside ns is not part of sub ∩ ns.
+			return true
+		}
+		return cover != nil && nameClassMatches(cover, sub.name, sub.ns)
+	case ncNsName:
+		if sub.ns != ns {
+			// sub matches only its own namespace, which is not ns.
+			return true
+		}
+		// sub ∩ ns = nsName(ns) minus sub.except; cover must cover that.
+		return nameClassCoversNSExcept(cover, ns, sub.except)
+	case ncAnyName:
+		// sub ∩ ns = nsName(ns) minus sub.except; cover must cover that.
+		return nameClassCoversNSExcept(cover, ns, sub.except)
 	}
 	return false
 }

--- a/relaxng/nameclass_overlap_test.go
+++ b/relaxng/nameclass_overlap_test.go
@@ -66,4 +66,42 @@ func TestNameClassOverlapExceptChoice(t *testing.T) {
 		require.NotEmpty(t, compile(t, schema),
 			"anyName-except{foo} overlaps choice(foo,bar) on bar and must conflict")
 	})
+
+	t.Run("disjoint anyName-except-nsName vs nsName compiles", func(t *testing.T) {
+		const schema = `<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <element name="root">
+      <attribute>
+        <anyName>
+          <except><nsName ns="http://example.com/X"/></except>
+        </anyName>
+      </attribute>
+      <attribute>
+        <nsName ns="http://example.com/X"/>
+      </attribute>
+    </element>
+  </start>
+</grammar>`
+		require.Empty(t, compile(t, schema),
+			"anyName-except-nsName(X) and nsName(X) are disjoint and must not conflict")
+	})
+
+	t.Run("genuinely overlapping anyName-except-name vs nsName errors", func(t *testing.T) {
+		const schema = `<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <element name="root">
+      <attribute>
+        <anyName>
+          <except><name ns="http://example.com/X">foo</name></except>
+        </anyName>
+      </attribute>
+      <attribute>
+        <nsName ns="http://example.com/X"/>
+      </attribute>
+    </element>
+  </start>
+</grammar>`
+		require.NotEmpty(t, compile(t, schema),
+			"anyName-except{foo} still overlaps nsName(X) on every other name in X and must conflict")
+	})
 }

--- a/relaxng/nameclass_overlap_test.go
+++ b/relaxng/nameclass_overlap_test.go
@@ -162,4 +162,64 @@ func TestNameClassOverlapExceptChoice(t *testing.T) {
 		require.NotEmpty(t, compile(t, schema),
 			"both classes match foo@X and must conflict")
 	})
+
+	// The excluded class covers a whole namespace by UNION, not by any single
+	// branch: (nsName(X) except foo) | name(foo) together match every name in X.
+	// So anyName except that choice matches NO name in X and is disjoint from
+	// nsName(X). The containment check must account for the union, not test each
+	// branch for full coverage independently.
+	t.Run("disjoint anyName-except-union-choice vs nsName compiles", func(t *testing.T) {
+		const schema = `<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <element name="root">
+      <attribute>
+        <anyName>
+          <except>
+            <choice>
+              <nsName ns="http://example.com/X">
+                <except><name ns="http://example.com/X">foo</name></except>
+              </nsName>
+              <name ns="http://example.com/X">foo</name>
+            </choice>
+          </except>
+        </anyName>
+      </attribute>
+      <attribute>
+        <nsName ns="http://example.com/X"/>
+      </attribute>
+    </element>
+  </start>
+</grammar>`
+		require.Empty(t, compile(t, schema),
+			"(nsName(X) except foo) | name(foo) covers all of X by union, so anyName-except-it is disjoint from nsName(X)")
+	})
+
+	// Same shape but the union LEAVES A GAP: the choice is only
+	// (nsName(X) except foo), with no sibling filling foo. So anyName-except-it
+	// matches foo@X, which nsName(X) also matches — a genuine overlap.
+	t.Run("genuinely overlapping anyName-except-partial-union vs nsName errors", func(t *testing.T) {
+		const schema = `<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <element name="root">
+      <attribute>
+        <anyName>
+          <except>
+            <choice>
+              <nsName ns="http://example.com/X">
+                <except><name ns="http://example.com/X">foo</name></except>
+              </nsName>
+              <name ns="http://example.com/X">bar</name>
+            </choice>
+          </except>
+        </anyName>
+      </attribute>
+      <attribute>
+        <nsName ns="http://example.com/X"/>
+      </attribute>
+    </element>
+  </start>
+</grammar>`
+		require.NotEmpty(t, compile(t, schema),
+			"the union leaves foo@X uncovered, so anyName-except-it matches foo@X and overlaps nsName(X)")
+	})
 }

--- a/relaxng/nameclass_overlap_test.go
+++ b/relaxng/nameclass_overlap_test.go
@@ -222,4 +222,33 @@ func TestNameClassOverlapExceptChoice(t *testing.T) {
 		require.NotEmpty(t, compile(t, schema),
 			"the union leaves foo@X uncovered, so anyName-except-it matches foo@X and overlaps nsName(X)")
 	})
+
+	// anyName except (nsName(X) except name(Y:foo)): the inner except removes
+	// name(foo) in a DIFFERENT namespace Y, which is never in X anyway, so within
+	// X the excluded class is ALL of X. The anyName therefore matches no name in
+	// X and is disjoint from nsName(X). The containment check must restrict the
+	// excluded class to the target namespace and ignore the irrelevant Y:foo,
+	// rather than demanding nsName(X) cover it.
+	t.Run("disjoint anyName-except-nsName-except-foreign-name vs nsName compiles", func(t *testing.T) {
+		const schema = `<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <element name="root">
+      <attribute>
+        <anyName>
+          <except>
+            <nsName ns="http://example.com/X">
+              <except><name ns="http://example.com/Y">foo</name></except>
+            </nsName>
+          </except>
+        </anyName>
+      </attribute>
+      <attribute>
+        <nsName ns="http://example.com/X"/>
+      </attribute>
+    </element>
+  </start>
+</grammar>`
+		require.Empty(t, compile(t, schema),
+			"name(Y:foo) is outside X, so within X the excluded class is all of X and anyName-except-it is disjoint from nsName(X)")
+	})
 }

--- a/relaxng/nameclass_overlap_test.go
+++ b/relaxng/nameclass_overlap_test.go
@@ -104,4 +104,62 @@ func TestNameClassOverlapExceptChoice(t *testing.T) {
 		require.NotEmpty(t, compile(t, schema),
 			"anyName-except{foo} still overlaps nsName(X) on every other name in X and must conflict")
 	})
+
+	// anyName except (nsName(X) except name(foo)) excludes every name in X but
+	// foo, so within X it matches ONLY foo. nsName(X) except name(foo) matches
+	// every name in X but foo. The two are disjoint (no shared name) and must
+	// compile — the excluded class carries its own finite except, which the
+	// containment check must recurse into rather than bail on.
+	t.Run("disjoint anyName-except-nsName-except vs nsName-except compiles", func(t *testing.T) {
+		const schema = `<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <element name="root">
+      <attribute>
+        <anyName>
+          <except>
+            <nsName ns="http://example.com/X">
+              <except><name ns="http://example.com/X">foo</name></except>
+            </nsName>
+          </except>
+        </anyName>
+      </attribute>
+      <attribute>
+        <nsName ns="http://example.com/X">
+          <except><name ns="http://example.com/X">foo</name></except>
+        </nsName>
+      </attribute>
+    </element>
+  </start>
+</grammar>`
+		require.Empty(t, compile(t, schema),
+			"anyName except (nsName(X) except foo) and nsName(X) except foo share no name and must not conflict")
+	})
+
+	// anyName except (nsName(X) except name(foo)) matches only foo within X.
+	// nsName(X) except name(bar) matches every name in X but bar, which INCLUDES
+	// foo (foo != bar). They share foo@X, genuinely overlap, and must conflict.
+	t.Run("genuinely overlapping anyName-except-nsName-except vs nsName-except errors", func(t *testing.T) {
+		const schema = `<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <element name="root">
+      <attribute>
+        <anyName>
+          <except>
+            <nsName ns="http://example.com/X">
+              <except><name ns="http://example.com/X">foo</name></except>
+            </nsName>
+          </except>
+        </anyName>
+      </attribute>
+      <attribute>
+        <nsName ns="http://example.com/X">
+          <except><name ns="http://example.com/X">bar</name></except>
+        </nsName>
+      </attribute>
+    </element>
+  </start>
+</grammar>`
+		require.NotEmpty(t, compile(t, schema),
+			"both classes match foo@X and must conflict")
+	})
 }


### PR DESCRIPTION
- `nameClassesOverlap` now subtracts an anyName `<except>` against nsName/choice classes, not just single names, so `anyName except nsName(X)` no longer false-conflicts with `nsName(X)`.
- conservative `nameClassContains`/coversNS/coversAll helpers keep genuine overlaps flagged.