### PR TITLE
allow distinct rsa-oaep digest and mgf1 hashes

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -335,7 +335,7 @@ XML Encryption 1.1 (W3C xmlenc-core1). Encrypt and decrypt XML elements/content.
   - `Decrypt(ctx, elem)` — terminal method
 - Block encryption: AES-128/256-CBC, AES-128/256-GCM
 - Secure by default: unset `BlockAlgorithm` → `DefaultBlockAlgorithm` (AES-256-GCM). Selecting a CBC block algorithm for **encryption** requires `Encryptor.AllowLegacyCBC(true)`, else `ErrCBCEncryptionRequiresOptIn`. **Decryption** of CBC requires `Decryptor.AllowUnauthenticatedCBC(true)`, else `ErrCBCRequiresOptIn`
-- Key transport: RSA-OAEP (1.0 + 1.1 with configurable digest/MGF)
+- Key transport: RSA-OAEP (1.0 + 1.1 with configurable digest/MGF; the OAEP label digest and the MGF1 hash may differ, via `rsa.EncryptOAEPWithOptions`/`OAEPOptions` — requires Go ≥ 1.26)
 - Key wrapping: AES-128/256-KeyWrap (RFC 3394)
 - Key sizes are bound to the declared algorithm URI on encrypt and decrypt (incl. after unwrap/key transport); mismatch → `KeySizeError`
 - Multi-recipient: `EncryptedData.EncryptedKeys []*EncryptedKey` holds one EncryptedKey per recipient; decrypt tries each candidate through full block decryption + plaintext validation (a bogus prepended key cannot mask the real one). `EncryptedData.EncryptedKey` is the **deprecated** single-key field — `EncryptedKeys` wins when non-empty, else the single field is treated as a one-element list; parse populates both

