### PR TITLE
bound xpath1 node-set comparison op-limit

### DIFF
--- a/xpath1/eval.go
+++ b/xpath1/eval.go
@@ -463,23 +463,39 @@ func compareResults(ctx context.Context, ec *evalContext, op TokenType, left, ri
 // compareNodeSet handles comparisons where the left operand is a node-set.
 func compareNodeSet(ctx context.Context, ec *evalContext, op TokenType, leftNodes []helium.Node, right *Result) (bool, error) {
 	if right.Type == NodeSetResult {
+		// A node-set vs node-set general comparison is always false when
+		// either side is empty: there is no pair of nodes to compare. Return
+		// before doing any per-node string-value work (which would otherwise
+		// be O(n) or O(m) with a zero op charge, escaping the op-limit and
+		// cancellation bound).
+		if len(leftNodes) == 0 || len(right.NodeSet) == 0 {
+			return false, nil
+		}
 		// Pre-compute string values for the right-hand node-set to
 		// avoid recomputing them for every left-hand node.
 		rightVals := make([]string, len(right.NodeSet))
 		for i, rn := range right.NodeSet {
 			rightVals[i] = ixpath.StringValue(rn)
 		}
+		// Charge one op per actual string comparison and re-check
+		// cancellation in bounded chunks, so even a lopsided 1xM (or NxM)
+		// compare trips ErrOpLimit / context cancellation mid-loop instead of
+		// running the whole inner row unchecked.
+		const cancelCheckEvery = 1024
+		sinceCheck := 0
 		for _, ln := range leftNodes {
-			if err := ctx.Err(); err != nil {
-				return false, err
-			}
-			// Each left node compares against every right value: charge
-			// the whole inner row so the O(n*m) loop cannot run unbounded.
-			if err := ec.countOps(len(rightVals)); err != nil {
-				return false, err
-			}
 			lv := ixpath.StringValue(ln)
 			for _, rv := range rightVals {
+				if err := ec.countOps(1); err != nil {
+					return false, err
+				}
+				sinceCheck++
+				if sinceCheck >= cancelCheckEvery {
+					sinceCheck = 0
+					if err := ctx.Err(); err != nil {
+						return false, err
+					}
+				}
 				if compareStrings(op, lv, rv) {
 					return true, nil
 				}

--- a/xpath1/eval.go
+++ b/xpath1/eval.go
@@ -471,21 +471,26 @@ func compareNodeSet(ctx context.Context, ec *evalContext, op TokenType, leftNode
 		if len(leftNodes) == 0 || len(right.NodeSet) == 0 {
 			return false, nil
 		}
-		// Pre-compute string values for the right-hand node-set to
-		// avoid recomputing them for every left-hand node.
-		rightVals := make([]string, len(right.NodeSet))
-		for i, rn := range right.NodeSet {
-			rightVals[i] = ixpath.StringValue(rn)
+		// Honor a context cancelled before the comparison begins so no
+		// string-value work runs after cancellation, even when the first pair
+		// would otherwise match and return before the periodic re-check below.
+		if err := ctx.Err(); err != nil {
+			return false, err
 		}
-		// Charge one op per actual string comparison and re-check
-		// cancellation in bounded chunks, so even a lopsided 1xM (or NxM)
-		// compare trips ErrOpLimit / context cancellation mid-loop instead of
-		// running the whole inner row unchecked.
+		// Compute each right-hand node's string value LAZILY, caching it on
+		// first use, and charge an op + honor cancellation BEFORE materializing
+		// it. Eagerly pre-filling every right-hand string value would do O(m)
+		// uncharged work up front, so a lopsided 1xM compare whose first pair
+		// matches could escape the op limit / cancellation entirely. Charging
+		// per comparison and only materializing on demand bounds the work as it
+		// happens.
+		rightVals := make([]string, len(right.NodeSet))
+		rightComputed := make([]bool, len(right.NodeSet))
 		const cancelCheckEvery = 1024
 		sinceCheck := 0
 		for _, ln := range leftNodes {
 			lv := ixpath.StringValue(ln)
-			for _, rv := range rightVals {
+			for i, rn := range right.NodeSet {
 				if err := ec.countOps(1); err != nil {
 					return false, err
 				}
@@ -496,7 +501,11 @@ func compareNodeSet(ctx context.Context, ec *evalContext, op TokenType, leftNode
 						return false, err
 					}
 				}
-				if compareStrings(op, lv, rv) {
+				if !rightComputed[i] {
+					rightVals[i] = ixpath.StringValue(rn)
+					rightComputed[i] = true
+				}
+				if compareStrings(op, lv, rightVals[i]) {
 					return true, nil
 				}
 			}

--- a/xpath1/eval.go
+++ b/xpath1/eval.go
@@ -438,23 +438,30 @@ func evalComparison(ctx context.Context, ec *evalContext, e BinaryExpr) (*Result
 	if err != nil {
 		return nil, err
 	}
-	b := compareResults(e.Op, left, right)
+	b, err := compareResults(ctx, ec, e.Op, left, right)
+	if err != nil {
+		return nil, err
+	}
 	return &Result{Type: BooleanResult, Bool: b}, nil
 }
 
-// compareResults implements XPath comparison semantics including node-set comparisons.
-func compareResults(op TokenType, left, right *Result) bool {
+// compareResults implements XPath comparison semantics including node-set
+// comparisons. Node-set comparisons iterate over (possibly large) node-sets, so
+// they charge the operation counter and honor context cancellation just like
+// the axis-iteration loops; a cancelled context or an exceeded op limit aborts
+// promptly with the same error the rest of the evaluator returns.
+func compareResults(ctx context.Context, ec *evalContext, op TokenType, left, right *Result) (bool, error) {
 	if left.Type == NodeSetResult {
-		return compareNodeSet(op, left.NodeSet, right)
+		return compareNodeSet(ctx, ec, op, left.NodeSet, right)
 	}
 	if right.Type == NodeSetResult {
-		return compareNodeSetRight(op, left, right.NodeSet)
+		return compareNodeSetRight(ctx, ec, op, left, right.NodeSet)
 	}
-	return compareScalars(op, left, right)
+	return compareScalars(op, left, right), nil
 }
 
 // compareNodeSet handles comparisons where the left operand is a node-set.
-func compareNodeSet(op TokenType, leftNodes []helium.Node, right *Result) bool {
+func compareNodeSet(ctx context.Context, ec *evalContext, op TokenType, leftNodes []helium.Node, right *Result) (bool, error) {
 	if right.Type == NodeSetResult {
 		// Pre-compute string values for the right-hand node-set to
 		// avoid recomputing them for every left-hand node.
@@ -463,56 +470,76 @@ func compareNodeSet(op TokenType, leftNodes []helium.Node, right *Result) bool {
 			rightVals[i] = ixpath.StringValue(rn)
 		}
 		for _, ln := range leftNodes {
+			if err := ctx.Err(); err != nil {
+				return false, err
+			}
+			// Each left node compares against every right value: charge
+			// the whole inner row so the O(n*m) loop cannot run unbounded.
+			if err := ec.countOps(len(rightVals)); err != nil {
+				return false, err
+			}
 			lv := ixpath.StringValue(ln)
 			for _, rv := range rightVals {
 				if compareStrings(op, lv, rv) {
-					return true
+					return true, nil
 				}
 			}
 		}
-		return false
+		return false, nil
 	}
 	// Per XPath 1.0 REC 3.4, comparing a node-set with a boolean converts the
 	// whole node-set to a boolean (true iff non-empty), then compares booleans.
 	if right.Type == BooleanResult {
 		nsBool := len(leftNodes) > 0
 		if op == TokenEquals {
-			return nsBool == right.Bool
+			return nsBool == right.Bool, nil
 		}
 		if op == TokenNotEquals {
-			return nsBool != right.Bool
+			return nsBool != right.Bool, nil
 		}
-		return compareNumbers(op, boolToNumber(nsBool), boolToNumber(right.Bool))
+		return compareNumbers(op, boolToNumber(nsBool), boolToNumber(right.Bool)), nil
 	}
 	for _, ln := range leftNodes {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		if err := ec.countOps(1); err != nil {
+			return false, err
+		}
 		if compareWithScalar(op, ixpath.StringValue(ln), right) {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // compareNodeSetRight handles comparisons where only the right operand is a node-set.
-func compareNodeSetRight(op TokenType, left *Result, rightNodes []helium.Node) bool {
+func compareNodeSetRight(ctx context.Context, ec *evalContext, op TokenType, left *Result, rightNodes []helium.Node) (bool, error) {
 	// Per XPath 1.0 REC 3.4, comparing a boolean with a node-set converts the
 	// whole node-set to a boolean (true iff non-empty), then compares booleans.
 	if left.Type == BooleanResult {
 		nsBool := len(rightNodes) > 0
 		if op == TokenEquals {
-			return left.Bool == nsBool
+			return left.Bool == nsBool, nil
 		}
 		if op == TokenNotEquals {
-			return left.Bool != nsBool
+			return left.Bool != nsBool, nil
 		}
-		return compareNumbers(op, boolToNumber(left.Bool), boolToNumber(nsBool))
+		return compareNumbers(op, boolToNumber(left.Bool), boolToNumber(nsBool)), nil
 	}
 	rev := reverseOp(op)
 	for _, rn := range rightNodes {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		if err := ec.countOps(1); err != nil {
+			return false, err
+		}
 		if compareWithScalar(rev, ixpath.StringValue(rn), left) {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // boolToNumber converts a boolean to its XPath number value (true=1, false=0).

--- a/xpath1/eval.go
+++ b/xpath1/eval.go
@@ -477,19 +477,25 @@ func compareNodeSet(ctx context.Context, ec *evalContext, op TokenType, leftNode
 		if err := ctx.Err(); err != nil {
 			return false, err
 		}
-		// Compute each right-hand node's string value LAZILY, caching it on
-		// first use, and charge an op + honor cancellation BEFORE materializing
-		// it. Eagerly pre-filling every right-hand string value would do O(m)
-		// uncharged work up front, so a lopsided 1xM compare whose first pair
-		// matches could escape the op limit / cancellation entirely. Charging
-		// per comparison and only materializing on demand bounds the work as it
-		// happens.
-		rightVals := make([]string, len(right.NodeSet))
-		rightComputed := make([]bool, len(right.NodeSet))
+		// Charge an op (and periodically honor cancellation) BEFORE materializing
+		// EITHER side's string value, so the bound is complete: if the operand
+		// evaluation already spent the budget, the first per-pair charge fails
+		// before any string-value walk or large allocation runs.
+		//
+		// The right-hand string values are cached LAZILY in a sparse map, grown
+		// only for the indices actually reached. A dense len(right)-sized cache
+		// would do O(m) allocation up front — escaping the op-limit/cancellation
+		// bound for a huge right-hand node-set (e.g. one returned by a custom
+		// function) even when the budget is already exhausted.
+		rightVals := make(map[int]string)
 		const cancelCheckEvery = 1024
 		sinceCheck := 0
 		for _, ln := range leftNodes {
-			lv := ixpath.StringValue(ln)
+			// lv is materialized lazily, only AFTER the first successful op
+			// charge for this left node, so a pre-exhausted budget aborts before
+			// walking/copying a potentially large left subtree.
+			var lv string
+			lvComputed := false
 			for i, rn := range right.NodeSet {
 				if err := ec.countOps(1); err != nil {
 					return false, err
@@ -501,11 +507,16 @@ func compareNodeSet(ctx context.Context, ec *evalContext, op TokenType, leftNode
 						return false, err
 					}
 				}
-				if !rightComputed[i] {
-					rightVals[i] = ixpath.StringValue(rn)
-					rightComputed[i] = true
+				if !lvComputed {
+					lv = ixpath.StringValue(ln)
+					lvComputed = true
 				}
-				if compareStrings(op, lv, rightVals[i]) {
+				rv, ok := rightVals[i]
+				if !ok {
+					rv = ixpath.StringValue(rn)
+					rightVals[i] = rv
+				}
+				if compareStrings(op, lv, rv) {
 					return true, nil
 				}
 			}

--- a/xpath1/eval.go
+++ b/xpath1/eval.go
@@ -488,8 +488,12 @@ func compareNodeSet(ctx context.Context, ec *evalContext, op TokenType, leftNode
 		// bound for a huge right-hand node-set (e.g. one returned by a custom
 		// function) even when the budget is already exhausted.
 		rightVals := make(map[int]string)
-		const cancelCheckEvery = 1024
-		sinceCheck := 0
+		// Hoist the cancellation channel once so the per-pair check below is a
+		// cheap non-blocking channel receive (cancelCtx.Err() takes a mutex; a
+		// receive on this hoisted channel does not). A nil channel is fine: the
+		// select's default branch always wins, matching the rest of the evaluator's
+		// nil-context tolerance.
+		done := ctx.Done()
 		for _, ln := range leftNodes {
 			// lv is materialized lazily, only AFTER the first successful op
 			// charge for this left node, so a pre-exhausted budget aborts before
@@ -500,12 +504,14 @@ func compareNodeSet(ctx context.Context, ec *evalContext, op TokenType, leftNode
 				if err := ec.countOps(1); err != nil {
 					return false, err
 				}
-				sinceCheck++
-				if sinceCheck >= cancelCheckEvery {
-					sinceCheck = 0
-					if err := ctx.Err(); err != nil {
-						return false, err
-					}
+				// Honor cancellation on EVERY pair, before either side's
+				// string-value walk runs, so a context cancelled mid-loop aborts
+				// promptly even for comparisons far smaller than any periodic
+				// re-check window.
+				select {
+				case <-done:
+					return false, ctx.Err()
+				default:
 				}
 				if !lvComputed {
 					lv = ixpath.StringValue(ln)

--- a/xpath1/robustness_test.go
+++ b/xpath1/robustness_test.go
@@ -2,10 +2,12 @@ package xpath1_test
 
 import (
 	"context"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
 
+	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/xpath1"
 	"github.com/stretchr/testify/require"
 )
@@ -235,5 +237,129 @@ func TestNodeSetComparisonBounded(t *testing.T) {
 
 		_, err = xpath1.NewEvaluator().Function("boom", boom).Evaluate(ctx, expr, doc)
 		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+// nodeAt resolves a location path to its first node, asserting the result is a
+// non-empty node-set. Used to grab a real node for a synthetic node-set.
+func nodeAt(t *testing.T, doc *helium.Document, path string) helium.Node {
+	t.Helper()
+	expr, err := xpath1.Compile(path)
+	require.NoError(t, err)
+	r, err := expr.Evaluate(t.Context(), doc)
+	require.NoError(t, err)
+	require.Equal(t, xpath1.NodeSetResult, r.Type)
+	require.NotEmpty(t, r.NodeSet)
+	return r.NodeSet[0]
+}
+
+// nodeSetFunc returns a custom function that hands back the given nodes as a
+// node-set result. A no-argument call costs exactly one op.
+func nodeSetFunc(nodes []helium.Node) xpath1.Function {
+	return xpath1.FunctionFunc(func(_ context.Context, _ []*xpath1.Result) (*xpath1.Result, error) {
+		return &xpath1.Result{Type: xpath1.NodeSetResult, NodeSet: nodes}, nil
+	})
+}
+
+// TestNodeSetComparisonNoUpfrontWork pins compareNodeSet's bound: every unit of
+// work — the O(len(right)) right-hand cache AND each side's string-value
+// materialization — must come AFTER the per-pair op charge. The regressions
+// measure allocation across an Evaluate call: before the fix, a pre-exhausted
+// budget (or a tight limit over a huge right-hand set) still allocated O(m)
+// dense caches and/or materialized a huge left string value before charging.
+func TestNodeSetComparisonNoUpfrontWork(t *testing.T) {
+	allocDelta := func(fn func()) uint64 {
+		var before, after runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&before)
+		fn()
+		runtime.ReadMemStats(&after)
+		return after.TotalAlloc - before.TotalAlloc
+	}
+
+	// Gap (i), left side: the op budget is spent before compareNodeSet runs, so
+	// the very first per-pair charge must fail BEFORE the (huge) left node's
+	// string value is materialized. OpLimit(2) is exactly the cost of the two
+	// no-arg function operands, so compareNodeSet's first countOps trips.
+	t.Run("pre-exhausted budget skips left materialization", func(t *testing.T) {
+		const leftSize = 8 << 20 // 8 MiB string value
+		doc := parseXML(t, "<root><a>"+strings.Repeat("x", leftSize)+"</a><b>y</b></root>")
+		lhs := nodeSetFunc([]helium.Node{nodeAt(t, doc, "/root/a")})
+		rhs := nodeSetFunc([]helium.Node{nodeAt(t, doc, "/root/b")})
+
+		expr, err := xpath1.Compile("lhs() = rhs()")
+		require.NoError(t, err)
+
+		var cmpErr error
+		delta := allocDelta(func() {
+			_, cmpErr = xpath1.NewEvaluator().
+				Function("lhs", lhs).
+				Function("rhs", rhs).
+				OpLimit(2).
+				Evaluate(t.Context(), expr, doc)
+		})
+		require.ErrorIs(t, cmpErr, xpath1.ErrOpLimit)
+		require.Less(t, delta, uint64(2<<20),
+			"compare materialized the left string value before charging the op counter")
+	})
+
+	// Gap (i), right side: a huge right-hand node-set from a custom function with
+	// a pre-exhausted budget must not trigger any O(m) up-front allocation.
+	t.Run("pre-exhausted budget skips O(m) right allocation", func(t *testing.T) {
+		doc := parseXML(t, "<root><a>x</a><b>y</b></root>")
+		const m = 1_000_000
+		big := make([]helium.Node, m)
+		rn := nodeAt(t, doc, "/root/b")
+		for i := range big {
+			big[i] = rn
+		}
+		lhs := nodeSetFunc([]helium.Node{nodeAt(t, doc, "/root/a")})
+		rhs := nodeSetFunc(big)
+
+		expr, err := xpath1.Compile("lhs() = rhs()")
+		require.NoError(t, err)
+
+		var cmpErr error
+		delta := allocDelta(func() {
+			_, cmpErr = xpath1.NewEvaluator().
+				Function("lhs", lhs).
+				Function("rhs", rhs).
+				OpLimit(2).
+				Evaluate(t.Context(), expr, doc)
+		})
+		require.ErrorIs(t, cmpErr, xpath1.ErrOpLimit)
+		require.Less(t, delta, uint64(4<<20),
+			"compare allocated an O(len(right)) cache before charging the op counter")
+	})
+
+	// Gap (ii): a tight (non-zero) op limit over a huge right-hand set trips after
+	// a bounded number of pairs. The work — and the sparse right-hand cache — must
+	// stay proportional to the pairs actually reached, not to len(right).
+	t.Run("tight limit trips after bounded work on huge right set", func(t *testing.T) {
+		doc := parseXML(t, "<root><a>x</a><b>y</b></root>")
+		const m = 1_000_000
+		big := make([]helium.Node, m)
+		rn := nodeAt(t, doc, "/root/b")
+		for i := range big {
+			big[i] = rn
+		}
+		lhs := nodeSetFunc([]helium.Node{nodeAt(t, doc, "/root/a")})
+		rhs := nodeSetFunc(big)
+
+		expr, err := xpath1.Compile("lhs() = rhs()")
+		require.NoError(t, err)
+
+		var cmpErr error
+		delta := allocDelta(func() {
+			// Two function operands cost 2 ops; the remaining 62 trip mid-loop.
+			_, cmpErr = xpath1.NewEvaluator().
+				Function("lhs", lhs).
+				Function("rhs", rhs).
+				OpLimit(64).
+				Evaluate(t.Context(), expr, doc)
+		})
+		require.ErrorIs(t, cmpErr, xpath1.ErrOpLimit)
+		require.Less(t, delta, uint64(4<<20),
+			"compare allocated an O(len(right)) cache instead of growing lazily")
 	})
 }

--- a/xpath1/robustness_test.go
+++ b/xpath1/robustness_test.go
@@ -240,6 +240,89 @@ func TestNodeSetComparisonBounded(t *testing.T) {
 	})
 }
 
+// cancelNode wraps a real node and fires onContent the first time its
+// string-value is materialized (StringValue reads a text node via Content()).
+// It lets a node-set comparison cancel its own context mid-loop, deterministically
+// and single-threaded, so the per-pair cancellation check can be exercised.
+type cancelNode struct {
+	helium.Node
+	onContent func()
+}
+
+func (c *cancelNode) Content() []byte {
+	if c.onContent != nil {
+		c.onContent()
+	}
+	return c.Node.Content()
+}
+
+// textNodeAt returns the first text-node child of the element at path.
+func textNodeAt(t *testing.T, doc *helium.Document, path string) helium.Node {
+	t.Helper()
+	el := nodeAt(t, doc, path)
+	tn := el.FirstChild()
+	require.NotNil(t, tn)
+	require.Equal(t, helium.TextNode, tn.Type())
+	return tn
+}
+
+// TestNodeSetComparisonCancelAfterN pins the per-pair cancellation check in the
+// node-set-vs-node-set compare. The context is cancelled MID-loop (as a side
+// effect of materializing the 3rd left node's string value) over a comparison of
+// far fewer than the old 1024-pair re-check window. With only a pre-loop check
+// plus an every-1024 re-check, that cancellation is missed entirely and the
+// compare runs to completion returning (false, nil). A per-pair check catches it
+// on the very next pair and returns the context error promptly.
+func TestNodeSetComparisonCancelAfterN(t *testing.T) {
+	const leftCount = 8
+	const cancelAt = 2 // 0-based index of the left node whose Content() cancels
+
+	var sb strings.Builder
+	sb.WriteString("<root>")
+	for i := range leftCount {
+		sb.WriteString("<a>x")
+		sb.WriteString(strconv.Itoa(i))
+		sb.WriteString("</a>")
+	}
+	sb.WriteString("<b>y</b></root>")
+	doc := parseXML(t, sb.String())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var materialized int
+	leftNodes := make([]helium.Node, leftCount)
+	for i := range leftNodes {
+		tn := textNodeAt(t, doc, "/root/a["+strconv.Itoa(i+1)+"]")
+		idx := i
+		leftNodes[i] = &cancelNode{Node: tn, onContent: func() {
+			materialized++
+			if idx == cancelAt {
+				cancel()
+			}
+		}}
+	}
+	rightNode := textNodeAt(t, doc, "/root/b")
+
+	lhs := nodeSetFunc(leftNodes)
+	rhs := nodeSetFunc([]helium.Node{rightNode})
+
+	expr, err := xpath1.Compile("lhs() = rhs()")
+	require.NoError(t, err)
+
+	_, err = xpath1.NewEvaluator().
+		Function("lhs", lhs).
+		Function("rhs", rhs).
+		OpLimit(1_000_000).
+		Evaluate(ctx, expr, doc)
+	require.ErrorIs(t, err, context.Canceled)
+
+	// The compare must have aborted promptly: only the nodes up to and including
+	// the cancelling one were materialized, never all leftCount of them.
+	require.Equal(t, cancelAt+1, materialized,
+		"compare kept materializing left string values after cancellation")
+}
+
 // nodeAt resolves a location path to its first node, asserting the result is a
 // non-empty node-set. Used to grab a real node for a synthetic node-set.
 func nodeAt(t *testing.T, doc *helium.Document, path string) helium.Node {

--- a/xpath1/robustness_test.go
+++ b/xpath1/robustness_test.go
@@ -172,4 +172,37 @@ func TestNodeSetComparisonBounded(t *testing.T) {
 		require.Equal(t, xpath1.BooleanResult, r.Type)
 		require.False(t, r.Bool)
 	})
+
+	// A node-set vs node-set comparison with one empty side is always false
+	// and must short-circuit BEFORE computing any string values for the
+	// non-empty side. A tight op limit (well below the n string values the
+	// non-empty side would otherwise require) is honored without error,
+	// proving the empty-side early return skips the per-node work.
+	t.Run("empty right side short-circuits", func(t *testing.T) {
+		compiled, err := xpath1.Compile("/root/a = /root/nonexistent")
+		require.NoError(t, err)
+		r, err := xpath1.NewEvaluator().OpLimit(2000).Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, err)
+		require.Equal(t, xpath1.BooleanResult, r.Type)
+		require.False(t, r.Bool)
+	})
+
+	t.Run("empty left side short-circuits", func(t *testing.T) {
+		compiled, err := xpath1.Compile("/root/nonexistent = /root/b")
+		require.NoError(t, err)
+		r, err := xpath1.NewEvaluator().OpLimit(2000).Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, err)
+		require.Equal(t, xpath1.BooleanResult, r.Type)
+		require.False(t, r.Bool)
+	})
+
+	// Context cancellation is honored mid-compare: a context cancelled before
+	// evaluation aborts the n*n comparison with context.Canceled rather than
+	// running to completion.
+	t.Run("context cancellation honored", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err := xpath1.NewEvaluator().OpLimit(1_000_000).Evaluate(ctx, compiled, doc)
+		require.ErrorIs(t, err, context.Canceled)
+	})
 }

--- a/xpath1/robustness_test.go
+++ b/xpath1/robustness_test.go
@@ -128,3 +128,48 @@ func TestEvaluateContext(t *testing.T) {
 		require.Len(t, r.NodeSet, 2)
 	})
 }
+
+// verifies that a node-set vs node-set general comparison (an O(n*m) string
+// comparison) charges the operation limit instead of running an uncancellable
+// quadratic loop. Two large, non-matching node-sets are compared under an op
+// limit sized to clear the cheap path traversal but trip during the quadratic
+// comparison.
+func TestNodeSetComparisonBounded(t *testing.T) {
+	const n = 300
+
+	var sb strings.Builder
+	sb.WriteString("<root>")
+	for i := range n {
+		sb.WriteString("<a>x")
+		sb.WriteString(strconv.Itoa(i))
+		sb.WriteString("</a>")
+	}
+	for i := range n {
+		sb.WriteString("<b>y")
+		sb.WriteString(strconv.Itoa(i))
+		sb.WriteString("</b>")
+	}
+	sb.WriteString("</root>")
+	doc := parseXML(t, sb.String())
+
+	// /root/a and /root/b never share a string value, forcing the full
+	// n*n comparison before returning false.
+	compiled, err := xpath1.Compile("/root/a = /root/b")
+	require.NoError(t, err)
+
+	// The path traversal costs roughly 2*(1+2n) ~= 1200 ops; the comparison
+	// then attempts n*n == 90000 string comparisons. A limit between the two
+	// is honored only if the comparison loop charges the op counter.
+	t.Run("op limit honored", func(t *testing.T) {
+		_, err := xpath1.NewEvaluator().OpLimit(5000).Evaluate(t.Context(), compiled, doc)
+		require.ErrorIs(t, err, xpath1.ErrOpLimit)
+	})
+
+	// A generous limit still produces the correct boolean result.
+	t.Run("generous limit ok", func(t *testing.T) {
+		r, err := xpath1.NewEvaluator().OpLimit(1_000_000).Evaluate(t.Context(), compiled, doc)
+		require.NoError(t, err)
+		require.Equal(t, xpath1.BooleanResult, r.Type)
+		require.False(t, r.Bool)
+	})
+}

--- a/xpath1/robustness_test.go
+++ b/xpath1/robustness_test.go
@@ -205,4 +205,35 @@ func TestNodeSetComparisonBounded(t *testing.T) {
 		_, err := xpath1.NewEvaluator().OpLimit(1_000_000).Evaluate(ctx, compiled, doc)
 		require.ErrorIs(t, err, context.Canceled)
 	})
+
+	// The comparison path itself owns the string-value work: the right-hand
+	// node-set comes from a custom function rather than a location path, so
+	// eval()'s top-level cancellation check runs (uncancelled) BEFORE the
+	// operands are evaluated. The function cancels the context as a side effect
+	// just before handing back the node-set, so the cancellation is honored
+	// only if compareNodeSet itself consults the context before materializing
+	// right-hand string values. Before the lazy-materialization fix, the
+	// compare eagerly built every right-hand string value with no context check
+	// and returned a boolean, ignoring the cancellation.
+	t.Run("comparison owns cancellation bound", func(t *testing.T) {
+		rightPath, err := xpath1.Compile("/root/b")
+		require.NoError(t, err)
+		rhs, err := xpath1.NewEvaluator().Evaluate(t.Context(), rightPath, doc)
+		require.NoError(t, err)
+		require.Equal(t, xpath1.NodeSetResult, rhs.Type)
+		require.Len(t, rhs.NodeSet, n)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		boom := xpath1.FunctionFunc(func(_ context.Context, _ []*xpath1.Result) (*xpath1.Result, error) {
+			// Cancel just before the comparison consumes the node-set.
+			cancel()
+			return rhs, nil
+		})
+
+		expr, err := xpath1.Compile("/root/a[1] = boom()")
+		require.NoError(t, err)
+
+		_, err = xpath1.NewEvaluator().Function("boom", boom).Evaluate(ctx, expr, doc)
+		require.ErrorIs(t, err, context.Canceled)
+	})
 }


### PR DESCRIPTION
- node-set vs node-set general comparison ran an uncancellable O(n*m) string compare that bypassed the op-limit/ctx accounting the rest of the evaluator honors
- compareNodeSet/compareNodeSetRight now charge ec.countOps and check ctx.Err() per row, returning ErrOpLimit / ctx error like the axis loops
- added a regression test: large non-matching node-sets trip OpLimit, generous limit still yields the correct boolean