### PR TITLE
cap xpath3 simple-map and unparsed-text-lines

### DIFF
--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -155,6 +155,16 @@ All delegate to Go `math` package.
 ### `functions_unparsed_text.go`
 `unparsed-text`, `unparsed-text-lines`, `unparsed-text-available`
 
+`fn:unparsed-text-lines` bounds line production by the **effective** budget in
+force — `min(fnMaxNodes(ec), fnRemainingOps(ec))` — not just `maxNodes`, so a
+small `OpLimit` (far below the 10M default node-set cap) stops splitting after
+~`OpLimit` lines instead of first allocating a `[]string` proportional to the
+resource's full line count. `LoadTextLinesBounded` produces at most `limit+1`
+lines; the produced count is then charged via `fnCountOps`, surfacing
+`ErrOpLimit` (op budget binding) or `ErrNodeSetLimit` (node-set cap binding).
+`fnRemainingOps` (in `functions_hof.go`) returns the remaining op budget and
+whether one is in force (false when `OpLimit` is unset or `ec == nil`).
+
 ## FunctionItem Mechanics
 
 Inline functions, named refs, partial applications → all produce `FunctionItem`.

--- a/internal/unparsedtext/unparsedtext.go
+++ b/internal/unparsedtext/unparsedtext.go
@@ -146,6 +146,20 @@ func LoadTextLines(ctx context.Context, cfg *Config, href, encoding string) ([]s
 	return SplitLines(text), nil
 }
 
+// LoadTextLinesBounded behaves like LoadTextLines but stops splitting once
+// limit+1 lines have been produced (limit <= 0 imposes no bound). The returned
+// bool reports whether the resource contained more than limit lines, so a caller
+// enforcing a line-count cap can reject an over-cap resource without ever
+// building the full line slice — LoadTextLines would split every line up front.
+func LoadTextLinesBounded(ctx context.Context, cfg *Config, href, encoding string, limit int) ([]string, bool, error) {
+	text, err := LoadText(ctx, cfg, href, encoding)
+	if err != nil {
+		return nil, false, err
+	}
+	lines, truncated := SplitLinesBounded(text, limit)
+	return lines, truncated, nil
+}
+
 // IsAvailable returns true if LoadText would succeed for the given href
 // and encoding.
 func IsAvailable(ctx context.Context, cfg *Config, href, encoding string) bool {
@@ -476,6 +490,52 @@ func SplitLines(text string) []string {
 		lines = lines[:len(lines)-1]
 	}
 	return lines
+}
+
+// SplitLinesBounded splits text into lines following the same rules as
+// SplitLines (CRLF and CR normalize to LF; a trailing newline does not yield an
+// extra empty final line), but stops as soon as limit+1 lines have been produced
+// when limit > 0. The returned bool reports whether text contained more than
+// limit lines (collection was truncated at limit+1). This lets a caller reject
+// an over-cap resource without materializing the full line slice. A limit <= 0
+// imposes no bound and collects every line. Unlike SplitLines it does not first
+// build a fully normalized copy of text; it streams lines directly so an
+// over-cap resource stops early.
+func SplitLinesBounded(text string, limit int) ([]string, bool) {
+	var lines []string
+	var cur strings.Builder
+	// emit records the current segment as a line and reports whether the line
+	// count has now exceeded limit.
+	emit := func() bool {
+		lines = append(lines, cur.String())
+		cur.Reset()
+		return limit > 0 && len(lines) > limit
+	}
+	for i := 0; i < len(text); i++ {
+		switch text[i] {
+		case '\r':
+			if emit() {
+				return lines, true
+			}
+			if i+1 < len(text) && text[i+1] == '\n' {
+				i++
+			}
+		case '\n':
+			if emit() {
+				return lines, true
+			}
+		default:
+			cur.WriteByte(text[i])
+		}
+	}
+	// The segment after the last newline is a line only when non-empty; an empty
+	// trailing segment is the dropped extra line a trailing newline would create.
+	if cur.Len() > 0 {
+		if emit() {
+			return lines, true
+		}
+	}
+	return lines, false
 }
 
 // ValidateXMLChars checks that the string contains only valid XML 1.0

