### PR TITLE
fix keyinfo before object in enveloping signature

### DIFF
--- a/xmldsig1/sign.go
+++ b/xmldsig1/sign.go
@@ -130,8 +130,16 @@ func signEnveloping(ctx context.Context, cfg *signerConfig, doc *helium.Document
 		if err != nil {
 			return nil, err
 		}
-		// Insert KeyInfo before Object.
+		// The XML-DSig schema content model is (SignedInfo, SignatureValue,
+		// KeyInfo?, Object*), so KeyInfo must precede the Object. Append KeyInfo
+		// (landing it after SignatureValue, before Object), then re-append the
+		// Object so it moves to the end after KeyInfo. AddChild auto-unlinks the
+		// already-linked Object before relinking it, so this is a move, not a
+		// duplicate.
 		if err := sigElem.AddChild(keyInfoElem); err != nil {
+			return nil, err
+		}
+		if err := sigElem.AddChild(objElem); err != nil {
 			return nil, err
 		}
 	}

--- a/xmldsig1/sign_test.go
+++ b/xmldsig1/sign_test.go
@@ -49,6 +49,42 @@ func TestSign(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	// enveloping with KeyInfo must place KeyInfo before the Object element so the
+	// Signature child order matches the XML-DSig schema content model
+	// (SignedInfo, SignatureValue, KeyInfo?, Object*).
+	t.Run("enveloping keyinfo precedes object", func(t *testing.T) {
+		key := generateRSAKey(t)
+		doc := mustParseXML(t, `<root><data Id="d1">covered</data></root>`)
+
+		payload := doc.CreateElement("Payload")
+		require.NoError(t, payload.AddChild(doc.CreateText([]byte("hello"))))
+
+		signer := xmldsig1.NewSigner().
+			SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+			Reference(xmldsig1.ReferenceConfig{
+				URI:             "#d1",
+				DigestAlgorithm: xmldsig1.DigestSHA256,
+				Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+			}).
+			KeyInfo(xmldsig1.RSAKeyValueKeyInfo())
+
+		sigElem, err := signer.SignEnveloping(t.Context(), doc, []helium.Node{payload}, key)
+		require.NoError(t, err)
+
+		var order []string
+		for c := sigElem.FirstChild(); c != nil; c = c.NextSibling() {
+			if e, ok := c.(*helium.Element); ok {
+				order = append(order, e.LocalName())
+			}
+		}
+		require.Equal(t, []string{"SignedInfo", "SignatureValue", "KeyInfo", "Object"}, order)
+
+		require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+		verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+		_, err = verifier.Verify(t.Context(), doc)
+		require.NoError(t, err)
+	})
+
 	// detached with KeyInfo and ID drives the full signDetached path including
 	// the KeyInfo builder branch and Id/Type attributes.
 	t.Run("detached with keyinfo and id", func(t *testing.T) {


### PR DESCRIPTION
- enveloping signature now appends KeyInfo then re-appends Object so child order is (SignedInfo, SignatureValue, KeyInfo?, Object*) per the XML-DSig schema
- prior order put Object before KeyInfo, violating the content model