### PR TITLE
cap EncryptedKey trial-decrypts in xmlenc1 Decryptor

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -331,8 +331,9 @@ XML Encryption 1.1 (W3C xmlenc-core1). Encrypt and decrypt XML elements/content.
   - `BlockAlgorithm(uri)`, `AllowLegacyCBC(bool)`, `KeyTransportAlgorithm(uri)`, `RecipientPublicKey(key)`, `SessionKey(key)`, `KeyWrapAlgorithm(uri)`, `KeyEncryptionKey(kek)`, `OAEPDigest(uri)`, `OAEPMGF(uri)`, `OAEPParams(params)` — builder methods
   - `EncryptElement(ctx, elem)`, `EncryptContent(ctx, elem)` — terminal methods
 - **NewDecryptor() → Decryptor** — create fluent builder for decryption
-  - `PrivateKey(key)`, `KeyEncryptionKey(kek)`, `SessionKey(key)`, `AllowUnauthenticatedCBC(bool)` — builder methods
+  - `PrivateKey(key)`, `KeyEncryptionKey(kek)`, `SessionKey(key)`, `AllowUnauthenticatedCBC(bool)`, `MaxEncryptedKeys(n)` — builder methods
   - `Decrypt(ctx, elem)` — terminal method
+- `Decryptor.MaxEncryptedKeys(n)` caps trial-decrypted `<EncryptedKey>` candidates (DoS guard): zero → `DefaultMaxEncryptedKeys` (100), negative → unlimited; over-cap fails with `ErrTooManyEncryptedKeys` before any RSA op. The candidate loop also polls `ctx.Err()` between candidates
 - Block encryption: AES-128/256-CBC, AES-128/256-GCM
 - Secure by default: unset `BlockAlgorithm` → `DefaultBlockAlgorithm` (AES-256-GCM). Selecting a CBC block algorithm for **encryption** requires `Encryptor.AllowLegacyCBC(true)`, else `ErrCBCEncryptionRequiresOptIn`. **Decryption** of CBC requires `Decryptor.AllowUnauthenticatedCBC(true)`, else `ErrCBCRequiresOptIn`
 - Key transport: RSA-OAEP (1.0 + 1.1 with configurable digest/MGF)

