### PR TITLE
reject invalid CipherData/CipherValue cardinality

### DIFF
--- a/xmlenc1/parse.go
+++ b/xmlenc1/parse.go
@@ -127,6 +127,10 @@ func parseEncryptedKey(elem *helium.Element) (*EncryptedKey, error) {
 		}
 	}
 
+	if ek.CipherValue == nil {
+		return nil, fmt.Errorf("%w: EncryptedKey missing CipherData/CipherValue", ErrMalformedEncrypted)
+	}
+
 	return ek, nil
 }
 
@@ -160,21 +164,35 @@ func parseEncryptionMethod(elem *helium.Element) (*EncryptionMethod, error) {
 	return em, nil
 }
 
+// parseCipherData parses a CipherData element. Per the XML-Enc schema,
+// CipherData is a choice of exactly one CipherValue or one CipherReference.
+// Only CipherValue is supported here; a second CipherValue (or none) is
+// schema-invalid and rejected at parse rather than silently using the first.
 func parseCipherData(elem *helium.Element) ([]byte, error) {
+	var decoded []byte
+	var seenCipherValue bool
 	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
 		e, ok := helium.AsNode[*helium.Element](child)
 		if !ok {
 			continue
 		}
-		if isXMLEncElem(e, "CipherValue") {
-			decoded, err := xmlbase64.DecodeString(domutil.TextContent(e))
-			if err != nil {
-				return nil, fmt.Errorf("%w: invalid CipherValue: %v", ErrMalformedEncrypted, err)
-			}
-			return decoded, nil
+		if !isXMLEncElem(e, "CipherValue") {
+			continue
 		}
+		if seenCipherValue {
+			return nil, fmt.Errorf("%w: duplicate CipherValue", ErrMalformedEncrypted)
+		}
+		seenCipherValue = true
+		d, err := xmlbase64.DecodeString(domutil.TextContent(e))
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid CipherValue: %v", ErrMalformedEncrypted, err)
+		}
+		decoded = d
 	}
-	return nil, fmt.Errorf("%w: missing CipherValue", ErrMalformedEncrypted)
+	if !seenCipherValue {
+		return nil, fmt.Errorf("%w: missing CipherValue", ErrMalformedEncrypted)
+	}
+	return decoded, nil
 }
 
 // isElemNS reports whether e has the given local name and one of the

--- a/xmlenc1/parse.go
+++ b/xmlenc1/parse.go
@@ -165,31 +165,41 @@ func parseEncryptionMethod(elem *helium.Element) (*EncryptionMethod, error) {
 }
 
 // parseCipherData parses a CipherData element. Per the XML-Enc schema,