--- a/internal/unparsedtext/unparsedtext_test.go
+++ b/internal/unparsedtext/unparsedtext_test.go
@@ -59,6 +59,45 @@ func TestSplitLines(t *testing.T) {
 	}
 }
 
+// SplitLinesBounded must agree with SplitLines whenever the line count stays
+// within the limit, and must stop early (without producing every line) when the
+// input exceeds it.
+func TestSplitLinesBounded(t *testing.T) {
+	t.Run("matches SplitLines within and at the limit", func(t *testing.T) {
+		// limit 0 (unbounded) and a generous limit must both reproduce SplitLines.
+		inputs := []string{
+			"", "hello", "a\nb\n", "a\r\nb\r\n", "a\rb\r",
+			"a\r\nb\rc\nd\n", "a\nb", "a\n\nb\n", "\n", "\r\n", "\r",
+			"a\n\n\n",
+		}
+		for _, in := range inputs {
+			want := unparsedtext.SplitLines(in)
+			for _, limit := range []int{0, len(want), len(want) + 5} {
+				got, truncated := unparsedtext.SplitLinesBounded(in, limit)
+				require.False(t, truncated, "input %q limit %d", in, limit)
+				require.Equal(t, want, got, "input %q limit %d", in, limit)
+			}
+		}
+	})
+
+	t.Run("stops early when over the limit", func(t *testing.T) {
+		const lines = 1000
+		const limit = 20
+
+		var b strings.Builder
+		for range lines {
+			b.WriteString("line\n")
+		}
+
+		got, truncated := unparsedtext.SplitLinesBounded(b.String(), limit)
+		require.True(t, truncated)
+		// It must stop as soon as limit+1 lines prove the input is over-cap, never
+		// building the full 1000-line slice.
+		require.LessOrEqual(t, len(got), limit+1)
+		require.Less(t, len(got), lines)
+	})
+}
+
 func TestValidateXMLChars(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/xpath3/eval_control.go
+++ b/xpath3/eval_control.go
@@ -201,7 +201,12 @@ func evalFLWOR(evalFn exprEvaluator, ctx context.Context, ec *evalContext, e FLW
 		if err != nil {
 			return err
 		}
-		result, err = appendBounded(result, seqMaterialize(r), ec.maxNodes)
+		// Accumulate the return sequence lazily so the aggregate maxNodes /
+		// OpLimit / cancellation bound is enforced item-by-item BEFORE the whole
+		// per-tuple sub-sequence is materialized — a return expression bound to a
+		// large lazy Sequence (e.g. a borrowed range variable) is rejected without
+		// first materializing it in full, matching evalSimpleMapExpr.
+		result, err = appendBoundedSeq(ctx, ec, result, r, ec.maxNodes)
 		if err != nil {
 			return err
 		}

--- a/xpath3/eval_operators.go
+++ b/xpath3/eval_operators.go
@@ -189,7 +189,11 @@ func evalSimpleMapExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContex
 		if err != nil {
 			return nil, err
 		}
-		result, err = appendBounded(result, seqMaterialize(r), ec.maxNodes)
+		// Accumulate the right-hand sequence lazily so the aggregate maxNodes /
+		// OpLimit / cancellation bound is enforced item-by-item BEFORE the whole
+		// sub-sequence is materialized — a per-item right expression producing a
+		// large lazy Sequence is rejected without first allocating it in full.
+		result, err = appendBoundedSeq(ctx, ec, result, r, ec.maxNodes)
 		if err != nil {
 			return nil, err
 		}

--- a/xpath3/eval_operators_test.go
+++ b/xpath3/eval_operators_test.go
@@ -58,3 +58,49 @@ func TestEvalSimpleMapExpr_WithinMaxNodes(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 6, res.Sequence().Len())
 }
+
+// A FLWOR return clause has the same materialize-before-cap hazard as
+// simple-map: `for $i in 1 return $big` with a borrowed lazy $big must enforce
+// the node-set/sequence limit item-by-item BEFORE the return sub-sequence is
+// materialized. The right side is bound to a lazy Range that counts how many
+// items it actually produces; the bound (20) is far below the range length
+// (1000). Before the fix the return clause called seqMaterialize first, so all
+// 1000 items were produced before the aggregate cap rejected the result.
+func TestEvalFLWOR_LazyReturnHonorsMaxNodesBeforeMaterialize(t *testing.T) {
+	const rangeLen = 1000
+	const limit = 20
+
+	var produced int
+	big := sequence.NewRange[xpath3.Item](rangeLen, func(int) xpath3.Item {
+		produced++
+		return xpath3.AtomicValue{TypeName: xpath3.TypeString, Value: "x"}
+	})
+
+	compiled, err := xpath3.NewCompiler().Compile("for $i in 1 return $big")
+	require.NoError(t, err)
+
+	// EvalBorrowing keeps $big lazy (DefaultEvaluatorOptions would clone and thus
+	// materialize the sequence up front, defeating the laziness probe).
+	_, err = xpath3.NewEvaluator(xpath3.EvalBorrowing).
+		Variables(map[string]xpath3.Sequence{"big": big}).
+		MaxNodesForTesting(limit).
+		Evaluate(t.Context(), compiled, nil)
+	require.ErrorIs(t, err, xpath3.ErrNodeSetLimit)
+	require.Less(t, produced, rangeLen, "return sub-sequence was fully materialized before the cap check")
+	require.LessOrEqual(t, produced, limit+1)
+}
+
+// A FLWOR whose accumulated result stays within the cap must succeed and return
+// the full sequence, confirming the bound does not reject legitimate results.
+func TestEvalFLWOR_WithinMaxNodes(t *testing.T) {
+	const limit = 20
+
+	compiled, err := xpath3.NewCompiler().Compile("for $i in (1, 2, 3) return (1 to 2)")
+	require.NoError(t, err)
+
+	res, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		MaxNodesForTesting(limit).
+		Evaluate(t.Context(), compiled, nil)
+	require.NoError(t, err)
+	require.Equal(t, 6, res.Sequence().Len())
+}

--- a/xpath3/eval_operators_test.go
+++ b/xpath3/eval_operators_test.go
@@ -1,0 +1,60 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/internal/sequence"
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// A simple-map expression (E1 ! E2) whose right side yields a large lazy
+// sequence must enforce the configured node-set/sequence limit BEFORE
+// materializing the whole right-hand sequence. The right side is bound to a lazy
+// Range that counts how many items it actually produces; the bound (20) is far
+// below the range length (1000). The lazy accumulation must stop as soon as the
+// running total would exceed the cap, so only a handful of items are ever
+// produced. Before the fix the operator materialized the entire right-hand
+// sequence first and only then checked the aggregate cap, producing all 1000
+// items before erroring.
+func TestEvalSimpleMapExpr_LazyRightHonorsMaxNodesBeforeMaterialize(t *testing.T) {
+	const rangeLen = 1000
+	const limit = 20
+
+	var produced int
+	big := sequence.NewRange[xpath3.Item](rangeLen, func(int) xpath3.Item {
+		produced++
+		return xpath3.AtomicValue{TypeName: xpath3.TypeString, Value: "x"}
+	})
+
+	compiled, err := xpath3.NewCompiler().Compile("1 ! $big")
+	require.NoError(t, err)
+
+	// EvalBorrowing keeps $big lazy (DefaultEvaluatorOptions would clone and thus
+	// materialize the sequence up front, defeating the laziness probe).
+	_, err = xpath3.NewEvaluator(xpath3.EvalBorrowing).
+		Variables(map[string]xpath3.Sequence{"big": big}).
+		MaxNodesForTesting(limit).
+		Evaluate(t.Context(), compiled, nil)
+	require.ErrorIs(t, err, xpath3.ErrNodeSetLimit)
+	// The cap must trip after producing only a bounded prefix, never the whole
+	// 1000-item range.
+	require.Less(t, produced, rangeLen, "right-hand sequence was fully materialized before the cap check")
+	require.LessOrEqual(t, produced, limit+1)
+}
+
+// A simple-map whose accumulated result stays within the cap must succeed and
+// return the full sequence, confirming the bound does not reject legitimate
+// results.
+func TestEvalSimpleMapExpr_WithinMaxNodes(t *testing.T) {
+	const limit = 20
+
+	compiled, err := xpath3.NewCompiler().Compile("(1, 2, 3) ! (1 to 2)")
+	require.NoError(t, err)
+
+	res, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		MaxNodesForTesting(limit).
+		Evaluate(t.Context(), compiled, nil)
+	require.NoError(t, err)
+	require.Equal(t, 6, res.Sequence().Len())
+}

--- a/xpath3/functions_hof.go
+++ b/xpath3/functions_hof.go
@@ -31,6 +31,21 @@ func fnMaxNodes(ec *evalContext) int {
 	return ec.maxNodes
 }
 
+// fnRemainingOps reports the op budget still available to this evaluation and
+// whether a budget is in force. bounded is false when no OpLimit is configured
+// (opLimit <= 0) or the function runs outside an evaluation (ec == nil); the
+// returned count is meaningless in that case. A negative remainder (the budget
+// is already exhausted) is clamped to 0. Built-ins that produce a slice up
+// front use this to cap production at the EFFECTIVE budget actually in force,
+// not just maxNodes, so a small OpLimit does not first materialize a slice
+// proportional to the input before the op charge rejects it.
+func fnRemainingOps(ec *evalContext) (remaining int, bounded bool) {
+	if ec == nil || ec.opLimit <= 0 || ec.opCount == nil {
+		return 0, false
+	}
+	return max(ec.opLimit-*ec.opCount, 0), true
+}
+
 // fnCountOp charges one operation against the evaluation's op-counter and
 // honors context cancellation. It is a no-op (other than the cancellation
 // check) when called outside an evaluation. Accumulating built-ins call it once

--- a/xpath3/functions_unparsed_text.go
+++ b/xpath3/functions_unparsed_text.go
@@ -100,18 +100,22 @@ func fnUnparsedTextLines(ctx context.Context, args []Sequence) (Sequence, error)
 		}
 	}
 
