### PR TITLE
reject empty alg and duplicate EncryptionMethod children

### DIFF
--- a/xmlenc1/parse.go
+++ b/xmlenc1/parse.go
@@ -133,10 +133,16 @@ func parseEncryptedKey(elem *helium.Element) (*EncryptedKey, error) {
 func parseEncryptionMethod(elem *helium.Element) (*EncryptionMethod, error) {
 	em := &EncryptionMethod{}
 	alg, ok := elem.GetAttribute("Algorithm")
-	if !ok {
-		return nil, fmt.Errorf("%w: EncryptionMethod missing Algorithm", ErrMalformedEncrypted)
+	if !ok || alg == "" {
+		return nil, fmt.Errorf("%w: EncryptionMethod missing/empty Algorithm", ErrMalformedEncrypted)
 	}
 	em.Algorithm = alg
+
+	// Enforce at-most-one cardinality on the optional sub-elements,
+	// mirroring the duplicate-EncryptionMethod/CipherData guards in the
+	// parent parsers. Boolean sentinels are used because an empty
+	// attribute/text value is otherwise ambiguous.
+	var seenDigestMethod, seenMGF, seenOAEPParams bool
 
 	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
 		e, ok := helium.AsNode[*helium.Element](child)
@@ -145,10 +151,22 @@ func parseEncryptionMethod(elem *helium.Element) (*EncryptionMethod, error) {
 		}
 		switch {
 		case isDSigElem(e, "DigestMethod"):
+			if seenDigestMethod {
+				return nil, fmt.Errorf("%w: duplicate DigestMethod", ErrMalformedEncrypted)
+			}
+			seenDigestMethod = true
 			em.DigestMethod, _ = e.GetAttribute("Algorithm")
 		case isMGFElem(e):
+			if seenMGF {
+				return nil, fmt.Errorf("%w: duplicate MGF", ErrMalformedEncrypted)
+			}
+			seenMGF = true
 			em.MGFAlgorithm, _ = e.GetAttribute("Algorithm")
 		case isXMLEncElem(e, "OAEPparams"):
+			if seenOAEPParams {
+				return nil, fmt.Errorf("%w: duplicate OAEPparams", ErrMalformedEncrypted)
+			}
+			seenOAEPParams = true
 			decoded, err := xmlbase64.DecodeString(domutil.TextContent(e))
 			if err != nil {
 				return nil, fmt.Errorf("%w: invalid OAEPparams: %v", ErrMalformedEncrypted, err)

--- a/xmlenc1/parse.go
+++ b/xmlenc1/parse.go
@@ -142,7 +142,7 @@ func parseEncryptionMethod(elem *helium.Element) (*EncryptionMethod, error) {
 	// mirroring the duplicate-EncryptionMethod/CipherData guards in the
 	// parent parsers. Boolean sentinels are used because an empty
 	// attribute/text value is otherwise ambiguous.
-	var seenDigestMethod, seenMGF, seenOAEPParams bool
+	var seenDigestMethod, seenMGF, seenOAEPParams, seenKeySize bool
 
 	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
 		e, ok := helium.AsNode[*helium.Element](child)
@@ -155,13 +155,30 @@ func parseEncryptionMethod(elem *helium.Element) (*EncryptionMethod, error) {
 				return nil, fmt.Errorf("%w: duplicate DigestMethod", ErrMalformedEncrypted)
 			}
 			seenDigestMethod = true
-			em.DigestMethod, _ = e.GetAttribute("Algorithm")
+			alg, ok := e.GetAttribute("Algorithm")
+			if !ok || alg == "" {
+				return nil, fmt.Errorf("%w: DigestMethod missing/empty Algorithm", ErrMalformedEncrypted)
+			}
+			em.DigestMethod = alg
 		case isMGFElem(e):
 			if seenMGF {
 				return nil, fmt.Errorf("%w: duplicate MGF", ErrMalformedEncrypted)
 			}
 			seenMGF = true
-			em.MGFAlgorithm, _ = e.GetAttribute("Algorithm")
+			alg, ok := e.GetAttribute("Algorithm")
+			if !ok || alg == "" {
+				return nil, fmt.Errorf("%w: MGF missing/empty Algorithm", ErrMalformedEncrypted)
+			}
+			em.MGFAlgorithm = alg
+		case isXMLEncElem(e, "KeySize"):
+			// KeySize is an optional singleton in the schema. The package
+			// derives key sizes from the algorithm URI and does not consume
+			// KeySize, so enforce at-most-one cardinality to stay consistent
+			// with the other sub-element guards.
+			if seenKeySize {
+				return nil, fmt.Errorf("%w: duplicate KeySize", ErrMalformedEncrypted)
+			}
+			seenKeySize = true
 		case isXMLEncElem(e, "OAEPparams"):
 			if seenOAEPParams {
 				return nil, fmt.Errorf("%w: duplicate OAEPparams", ErrMalformedEncrypted)

--- a/xmlenc1/parse_test.go
+++ b/xmlenc1/parse_test.go
@@ -233,6 +233,28 @@ func TestEncryptionMethodCardinality(t *testing.T) {
 		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
 	})
 
+	t.Run("DigestMethod missing Algorithm rejected", func(t *testing.T) {
+		_, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.RSAOAEP11+`">`+
+			`<ds:DigestMethod/>`+
+			`</xenc:EncryptionMethod>`)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+
+	t.Run("MGF empty Algorithm rejected", func(t *testing.T) {
+		_, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.RSAOAEP11+`">`+
+			`<xenc11:MGF Algorithm=""/>`+
+			`</xenc:EncryptionMethod>`)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+
+	t.Run("duplicate KeySize rejected", func(t *testing.T) {
+		_, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.AES256GCM+`">`+
+			`<xenc:KeySize>256</xenc:KeySize>`+
+			`<xenc:KeySize>256</xenc:KeySize>`+
+			`</xenc:EncryptionMethod>`)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+
 	t.Run("duplicate OAEPparams rejected", func(t *testing.T) {
 		_, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.RSAOAEP11+`">`+
 			`<xenc:OAEPparams>AAAA</xenc:OAEPparams>`+

--- a/xmlenc1/parse_test.go
+++ b/xmlenc1/parse_test.go
@@ -195,3 +195,62 @@ func TestMarshalParseRoundTrip(t *testing.T) {
 	require.Equal(t, []byte("wrapped-key-bytes"), parsed.EncryptedKeys[0].CipherValue)
 	require.Equal(t, []byte("cipher-bytes"), parsed.CipherValue)
 }
+
+// TestEncryptionMethodCardinality verifies that parseEncryptionMethod is
+// fail-closed: an empty Algorithm and duplicate DigestMethod/MGF/OAEPparams
+// children are rejected as ErrMalformedEncrypted, while a well-formed single
+// occurrence still parses.
+func TestEncryptionMethodCardinality(t *testing.T) {
+	const head = `<xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">`
+	const cipher = `<xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData></xenc:EncryptedData>`
+
+	parse := func(t *testing.T, em string) (*xmlenc1.EncryptedData, error) {
+		t.Helper()
+		doc := mustParseXML(t, head+em+cipher)
+		elem, ok := helium.AsNode[*helium.Element](doc.DocumentElement())
+		require.True(t, ok)
+		return xmlenc1.ParseEncryptedDataForTest(elem)
+	}
+
+	t.Run("empty Algorithm rejected", func(t *testing.T) {
+		_, err := parse(t, `<xenc:EncryptionMethod Algorithm=""/>`)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+
+	t.Run("duplicate DigestMethod rejected", func(t *testing.T) {
+		_, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.RSAOAEP11+`">`+
+			`<ds:DigestMethod Algorithm="`+xmlenc1.DigestSHA256+`"/>`+
+			`<ds:DigestMethod Algorithm="`+xmlenc1.DigestSHA1+`"/>`+
+			`</xenc:EncryptionMethod>`)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+
+	t.Run("duplicate MGF rejected", func(t *testing.T) {
+		_, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.RSAOAEP11+`">`+
+			`<xenc11:MGF Algorithm="`+xmlenc1.MGFSHA256+`"/>`+
+			`<xenc11:MGF Algorithm="`+xmlenc1.MGFSHA1+`"/>`+
+			`</xenc:EncryptionMethod>`)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+
+	t.Run("duplicate OAEPparams rejected", func(t *testing.T) {
+		_, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.RSAOAEP11+`">`+
+			`<xenc:OAEPparams>AAAA</xenc:OAEPparams>`+
+			`<xenc:OAEPparams>BBBB</xenc:OAEPparams>`+
+			`</xenc:EncryptionMethod>`)
+		require.ErrorIs(t, err, xmlenc1.ErrMalformedEncrypted)
+	})
+
+	t.Run("well-formed single still parses", func(t *testing.T) {
+		ed, err := parse(t, `<xenc:EncryptionMethod Algorithm="`+xmlenc1.RSAOAEP11+`">`+
+			`<ds:DigestMethod Algorithm="`+xmlenc1.DigestSHA256+`"/>`+
+			`<xenc11:MGF Algorithm="`+xmlenc1.MGFSHA256+`"/>`+
+			`<xenc:OAEPparams>AAAA</xenc:OAEPparams>`+
+			`</xenc:EncryptionMethod>`)
+		require.NoError(t, err)
+		require.NotNil(t, ed.EncryptionMethod)
+		require.Equal(t, xmlenc1.RSAOAEP11, ed.EncryptionMethod.Algorithm)
+		require.Equal(t, xmlenc1.DigestSHA256, ed.EncryptionMethod.DigestMethod)
+		require.Equal(t, xmlenc1.MGFSHA256, ed.EncryptionMethod.MGFAlgorithm)
+	})
+}


### PR DESCRIPTION
- xmlenc1: parseEncryptionMethod now rejects an empty Algorithm and duplicate DigestMethod/MGF/OAEPparams children with ErrMalformedEncrypted
- fail-closed parse tightening, user-approved; only malformed input newly rejected, no well-formed document changes behavior