--- a/xmlenc1/keytransport.go
+++ b/xmlenc1/keytransport.go
@@ -1,23 +1,28 @@
 package xmlenc1
 
 import (
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1"
-	"crypto/sha256"
 	"fmt"
-	"hash"
+
+	_ "crypto/sha1"   // register SHA-1 for crypto.Hash.New (OAEP digest/MGF)
+	_ "crypto/sha256" // register SHA-256 for crypto.Hash.New (OAEP digest/MGF)
 )
 
 func encryptSessionKey(algorithm string, pub *rsa.PublicKey, sessionKey []byte, oaepDigest, oaepMGF string, oaepParams []byte) ([]byte, error) {
-	h, err := oaepHashFunc(algorithm, oaepDigest, oaepMGF)
+	digestHash, mgfHash, err := oaepHashes(algorithm, oaepDigest, oaepMGF)
 	if err != nil {
-		// oaepHashFunc returns an unwrapped parameter error; classify it
+		// oaepHashes returns an unwrapped parameter error; classify it
 		// for the encrypt path so callers see ErrEncryptionFailed while
 		// preserving the typed error in the chain for errors.As.
 		return nil, fmt.Errorf("%w: %w", ErrEncryptionFailed, err)
 	}
-	ciphertext, err := rsa.EncryptOAEP(h(), rand.Reader, pub, sessionKey, oaepParams)
+	ciphertext, err := rsa.EncryptOAEPWithOptions(rand.Reader, pub, sessionKey, &rsa.OAEPOptions{
+		Hash:    digestHash,
+		MGFHash: mgfHash,
+		Label:   oaepParams,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrEncryptionFailed, err)
 	}
@@ -25,121 +30,91 @@ func encryptSessionKey(algorithm string, pub *rsa.PublicKey, sessionKey []byte, 
 }
 
 func decryptSessionKey(algorithm string, priv *rsa.PrivateKey, ciphertext []byte, oaepDigest, oaepMGF string, oaepParams []byte) ([]byte, error) {
-	h, err := oaepHashFunc(algorithm, oaepDigest, oaepMGF)
+	digestHash, mgfHash, err := oaepHashes(algorithm, oaepDigest, oaepMGF)
 	if err != nil {
-		// oaepHashFunc returns an unwrapped parameter error; classify it
+		// oaepHashes returns an unwrapped parameter error; classify it
 		// for the decrypt path so callers see ErrDecryptionFailed while
 		// preserving the typed error in the chain for errors.As.
 		return nil, fmt.Errorf("%w: %w", ErrDecryptionFailed, err)
 	}
-	plaintext, err := rsa.DecryptOAEP(h(), rand.Reader, priv, ciphertext, oaepParams)
+	plaintext, err := priv.Decrypt(rand.Reader, ciphertext, &rsa.OAEPOptions{
+		Hash:    digestHash,
+		MGFHash: mgfHash,
+		Label:   oaepParams,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrDecryptionFailed, err)
 	}
 	return plaintext, nil
 }
 
-// oaepHashFunc resolves the hash used for both the OAEP digest and the
-// MGF1 mask generation function from the declared digest and MGF URIs.
+// oaepHashes resolves the OAEP label digest and the MGF1 mask-generation
+// hash from the declared digest and MGF URIs.
 //
-// Go's crypto/rsa OAEP API (rsa.EncryptOAEP / rsa.DecryptOAEP) uses a
-// SINGLE hash for both the label digest and the MGF1 mask generation.
-// XML Encryption, by contrast, lets the DigestMethod and MGF advertise
-// different hashes. To avoid serializing metadata that lies about the
-// crypto actually performed, this function rejects any combination Go
-// cannot faithfully represent (digest hash != MGF hash). It NEVER
-// silently falls back to SHA-1: an unknown or empty digest/MGF URI is a
-// hard error.
+// crypto/rsa's option-bearing OAEP API (rsa.EncryptOAEPWithOptions and
+// rsa.PrivateKey.Decrypt with *rsa.OAEPOptions) can represent a distinct
+// label digest and MGF1 hash, which mirrors XML Encryption's separate
+// DigestMethod and MGF elements. The two hashes need NOT agree, so this
+// function returns them independently.
+//
+// It NEVER silently falls back to SHA-1 for an unrecognized URI: an unknown
+// (non-empty) digest/MGF URI is a hard error. Empty URIs resolve to the
+// XML-Encryption default for the algorithm.
 //
 // All errors returned here are UNWRAPPED parameter-validation errors
-// (e.g. *UnsupportedAlgorithmError). Callers on the encrypt path wrap
-// them with ErrEncryptionFailed and callers on the decrypt path wrap
-// them with ErrDecryptionFailed, so errors.Is reflects which path the
-// failure occurred on.
-func oaepHashFunc(algorithm, digest, mgf string) (func() hash.Hash, error) {
-	// Whitelist the key-transport algorithm itself. Only the two
-	// supported RSA-OAEP variants may proceed; any other (or empty) URI
-	// is rejected here rather than silently performing RSA-OAEP and
-	// serializing a metadata @Algorithm that lies about (or cannot
-	// describe) the crypto actually performed.
+// (e.g. *UnsupportedAlgorithmError). Callers on the encrypt path wrap them
+// with ErrEncryptionFailed and callers on the decrypt path wrap them with
+// ErrDecryptionFailed, so errors.Is reflects which path failed.
+func oaepHashes(algorithm, digest, mgf string) (crypto.Hash, crypto.Hash, error) {
+	// Whitelist the key-transport algorithm itself. Only the two supported
+	// RSA-OAEP variants may proceed; any other (or empty) URI is rejected
+	// here rather than silently performing RSA-OAEP and serializing a
+	// metadata @Algorithm that lies about the crypto actually performed.
 	switch algorithm {
 	case RSAOAEP, RSAOAEP11:
 	default:
-		return nil, &UnsupportedAlgorithmError{Algorithm: algorithm}
+		return 0, 0, &UnsupportedAlgorithmError{Algorithm: algorithm}
 	}
 
-	// Resolve the digest hash. An empty digest defaults to SHA-1, which
+	// Resolve the label digest. An empty digest defaults to SHA-1, which
 	// matches the XML Encryption default for RSA-OAEP. An unrecognized
 	// (non-empty) digest URI is rejected rather than downgraded.
-	var digestHash func() hash.Hash
+	var digestHash crypto.Hash
 	switch digest {
 	case "", DigestSHA1:
-		digestHash = sha1.New
+		digestHash = crypto.SHA1
 	case DigestSHA256:
-		digestHash = sha256.New
+		digestHash = crypto.SHA256
 	default:
-		return nil, &UnsupportedAlgorithmError{Algorithm: digest}
+		return 0, 0, &UnsupportedAlgorithmError{Algorithm: digest}
 	}
 
-	// Resolve the MGF hash. The legacy RSAOAEP (rsa-oaep-mgf1p) URI fixes
+	// Resolve the MGF1 hash. The legacy RSAOAEP (rsa-oaep-mgf1p) URI fixes
 	// MGF1 to SHA-1; an explicit MGF URI is not permitted for it. The
-	// RSAOAEP11 URI carries an explicit MGF, defaulting to MGF1-SHA1.
-	var mgfHash func() hash.Hash
+	// RSAOAEP11 URI carries an explicit MGF; when absent it defaults to the
+	// label digest (crypto/rsa's MGFHash==Hash semantics).
+	var mgfHash crypto.Hash
 	switch algorithm {
 	case RSAOAEP:
 		// XML-Enc 1.1: an xenc11:MGF element MUST NOT be provided for
 		// rsa-oaep-mgf1p; its MGF1-SHA-1 is implicit. Reject any MGF.
 		if mgf != "" {
-			return nil, &UnsupportedAlgorithmError{Algorithm: mgf}
+			return 0, 0, &UnsupportedAlgorithmError{Algorithm: mgf}
 		}
-		mgfHash = sha1.New
+		mgfHash = crypto.SHA1
 	default: // RSAOAEP11, which carries an explicit MGF.
 		switch mgf {
-		case "", MGFSHA1:
-			mgfHash = sha1.New
+		case "":
+			// Default the MGF1 hash to the label digest.
+			mgfHash = digestHash
+		case MGFSHA1:
+			mgfHash = crypto.SHA1
 		case MGFSHA256:
-			mgfHash = sha256.New
+			mgfHash = crypto.SHA256
 		default:
-			return nil, &UnsupportedAlgorithmError{Algorithm: mgf}
+			return 0, 0, &UnsupportedAlgorithmError{Algorithm: mgf}
 		}
 	}
 
-	// Go uses one hash for both digest and MGF1. If the declared hashes
-	// differ, the metadata cannot honestly describe what would be done,
-	// so reject rather than silently using one for both. This is an
-	// unwrapped parameter error; the caller classifies it per path.
-	if hashName(digestHash) != hashName(mgfHash) {
-		return nil, fmt.Errorf("RSA-OAEP digest hash and MGF1 hash must match (crypto/rsa uses a single hash for both); got digest %q and MGF %q",
-			oaepDigestName(digest), oaepMGFName(algorithm, mgf))
-	}
-
-	return digestHash, nil
-}
-
-// hashName returns a stable identifier for a hash constructor so two
-// constructors can be compared for equality.
-func hashName(h func() hash.Hash) string {
-	switch h().Size() {
-	case sha256.Size:
-		return "sha256"
-	default:
-		return "sha1"
-	}
-}
-
-func oaepDigestName(digest string) string {
-	if digest == "" {
-		return DigestSHA1 + " (default)"
-	}
-	return digest
-}
-
-func oaepMGFName(algorithm, mgf string) string {
-	if mgf != "" {
-		return mgf
-	}
-	if algorithm == RSAOAEP {
-		return MGFSHA1 + " (implied by rsa-oaep-mgf1p)"
-	}
-	return MGFSHA1 + " (default)"
+	return digestHash, mgfHash, nil
 }

--- a/xmlenc1/keytransport.go
+++ b/xmlenc1/keytransport.go
@@ -91,8 +91,9 @@ func oaepHashes(algorithm, digest, mgf string) (crypto.Hash, crypto.Hash, error)
 
 	// Resolve the MGF1 hash. The legacy RSAOAEP (rsa-oaep-mgf1p) URI fixes
 	// MGF1 to SHA-1; an explicit MGF URI is not permitted for it. The
-	// RSAOAEP11 URI carries an explicit MGF; when absent it defaults to the
-	// label digest (crypto/rsa's MGFHash==Hash semantics).
+	// RSAOAEP11 URI carries an explicit MGF; when absent it defaults to
+	// MGF1 with SHA-1 per W3C xmlenc-core1 §5.5.2, INDEPENDENT of the
+	// DigestMethod (a distinct DigestMethod is still honored via OAEPOptions).
 	var mgfHash crypto.Hash
 	switch algorithm {
 	case RSAOAEP:
@@ -105,8 +106,11 @@ func oaepHashes(algorithm, digest, mgf string) (crypto.Hash, crypto.Hash, error)
 	default: // RSAOAEP11, which carries an explicit MGF.
 		switch mgf {
 		case "":
-			// Default the MGF1 hash to the label digest.
-			mgfHash = digestHash
+			// W3C xmlenc-core1 §5.5.2: an absent MGF defaults to MGF1
+			// with SHA-1, independent of the DigestMethod. Conforming
+			// implementations assume SHA-1 MGF when no MGF is present,
+			// so defaulting to digestHash here would break interop.
+			mgfHash = crypto.SHA1
 		case MGFSHA1:
 			mgfHash = crypto.SHA1
 		case MGFSHA256:

--- a/xmlenc1/keytransport_test.go
+++ b/xmlenc1/keytransport_test.go
@@ -109,6 +109,51 @@ func TestRSAOAEP(t *testing.T) {
 		require.Len(t, nodes, 1)
 	})
 
+	t.Run("oaep11 absent MGF defaults to SHA-1 not digest", func(t *testing.T) {
+		// W3C xmlenc-core1 §5.5.2: an absent xenc11:MGF defaults to MGF1
+		// with SHA-1, INDEPENDENT of DigestMethod. A no-MGF ciphertext must
+		// therefore interoperate with explicit MGFSHA1 semantics even when
+		// the label digest is SHA-256 (it must NOT use a SHA-256 MGF).
+		key := generateRSAKey(t)
+		doc := mustParseXML(t, samlAssertion)
+
+		encryptor := xmlenc1.NewEncryptor().
+			BlockAlgorithm(xmlenc1.AES256GCM).
+			KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+			OAEPDigest(xmlenc1.DigestSHA256).
+			RecipientPublicKey(&key.PublicKey)
+
+		_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+		require.NoError(t, err)
+
+		// No MGF element must be serialized when none was requested.
+		xml, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.Contains(t, xml, xmlenc1.DigestSHA256)
+		require.NotContains(t, xml, "MGF")
+
+		// Inject an explicit MGF1-SHA-1 element into the EncryptionMethod.
+		// Because the absent-MGF default is SHA-1, decryption under explicit
+		// MGFSHA1 must succeed. Had the default been the SHA-256 digest, the
+		// MGF1 hashes would mismatch and decryption would fail.
+		mgfElem := `<xenc11:MGF xmlns:xenc11="` + xmlenc1.NamespaceXMLEnc11 + `" Algorithm="` + xmlenc1.MGFSHA1 + `"/>`
+		tampered := strings.Replace(xml, "</xenc:EncryptionMethod>", mgfElem+"</xenc:EncryptionMethod>", 1)
+		require.NotEqual(t, xml, tampered)
+
+		tdoc := mustParseXML(t, tampered)
+		edNode := findEncryptedData(t, tdoc.DocumentElement())
+		require.NotNil(t, edNode)
+
+		decryptor := xmlenc1.NewDecryptor().PrivateKey(key)
+		nodes, err := decryptor.Decrypt(t.Context(), edNode)
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+
+		s, err := helium.WriteString(nodes[0])
+		require.NoError(t, err)
+		require.Contains(t, s, "user@example.com")
+	})
+
 	t.Run("decrypt unsupported digest errors", func(t *testing.T) {
 		key := generateRSAKey(t)
 		doc := mustParseXML(t, samlAssertion)

--- a/xmlenc1/keytransport_test.go
+++ b/xmlenc1/keytransport_test.go
@@ -55,7 +55,11 @@ func TestRSAOAEP(t *testing.T) {
 		require.ErrorAs(t, err, &unsupp)
 	})
 
-	t.Run("oaep11 mismatched MGF errors", func(t *testing.T) {
+	t.Run("oaep11 distinct digest and MGF hash round-trip", func(t *testing.T) {
+		// XML Encryption 1.1 permits an RSA-OAEP DigestMethod that differs
+		// from the MGF1 hash. crypto/rsa's option-bearing OAEP API can
+		// represent the two distinctly, so this must round-trip rather than
+		// be rejected.
 		key := generateRSAKey(t)
 		doc := mustParseXML(t, samlAssertion)
 
@@ -66,12 +70,27 @@ func TestRSAOAEP(t *testing.T) {
 			OAEPMGF(xmlenc1.MGFSHA1).
 			RecipientPublicKey(&key.PublicKey)
 
-		_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
-		require.Error(t, err)
-		require.ErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
+		edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+		require.NoError(t, err)
+
+		xml, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.Contains(t, xml, xmlenc1.DigestSHA256)
+		require.Contains(t, xml, xmlenc1.MGFSHA1)
+
+		decryptor := xmlenc1.NewDecryptor().PrivateKey(key)
+		nodes, err := decryptor.Decrypt(t.Context(), edElem)
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+
+		s, err := helium.WriteString(nodes[0])
+		require.NoError(t, err)
+		require.Contains(t, s, "user@example.com")
 	})
 
-	t.Run("mgf1p with sha256 digest errors", func(t *testing.T) {
+	t.Run("mgf1p with sha256 digest round-trip", func(t *testing.T) {
+		// rsa-oaep-mgf1p fixes MGF1 to SHA-1 but the label digest may still
+		// be SHA-256; that distinct-hash combination must now round-trip.
 		key := generateRSAKey(t)
 		doc := mustParseXML(t, samlAssertion)
 
@@ -81,9 +100,13 @@ func TestRSAOAEP(t *testing.T) {
 			OAEPDigest(xmlenc1.DigestSHA256).
 			RecipientPublicKey(&key.PublicKey)
 
-		_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
-		require.Error(t, err)
-		require.ErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
+		edElem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+		require.NoError(t, err)
+
+		decryptor := xmlenc1.NewDecryptor().PrivateKey(key)
+		nodes, err := decryptor.Decrypt(t.Context(), edElem)
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
 	})
 
 	t.Run("decrypt unsupported digest errors", func(t *testing.T) {
@@ -329,59 +352,6 @@ func TestResolveSessionKey(t *testing.T) {
 		require.ErrorIs(t, err, xmlenc1.ErrDecryptionFailed)
 		var unsupported *xmlenc1.UnsupportedAlgorithmError
 		require.ErrorAs(t, err, &unsupported)
-	})
-}
-
-// TestOAEPNameHelperBranches drives the digest/MGF-name formatting helpers
-// (oaepDigestName / oaepMGFName) through their non-default and default
-// branches. They are only reached when oaepHashFunc rejects a digest/MGF
-// hash mismatch, so each case sets up an RSA-OAEP 1.1 configuration whose
-// declared digest and MGF hashes disagree and asserts the encrypt path
-// surfaces ErrEncryptionFailed.
-func TestOAEPNameHelperBranches(t *testing.T) {
-	key := generateRSAKey(t)
-
-	t.Run("default digest vs explicit SHA256 MGF", func(t *testing.T) {
-		// digest unset -> SHA1 (default); MGF SHA256 -> mismatch.
-		// Exercises oaepDigestName("") default branch and the
-		// oaepMGFName non-empty branch.
-		doc := mustParseXML(t, samlAssertion)
-		encryptor := xmlenc1.NewEncryptor().
-			BlockAlgorithm(xmlenc1.AES256GCM).
-			KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
-			OAEPMGF(xmlenc1.MGFSHA256).
-			RecipientPublicKey(&key.PublicKey)
-
-		_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
-		require.ErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
-	})
-
-	t.Run("explicit SHA256 digest vs default MGF", func(t *testing.T) {
-		// digest SHA256; MGF unset -> SHA1 (default) -> mismatch.
-		// Exercises the oaepMGFName default branch for RSAOAEP11.
-		doc := mustParseXML(t, samlAssertion)
-		encryptor := xmlenc1.NewEncryptor().
-			BlockAlgorithm(xmlenc1.AES256GCM).
-			KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
-			OAEPDigest(xmlenc1.DigestSHA256).
-			RecipientPublicKey(&key.PublicKey)
-
-		_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
-		require.ErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
-	})
-
-	t.Run("legacy mgf1p with SHA256 digest", func(t *testing.T) {
-		// rsa-oaep-mgf1p fixes MGF to SHA1; a SHA256 digest mismatches.
-		// Exercises oaepMGFName's "implied by rsa-oaep-mgf1p" branch.
-		doc := mustParseXML(t, samlAssertion)
-		encryptor := xmlenc1.NewEncryptor().
-			BlockAlgorithm(xmlenc1.AES256GCM).
-			KeyTransportAlgorithm(xmlenc1.RSAOAEP).
-			OAEPDigest(xmlenc1.DigestSHA256).
-			RecipientPublicKey(&key.PublicKey)
-
-		_, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
-		require.ErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
 	})
 }
 

--- a/xmlenc1/keytransport_test.go
+++ b/xmlenc1/keytransport_test.go
@@ -127,10 +127,13 @@ func TestRSAOAEP(t *testing.T) {
 		require.NoError(t, err)
 
 		// No MGF element must be serialized when none was requested.
+		// Match the element start-tag markup (":MGF"), not the bare
+		// substring "MGF": the latter can appear by chance inside the
+		// randomized base64 CipherValue, but a colon never can.
 		xml, err := helium.WriteString(doc)
 		require.NoError(t, err)
 		require.Contains(t, xml, xmlenc1.DigestSHA256)
-		require.NotContains(t, xml, "MGF")
+		require.NotContains(t, xml, ":MGF")
 
 		// Inject an explicit MGF1-SHA-1 element into the EncryptionMethod.
 		// Because the absent-MGF default is SHA-1, decryption under explicit
@@ -203,9 +206,11 @@ func TestRSAOAEP(t *testing.T) {
 			require.ErrorIs(t, err, xmlenc1.ErrEncryptionFailed)
 
 			// No partial EncryptedData/MGF element should have been serialized.
+			// Match the element start-tag markup (":MGF") rather than the bare
+			// "MGF" substring, which a random base64 CipherValue could contain.
 			xml, werr := helium.WriteString(doc)
 			require.NoError(t, werr)
-			require.NotContains(t, xml, "MGF")
+			require.NotContains(t, xml, ":MGF")
 		}
 	})
 


### PR DESCRIPTION
- Drop the equal-hash rejection in RSA-OAEP key transport; resolve the OAEP label digest and MGF1 hash independently and run via `rsa.EncryptOAEPWithOptions` / `priv.Decrypt` with `OAEPOptions` (Go 1.26).
- Internal-only relaxation (no public API change), user-approved: spec-valid XML-Enc EncryptedKeys with distinct DigestMethod vs MGF now round-trip; equal-hash case unchanged.