-// CipherData is a choice of exactly one CipherValue or one CipherReference.
-// Only CipherValue is supported here; a second CipherValue (or none) is
-// schema-invalid and rejected at parse rather than silently using the first.
+// CipherData is a choice of EXACTLY ONE CipherValue or one CipherReference.
+// A second choice member of either kind (CipherValue+CipherValue,
+// CipherValue+CipherReference, CipherReference+CipherValue, or two
+// CipherReferences) is schema-invalid and rejected at parse rather than
+// silently using the first. CipherReference (indirect cipher text fetched
+// via a URI plus transforms) is not supported by helium and is rejected
+// explicitly; ignoring it would both lose data and defeat the
+// exactly-one-choice rule.
 func parseCipherData(elem *helium.Element) ([]byte, error) {
 	var decoded []byte
-	var seenCipherValue bool
+	var seenChoice bool
 	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
 		e, ok := helium.AsNode[*helium.Element](child)
 		if !ok {
 			continue
 		}
-		if !isXMLEncElem(e, "CipherValue") {
-			continue
+		switch {
+		case isXMLEncElem(e, "CipherValue"):
+			if seenChoice {
+				return nil, fmt.Errorf("%w: CipherData allows exactly one of CipherValue or CipherReference", ErrMalformedEncrypted)
+			}
+			seenChoice = true
+			d, err := xmlbase64.DecodeString(domutil.TextContent(e))
+			if err != nil {
+				return nil, fmt.Errorf("%w: invalid CipherValue: %v", ErrMalformedEncrypted, err)
+			}
+			decoded = d
+		case isXMLEncElem(e, "CipherReference"):
+			if seenChoice {
+				return nil, fmt.Errorf("%w: CipherData allows exactly one of CipherValue or CipherReference", ErrMalformedEncrypted)
+			}
+			return nil, fmt.Errorf("%w: CipherReference is not supported", ErrMalformedEncrypted)
 		}
-		if seenCipherValue {
-			return nil, fmt.Errorf("%w: duplicate CipherValue", ErrMalformedEncrypted)
-		}
-		seenCipherValue = true
-		d, err := xmlbase64.DecodeString(domutil.TextContent(e))
-		if err != nil {
-			return nil, fmt.Errorf("%w: invalid CipherValue: %v", ErrMalformedEncrypted, err)
-		}
-		decoded = d
 	}
-	if !seenCipherValue {
+	if !seenChoice {
 		return nil, fmt.Errorf("%w: missing CipherValue", ErrMalformedEncrypted)
 	}
 	return decoded, nil

--- a/xmlenc1/parse_test.go
+++ b/xmlenc1/parse_test.go
@@ -31,6 +31,28 @@ func TestParse(t *testing.T) {
 			_, err := xmlenc1.ParseEncryptedDataForTest(elem)
 			require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
 		})
+
+		t.Run("duplicate CipherValue", func(t *testing.T) {
+			// CipherData is a choice of exactly one CipherValue (or one
+			// CipherReference); two CipherValue children are schema-invalid
+			// and must be rejected at parse rather than silently using the
+			// first.
+			doc := mustParseXML(t, `<xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"><xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue><xenc:CipherValue>BBBB</xenc:CipherValue></xenc:CipherData></xenc:EncryptedData>`)
+			elem, ok := helium.AsNode[*helium.Element](doc.DocumentElement())
+			require.True(t, ok)
+			_, err := xmlenc1.ParseEncryptedDataForTest(elem)
+			require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+		})
+
+		t.Run("EncryptedKey missing CipherData", func(t *testing.T) {
+			// An EncryptedKey carried in KeyInfo with no CipherData/CipherValue
+			// must be rejected at parse, not deferred to a later crypto error.
+			doc := mustParseXML(t, `<xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:KeyInfo><xenc:EncryptedKey><xenc:EncryptionMethod Algorithm="`+xmlenc1.RSAOAEP11+`"/></xenc:EncryptedKey></ds:KeyInfo><xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData></xenc:EncryptedData>`)
+			elem, ok := helium.AsNode[*helium.Element](doc.DocumentElement())
+			require.True(t, ok)
+			_, err := xmlenc1.ParseEncryptedDataForTest(elem)
+			require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+		})
 	})
 
 	t.Run("encryption method missing algorithm", func(t *testing.T) {

--- a/xmlenc1/parse_test.go
+++ b/xmlenc1/parse_test.go
@@ -44,6 +44,51 @@ func TestParse(t *testing.T) {
 			require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
 		})
 
+		t.Run("CipherValue plus CipherReference", func(t *testing.T) {
+			// CipherData is a choice of EXACTLY ONE CipherValue or one
+			// CipherReference. A CipherValue accompanied by a CipherReference
+			// (in either order, under EncryptedData or EncryptedKey) is
+			// schema-invalid and must be rejected, not silently reduced to
+			// the CipherValue.
+			const xencNS = "http://www.w3.org/2001/04/xmlenc#"
+			const dsigNS = "http://www.w3.org/2000/09/xmldsig#"
+
+			edWith := func(cipherData string) string {
+				return `<xenc:EncryptedData xmlns:xenc="` + xencNS + `">` +
+					`<xenc:CipherData>` + cipherData + `</xenc:CipherData>` +
+					`</xenc:EncryptedData>`
+			}
+			ekWith := func(cipherData string) string {
+				return `<xenc:EncryptedData xmlns:xenc="` + xencNS + `" xmlns:ds="` + dsigNS + `">` +
+					`<ds:KeyInfo><xenc:EncryptedKey>` +
+					`<xenc:CipherData>` + cipherData + `</xenc:CipherData>` +
+					`</xenc:EncryptedKey></ds:KeyInfo>` +
+					`<xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData>` +
+					`</xenc:EncryptedData>`
+			}
+
+			const valueFirst = `<xenc:CipherValue>AAAA</xenc:CipherValue><xenc:CipherReference URI="#ref"/>`
+			const refFirst = `<xenc:CipherReference URI="#ref"/><xenc:CipherValue>AAAA</xenc:CipherValue>`
+
+			for _, tc := range []struct {
+				name string
+				xml  string
+			}{
+				{"EncryptedData value-then-reference", edWith(valueFirst)},
+				{"EncryptedData reference-then-value", edWith(refFirst)},
+				{"EncryptedKey value-then-reference", ekWith(valueFirst)},
+				{"EncryptedKey reference-then-value", ekWith(refFirst)},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					doc := mustParseXML(t, tc.xml)
+					elem, ok := helium.AsNode[*helium.Element](doc.DocumentElement())
+					require.True(t, ok)
+					_, err := xmlenc1.ParseEncryptedDataForTest(elem)
+					require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+				})
+			}
+		})
+
 		t.Run("EncryptedKey missing CipherData", func(t *testing.T) {
 			// An EncryptedKey carried in KeyInfo with no CipherData/CipherValue
 			// must be rejected at parse, not deferred to a later crypto error.


### PR DESCRIPTION
- parseEncryptedKey now rejects an EncryptedKey with no CipherData/CipherValue instead of returning a nil CipherValue
- parseCipherData rejects a duplicate CipherValue instead of silently using the first