### PR TITLE
bound xpath3 value/general comparison work

### DIFF
--- a/.claude/docs/xpath3-eval.md
+++ b/.claude/docs/xpath3-eval.md
@@ -158,10 +158,10 @@ Evaluate key/value pairs → keys must atomize to AtomicValue → build MapItem.
 ## Comparison Engine (`compare.go`)
 
 ### General Comparison (`= != < <= > >=`)
-Atomize both → for each pair → type promotion → value compare. True if ANY pair matches.
+Atomize both → for each pair → type promotion → value compare. True if ANY pair matches. The O(N·M) left×right scan charges one op (via `fnCountOp`) and checks `ctx.Err()` per candidate pair, so a comparison over two large sequences honors `OpLimit` / context cancellation instead of running unbounded.
 
 ### Value Comparison (`eq ne lt le gt ge`)
-Both must be single items. Error if sequence length > 1.
+Both must be single items. Error (XPTY0004) if sequence length > 1. Operands are atomized with an early stop (`atomizeSingletonOperand`, cap 2) so a multi-item or unbounded-lazy operand raises the cardinality error without materializing the whole sequence.
 
 ### Node Comparison (`is << >>`)
 Compare node identity or document order.

--- a/xpath3/compare.go
+++ b/xpath3/compare.go
@@ -58,7 +58,12 @@ func compareSingletonAgainstRange(evalFn exprEvaluator, ctx context.Context, ec 
 	if seqLen(singletonSeq) == 0 {
 		return false, true, nil
 	}
-	singletonAtoms, err := AtomizeSequence(singletonSeq)
+	// Atomize with an early stop (cap 2): the range fast-path only applies when
+	// the non-range side is a singleton, so a multi-item or unbounded-lazy operand
+	// (e.g. another large range) must be detected WITHOUT materializing/draining
+	// the whole sequence. When more than one atom is produced, fall back to the
+	// general O(N*M) path, which honors OpLimit / context cancellation.
+	singletonAtoms, err := atomizeSingletonOperand(singletonSeq)
 	if err != nil {
 		return false, true, err
 	}

--- a/xpath3/compare.go
+++ b/xpath3/compare.go
@@ -33,7 +33,7 @@ func evalGeneralComparison(evalFn exprEvaluator, ctx context.Context, ec *evalCo
 		return nil, err
 	}
 	coll := ec.resolveDefaultCollation()
-	result, err := generalCompareWithCollation(e.Op, left, right, coll, ec)
+	result, err := generalCompareWithCollation(ctx, e.Op, left, right, coll, ec)
 	if err != nil {
 		return nil, err
 	}
@@ -195,12 +195,15 @@ func evalValueComparison(evalFn exprEvaluator, ctx context.Context, ec *evalCont
 	if err != nil {
 		return nil, err
 	}
-	// Atomize operands (handles arrays, nodes, etc.)
-	leftAtoms, err := AtomizeSequence(left)
+	// Atomize operands (handles arrays, nodes, etc.). A value comparison only
+	// needs to distinguish empty / one / more-than-one item, so atomize with an
+	// early stop: a multi-item (or unbounded lazy) operand is rejected with
+	// XPTY0004 below without materializing the whole sequence.
+	leftAtoms, err := atomizeSingletonOperand(left)
 	if err != nil {
 		return nil, err
 	}
-	rightAtoms, err := AtomizeSequence(right)
+	rightAtoms, err := atomizeSingletonOperand(right)
 	if err != nil {
 		return nil, err
 	}
@@ -220,6 +223,24 @@ func evalValueComparison(evalFn exprEvaluator, ctx context.Context, ec *evalCont
 		return nil, err
 	}
 	return SingleBoolean(result), nil
+}
+
+// atomizeSingletonOperand atomizes seq for a value comparison, stopping as soon
+// as a second atomic value is produced. Value comparison only needs to tell
+// empty / one / more-than-one apart, so a multi-item (or unbounded lazy) operand
+// can be detected without materializing the whole sequence. It returns at most
+// two atoms; a genuine atomization error (e.g. FOTY0013 for a map/function item
+// encountered before the cap) still propagates.
+func atomizeSingletonOperand(seq Sequence) ([]AtomicValue, error) {
+	atoms := make([]AtomicValue, 0, 2)
+	err := atomizeStream(seq, func(av AtomicValue) (bool, error) {
+		atoms = append(atoms, av)
+		return len(atoms) < 2, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return atoms, nil
 }
 
 func evalNodeComparison(evalFn exprEvaluator, ctx context.Context, ec *evalContext, e BinaryExpr) (Sequence, error) {
@@ -265,12 +286,17 @@ func evalNodeComparison(evalFn exprEvaluator, ctx context.Context, ec *evalConte
 // Atomizes both sides and returns true if any pair of atomic values
 // satisfies the operator.
 func GeneralCompare(op TokenType, left, right Sequence) (bool, error) {
-	return generalCompareWithCollation(op, left, right, nil, nil)
+	return generalCompareWithCollation(context.Background(), op, left, right, nil, nil)
 }
 
 // generalCompareWithCollation is the collation-aware implementation of
 // general comparison.  When coll is nil, codepoint collation is used.
-func generalCompareWithCollation(op TokenType, left, right Sequence, coll *collationImpl, ec *evalContext) (bool, error) {
+//
+// The existential left x right scan is O(N*M), so it charges one op (and honors
+// context cancellation) per candidate pair via fnCountOp. A comparison over two
+// large sequences therefore respects OpLimit / context cancellation instead of
+// running to completion unbounded and uncancellable.
+func generalCompareWithCollation(ctx context.Context, op TokenType, left, right Sequence, coll *collationImpl, ec *evalContext) (bool, error) {
 	leftIter := newAtomicSequenceIter(left)
 	rightAtoms := newCachedAtomicSequence(right)
 	for {
@@ -282,6 +308,9 @@ func generalCompareWithCollation(op TokenType, left, right Sequence, coll *colla
 			return false, nil
 		}
 		for i := 0; ; i++ {
+			if err := fnCountOp(ctx, ec); err != nil {
+				return false, err
+			}
 			ra, ok, err := rightAtoms.At(i)
 			if err != nil {
 				return false, err

--- a/xpath3/compare_bound_test.go
+++ b/xpath3/compare_bound_test.go
@@ -1,0 +1,79 @@
+package xpath3_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lestrrat-go/helium/internal/sequence"
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// Finding XPATH3-108: a value comparison (eq/ne/lt/le/gt/ge) whose operand
+// atomizes to more than one item must raise the cardinality error XPTY0004
+// using an early-stop atomization — it must NOT materialize the whole
+// (potentially huge or lazy) operand first. A counting lazy sequence proves
+// that only a bounded number of items are ever produced.
+func TestValueComparison_CardinalityEarlyStop(t *testing.T) {
+	const n = 1_000_000
+	doc := mustParseXML(t, "<root/>")
+
+	var produced int
+	big := sequence.NewRange[xpath3.Item](n, func(i int) xpath3.Item {
+		produced++
+		return xpath3.AtomicValue{TypeName: "xs:integer", Value: int64(i + 1)}
+	})
+
+	compiled, err := xpath3.NewCompiler().Compile("$big eq 0")
+	require.NoError(t, err)
+
+	// EvalBorrowing avoids the defensive variable-map clone, which would
+	// otherwise materialize the whole lazy sequence before evaluation even
+	// begins and mask the early-stop behavior under test.
+	_, err = xpath3.NewEvaluator(xpath3.EvalBorrowing).
+		Variables(map[string]xpath3.Sequence{"big": big}).
+		Evaluate(t.Context(), compiled, doc)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "XPTY0004")
+	// Distinguishing empty / one / more-than-one needs at most two atoms; the
+	// fix must early-stop rather than drain all n items.
+	require.LessOrEqual(t, produced, 2,
+		"value comparison must early-stop atomization, not materialize the whole operand")
+}
+
+// Finding XPATH3-101: a general comparison (= != < <= > >=) over two large
+// sequences runs an O(N*M) left x right loop. That loop must consult the
+// context so a context cancelled after evaluation begins aborts promptly,
+// instead of scanning every pair. The cancel-after context lets evaluation
+// start and only reports cancellation once the comparison loop is iterating.
+func TestGeneralComparison_LargeLoopCancellable(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	// No pair is equal (1..1000 vs 2000..3000), so "=" must run the full
+	// 1,000,000-pair loop unless it bails on cancellation.
+	compiled, err := xpath3.NewCompiler().Compile("(1 to 1000) = (2000 to 3000)")
+	require.NoError(t, err)
+
+	const cancelAfter = 500
+	ctx := &cancelAfterNContext{cancelAfter: cancelAfter}
+
+	_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Evaluate(ctx, compiled, doc)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, ctx.calls, 1000*1000,
+		"general comparison must bail on cancellation, not scan every pair")
+}
+
+// Finding XPATH3-101: the general-comparison loop must charge ops against the
+// configured op-limit so a large comparison cannot run unbounded.
+func TestGeneralComparison_LargeLoopOpLimited(t *testing.T) {
+	doc := mustParseXML(t, "<root/>")
+
+	compiled, err := xpath3.NewCompiler().Compile("(1 to 1000) = (2000 to 3000)")
+	require.NoError(t, err)
+
+	_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		OpLimit(500).
+		Evaluate(t.Context(), compiled, doc)
+	require.ErrorIs(t, err, xpath3.ErrOpLimit)
+}

--- a/xpath3/eval_test.go
+++ b/xpath3/eval_test.go
@@ -2,6 +2,7 @@ package xpath3_test
 
 import (
 	"context"
+	"iter"
 	"math/big"
 	"testing"
 
@@ -675,6 +676,72 @@ func TestGeneralComparison_AgainstRange(t *testing.T) {
 		require.True(t, ok, tc.expr)
 		require.Equal(t, tc.expect, b, tc.expr)
 	}
+}
+
+// panicPastTwoSeq is a Sequence of n integer items (1..n) that panics the
+// moment any item at index >= 2 is produced — via Get, the Items iterator, or
+// Materialize. It lets a test prove that a consumer inspects at most the first
+// two items (e.g. a singleton-cardinality probe with an early stop) and never
+// drains the whole non-singleton operand.
+type panicPastTwoSeq struct{ n int }
+
+func (s panicPastTwoSeq) Len() int { return s.n }
+
+func (s panicPastTwoSeq) Get(i int) xpath3.Item {
+	if i >= 2 {
+		panic("panicPastTwoSeq: item past index 1 accessed")
+	}
+	return xpath3.SingleInteger(int64(i + 1)).Get(0)
+}
+
+func (s panicPastTwoSeq) Items() iter.Seq[xpath3.Item] {
+	return func(yield func(xpath3.Item) bool) {
+		for i := range s.n {
+			if !yield(s.Get(i)) {
+				return
+			}
+		}
+	}
+}
+
+func (s panicPastTwoSeq) Materialize() []xpath3.Item {
+	panic("panicPastTwoSeq: Materialize called")
+}
+
+// TestGeneralComparison_RangeProbeDoesNotDrain proves the range fast-path probe
+// in compareSingletonAgainstRange inspects at most the first two atoms of the
+// NON-range operand before deciding the singleton fast-path is inapplicable. A
+// regression that atomized the whole operand (AtomizeSequence) would drain a
+// large/lazy non-singleton side just to discover it is not a singleton —
+// ignoring OpLimit / context cancellation before the bounded general comparison
+// even runs.
+//
+// The non-range operand is a panicPastTwoSeq bound via a borrowed variable:
+// producing any item past index 1 panics, so a full-drain probe panics here.
+// The early-stop probe reads exactly two atoms, falls back to the general
+// comparison, and matches on the first element (value 1 is in 1..10) — so the
+// whole evaluation touches only the first two items and never panics.
+func TestGeneralComparison_RangeProbeDoesNotDrain(t *testing.T) {
+	t.Parallel()
+
+	compiled, err := xpath3.NewCompiler().Compile(`$big = (1 to 10)`)
+	require.NoError(t, err)
+
+	vars := map[string]xpath3.Sequence{"big": panicPastTwoSeq{n: 1 << 20}}
+
+	var res *xpath3.Result
+	var evalErr error
+	require.NotPanics(t, func() {
+		// EvalBorrowing keeps the lazy operand out of the variable-clone path so
+		// it reaches the comparison unmaterialized.
+		res, evalErr = xpath3.NewEvaluator(xpath3.EvalBorrowing).
+			Variables(vars).
+			Evaluate(t.Context(), compiled, nil)
+	})
+	require.NoError(t, evalErr)
+	b, ok := res.IsBoolean()
+	require.True(t, ok)
+	require.True(t, b)
 }
 
 // try/catch exercises parseCatchCode (parse-time) and catchCodeMatches


### PR DESCRIPTION
- general comparison (= != …) now charges an op and checks ctx per left×right pair, so a large comparison honors OpLimit/cancellation
- value comparison (eq …) atomizes operands with an early stop (cap 2), raising XPTY0004 without materializing a huge/lazy operand