### PR TITLE
require system literal in public externalid

### DIFF
--- a/dtd_test.go
+++ b/dtd_test.go
@@ -303,3 +303,48 @@ func TestDTDDeclarationNodeWrappers(t *testing.T) {
 		_ = ent.Replace()
 	})
 }
+
+// TestExternalIDPublicSystemLiteral covers XML 1.0 [75] ExternalID: the PUBLIC
+// form requires a following SystemLiteral, whereas NotationDecl [83] PublicID
+// permits PUBLIC with only a PubidLiteral.
+func TestExternalIDPublicSystemLiteral(t *testing.T) {
+	t.Parallel()
+
+	t.Run("doctype PUBLIC without system literal rejected", func(t *testing.T) {
+		t.Parallel()
+
+		const input = `<?xml version="1.0"?>
+<!DOCTYPE r PUBLIC "-//Example//DTD//EN">
+<r/>`
+
+		p := helium.NewParser()
+		_, err := p.Parse(t.Context(), []byte(input))
+		require.Error(t, err, "PUBLIC ExternalID without a SystemLiteral must be rejected")
+	})
+
+	t.Run("doctype PUBLIC with system literal accepted", func(t *testing.T) {
+		t.Parallel()
+
+		const input = `<?xml version="1.0"?>
+<!DOCTYPE r PUBLIC "-//Example//DTD//EN" "example.dtd">
+<r/>`
+
+		p := helium.NewParser()
+		_, err := p.Parse(t.Context(), []byte(input))
+		require.NoError(t, err, "a complete PUBLIC ExternalID must parse")
+	})
+
+	t.Run("notation PUBLIC without system literal accepted", func(t *testing.T) {
+		t.Parallel()
+
+		const input = `<?xml version="1.0"?>
+<!DOCTYPE r [
+  <!NOTATION n PUBLIC "-//Example//Notation//EN">
+]>
+<r/>`
+
+		p := helium.NewParser()
+		_, err := p.Parse(t.Context(), []byte(input))
+		require.NoError(t, err, "NotationDecl PublicID form must remain accepted")
+	})
+}

--- a/parser_dtd_attr.go
+++ b/parser_dtd_attr.go
@@ -464,7 +464,7 @@ func (pctx *parserCtx) parseNotationDecl(ctx context.Context) error {
 		return pctx.error(ctx, ErrSpaceRequired)
 	}
 
-	systemID, publicID, err := pctx.parseExternalID(ctx)
+	systemID, publicID, err := pctx.parseExternalID(ctx, false)
 	if err != nil {
 		return pctx.error(ctx, err)
 	}
@@ -577,7 +577,13 @@ func isPubidChar(r rune) bool {
 	return false
 }
 
-func (pctx *parserCtx) parseExternalID(ctx context.Context) (string, string, error) {
+// parseExternalID parses an ExternalID [75] or, when strict is false, a
+// NotationDecl PublicID [83]. ExternalID's PUBLIC form requires "S
+// SystemLiteral" after the PubidLiteral; NotationDecl's PublicID form permits
+// PUBLIC with only the PubidLiteral. Pass strict=true for every ExternalID
+// production (DOCTYPE external subset, entity declarations) and strict=false
+// only for NotationDecl.
+func (pctx *parserCtx) parseExternalID(ctx context.Context, strict bool) (string, string, error) {
 	cur := pctx.getCursor()
 	if cur == nil {
 		return "", "", pctx.error(ctx, errNoCursor)
@@ -612,12 +618,23 @@ func (pctx *parserCtx) parseExternalID(ctx context.Context) (string, string, err
 		if err != nil {
 			return "", "", pctx.error(ctx, errors.New("public ID required"))
 		}
-		if !isBlankByte(cur.Peek()) {
-			return "", publicID, nil
-		}
-		pctx.skipBlanks(ctx)
-		if c := cur.Peek(); c != '\'' && c != '"' {
-			return "", publicID, nil
+		if strict {
+			// ExternalID [75]: "S SystemLiteral" is mandatory after the
+			// PubidLiteral, so a space (then the SystemLiteral below) is required.
+			if !isBlankByte(cur.Peek()) {
+				return "", "", pctx.error(ctx, ErrSpaceRequired)
+			}
+			pctx.skipBlanks(ctx)
+		} else {
+			// NotationDecl PublicID [83]: the SystemLiteral is optional, so return
+			// the PubidLiteral alone when no quoted SystemLiteral follows.
+			if !isBlankByte(cur.Peek()) {
+				return "", publicID, nil
+			}
+			pctx.skipBlanks(ctx)
+			if c := cur.Peek(); c != '\'' && c != '"' {
+				return "", publicID, nil
+			}
 		}
 		uri, err := pctx.parseQuotedText(func(qch byte) (string, error) {
 			return pctx.parseSystemLiteral(ctx, qch)

--- a/parser_dtd_subset.go
+++ b/parser_dtd_subset.go
@@ -29,7 +29,7 @@ func (pctx *parserCtx) parseDocTypeDecl(ctx context.Context) error {
 	pctx.intSubName = name
 
 	pctx.skipBlanks(ctx)
-	u, eid, err := pctx.parseExternalID(ctx)
+	u, eid, err := pctx.parseExternalID(ctx, true)
 	if err != nil {
 		return pctx.error(ctx, err)
 	}

--- a/parser_entity_decl.go
+++ b/parser_entity_decl.go
@@ -509,7 +509,7 @@ func (pctx *parserCtx) parseEntityDecl(ctx context.Context) error {
 			// declaration carries no public ID, so guarding on the public ID would
 			// drop every SYSTEM parameter entity), and pass publicID/systemID to
 			// EntityDecl in that order.
-			literal, uri, err = pctx.parseExternalID(ctx)
+			literal, uri, err = pctx.parseExternalID(ctx, true)
 			if err != nil {
 				return pctx.error(ctx, ErrValueRequired)
 			}
@@ -546,7 +546,7 @@ func (pctx *parserCtx) parseEntityDecl(ctx context.Context) error {
 				}
 			}
 		} else {
-			literal, uri, err = pctx.parseExternalID(ctx)
+			literal, uri, err = pctx.parseExternalID(ctx, true)
 			if err != nil {
 				return pctx.error(ctx, ErrValueRequired)
 			}


### PR DESCRIPTION
- XML 1.0 [75] ExternalID PUBLIC form requires a following SystemLiteral; the parser accepted PUBLIC with only a PubidLiteral
- parseExternalID gains a strict flag: DOCTYPE/entity ExternalID sites enforce the SystemLiteral, NotationDecl [83] PublicID stays optional
- adds focused tests for the DOCTYPE reject and NotationDecl accept cases