### PR TITLE
reserve principal output uri for xtde1490

### DIFF
--- a/xslt3/execute.go
+++ b/xslt3/execute.go
@@ -98,6 +98,7 @@ type execContext struct {
 	primaryClaimedImplicitly     bool                          // true when implicit content has been written to primary output
 	staticBaseURIOverride        string                        // non-empty when xml:base on an LRE overrides the template's base URI
 	currentOutputURI             string                        // current output URI for current-output-uri() function
+	canonicalPrimaryURI          string                        // canonical principal (base) output URI, tracked separately from the "" primary sentinel; seeded into usedResultURIs so a secondary href resolving to it raises XTDE1490
 	inPatternMatch               bool                          // true during pattern matching (current-output-uri() returns empty)
 	patternNamespaces            map[string]string             // the matching pattern's lexical xmlns snapshot (prefix→URI) during pattern matching
 	patternMatchErr              error                         // non-nil if a fatal error occurred during pattern matching

--- a/xslt3/execute_transform.go
+++ b/xslt3/execute_transform.go
@@ -328,6 +328,16 @@ func executeTransform(ctx context.Context, source *helium.Document, ss *Styleshe
 	}
 	if cfg != nil && cfg.baseOutputURI != "" {
 		ec.currentOutputURI = cfg.baseOutputURI
+		// The principal result tree always exists and its URI is the base output
+		// URI, so reserve the canonical form of that URI up front. A secondary
+		// xsl:result-document whose href resolves to it denotes the SAME final
+		// result tree and must raise XTDE1490. Canonicalize with the SAME resolver
+		// the secondary duplicate key uses (canonicalResultURIKey) so a relative
+		// secondary href and the equivalent absolute one both match this seed.
+		// The primary output itself keys on the "" sentinel, so this distinct
+		// canonical key never makes the primary collide with itself.
+		ec.canonicalPrimaryURI = canonicalResultURIKey(cfg.baseOutputURI, "")
+		ec.usedResultURIs[ec.canonicalPrimaryURI] = struct{}{}
 	}
 	// Make the transform config (and thus its URIResolver) available before
 	// any runtime resource loading. initGlobalVars also assigns this; setting

--- a/xslt3/resultdoc_uri_test.go
+++ b/xslt3/resultdoc_uri_test.go
@@ -533,6 +533,67 @@ func TestResultDocumentPrimaryUndeclarePrefixesAVT(t *testing.T) {
 		"the primary result-document undeclare-prefixes override must reach the effective output def")
 }
 
+// XSLT3-101: a SECONDARY xsl:result-document whose href resolves to the PRINCIPAL
+// (base) output URI denotes the same final result tree as the principal output and
+// must collide with XTDE1490. The principal output URI is seeded into the used-URI
+// set so a secondary href resolving to it (here href="main.xml" against
+// BaseOutputURI="file:///base/dir/main.xml") is detected. (Regression: the primary
+// output keyed only on the "" sentinel and nothing reserved the canonical principal
+// URI, so a secondary resolving to it evaded the duplicate-URI check and silently
+// produced two final results for the same URI.)
+func TestResultDocumentSecondaryResolvingToPrincipalURICollides(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:result-document href="main.xml"><a/></xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	_, err := ss.Transform(parseTransformSource(t)).
+		BaseOutputURI("file:///base/dir/main.xml").
+		Do(t.Context())
+	require.Error(t, err, "a secondary href resolving to the principal output URI must collide")
+	require.Contains(t, err.Error(), "XTDE1490")
+}
+
+// XSLT3-101: an absolute secondary href equal to the principal (base) output URI
+// must collide with XTDE1490, exactly like the relative form above.
+func TestResultDocumentSecondaryAbsoluteEqualToPrincipalURICollides(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:result-document href="file:///base/dir/main.xml"><a/></xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	_, err := ss.Transform(parseTransformSource(t)).
+		BaseOutputURI("file:///base/dir/main.xml").
+		Do(t.Context())
+	require.Error(t, err, "an absolute secondary href equal to the principal output URI must collide")
+	require.Contains(t, err.Error(), "XTDE1490")
+}
+
+// XSLT3-101: a secondary xsl:result-document whose href resolves to a DIFFERENT URI
+// than the principal (base) output URI must still succeed — seeding the principal
+// URI must not reject distinct secondary destinations.
+func TestResultDocumentSecondaryDistinctFromPrincipalURISucceeds(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:result-document href="other.xml"><a/></xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	collector := &resultDocCollect{docs: map[string]*helium.Document{}}
+	_, err := ss.Transform(parseTransformSource(t)).
+		BaseOutputURI("file:///base/dir/main.xml").
+		ResultDocumentHandler(collector).
+		Do(t.Context())
+	require.NoError(t, err, "a secondary href distinct from the principal output URI must succeed")
+	_, ok := collector.docs["other.xml"]
+	require.True(t, ok, "the distinct secondary result document must be delivered")
+}
+
 // An xsl:result-document with a CONSTANT (non-AVT) invalid allow-duplicate-names
 // value must be rejected at compile time with SEPM0016, like every other boolean
 // serialization attribute. (Regression: allow-duplicate-names was missing from


### PR DESCRIPTION
- Seed the canonical principal (base) output URI into the used-URI set so a secondary xsl:result-document whose href resolves to it raises XTDE1490 instead of silently producing two final results for the same URI.
- Track the canonical principal URI separately from the "" primary sentinel; the primary still keys on "" so it never collides with itself.