-	lines, err := unparsedtext.LoadTextLines(ctx, unparsedTextConfig(ctx), href, encoding)
+	// Enforce the aggregate node-set/sequence cap BEFORE the whole resource is
+	// split into lines: LoadTextLinesBounded stops once maxNodes+1 lines would be
+	// produced, so an over-line-count resource is rejected without ever building
+	// the full line slice. (LoadTextLines splits every line up front, then this
+	// site could only reject after the fact.)
+	ec := getFnContext(ctx)
+	maxNodes := fnMaxNodes(ec)
+	lines, truncated, err := unparsedtext.LoadTextLinesBounded(ctx, unparsedTextConfig(ctx), href, encoding, maxNodes)
 	if err != nil {
 		return nil, wrapUnparsedTextError(err)
 	}
-	// Enforce the aggregate node-set/sequence cap (and charge ops + honor
-	// cancellation) BEFORE materializing one Item per line, matching how
-	// functions_array / functions_map guard one-shot materialization.
-	ec := getFnContext(ctx)
-	maxNodes := fnMaxNodes(ec)
-	if maxNodes > 0 && len(lines) > maxNodes {
+	if truncated {
 		return nil, ErrNodeSetLimit
 	}
+	// Charge ops + honor cancellation before materializing one Item per line,
+	// matching how functions_array / functions_map guard one-shot materialization.
 	if err := fnCountOps(ctx, ec, len(lines)); err != nil {
 		return nil, err
 	}

--- a/xpath3/functions_unparsed_text.go
+++ b/xpath3/functions_unparsed_text.go
@@ -104,6 +104,17 @@ func fnUnparsedTextLines(ctx context.Context, args []Sequence) (Sequence, error)
 	if err != nil {
 		return nil, wrapUnparsedTextError(err)
 	}
+	// Enforce the aggregate node-set/sequence cap (and charge ops + honor
+	// cancellation) BEFORE materializing one Item per line, matching how
+	// functions_array / functions_map guard one-shot materialization.
+	ec := getFnContext(ctx)
+	maxNodes := fnMaxNodes(ec)
+	if maxNodes > 0 && len(lines) > maxNodes {
+		return nil, ErrNodeSetLimit
+	}
+	if err := fnCountOps(ctx, ec, len(lines)); err != nil {
+		return nil, err
+	}
 	result := make(ItemSlice, len(lines))
 	for i, line := range lines {
 		result[i] = AtomicValue{TypeName: TypeString, Value: line}

--- a/xpath3/functions_unparsed_text.go
+++ b/xpath3/functions_unparsed_text.go
@@ -100,24 +100,42 @@ func fnUnparsedTextLines(ctx context.Context, args []Sequence) (Sequence, error)
 		}
 	}
 
