### PR TITLE
reject incomplete RSAKeyValue/ECKeyValue key material

### DIFF
--- a/xmldsig1/keyinfo.go
+++ b/xmldsig1/keyinfo.go
@@ -300,6 +300,13 @@ func parseRSAKeyValue(elem *helium.Element, data *KeyInfoData) error {
 			kv.Exponent = int(exp.Int64())
 		}
 	}
+	// An RSAKeyValue requires BOTH Modulus and Exponent (XML-Signature core).
+	// Refuse to emit a partial key (e.g. Exponent-only, or a Modulus whose
+	// element was skipped as a foreign-namespace look-alike): such material must
+	// never reach the KeySource.
+	if kv.Modulus == nil || kv.Exponent == 0 {
+		return fmt.Errorf("%w: RSAKeyValue requires both Modulus and Exponent", ErrInvalidKeyInfo)
+	}
 	data.RSAKeyValue = kv
 	return nil
 }
@@ -340,6 +347,12 @@ func parseECKeyValue(elem *helium.Element, data *KeyInfoData) error {
 				return fmt.Errorf("%w: invalid EC public key point", ErrInvalidKeyInfo)
 			}
 		}
+	}
+	// An ECKeyValue requires both the NamedCurve and the PublicKey point
+	// (XML-Signature 1.1). Refuse to emit a partial key (e.g. NamedCurve-only):
+	// such material must never reach the KeySource.
+	if kv.Curve == nil || kv.X == nil || kv.Y == nil {
+		return fmt.Errorf("%w: ECKeyValue requires both NamedCurve and PublicKey", ErrInvalidKeyInfo)
 	}
 	data.ECKeyValue = kv
 	return nil

--- a/xmldsig1/keyinfo_internal_test.go
+++ b/xmldsig1/keyinfo_internal_test.go
@@ -91,6 +91,17 @@ func TestParseECKeyValueErrors(t *testing.T) {
 		require.Contains(t, err.Error(), "missing NamedCurve")
 	})
 
+	// only NamedCurve (no PublicKey point) must be rejected as an incomplete
+	// ECKeyValue rather than yielding a partial key with a nil point.
+	t.Run("named curve without public key", func(t *testing.T) {
+		elem := ecElem(t, `<dsig11:NamedCurve xmlns:dsig11="`+NamespaceDSig11+`" URI="urn:oid:1.2.840.10045.3.1.7"/>`)
+		var data KeyInfoData
+		err := parseECKeyValue(elem, &data)
+		require.ErrorIs(t, err, ErrInvalidKeyInfo)
+		require.Nil(t, data.ECKeyValue,
+			"an ECKeyValue without a PublicKey point must not produce a partial key")
+	})
+
 	// invalid point covers the invalid-point branch: a valid curve but a
 	// PublicKey blob that does not unmarshal to a point.
 	t.Run("invalid point", func(t *testing.T) {
@@ -133,6 +144,27 @@ func TestParseRSAKeyValue(t *testing.T) {
 		var data KeyInfoData
 		err := parseRSAKeyValue(d.DocumentElement(), &data)
 		require.ErrorIs(t, err, ErrInvalidKeyInfo)
+	})
+
+	// only Exponent (no Modulus) must be rejected as an incomplete RSAKeyValue
+	// rather than yielding a partial key with a nil modulus.
+	t.Run("exponent without modulus", func(t *testing.T) {
+		d := mustParse(t, `<ds:RSAKeyValue xmlns:ds="`+NamespaceDSig+`"><ds:Exponent xmlns:ds="`+NamespaceDSig+`">AQAB</ds:Exponent></ds:RSAKeyValue>`)
+		var data KeyInfoData
+		err := parseRSAKeyValue(d.DocumentElement(), &data)
+		require.ErrorIs(t, err, ErrInvalidKeyInfo)
+		require.Nil(t, data.RSAKeyValue,
+			"an RSAKeyValue without a Modulus must not produce a partial key")
+	})
+
+	// only Modulus (no Exponent) must likewise be rejected.
+	t.Run("modulus without exponent", func(t *testing.T) {
+		d := mustParse(t, `<ds:RSAKeyValue xmlns:ds="`+NamespaceDSig+`"><ds:Modulus xmlns:ds="`+NamespaceDSig+`">AQAB</ds:Modulus></ds:RSAKeyValue>`)
+		var data KeyInfoData
+		err := parseRSAKeyValue(d.DocumentElement(), &data)
+		require.ErrorIs(t, err, ErrInvalidKeyInfo)
+		require.Nil(t, data.RSAKeyValue,
+			"an RSAKeyValue without an Exponent must not produce a partial key")
 	})
 }
 
@@ -185,13 +217,14 @@ func TestParseForeignChild(t *testing.T) {
 	})
 
 	// rsa key value child covers parseRSAKeyValue's foreign-namespace child
-	// continue branch.
+	// continue branch: the foreign Modulus is skipped, leaving an incomplete
+	// RSAKeyValue that must be rejected rather than emitted as a partial key.
 	t.Run("rsa key value child", func(t *testing.T) {
 		doc := mustParse(t, `<ds:RSAKeyValue xmlns:ds="`+NamespaceDSig+`"><evil:Modulus xmlns:evil="urn:evil">AQAB</evil:Modulus></ds:RSAKeyValue>`)
 		var data KeyInfoData
-		require.NoError(t, parseRSAKeyValue(doc.DocumentElement(), &data))
-		require.NotNil(t, data.RSAKeyValue)
-		require.Nil(t, data.RSAKeyValue.Modulus) // foreign Modulus was skipped
+		err := parseRSAKeyValue(doc.DocumentElement(), &data)
+		require.ErrorIs(t, err, ErrInvalidKeyInfo)
+		require.Nil(t, data.RSAKeyValue) // foreign Modulus was skipped -> incomplete
 	})
 
 	// key info child covers parseKeyInfo's continue branch for a foreign-namespace


### PR DESCRIPTION
- RSAKeyValue with only Exponent (no Modulus) and ECKeyValue with only NamedCurve (no PublicKey) were parsed into partial keys reaching the KeySource
- now require both components, returning ErrInvalidKeyInfo when either is absent
- internal-only; reuses existing error machinery, no API change