--- a/xmlenc1/errors.go
+++ b/xmlenc1/errors.go
@@ -15,6 +15,13 @@ var (
 	// ErrMissingKey is returned when no decryption key is available.
 	ErrMissingKey = errors.New("xmlenc1: no decryption key available")
 
+	// ErrTooManyEncryptedKeys is returned when an EncryptedData carries more
+	// EncryptedKey candidates than the Decryptor's effective limit (see
+	// Decryptor.MaxEncryptedKeys and DefaultMaxEncryptedKeys). Each candidate
+	// would force a full RSA trial-decrypt, so an unbounded count is a CPU
+	// amplification (DoS) vector; the cap is enforced before any crypto runs.
+	ErrTooManyEncryptedKeys = errors.New("xmlenc1: too many EncryptedKey candidates")
+
 	// ErrInvalidPadding is returned when PKCS#7 padding is invalid.
 	ErrInvalidPadding = errors.New("xmlenc1: invalid PKCS#7 padding")
 

--- a/xmlenc1/maxkeys_test.go
+++ b/xmlenc1/maxkeys_test.go
@@ -1,0 +1,96 @@
+package xmlenc1_test
+
+import (
+	"context"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xmlenc1"
+	"github.com/stretchr/testify/require"
+)
+
+// manyKeyEncryptedData builds an EncryptedData element carrying n junk RSA
+// EncryptedKey candidates, used to exercise the trial-decrypt cap.
+func manyKeyEncryptedData(t *testing.T, n int) *helium.Element {
+	t.Helper()
+	doc := mustParseXML(t, `<root/>`)
+	keys := make([]*xmlenc1.EncryptedKey, 0, n)
+	for range n {
+		keys = append(keys, &xmlenc1.EncryptedKey{
+			EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.RSAOAEP},
+			CipherValue:      make([]byte, 256),
+		})
+	}
+	ed := &xmlenc1.EncryptedData{
+		Type:             xmlenc1.TypeElement,
+		EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256GCM},
+		EncryptedKeys:    keys,
+		CipherValue:      make([]byte, 48),
+	}
+	elem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+	require.NoError(t, err)
+	return elem
+}
+
+func TestMaxEncryptedKeys(t *testing.T) {
+	t.Run("over default cap fails fast", func(t *testing.T) {
+		elem := manyKeyEncryptedData(t, xmlenc1.DefaultMaxEncryptedKeys+1)
+		_, err := xmlenc1.NewDecryptor().PrivateKey(generateRSAKey(t)).Decrypt(t.Context(), elem)
+		require.ErrorIs(t, err, xmlenc1.ErrTooManyEncryptedKeys)
+	})
+
+	t.Run("at default cap is not rejected by the cap", func(t *testing.T) {
+		elem := manyKeyEncryptedData(t, xmlenc1.DefaultMaxEncryptedKeys)
+		_, err := xmlenc1.NewDecryptor().PrivateKey(generateRSAKey(t)).Decrypt(t.Context(), elem)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, xmlenc1.ErrTooManyEncryptedKeys)
+	})
+
+	t.Run("explicit cap rejects above it", func(t *testing.T) {
+		elem := manyKeyEncryptedData(t, 3)
+		_, err := xmlenc1.NewDecryptor().PrivateKey(generateRSAKey(t)).MaxEncryptedKeys(2).Decrypt(t.Context(), elem)
+		require.ErrorIs(t, err, xmlenc1.ErrTooManyEncryptedKeys)
+	})
+
+	t.Run("negative cap removes the limit", func(t *testing.T) {
+		elem := manyKeyEncryptedData(t, xmlenc1.DefaultMaxEncryptedKeys+5)
+		_, err := xmlenc1.NewDecryptor().PrivateKey(generateRSAKey(t)).MaxEncryptedKeys(-1).Decrypt(t.Context(), elem)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, xmlenc1.ErrTooManyEncryptedKeys)
+	})
+
+	t.Run("normal document still decrypts", func(t *testing.T) {
+		key := generateRSAKey(t)
+		doc := mustParseXML(t, samlAssertion)
+		encryptor := xmlenc1.NewEncryptor().
+			BlockAlgorithm(xmlenc1.AES256GCM).
+			KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+			OAEPDigest(xmlenc1.DigestSHA256).
+			OAEPMGF(xmlenc1.MGFSHA256).
+			RecipientPublicKey(&key.PublicKey)
+		edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+		require.NoError(t, err)
+
+		nodes, err := xmlenc1.NewDecryptor().PrivateKey(key).Decrypt(t.Context(), edElem)
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+	})
+
+	t.Run("cancelled context aborts the candidate loop", func(t *testing.T) {
+		key := generateRSAKey(t)
+		doc := mustParseXML(t, samlAssertion)
+		encryptor := xmlenc1.NewEncryptor().
+			BlockAlgorithm(xmlenc1.AES256GCM).
+			KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+			OAEPDigest(xmlenc1.DigestSHA256).
+			OAEPMGF(xmlenc1.MGFSHA256).
+			RecipientPublicKey(&key.PublicKey)
+		edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err = xmlenc1.NewDecryptor().PrivateKey(key).Decrypt(ctx, edElem)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -303,12 +303,21 @@ func removeChildren(elem *helium.Element) {
 	}
 }
 
+// DefaultMaxEncryptedKeys bounds how many <EncryptedKey> candidates a
+// Decryptor will trial-decrypt for a single EncryptedData when
+// MaxEncryptedKeys is not set. Each candidate forces a full RSA
+// private-key operation, so an unbounded count is a CPU amplification
+// (DoS) vector. The default mirrors jwx's WithMaxRecipients (100), which
+// is generous for real multi-recipient documents yet caps amplification.
+const DefaultMaxEncryptedKeys = 100
+
 // decryptConfig holds the configuration for a Decryptor.
 type decryptConfig struct {
 	privateKey              *rsa.PrivateKey
 	keyEncryptionKey        []byte
 	sessionKey              []byte
 	allowUnauthenticatedCBC bool
+	maxEncryptedKeys        int
 }
 
 // Decryptor decrypts XML EncryptedData elements. It uses clone-on-write
@@ -368,6 +377,21 @@ func (d Decryptor) AllowUnauthenticatedCBC(v bool) Decryptor {
 	return d
 }
 
+// MaxEncryptedKeys caps the number of <EncryptedKey> candidates the
+// Decryptor will trial-decrypt for a single EncryptedData. Each candidate
+// forces a full RSA private-key operation, so a document packed with junk
+// EncryptedKey elements is a CPU amplification (DoS) vector; the cap is
+// enforced before any crypto runs.
+//
+// Zero (the default) uses [DefaultMaxEncryptedKeys]; a negative value
+// removes the limit (matching helium's MaxDepth convention). A document
+// exceeding the effective cap fails with [ErrTooManyEncryptedKeys].
+func (d Decryptor) MaxEncryptedKeys(n int) Decryptor {
+	d = d.clone()
+	d.cfg.maxEncryptedKeys = n
+	return d
+}
+
 // Decrypt decrypts an EncryptedData element and returns the decrypted nodes.
 func (d Decryptor) Decrypt(ctx context.Context, elem *helium.Element) ([]helium.Node, error) {
 	return decryptElement(ctx, d.cfg, elem)
@@ -417,6 +441,19 @@ func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Elemen
 		return nil, ErrMissingKey
 	}
 
+	// Bound the trial-decrypt work before any RSA operation runs. Each
+	// candidate forces a full RSA private-key op, so an attacker who can
+	// pack a document with junk <EncryptedKey> elements gets CPU
+	// amplification. Fail closed when the count exceeds the effective cap
+	// (zero => default, negative => unlimited).
+	maxKeys := cfg.maxEncryptedKeys
+	if maxKeys == 0 {
+		maxKeys = DefaultMaxEncryptedKeys
+	}
+	if maxKeys >= 0 && len(keys) > maxKeys {
+		return nil, ErrTooManyEncryptedKeys
+	}
+
 	// A document may carry several EncryptedKey candidates (one per
 	// recipient), and an attacker can prepend a junk EncryptedKey that
 	// unwraps cleanly under the recipient's key while wrapping the WRONG
@@ -427,6 +464,12 @@ func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Elemen
 	// stops a bogus-but-valid EncryptedKey from masking the real one.
 	var lastErr error
 	for _, ek := range keys {
+		// Poll the caller's deadline between candidates so a cancellation
+		// interrupts the per-candidate RSA work rather than running to
+		// completion over every EncryptedKey.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		sessionKey, err := resolveSessionKeyFromEncryptedKey(cfg, ek)
 		if err != nil {
 			lastErr = preferInformativeErr(lastErr, err)


### PR DESCRIPTION
- bound per-EncryptedData RSA trial-decrypts and poll ctx between candidates to stop EncryptedKey-flood CPU amplification
- public API addition (MaxEncryptedKeys/DefaultMaxEncryptedKeys/ErrTooManyEncryptedKeys) — user-approved
- zero => DefaultMaxEncryptedKeys (100), negative => unlimited; over-cap fails fast with ErrTooManyEncryptedKeys