-	// Enforce the aggregate node-set/sequence cap BEFORE the whole resource is
-	// split into lines: LoadTextLinesBounded stops once maxNodes+1 lines would be
-	// produced, so an over-line-count resource is rejected without ever building
-	// the full line slice. (LoadTextLines splits every line up front, then this
-	// site could only reject after the fact.)
+	// Bound line production by the EFFECTIVE budget actually in force for this
+	// call — the smaller of the node-set cap (maxNodes) and the remaining op
+	// budget — so an OpLimit far below maxNodes stops splitting after ~OpLimit
+	// lines instead of allocating a []string proportional to the resource's full
+	// line count. LoadTextLinesBounded stops once limit+1 lines would be produced;
+	// the +1 lets the op charge below detect the overflow precisely.
 	ec := getFnContext(ctx)
 	maxNodes := fnMaxNodes(ec)
-	lines, truncated, err := unparsedtext.LoadTextLinesBounded(ctx, unparsedTextConfig(ctx), href, encoding, maxNodes)
+	limit := maxNodes
+	opBounded := false
+	if rem, bounded := fnRemainingOps(ec); bounded && rem < limit {
+		limit = rem
+		opBounded = true
+	}
+	// SplitLinesBounded treats limit <= 0 as "no bound"; a fully-exhausted op
+	// budget (rem == 0) must still cap allocation, so floor the splitter bound at
+	// 1. The op charge below then rejects the single produced line via ErrOpLimit.
+	splitLimit := limit
+	if opBounded && splitLimit < 1 {
+		splitLimit = 1
+	}
+
+	lines, truncated, err := unparsedtext.LoadTextLinesBounded(ctx, unparsedTextConfig(ctx), href, encoding, splitLimit)
 	if err != nil {
 		return nil, wrapUnparsedTextError(err)
 	}
-	if truncated {
-		return nil, ErrNodeSetLimit
-	}
-	// Charge ops + honor cancellation before materializing one Item per line,
-	// matching how functions_array / functions_map guard one-shot materialization.
+	// Charge the produced lines against the op-counter (honoring cancellation)
+	// BEFORE materializing one Item per line, matching how functions_array /
+	// functions_map guard one-shot materialization. When the op budget is the
+	// binding constraint this surfaces ErrOpLimit; truncation past the node-set
+	// cap surfaces ErrNodeSetLimit.
 	if err := fnCountOps(ctx, ec, len(lines)); err != nil {
 		return nil, err
+	}
+	if truncated {
+		return nil, ErrNodeSetLimit
 	}
 	result := make(ItemSlice, len(lines))
 	for i, line := range lines {

--- a/xpath3/functions_unparsed_text_test.go
+++ b/xpath3/functions_unparsed_text_test.go
@@ -41,6 +41,44 @@ func TestFnUnparsedTextLines_HonorsMaxNodes(t *testing.T) {
 	require.ErrorIs(t, err, xpath3.ErrNodeSetLimit)
 }
 
+// fn:unparsed-text-lines over a many-line resource with a small OpLimit must
+// reject via the op limit AND must not first allocate a []string proportional to
+// the resource's full line count. The line production is bounded by the
+// EFFECTIVE budget (min of maxNodes and the remaining op budget), so an
+// OpLimit far below the 10M default maxNodes stops splitting after ~OpLimit
+// lines. Before the fix the splitter was handed maxNodes (10M), so a 1M-line
+// resource built a 1M-entry slice before the op charge rejected it — the
+// allocation count below catches that regression (it grows with the line count
+// under the bug, stays tiny under the fix).
+func TestFnUnparsedTextLines_BoundsAllocationByOpLimit(t *testing.T) {
+	const lines = 1_000_000
+	const opLimit = 1000
+
+	var b strings.Builder
+	for range lines {
+		b.WriteString("x\n")
+	}
+	resolver := stringURIResolver{content: b.String()}
+
+	compiled, err := xpath3.NewCompiler().Compile("unparsed-text-lines('http://example.com/lines.txt')")
+	require.NoError(t, err)
+
+	eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		URIResolver(resolver).
+		OpLimit(opLimit)
+
+	var evalErr error
+	allocs := testing.AllocsPerRun(1, func() {
+		_, evalErr = eval.Evaluate(t.Context(), compiled, nil)
+	})
+	require.ErrorIs(t, evalErr, xpath3.ErrOpLimit)
+	// Under the fix the splitter produces ~opLimit lines, so allocations stay a
+	// few orders of magnitude below the 1M line count. A threshold well under the
+	// line count cleanly separates the bounded fix from the proportional bug.
+	require.Less(t, allocs, float64(100_000),
+		"line splitting must be bounded by the active op limit, not the resource line count")
+}
+
 // A resource whose line count is within the cap must succeed and return every
 // line, confirming the bound does not reject legitimate results.
 func TestFnUnparsedTextLines_WithinMaxNodes(t *testing.T) {

--- a/xpath3/functions_unparsed_text_test.go
+++ b/xpath3/functions_unparsed_text_test.go
@@ -1,0 +1,65 @@
+package xpath3_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// stringURIResolver returns fixed content for any URI.
+type stringURIResolver struct{ content string }
+
+func (r stringURIResolver) ResolveURI(string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(r.content)), nil
+}
+
+// fn:unparsed-text-lines over a resource with more lines than the configured
+// node-set/sequence cap must reject the result via the cap rather than
+// materializing the whole line sequence. Before the fix the function built an
+// ItemSlice of every line with no fnMaxNodes guard, so an oversized resource
+// produced an unbounded sequence.
+func TestFnUnparsedTextLines_HonorsMaxNodes(t *testing.T) {
+	const lines = 1000
+	const limit = 20
+
+	var b strings.Builder
+	for range lines {
+		b.WriteString("line\n")
+	}
+	resolver := stringURIResolver{content: b.String()}
+
+	compiled, err := xpath3.NewCompiler().Compile("unparsed-text-lines('http://example.com/lines.txt')")
+	require.NoError(t, err)
+
+	_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		URIResolver(resolver).
+		MaxNodesForTesting(limit).
+		Evaluate(t.Context(), compiled, nil)
+	require.ErrorIs(t, err, xpath3.ErrNodeSetLimit)
+}
+
+// A resource whose line count is within the cap must succeed and return every
+// line, confirming the bound does not reject legitimate results.
+func TestFnUnparsedTextLines_WithinMaxNodes(t *testing.T) {
+	const lines = 5
+	const limit = 20
+
+	var b strings.Builder
+	for range lines {
+		b.WriteString("line\n")
+	}
+	resolver := stringURIResolver{content: b.String()}
+
+	compiled, err := xpath3.NewCompiler().Compile("unparsed-text-lines('http://example.com/lines.txt')")
+	require.NoError(t, err)
+
+	res, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		URIResolver(resolver).
+		MaxNodesForTesting(limit).
+		Evaluate(t.Context(), compiled, nil)
+	require.NoError(t, err)
+	require.Equal(t, lines, res.Sequence().Len())
+}


### PR DESCRIPTION
- fn:unparsed-text-lines now checks fnMaxNodes + charges ops/cancellation before building one Item per line
- simple-map (!) accumulates the RHS via lazy appendBoundedSeq so the cap trips before materializing each RHS