### PR TITLE
raise XTDE1030 for incompatible multi-key sort keys

### DIFF
--- a/xslt3/sort.go
+++ b/xslt3/sort.go
@@ -521,6 +521,13 @@ func fillSingletonSortValue(sv *sortValue, item xpath3.Item, dtMode *dataTypeMod
 // make every such key compare as "" under text comparison. The atom is recorded
 // by the caller either way so the XTDE1030 orderability gate still sees the true
 // source type.
+//
+// The orderable-type detection is BaseType-AWARE: a schema-derived
+// date/time/duration is recognized and rewritten by value, mirroring what the
+// XTDE1030 gate accepts. It delegates to atomicToNumericSortValue, which resolves
+// the built-in primitive through PromoteSchemaType; a plain numeric reaches here
+// only after the IsNumeric flip + early return, so this delegation never touches
+// numerics (those stay text and are converted later by convertAutoNumeric).
 func applyAutoSortPromotion(sv *sortValue, av xpath3.AtomicValue, dtMode *dataTypeMode, implicitTZ *time.Location) {
 	sv.typeName = av.TypeName
 	if *dtMode == dataTypeAuto && av.IsNumeric() {
@@ -529,31 +536,8 @@ func applyAutoSortPromotion(sv *sortValue, av xpath3.AtomicValue, dtMode *dataTy
 	if *dtMode != dataTypeAuto {
 		return
 	}
-	// Duration types: use numeric comparison based on total months or seconds.
-	if av.TypeName == xpath3.TypeYearMonthDuration || av.TypeName == xpath3.TypeDayTimeDuration {
-		d := av.DurationVal()
-		f := float64(d.Months)
-		if av.TypeName == xpath3.TypeDayTimeDuration {
-			f = d.Seconds
-		}
-		if d.Negative {
-			f = -f
-		}
-		*sv = sortValue{kind: sortValueNumber, num: f, typeName: av.TypeName}
-		*dtMode = dataTypeNumberAuto
-	}
-	// Date/time types: use Unix seconds for numeric comparison.
-	switch av.TypeName {
-	case xpath3.TypeDateTime, xpath3.TypeDateTimeStamp, xpath3.TypeDate:
-		t := xpath3.ApplyImplicitTZ(av.TimeVal(), implicitTZ)
-		f := float64(t.Unix()) + float64(t.Nanosecond())/1e9
-		*sv = sortValue{kind: sortValueNumber, num: f, typeName: av.TypeName}
-		*dtMode = dataTypeNumberAuto
-	case xpath3.TypeTime:
-		// xs:time comparison uses reference date 1972-12-31 per F&O §10.4.4
-		t := xpath3.TimeToReferenceDateTime(xpath3.ApplyImplicitTZ(av.TimeVal(), implicitTZ))
-		f := float64(t.Unix()) + float64(t.Nanosecond())/1e9
-		*sv = sortValue{kind: sortValueNumber, num: f, typeName: av.TypeName}
+	if nv, ok := atomicToNumericSortValue(av, implicitTZ); ok {
+		*sv = nv
 		*dtMode = dataTypeNumberAuto
 	}
 }
@@ -758,6 +742,16 @@ func parseToNumericSortValue(s string) sortValue {
 // for types that support ordering: numeric, duration, date/time.
 // implicitTZ is used for xs:time values that lack an explicit timezone;
 // pass nil to fall back to the system local timezone.
+//
+// It is BaseType-AWARE: a schema-derived atomic (a user-defined TypeName whose
+// built-in BaseType is a numeric/date/time/duration primitive) is converted by
+// its typed value, not skipped. This keeps the comparison-value conversion
+// consistent with the XTDE1030 validation gate, which accepts derived types via
+// xpath3.ValueCompare (itself promoting through PromoteSchemaType). The original
+// av.TypeName is preserved on the returned sortValue so the gate still sees the
+// untouched source type. Numerics are already BaseType-aware via IsNumeric/
+// ToFloat64; the date/time/duration branches resolve the primitive type through
+// PromoteSchemaType before switching on it.
 func atomicToNumericSortValue(av xpath3.AtomicValue, implicitTZ *time.Location) (sortValue, bool) {
 	if av.IsNumeric() {
 		f := av.ToFloat64()
@@ -766,29 +760,32 @@ func atomicToNumericSortValue(av xpath3.AtomicValue, implicitTZ *time.Location) 
 		}
 		return sortValue{kind: sortValueNumber, num: f, typeName: av.TypeName}, true
 	}
-	switch av.TypeName {
+	// Resolve a schema-derived date/time/duration to its built-in primitive so the
+	// switch matches a derived type, then preserve the original TypeName below.
+	prim := xpath3.PromoteSchemaType(av)
+	switch prim.TypeName {
 	case xpath3.TypeYearMonthDuration:
-		d := av.DurationVal()
+		d := prim.DurationVal()
 		f := float64(d.Months)
 		if d.Negative {
 			f = -f
 		}
 		return sortValue{kind: sortValueNumber, num: f, typeName: av.TypeName}, true
 	case xpath3.TypeDayTimeDuration:
-		d := av.DurationVal()
+		d := prim.DurationVal()
 		f := d.Seconds
 		if d.Negative {
 			f = -f
 		}
 		return sortValue{kind: sortValueNumber, num: f, typeName: av.TypeName}, true
 	case xpath3.TypeDateTime, xpath3.TypeDateTimeStamp, xpath3.TypeDate:
-		t := av.TimeVal()
+		t := prim.TimeVal()
 		t = xpath3.ApplyImplicitTZ(t, implicitTZ)
 		// Use Unix seconds + fractional nanoseconds to avoid int64 overflow for large years
 		f := float64(t.Unix()) + float64(t.Nanosecond())/1e9
 		return sortValue{kind: sortValueNumber, num: f, typeName: av.TypeName}, true
 	case xpath3.TypeTime:
-		t := av.TimeVal()
+		t := prim.TimeVal()
 		// xs:time comparison uses reference date 1972-12-31 per F&O §10.4.4
 		t = xpath3.TimeToReferenceDateTime(xpath3.ApplyImplicitTZ(t, implicitTZ))
 		f := float64(t.Unix()) + float64(t.Nanosecond())/1e9

--- a/xslt3/sort.go
+++ b/xslt3/sort.go
@@ -494,36 +494,39 @@ func fillSingletonSortValue(sv *sortValue, item xpath3.Item, dtMode *dataTypeMod
 		if *dtMode == dataTypeAuto && v.IsNumeric() {
 			*dtMode = dataTypeNumberAuto
 		}
-		// Duration types: use numeric comparison based on total months or seconds.
-		if v.TypeName == xpath3.TypeYearMonthDuration || v.TypeName == xpath3.TypeDayTimeDuration {
-			d := v.DurationVal()
-			f := float64(d.Months)
-			if v.TypeName == xpath3.TypeDayTimeDuration {
-				f = d.Seconds
-			}
-			if d.Negative {
-				f = -f
-			}
-			*sv = sortValue{kind: sortValueNumber, num: f, typeName: v.TypeName}
-			if *dtMode == dataTypeAuto {
+		// Only an auto-detect data-type level rewrites orderable
+		// duration/date/time keys into a numeric sortValue (and flips the level
+		// to dataTypeNumberAuto). An explicit data-type="text" level must keep
+		// the string value already stored in sv.str — a numeric rewrite there
+		// would blank str and make every such key compare as "" under text
+		// comparison. The atom is recorded by the caller either way so the
+		// XTDE1030 orderability gate still sees the true source type.
+		if *dtMode == dataTypeAuto {
+			// Duration types: use numeric comparison based on total months or seconds.
+			if v.TypeName == xpath3.TypeYearMonthDuration || v.TypeName == xpath3.TypeDayTimeDuration {
+				d := v.DurationVal()
+				f := float64(d.Months)
+				if v.TypeName == xpath3.TypeDayTimeDuration {
+					f = d.Seconds
+				}
+				if d.Negative {
+					f = -f
+				}
+				*sv = sortValue{kind: sortValueNumber, num: f, typeName: v.TypeName}
 				*dtMode = dataTypeNumberAuto
 			}
-		}
-		// Date/time types: use Unix seconds for numeric comparison.
-		switch v.TypeName {
-		case xpath3.TypeDateTime, xpath3.TypeDateTimeStamp, xpath3.TypeDate:
-			t := xpath3.ApplyImplicitTZ(v.TimeVal(), implicitTZ)
-			f := float64(t.Unix()) + float64(t.Nanosecond())/1e9
-			*sv = sortValue{kind: sortValueNumber, num: f, typeName: v.TypeName}
-			if *dtMode == dataTypeAuto {
+			// Date/time types: use Unix seconds for numeric comparison.
+			switch v.TypeName {
+			case xpath3.TypeDateTime, xpath3.TypeDateTimeStamp, xpath3.TypeDate:
+				t := xpath3.ApplyImplicitTZ(v.TimeVal(), implicitTZ)
+				f := float64(t.Unix()) + float64(t.Nanosecond())/1e9
+				*sv = sortValue{kind: sortValueNumber, num: f, typeName: v.TypeName}
 				*dtMode = dataTypeNumberAuto
-			}
-		case xpath3.TypeTime:
-			// xs:time comparison uses reference date 1972-12-31 per F&O §10.4.4
-			t := xpath3.TimeToReferenceDateTime(xpath3.ApplyImplicitTZ(v.TimeVal(), implicitTZ))
-			f := float64(t.Unix()) + float64(t.Nanosecond())/1e9
-			*sv = sortValue{kind: sortValueNumber, num: f, typeName: v.TypeName}
-			if *dtMode == dataTypeAuto {
+			case xpath3.TypeTime:
+				// xs:time comparison uses reference date 1972-12-31 per F&O §10.4.4
+				t := xpath3.TimeToReferenceDateTime(xpath3.ApplyImplicitTZ(v.TimeVal(), implicitTZ))
+				f := float64(t.Unix()) + float64(t.Nanosecond())/1e9
+				*sv = sortValue{kind: sortValueNumber, num: f, typeName: v.TypeName}
 				*dtMode = dataTypeNumberAuto
 			}
 		}
@@ -585,9 +588,13 @@ func evaluateSortKey(ctx context.Context, ec *execContext, sk *sortKey, node hel
 		if *dtMode == dataTypeNumberAuto {
 			// Auto-detected numeric: preserve date/time ordering.
 			sv := extractNumericSortValue(seq, result.StringValue(), false, implicitTZ)
-			// Preserve original type/atom for XTDE1030 checking
+			// Preserve the original atom/type for the XTDE1030 gate. Atomize ANY
+			// singleton item — a NodeItem is atomizable too, and skipping it
+			// (recording an atom only for an already-atomic value) let a later
+			// node key with an incompatible atomized type bypass the per-level
+			// type check. The numeric key extracted above is left unchanged.
 			if seqLen == 1 {
-				if av, ok := seq.Get(0).(xpath3.AtomicValue); ok {
+				if av, err := xpath3.AtomizeItem(seq.Get(0)); err == nil {
 					sv.typeName = av.TypeName
 					sv.atom = av
 					sv.hasAtom = true
@@ -645,7 +652,11 @@ func evaluateSortKey(ctx context.Context, ec *execContext, sk *sortKey, node hel
 		// dropping it and bypassing the XTDE1030 check on later items.
 		sv := extractNumericSortValue(val, stringifySequence(val), false, implicitTZBody)
 		if val != nil && sequence.Len(val) == 1 {
-			if av, ok := val.Get(0).(xpath3.AtomicValue); ok {
+			// Atomize ANY singleton item (node or atomic), mirroring the select
+			// path: a NodeItem key must still be recorded so a later body key
+			// with an incompatible atomized type cannot bypass the XTDE1030 gate.
+			// The numeric key extracted above is left unchanged.
+			if av, err := xpath3.AtomizeItem(val.Get(0)); err == nil {
 				sv.typeName = av.TypeName
 				sv.atom = av
 				sv.hasAtom = true

--- a/xslt3/sort.go
+++ b/xslt3/sort.go
@@ -488,57 +488,74 @@ func (rs *resolvedSort) compareKeys(aKeys, bKeys []sortValue, aIdx, bIdx int) in
 // and would otherwise drop the atom. Shared by the select and body sort-key
 // paths so both record the source atom identically.
 func fillSingletonSortValue(sv *sortValue, item xpath3.Item, dtMode *dataTypeMode, implicitTZ *time.Location) (xpath3.AtomicValue, bool) {
+	var av xpath3.AtomicValue
 	switch v := item.(type) {
 	case xpath3.AtomicValue:
-		sv.typeName = v.TypeName
-		if *dtMode == dataTypeAuto && v.IsNumeric() {
-			*dtMode = dataTypeNumberAuto
-		}
-		// Only an auto-detect data-type level rewrites orderable
-		// duration/date/time keys into a numeric sortValue (and flips the level
-		// to dataTypeNumberAuto). An explicit data-type="text" level must keep
-		// the string value already stored in sv.str — a numeric rewrite there
-		// would blank str and make every such key compare as "" under text
-		// comparison. The atom is recorded by the caller either way so the
-		// XTDE1030 orderability gate still sees the true source type.
-		if *dtMode == dataTypeAuto {
-			// Duration types: use numeric comparison based on total months or seconds.
-			if v.TypeName == xpath3.TypeYearMonthDuration || v.TypeName == xpath3.TypeDayTimeDuration {
-				d := v.DurationVal()
-				f := float64(d.Months)
-				if v.TypeName == xpath3.TypeDayTimeDuration {
-					f = d.Seconds
-				}
-				if d.Negative {
-					f = -f
-				}
-				*sv = sortValue{kind: sortValueNumber, num: f, typeName: v.TypeName}
-				*dtMode = dataTypeNumberAuto
-			}
-			// Date/time types: use Unix seconds for numeric comparison.
-			switch v.TypeName {
-			case xpath3.TypeDateTime, xpath3.TypeDateTimeStamp, xpath3.TypeDate:
-				t := xpath3.ApplyImplicitTZ(v.TimeVal(), implicitTZ)
-				f := float64(t.Unix()) + float64(t.Nanosecond())/1e9
-				*sv = sortValue{kind: sortValueNumber, num: f, typeName: v.TypeName}
-				*dtMode = dataTypeNumberAuto
-			case xpath3.TypeTime:
-				// xs:time comparison uses reference date 1972-12-31 per F&O §10.4.4
-				t := xpath3.TimeToReferenceDateTime(xpath3.ApplyImplicitTZ(v.TimeVal(), implicitTZ))
-				f := float64(t.Unix()) + float64(t.Nanosecond())/1e9
-				*sv = sortValue{kind: sortValueNumber, num: f, typeName: v.TypeName}
-				*dtMode = dataTypeNumberAuto
-			}
-		}
-		return v, true
+		av = v
 	case xpath3.NodeItem:
-		// Atomize to get the typed value for type consistency checks.
-		if av, err := xpath3.AtomizeItem(v); err == nil {
-			sv.typeName = av.TypeName
-			return av, true
+		// Atomize to get the typed value. A schema/type-annotated node MUST then
+		// flow through the SAME auto numeric/date/duration promotion an atomic
+		// singleton receives, so a typed date/duration node sorts by its real
+		// value rather than as text. Reuse this single atomized value for both
+		// the comparison value and the XTDE1030 gate (don't atomize twice).
+		atom, err := xpath3.AtomizeItem(v)
+		if err != nil {
+			return xpath3.AtomicValue{}, false
 		}
+		av = atom
+	default:
+		return xpath3.AtomicValue{}, false
 	}
-	return xpath3.AtomicValue{}, false
+	applyAutoSortPromotion(sv, av, dtMode, implicitTZ)
+	return av, true
+}
+
+// applyAutoSortPromotion records av's type on sv and, for an auto-detect
+// data-type level, rewrites sv as a numeric sortValue for orderable
+// duration/date/time types (flipping the level to dataTypeNumberAuto). Shared by
+// atomic and atomized-node singleton keys so both promote identically.
+//
+// Only an auto-detect level rewrites orderable duration/date/time keys into a
+// numeric sortValue. An explicit data-type="text" level must keep the string
+// value already stored in sv.str — a numeric rewrite there would blank str and
+// make every such key compare as "" under text comparison. The atom is recorded
+// by the caller either way so the XTDE1030 orderability gate still sees the true
+// source type.
+func applyAutoSortPromotion(sv *sortValue, av xpath3.AtomicValue, dtMode *dataTypeMode, implicitTZ *time.Location) {
+	sv.typeName = av.TypeName
+	if *dtMode == dataTypeAuto && av.IsNumeric() {
+		*dtMode = dataTypeNumberAuto
+	}
+	if *dtMode != dataTypeAuto {
+		return
+	}
+	// Duration types: use numeric comparison based on total months or seconds.
+	if av.TypeName == xpath3.TypeYearMonthDuration || av.TypeName == xpath3.TypeDayTimeDuration {
+		d := av.DurationVal()
+		f := float64(d.Months)
+		if av.TypeName == xpath3.TypeDayTimeDuration {
+			f = d.Seconds
+		}
+		if d.Negative {
+			f = -f
+		}
+		*sv = sortValue{kind: sortValueNumber, num: f, typeName: av.TypeName}
+		*dtMode = dataTypeNumberAuto
+	}
+	// Date/time types: use Unix seconds for numeric comparison.
+	switch av.TypeName {
+	case xpath3.TypeDateTime, xpath3.TypeDateTimeStamp, xpath3.TypeDate:
+		t := xpath3.ApplyImplicitTZ(av.TimeVal(), implicitTZ)
+		f := float64(t.Unix()) + float64(t.Nanosecond())/1e9
+		*sv = sortValue{kind: sortValueNumber, num: f, typeName: av.TypeName}
+		*dtMode = dataTypeNumberAuto
+	case xpath3.TypeTime:
+		// xs:time comparison uses reference date 1972-12-31 per F&O §10.4.4
+		t := xpath3.TimeToReferenceDateTime(xpath3.ApplyImplicitTZ(av.TimeVal(), implicitTZ))
+		f := float64(t.Unix()) + float64(t.Nanosecond())/1e9
+		*sv = sortValue{kind: sortValueNumber, num: f, typeName: av.TypeName}
+		*dtMode = dataTypeNumberAuto
+	}
 }
 
 // evaluateSortKey evaluates a single sort key for one item and returns its typed value.
@@ -588,17 +605,15 @@ func evaluateSortKey(ctx context.Context, ec *execContext, sk *sortKey, node hel
 		if *dtMode == dataTypeNumberAuto {
 			// Auto-detected numeric: preserve date/time ordering.
 			sv := extractNumericSortValue(seq, result.StringValue(), false, implicitTZ)
-			// Preserve the original atom/type for the XTDE1030 gate. Atomize ANY
-			// singleton item — a NodeItem is atomizable too, and skipping it
-			// (recording an atom only for an already-atomic value) let a later
-			// node key with an incompatible atomized type bypass the per-level
-			// type check. The numeric key extracted above is left unchanged.
+			// Atomize ANY singleton item for the XTDE1030 gate — a NodeItem is
+			// atomizable too. A schema-typed date/duration NODE must ALSO supply
+			// its comparison value from the atomized typed value: extractNumeric-
+			// SortValue only converts already-atomic items, so a typed node would
+			// otherwise have fallen back to parsing its lexical string and sorted
+			// as NaN. Recompute the numeric value from the atom when orderable
+			// (for an atomic singleton this reproduces the same value).
 			if seqLen == 1 {
-				if av, err := xpath3.AtomizeItem(seq.Get(0)); err == nil {
-					sv.typeName = av.TypeName
-					sv.atom = av
-					sv.hasAtom = true
-				}
+				sv = applyNumberAutoSingleton(sv, seq.Get(0), implicitTZ)
 			}
 			return sv, nil
 		}
@@ -652,15 +667,12 @@ func evaluateSortKey(ctx context.Context, ec *execContext, sk *sortKey, node hel
 		// dropping it and bypassing the XTDE1030 check on later items.
 		sv := extractNumericSortValue(val, stringifySequence(val), false, implicitTZBody)
 		if val != nil && sequence.Len(val) == 1 {
-			// Atomize ANY singleton item (node or atomic), mirroring the select
-			// path: a NodeItem key must still be recorded so a later body key
-			// with an incompatible atomized type cannot bypass the XTDE1030 gate.
-			// The numeric key extracted above is left unchanged.
-			if av, err := xpath3.AtomizeItem(val.Get(0)); err == nil {
-				sv.typeName = av.TypeName
-				sv.atom = av
-				sv.hasAtom = true
-			}
+			// Mirror the select path: atomize the singleton for the XTDE1030 gate
+			// AND recompute the comparison value from the atomized typed value so
+			// a schema-typed date/duration NODE body result sorts by value rather
+			// than as NaN (extractNumericSortValue only converts already-atomic
+			// items).
+			sv = applyNumberAutoSingleton(sv, val.Get(0), implicitTZBody)
 		}
 		return sv, nil
 	}
@@ -709,6 +721,29 @@ func extractNumericSortValue(seq xpath3.Sequence, fallback string, numericOnly b
 		}
 	}
 	return parseToNumericSortValue(fallback)
+}
+
+// applyNumberAutoSingleton finalizes a dataTypeNumberAuto singleton sort value.
+// It atomizes the singleton item (recording the atom for the XTDE1030
+// orderability gate) and, when the atomized typed value is orderable, replaces
+// the comparison value with the numeric value derived from that typed value.
+// This makes a schema-typed date/duration NODE sort by value instead of the
+// NaN that extractNumericSortValue's string fallback would otherwise yield; for
+// an atomic singleton it reproduces the same value extractNumericSortValue
+// already computed. If atomization fails, sv is returned unchanged.
+func applyNumberAutoSingleton(sv sortValue, item xpath3.Item, implicitTZ *time.Location) sortValue {
+	av, err := xpath3.AtomizeItem(item)
+	if err != nil {
+		return sv
+	}
+	if nv, ok := atomicToNumericSortValue(av, implicitTZ); ok {
+		sv = nv
+	} else {
+		sv.typeName = av.TypeName
+	}
+	sv.atom = av
+	sv.hasAtom = true
+	return sv
 }
 
 func parseToNumericSortValue(s string) sortValue {

--- a/xslt3/sort.go
+++ b/xslt3/sort.go
@@ -364,6 +364,30 @@ func checkSortKeyTypeConsistency[T interface{ keyType() string }](entries []T) e
 	return nil
 }
 
+// keyedNLevel adapts one sort level of a multi-key entry to the keyType()
+// interface consumed by checkSortKeyTypeConsistency.
+type keyedNLevel struct{ typeName string }
+
+func (k keyedNLevel) keyType() string { return k.typeName }
+
+// checkSortKeysTypeConsistencyN applies checkSortKeyTypeConsistency to each of
+// the nLevels sort keys in a multi-key sort, raising XTDE1030 if any single
+// key's values are of mutually incomparable types across the sequence. Mirrors
+// the per-key check the single-key sort paths run; the multi-key paths must
+// validate each key in turn rather than skip the check entirely.
+func checkSortKeysTypeConsistencyN[T any](entries keyedSlice[T], nLevels int) error {
+	views := make([]keyedNLevel, len(entries))
+	for level := range nLevels {
+		for i := range entries {
+			views[i] = keyedNLevel{typeName: entries[i].keys[level].typeName}
+		}
+		if err := checkSortKeyTypeConsistency(views); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // isValidSortDataType reports whether s is a permitted xsl:sort data-type
 // value: "text", "number", or a QName denoting a non-absent namespace
 // (a prefixed lexical QName or an EQName Q{uri}local). The effect of a QName
@@ -944,6 +968,11 @@ func sortNodesN(ctx context.Context, ec *execContext, nodes []helium.Node, sortK
 		entries[i] = keyedN[helium.Node]{item: node, keys: keys, index: i}
 	}
 
+	// XTDE1030: validate each sort key's type consistency across the sequence.
+	if err := checkSortKeysTypeConsistencyN(entries, len(sortKeys)); err != nil {
+		return nil, err
+	}
+
 	rs, err := buildResolvedSort(ctx, ec, sortKeys)
 	if err != nil {
 		return nil, err
@@ -999,6 +1028,11 @@ func sortItemsN(ctx context.Context, ec *execContext, items xpath3.Sequence, sor
 			return nil, err
 		}
 		entries[i] = keyedN[xpath3.Item]{item: item, keys: keys, index: i}
+	}
+
+	// XTDE1030: validate each sort key's type consistency across the sequence.
+	if err := checkSortKeysTypeConsistencyN(entries, len(sortKeys)); err != nil {
+		return nil, err
 	}
 
 	rs, err := buildResolvedSort(ctx, ec, sortKeys)
@@ -1074,6 +1108,11 @@ func sortGroupsN(ctx context.Context, ec *execContext, groups []fegGroup, sortKe
 		entries[i] = keyedN[fegGroup]{item: groups[i], keys: keys, index: i}
 		return nil
 	}); err != nil {
+		return nil, err
+	}
+
+	// XTDE1030: validate each sort key's type consistency across the sequence.
+	if err := checkSortKeysTypeConsistencyN(entries, len(sortKeys)); err != nil {
 		return nil, err
 	}
 

--- a/xslt3/sort.go
+++ b/xslt3/sort.go
@@ -375,9 +375,19 @@ func (k keyedNLevel) keyType() string { return k.typeName }
 // key's values are of mutually incomparable types across the sequence. Mirrors
 // the per-key check the single-key sort paths run; the multi-key paths must
 // validate each key in turn rather than skip the check entirely.
-func checkSortKeysTypeConsistencyN[T any](entries keyedSlice[T], nLevels int) error {
+//
+// Only levels with the DEFAULT data type (no explicit data-type attribute, i.e.
+// dataTypeAuto / dataTypeNumberAuto) compare values by their own atomic types
+// and therefore need the cross-value consistency check. Levels with an explicit
+// data-type="text" stringify every value, and data-type="number" casts every
+// value to xs:double, so mixed original atomic types are always comparable and
+// the check is skipped for them.
+func checkSortKeysTypeConsistencyN[T any](entries keyedSlice[T], dtModes []dataTypeMode) error {
 	views := make([]keyedNLevel, len(entries))
-	for level := range nLevels {
+	for level, m := range dtModes {
+		if m == dataTypeText || m == dataTypeNumber {
+			continue
+		}
 		for i := range entries {
 			views[i] = keyedNLevel{typeName: entries[i].keys[level].typeName}
 		}
@@ -969,7 +979,7 @@ func sortNodesN(ctx context.Context, ec *execContext, nodes []helium.Node, sortK
 	}
 
 	// XTDE1030: validate each sort key's type consistency across the sequence.
-	if err := checkSortKeysTypeConsistencyN(entries, len(sortKeys)); err != nil {
+	if err := checkSortKeysTypeConsistencyN(entries, dtModes); err != nil {
 		return nil, err
 	}
 
@@ -1031,7 +1041,7 @@ func sortItemsN(ctx context.Context, ec *execContext, items xpath3.Sequence, sor
 	}
 
 	// XTDE1030: validate each sort key's type consistency across the sequence.
-	if err := checkSortKeysTypeConsistencyN(entries, len(sortKeys)); err != nil {
+	if err := checkSortKeysTypeConsistencyN(entries, dtModes); err != nil {
 		return nil, err
 	}
 
@@ -1112,7 +1122,7 @@ func sortGroupsN(ctx context.Context, ec *execContext, groups []fegGroup, sortKe
 	}
 
 	// XTDE1030: validate each sort key's type consistency across the sequence.
-	if err := checkSortKeysTypeConsistencyN(entries, len(sortKeys)); err != nil {
+	if err := checkSortKeysTypeConsistencyN(entries, dtModes); err != nil {
 		return nil, err
 	}
 

--- a/xslt3/sort.go
+++ b/xslt3/sort.go
@@ -317,15 +317,18 @@ func validateSortKeyAttrs(ctx context.Context, ec *execContext, sk *sortKey) err
 }
 
 // sortKeyTypesComparable reports whether two atomic sort-key values are mutually
-// comparable under XPath value-comparison semantics, reusing xpath3.ValueCompare
-// as the orderability oracle instead of comparing raw type names. Equality
-// definedness is the family-membership test: two values share a comparison
-// family iff `eq` is defined between them. This honors the repo's XSD 1.1 model
-// automatically — xs:dateTimeStamp ⊂ xs:dateTime, xs:anyURI/xs:string, the
-// numeric family, and untypedAtomic-as-string are all mutually comparable —
-// while genuinely incomparable families (e.g. xs:date vs xs:integer) remain so.
+// ORDERABLE under XPath value-comparison semantics, reusing xpath3.ValueCompare
+// with the less-than operator (`lt`) as the orderability oracle instead of
+// comparing raw type names. Sorting needs ordering, not just equality, so the
+// gate must probe `lt`: two values are consistent only if `lt` is DEFINED
+// between them. This honors the repo's XSD 1.1 model automatically — the numeric
+// family, xs:dateTimeStamp ⊂ xs:dateTime, xs:anyURI/xs:string, and
+// untypedAtomic-as-string are all mutually orderable — while equality-only
+// families (e.g. mixed xs:yearMonthDuration + xs:dayTimeDuration, which define
+// `eq` but raise XPTY0004 on `lt`) and genuinely incomparable families (e.g.
+// xs:date vs xs:integer) are correctly rejected with XTDE1030.
 func sortKeyTypesComparable(a, b xpath3.AtomicValue) bool {
-	_, err := xpath3.ValueCompare(xpath3.TokenEq, a, b)
+	_, err := xpath3.ValueCompare(xpath3.TokenLt, a, b)
 	return err == nil
 }
 
@@ -476,6 +479,65 @@ func (rs *resolvedSort) compareKeys(aKeys, bKeys []sortValue, aIdx, bIdx int) in
 
 // --- Key evaluation ---
 
+// fillSingletonSortValue records the atomized value of a singleton sort-key
+// item on sv (so the XTDE1030 orderability gate can probe it via
+// xpath3.ValueCompare), applies auto data-type promotion, and rebuilds sv as a
+// numeric value for orderable duration/date/time types. It returns the original
+// atomized value and whether one was captured; callers MUST set sv.atom/hasAtom
+// from the result LAST, because the duration/date rebuild replaces sv wholesale
+// and would otherwise drop the atom. Shared by the select and body sort-key
+// paths so both record the source atom identically.
+func fillSingletonSortValue(sv *sortValue, item xpath3.Item, dtMode *dataTypeMode, implicitTZ *time.Location) (xpath3.AtomicValue, bool) {
+	switch v := item.(type) {
+	case xpath3.AtomicValue:
+		sv.typeName = v.TypeName
+		if *dtMode == dataTypeAuto && v.IsNumeric() {
+			*dtMode = dataTypeNumberAuto
+		}
+		// Duration types: use numeric comparison based on total months or seconds.
+		if v.TypeName == xpath3.TypeYearMonthDuration || v.TypeName == xpath3.TypeDayTimeDuration {
+			d := v.DurationVal()
+			f := float64(d.Months)
+			if v.TypeName == xpath3.TypeDayTimeDuration {
+				f = d.Seconds
+			}
+			if d.Negative {
+				f = -f
+			}
+			*sv = sortValue{kind: sortValueNumber, num: f, typeName: v.TypeName}
+			if *dtMode == dataTypeAuto {
+				*dtMode = dataTypeNumberAuto
+			}
+		}
+		// Date/time types: use Unix seconds for numeric comparison.
+		switch v.TypeName {
+		case xpath3.TypeDateTime, xpath3.TypeDateTimeStamp, xpath3.TypeDate:
+			t := xpath3.ApplyImplicitTZ(v.TimeVal(), implicitTZ)
+			f := float64(t.Unix()) + float64(t.Nanosecond())/1e9
+			*sv = sortValue{kind: sortValueNumber, num: f, typeName: v.TypeName}
+			if *dtMode == dataTypeAuto {
+				*dtMode = dataTypeNumberAuto
+			}
+		case xpath3.TypeTime:
+			// xs:time comparison uses reference date 1972-12-31 per F&O §10.4.4
+			t := xpath3.TimeToReferenceDateTime(xpath3.ApplyImplicitTZ(v.TimeVal(), implicitTZ))
+			f := float64(t.Unix()) + float64(t.Nanosecond())/1e9
+			*sv = sortValue{kind: sortValueNumber, num: f, typeName: v.TypeName}
+			if *dtMode == dataTypeAuto {
+				*dtMode = dataTypeNumberAuto
+			}
+		}
+		return v, true
+	case xpath3.NodeItem:
+		// Atomize to get the typed value for type consistency checks.
+		if av, err := xpath3.AtomizeItem(v); err == nil {
+			sv.typeName = av.TypeName
+			return av, true
+		}
+	}
+	return xpath3.AtomicValue{}, false
+}
+
 // evaluateSortKey evaluates a single sort key for one item and returns its typed value.
 // Uses EvaluateReuse when evalState is non-nil to avoid per-item evalContext allocation.
 func evaluateSortKey(ctx context.Context, ec *execContext, sk *sortKey, node helium.Node, dtMode *dataTypeMode, evalState *xpath3.EvalState) (sortValue, error) {
@@ -538,55 +600,7 @@ func evaluateSortKey(ctx context.Context, ec *execContext, sk *sortKey, node hel
 		var keyAtom xpath3.AtomicValue
 		var haveAtom bool
 		if seqLen == 1 {
-			switch v := seq.Get(0).(type) {
-			case xpath3.AtomicValue:
-				sv.typeName = v.TypeName
-				keyAtom, haveAtom = v, true
-				if *dtMode == dataTypeAuto && v.IsNumeric() {
-					*dtMode = dataTypeNumberAuto
-				}
-				// Duration types: use numeric comparison based on total months or seconds
-				if v.TypeName == xpath3.TypeYearMonthDuration || v.TypeName == xpath3.TypeDayTimeDuration {
-					d := v.DurationVal()
-					var f float64
-					if v.TypeName == xpath3.TypeYearMonthDuration {
-						f = float64(d.Months)
-					} else {
-						f = d.Seconds
-					}
-					if d.Negative {
-						f = -f
-					}
-					sv = sortValue{kind: sortValueNumber, num: f, typeName: v.TypeName}
-					if *dtMode == dataTypeAuto {
-						*dtMode = dataTypeNumberAuto
-					}
-				}
-				// Date/time types: use Unix seconds for numeric comparison
-				switch v.TypeName {
-				case xpath3.TypeDateTime, xpath3.TypeDateTimeStamp, xpath3.TypeDate:
-					t := xpath3.ApplyImplicitTZ(v.TimeVal(), implicitTZ)
-					f := float64(t.Unix()) + float64(t.Nanosecond())/1e9
-					sv = sortValue{kind: sortValueNumber, num: f, typeName: v.TypeName}
-					if *dtMode == dataTypeAuto {
-						*dtMode = dataTypeNumberAuto
-					}
-				case xpath3.TypeTime:
-					// xs:time comparison uses reference date 1972-12-31 per F&O §10.4.4
-					t := xpath3.TimeToReferenceDateTime(xpath3.ApplyImplicitTZ(v.TimeVal(), implicitTZ))
-					f := float64(t.Unix()) + float64(t.Nanosecond())/1e9
-					sv = sortValue{kind: sortValueNumber, num: f, typeName: v.TypeName}
-					if *dtMode == dataTypeAuto {
-						*dtMode = dataTypeNumberAuto
-					}
-				}
-			case xpath3.NodeItem:
-				// Atomize to get the typed value for type consistency checks
-				if av, err := xpath3.AtomizeItem(v); err == nil {
-					sv.typeName = av.TypeName
-					keyAtom, haveAtom = av, true
-				}
-			}
+			keyAtom, haveAtom = fillSingletonSortValue(&sv, seq.Get(0), dtMode, implicitTZ)
 		}
 		// Carry the original atom for the XTDE1030 consistency gate. The
 		// duration/date branches above rebuild sv as a numeric value but the
@@ -620,33 +634,38 @@ func evaluateSortKey(ctx context.Context, ec *execContext, sk *sortKey, node hel
 
 	implicitTZBody := ec.currentTime.Location()
 	if *dtMode == dataTypeNumber {
+		// Explicit data-type="number" levels skip the XTDE1030 gate entirely
+		// (every value is cast to xs:double), so no atom needs recording.
 		return extractNumericSortValue(val, stringifySequence(val), true, implicitTZBody), nil
 	}
 	if *dtMode == dataTypeNumberAuto {
-		return extractNumericSortValue(val, stringifySequence(val), false, implicitTZBody), nil
+		// Auto-detected numeric (a prior item flipped the mode). The gate still
+		// runs for this level, so preserve the original atom/type for every
+		// singleton atomic result — mirroring the select path — instead of
+		// dropping it and bypassing the XTDE1030 check on later items.
+		sv := extractNumericSortValue(val, stringifySequence(val), false, implicitTZBody)
+		if val != nil && sequence.Len(val) == 1 {
+			if av, ok := val.Get(0).(xpath3.AtomicValue); ok {
+				sv.typeName = av.TypeName
+				sv.atom = av
+				sv.hasAtom = true
+			}
+		}
+		return sv, nil
 	}
 
 	sv := sortValue{kind: sortValueText, str: stringifySequence(val)}
-	if *dtMode == dataTypeAuto && val != nil && sequence.Len(val) == 1 {
-		if av, ok := val.Get(0).(xpath3.AtomicValue); ok {
-			if av.IsNumeric() {
-				*dtMode = dataTypeNumberAuto
-			} else if av.TypeName == xpath3.TypeYearMonthDuration || av.TypeName == xpath3.TypeDayTimeDuration {
-				d := av.DurationVal()
-				var f float64
-				if av.TypeName == xpath3.TypeYearMonthDuration {
-					f = float64(d.Months)
-				} else {
-					f = d.Seconds
-				}
-				if d.Negative {
-					f = -f
-				}
-				sv = sortValue{kind: sortValueNumber, num: f, typeName: av.TypeName, atom: av, hasAtom: true}
-				*dtMode = dataTypeNumberAuto
-			}
-		}
+	var keyAtom xpath3.AtomicValue
+	var haveAtom bool
+	if val != nil && sequence.Len(val) == 1 {
+		keyAtom, haveAtom = fillSingletonSortValue(&sv, val.Get(0), dtMode, implicitTZBody)
 	}
+	// Carry the original atom for the XTDE1030 consistency gate, mirroring the
+	// select path: record it LAST so the duration/date rebuild inside the helper
+	// does not drop it, and so validateSortLevelTypes can see every singleton
+	// atomic/atomized-node body result instead of bypassing the type check.
+	sv.atom = keyAtom
+	sv.hasAtom = haveAtom
 	return sv, nil
 }
 

--- a/xslt3/sort.go
+++ b/xslt3/sort.go
@@ -67,6 +67,13 @@ type sortValue struct {
 	str      string
 	num      float64
 	typeName string // original XSD type name (for XTDE1030 checking)
+	// atom carries the original atomized value (when hasAtom is true) so the
+	// XTDE1030 type-consistency check can probe true XPath comparability via
+	// xpath3.ValueCompare rather than comparing raw type names. Numeric/date
+	// pre-conversion to num is independent of this — atom always reflects the
+	// untouched source type for the consistency gate.
+	atom    xpath3.AtomicValue
+	hasAtom bool
 }
 
 // resolvedLevel holds the fully resolved configuration for one sort level.
@@ -88,8 +95,6 @@ type keyed1[T any] struct {
 	key   sortValue
 	index int
 }
-
-func (k keyed1[T]) keyType() string { return k.key.typeName }
 
 // keyedN pairs a value with pre-extracted typed sort keys and original index.
 type keyedN[T any] struct {
@@ -311,87 +316,74 @@ func validateSortKeyAttrs(ctx context.Context, ec *execContext, sk *sortKey) err
 	return nil
 }
 
-// sortKeyFamily returns a family name for type compatibility checking.
-// All numeric types belong to the "numeric" family and are mutually comparable.
-func sortKeyFamily(tn string) string {
-	switch tn {
-	case xpath3.TypeInteger, xpath3.TypeDecimal, xpath3.TypeFloat, xpath3.TypeDouble,
-		xpath3.TypeLong, xpath3.TypeInt, xpath3.TypeShort, xpath3.TypeByte,
-		xpath3.TypeUnsignedLong, xpath3.TypeUnsignedInt, xpath3.TypeUnsignedShort, xpath3.TypeUnsignedByte,
-		xpath3.TypeNonNegativeInteger, xpath3.TypeNonPositiveInteger,
-		xpath3.TypePositiveInteger, xpath3.TypeNegativeInteger:
-		return "numeric"
-	}
-	return tn
+// sortKeyTypesComparable reports whether two atomic sort-key values are mutually
+// comparable under XPath value-comparison semantics, reusing xpath3.ValueCompare
+// as the orderability oracle instead of comparing raw type names. Equality
+// definedness is the family-membership test: two values share a comparison
+// family iff `eq` is defined between them. This honors the repo's XSD 1.1 model
+// automatically — xs:dateTimeStamp ⊂ xs:dateTime, xs:anyURI/xs:string, the
+// numeric family, and untypedAtomic-as-string are all mutually comparable —
+// while genuinely incomparable families (e.g. xs:date vs xs:integer) remain so.
+func sortKeyTypesComparable(a, b xpath3.AtomicValue) bool {
+	_, err := xpath3.ValueCompare(xpath3.TokenEq, a, b)
+	return err == nil
 }
 
-// checkSortKeyTypeConsistency raises XTDE1030 if sort keys have incompatible types.
-// For example, mixing xs:untypedAtomic with xs:date is invalid because they
-// can't be compared using the lt operator without explicit casting.
-// All numeric types (integer, decimal, float, double, etc.) are mutually compatible.
-func checkSortKeyTypeConsistency[T interface{ keyType() string }](entries []T) error {
-	var firstNonString string
-	var firstFamily string
-	for _, e := range entries {
-		tn := e.keyType()
-		if tn == "" || tn == xpath3.TypeString || tn == xpath3.TypeUntypedAtomic {
+// validateSortLevelTypes is the SINGLE per-level XTDE1030 validation routine
+// shared by both the single-key and multi-key sort paths. It raises XTDE1030
+// when the values for one sort level have mutually incomparable atomic types.
+//
+// Levels with an explicit data-type="text" (every value is stringified) or
+// data-type="number" (every value is cast to xs:double) make mixed original
+// atomic types trivially comparable, so the check is skipped entirely for them.
+// Only default-data-type levels (dataTypeAuto / dataTypeNumberAuto) compare
+// values by their own atomic types and need the consistency check.
+func validateSortLevelTypes(values []sortValue, mode dataTypeMode) error {
+	if mode == dataTypeText || mode == dataTypeNumber {
+		return nil
+	}
+	var ref *xpath3.AtomicValue
+	for i := range values {
+		v := &values[i]
+		if !v.hasAtom {
 			continue
 		}
-		// xs:duration is only partially ordered and cannot be used as a sort key
-		if tn == xpath3.TypeDuration {
+		// xs:duration is only partially ordered and cannot be used as a sort key.
+		if v.atom.TypeName == xpath3.TypeDuration {
 			return dynamicError(errCodeXTDE1030,
-				"sort keys of type %s are only partially ordered", tn)
+				"sort keys of type %s are only partially ordered", xpath3.TypeDuration)
 		}
-		fam := sortKeyFamily(tn)
-		if firstNonString == "" {
-			firstNonString = tn
-			firstFamily = fam
-		} else if firstFamily != fam {
+		if ref == nil {
+			ref = &v.atom
+			continue
+		}
+		if !sortKeyTypesComparable(*ref, v.atom) {
 			return dynamicError(errCodeXTDE1030,
-				"sort keys have incompatible types: %s and %s", firstNonString, tn)
-		}
-	}
-	// If we have a non-string type AND string/untypedAtomic types, they're incompatible
-	if firstNonString != "" {
-		for _, e := range entries {
-			tn := e.keyType()
-			if tn == xpath3.TypeUntypedAtomic || tn == xpath3.TypeString {
-				return dynamicError(errCodeXTDE1030,
-					"sort keys have incompatible types: %s and %s", firstNonString, tn)
-			}
+				"sort keys have incompatible types: %s and %s", ref.TypeName, v.atom.TypeName)
 		}
 	}
 	return nil
 }
 
-// keyedNLevel adapts one sort level of a multi-key entry to the keyType()
-// interface consumed by checkSortKeyTypeConsistency.
-type keyedNLevel struct{ typeName string }
+// validateSortKeyTypes1 routes a single-key sort's values through the shared
+// per-level validator.
+func validateSortKeyTypes1[T any](entries []keyed1[T], mode dataTypeMode) error {
+	values := make([]sortValue, len(entries))
+	for i := range entries {
+		values[i] = entries[i].key
+	}
+	return validateSortLevelTypes(values, mode)
+}
 
-func (k keyedNLevel) keyType() string { return k.typeName }
-
-// checkSortKeysTypeConsistencyN applies checkSortKeyTypeConsistency to each of
-// the nLevels sort keys in a multi-key sort, raising XTDE1030 if any single
-// key's values are of mutually incomparable types across the sequence. Mirrors
-// the per-key check the single-key sort paths run; the multi-key paths must
-// validate each key in turn rather than skip the check entirely.
-//
-// Only levels with the DEFAULT data type (no explicit data-type attribute, i.e.
-// dataTypeAuto / dataTypeNumberAuto) compare values by their own atomic types
-// and therefore need the cross-value consistency check. Levels with an explicit
-// data-type="text" stringify every value, and data-type="number" casts every
-// value to xs:double, so mixed original atomic types are always comparable and
-// the check is skipped for them.
-func checkSortKeysTypeConsistencyN[T any](entries keyedSlice[T], dtModes []dataTypeMode) error {
-	views := make([]keyedNLevel, len(entries))
+// validateSortKeyTypesN routes each level of a multi-key sort through the shared
+// per-level validator.
+func validateSortKeyTypesN[T any](entries keyedSlice[T], dtModes []dataTypeMode) error {
+	values := make([]sortValue, len(entries))
 	for level, m := range dtModes {
-		if m == dataTypeText || m == dataTypeNumber {
-			continue
-		}
 		for i := range entries {
-			views[i] = keyedNLevel{typeName: entries[i].keys[level].typeName}
+			values[i] = entries[i].keys[level]
 		}
-		if err := checkSortKeyTypeConsistency(views); err != nil {
+		if err := validateSortLevelTypes(values, m); err != nil {
 			return err
 		}
 	}
@@ -531,20 +523,25 @@ func evaluateSortKey(ctx context.Context, ec *execContext, sk *sortKey, node hel
 		if *dtMode == dataTypeNumberAuto {
 			// Auto-detected numeric: preserve date/time ordering.
 			sv := extractNumericSortValue(seq, result.StringValue(), false, implicitTZ)
-			// Preserve original type name for XTDE1030 checking
+			// Preserve original type/atom for XTDE1030 checking
 			if seqLen == 1 {
 				if av, ok := seq.Get(0).(xpath3.AtomicValue); ok {
 					sv.typeName = av.TypeName
+					sv.atom = av
+					sv.hasAtom = true
 				}
 			}
 			return sv, nil
 		}
 
 		sv := sortValue{kind: sortValueText, str: result.StringValue()}
+		var keyAtom xpath3.AtomicValue
+		var haveAtom bool
 		if seqLen == 1 {
 			switch v := seq.Get(0).(type) {
 			case xpath3.AtomicValue:
 				sv.typeName = v.TypeName
+				keyAtom, haveAtom = v, true
 				if *dtMode == dataTypeAuto && v.IsNumeric() {
 					*dtMode = dataTypeNumberAuto
 				}
@@ -587,9 +584,15 @@ func evaluateSortKey(ctx context.Context, ec *execContext, sk *sortKey, node hel
 				// Atomize to get the typed value for type consistency checks
 				if av, err := xpath3.AtomizeItem(v); err == nil {
 					sv.typeName = av.TypeName
+					keyAtom, haveAtom = av, true
 				}
 			}
 		}
+		// Carry the original atom for the XTDE1030 consistency gate. The
+		// duration/date branches above rebuild sv as a numeric value but the
+		// gate must still see the untouched source type, so set it last.
+		sv.atom = keyAtom
+		sv.hasAtom = haveAtom
 		return sv, nil
 	}
 
@@ -639,7 +642,7 @@ func evaluateSortKey(ctx context.Context, ec *execContext, sk *sortKey, node hel
 				if d.Negative {
 					f = -f
 				}
-				sv = sortValue{kind: sortValueNumber, num: f, typeName: av.TypeName}
+				sv = sortValue{kind: sortValueNumber, num: f, typeName: av.TypeName, atom: av, hasAtom: true}
 				*dtMode = dataTypeNumberAuto
 			}
 		}
@@ -864,7 +867,7 @@ func sortNodes1(ctx context.Context, ec *execContext, nodes []helium.Node, sk *s
 	}
 
 	// XTDE1030: check for incompatible or non-orderable sort key types.
-	if err := checkSortKeyTypeConsistency(entries); err != nil {
+	if err := validateSortKeyTypes1(entries, dtMode); err != nil {
 		return nil, err
 	}
 
@@ -929,7 +932,7 @@ func sortItems1(ctx context.Context, ec *execContext, items xpath3.Sequence, sk 
 	}
 
 	// XTDE1030: check for heterogeneous sort key types that can't be compared.
-	if err := checkSortKeyTypeConsistency(entries); err != nil {
+	if err := validateSortKeyTypes1(entries, dtMode); err != nil {
 		return nil, err
 	}
 
@@ -979,7 +982,7 @@ func sortNodesN(ctx context.Context, ec *execContext, nodes []helium.Node, sortK
 	}
 
 	// XTDE1030: validate each sort key's type consistency across the sequence.
-	if err := checkSortKeysTypeConsistencyN(entries, dtModes); err != nil {
+	if err := validateSortKeyTypesN(entries, dtModes); err != nil {
 		return nil, err
 	}
 
@@ -1041,7 +1044,7 @@ func sortItemsN(ctx context.Context, ec *execContext, items xpath3.Sequence, sor
 	}
 
 	// XTDE1030: validate each sort key's type consistency across the sequence.
-	if err := checkSortKeysTypeConsistencyN(entries, dtModes); err != nil {
+	if err := validateSortKeyTypesN(entries, dtModes); err != nil {
 		return nil, err
 	}
 
@@ -1080,7 +1083,8 @@ func sortGroups1(ctx context.Context, ec *execContext, groups []fegGroup, sk *so
 		return nil, err
 	}
 
-	if err := checkSortKeyTypeConsistency(entries); err != nil {
+	// XTDE1030: check for incompatible or non-orderable sort key types.
+	if err := validateSortKeyTypes1(entries, dtMode); err != nil {
 		return nil, err
 	}
 
@@ -1122,7 +1126,7 @@ func sortGroupsN(ctx context.Context, ec *execContext, groups []fegGroup, sortKe
 	}
 
 	// XTDE1030: validate each sort key's type consistency across the sequence.
-	if err := checkSortKeysTypeConsistencyN(entries, dtModes); err != nil {
+	if err := validateSortKeyTypesN(entries, dtModes); err != nil {
 		return nil, err
 	}
 

--- a/xslt3/sort_derived_internal_test.go
+++ b/xslt3/sort_derived_internal_test.go
@@ -1,0 +1,122 @@
+package xslt3
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// derivedAtomic builds a synthetic schema-derived atomic value: a value cast to a
+// built-in primitive type whose TypeName is then re-tagged with a user-defined
+// name and whose BaseType records the built-in primitive. This mirrors what node
+// atomization produces for a type derived from a built-in (see AtomizeItem).
+//
+// It exists because the xsd schema compiler does not register
+// xs:dayTimeDuration / xs:yearMonthDuration as derivable base types, so a derived
+// duration cannot be materialized through the full import-schema pipeline; the
+// conversion helpers are exercised directly instead.
+func derivedAtomic(t *testing.T, lexical, builtin, derivedName string) xpath3.AtomicValue {
+	t.Helper()
+	av, err := xpath3.CastFromString(lexical, builtin)
+	require.NoError(t, err)
+	av.TypeName = derivedName
+	av.BaseType = builtin
+	return av
+}
+
+// XSLT3-102 r7: the sort comparison-value conversion must be BaseType-aware so a
+// schema-derived date/time/duration sorts by its typed value, matching what the
+// XTDE1030 validation gate accepts (it promotes via
+// xpath3.ValueCompare/PromoteSchemaType). Pre-r7 atomicToNumericSortValue
+// switched on the EXACT TypeName and returned ok=false for any derived type, so
+// such a key sorted as text or NaN instead of by value.
+func TestAtomicToNumericSortValueDerivedTypes(t *testing.T) {
+	t.Run("dayTimeDuration", func(t *testing.T) {
+		mk := func(lex string) float64 {
+			sv, ok := atomicToNumericSortValue(
+				derivedAtomic(t, lex, xpath3.TypeDayTimeDuration, "Q{urn:my}myDur"), nil)
+			require.True(t, ok, "derived dayTimeDuration must convert by value")
+			require.Equal(t, sortValueNumber, sv.kind)
+			return sv.num
+		}
+		// By value PT1H < PT3H < PT20H (text order would be PT1H < PT20H < PT3H).
+		require.Less(t, mk("PT1H"), mk("PT3H"))
+		require.Less(t, mk("PT3H"), mk("PT20H"))
+	})
+
+	t.Run("yearMonthDuration", func(t *testing.T) {
+		mk := func(lex string) float64 {
+			sv, ok := atomicToNumericSortValue(
+				derivedAtomic(t, lex, xpath3.TypeYearMonthDuration, "Q{urn:my}myYM"), nil)
+			require.True(t, ok, "derived yearMonthDuration must convert by value")
+			require.Equal(t, sortValueNumber, sv.kind)
+			return sv.num
+		}
+		// By value P1Y (12mo) < P18M (18mo) < P2Y (24mo).
+		require.Less(t, mk("P1Y"), mk("P18M"))
+		require.Less(t, mk("P18M"), mk("P2Y"))
+	})
+
+	t.Run("date", func(t *testing.T) {
+		mk := func(lex string) float64 {
+			sv, ok := atomicToNumericSortValue(
+				derivedAtomic(t, lex, xpath3.TypeDate, "Q{urn:my}myDate"), nil)
+			require.True(t, ok, "derived date must convert by value")
+			require.Equal(t, sortValueNumber, sv.kind)
+			return sv.num
+		}
+		// Chronological value order reverses the BCE text order.
+		require.Less(t, mk("-0100-01-01"), mk("-0044-01-01"))
+		require.Less(t, mk("-0044-01-01"), mk("0050-01-01"))
+	})
+
+	t.Run("dateTime", func(t *testing.T) {
+		mk := func(lex string) float64 {
+			sv, ok := atomicToNumericSortValue(
+				derivedAtomic(t, lex, xpath3.TypeDateTime, "Q{urn:my}myDT"), nil)
+			require.True(t, ok, "derived dateTime must convert by value")
+			require.Equal(t, sortValueNumber, sv.kind)
+			return sv.num
+		}
+		require.Less(t, mk("2019-01-01T00:00:00"), mk("2020-01-01T00:00:00"))
+	})
+
+	t.Run("non-orderable derived string stays unconverted", func(t *testing.T) {
+		_, ok := atomicToNumericSortValue(
+			derivedAtomic(t, "abc", xpath3.TypeString, "Q{urn:my}myStr"), nil)
+		require.False(t, ok)
+	})
+}
+
+// XSLT3-102 r7: applyAutoSortPromotion must also be BaseType-aware. A default
+// (auto) data-type level whose first key is a schema-derived date/duration must
+// flip to number-auto and rewrite the sort value numerically, just as it does for
+// the built-in types. Pre-r7 the exact-TypeName switches missed the derived type,
+// leaving the level in text mode.
+func TestApplyAutoSortPromotionDerivedTypes(t *testing.T) {
+	cases := []struct {
+		name    string
+		lexical string
+		builtin string
+		derived string
+	}{
+		{"date", "2020-01-01", xpath3.TypeDate, "Q{urn:my}myDate"},
+		{"dayTimeDuration", "PT3H", xpath3.TypeDayTimeDuration, "Q{urn:my}myDur"},
+		{"yearMonthDuration", "P1Y", xpath3.TypeYearMonthDuration, "Q{urn:my}myYM"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			av := derivedAtomic(t, tc.lexical, tc.builtin, tc.derived)
+			sv := sortValue{kind: sortValueText, str: tc.lexical}
+			mode := dataTypeAuto
+			applyAutoSortPromotion(&sv, av, &mode, nil)
+			require.Equal(t, dataTypeNumberAuto, mode,
+				"derived %s must flip the level to number-auto", tc.name)
+			require.Equal(t, sortValueNumber, sv.kind,
+				"derived %s must rewrite the sort value numerically", tc.name)
+			// The original derived TypeName must be preserved for the gate.
+			require.Equal(t, tc.derived, sv.typeName)
+		})
+	}
+}

--- a/xslt3/sort_validate_test.go
+++ b/xslt3/sort_validate_test.go
@@ -223,6 +223,11 @@ func TestMultiKeySortIncompatibleSecondKeyRaisesXTDE1030(t *testing.T) {
 // every value before comparison, so mutually incomparable original atomic types
 // (here xs:date vs xs:integer) are perfectly valid and must NOT raise XTDE1030.
 // The per-level type-consistency check only applies to default-data-type levels.
+//
+// XSLT3-102 r5: with a uniform primary key the secondary text level must drive
+// the order by STRING value. Document order is date-then-integer; correct text
+// order is "1" < "2020-01-01", so the integer item must come first. Pre-r5 the
+// date key's str was blanked to "" by the numeric rewrite and sorted first.
 func TestMultiKeySortTextSecondKeyMixedTypesNoError(t *testing.T) {
 	ss := compileStylesheetString(t, `
 <xsl:stylesheet version="3.0"
@@ -240,12 +245,12 @@ func TestMultiKeySortTextSecondKeyMixedTypesNoError(t *testing.T) {
 </xsl:stylesheet>`)
 
 	doc, err := helium.NewParser().Parse(t.Context(),
-		[]byte(`<root><item g="x" t="d" v="2020-01-01"/><item g="x" t="n" v="5"/></root>`))
+		[]byte(`<root><item g="x" t="d" v="2020-01-01"/><item g="x" t="n" v="1"/></root>`))
 	require.NoError(t, err)
 
 	result, err := ss.Transform(doc).Serialize(t.Context())
 	require.NoError(t, err)
-	require.Contains(t, result, "<out")
+	require.Contains(t, result, ">12020-01-01<")
 }
 
 // XSLT3-102 r3: a SINGLE-key sort with explicit data-type="text" stringifies
@@ -253,6 +258,13 @@ func TestMultiKeySortTextSecondKeyMixedTypesNoError(t *testing.T) {
 // xs:integer) are perfectly valid and must NOT raise XTDE1030. The single-key
 // path must skip the type-consistency check for explicit text levels exactly
 // like the multi-key path does.
+//
+// XSLT3-102 r5: the result must also be ordered by the STRING value of each
+// key. Pre-r5 fillSingletonSortValue rewrote the xs:date key into a numeric
+// sortValue with an empty str, so under text comparison the date key compared
+// as "" (sorting before the integer's "1") and the order was wrong. Document
+// order is date-then-integer; correct text order is "1" < "2020-01-01", so the
+// integer must come first.
 func TestSingleKeyTextSortMixedTypesNoError(t *testing.T) {
 	ss := compileStylesheetString(t, `
 <xsl:stylesheet version="3.0"
@@ -269,12 +281,104 @@ func TestSingleKeyTextSortMixedTypesNoError(t *testing.T) {
 </xsl:stylesheet>`)
 
 	doc, err := helium.NewParser().Parse(t.Context(),
-		[]byte(`<root><item t="d" v="2020-01-01"/><item t="n" v="5"/></root>`))
+		[]byte(`<root><item t="d" v="2020-01-01"/><item t="n" v="1"/></root>`))
 	require.NoError(t, err)
 
 	result, err := ss.Transform(doc).Serialize(t.Context())
 	require.NoError(t, err)
-	require.Contains(t, result, "<out")
+	require.Contains(t, result, ">12020-01-01<")
+}
+
+// XSLT3-102 r5: a default single-key sort over xs:date keys with explicit
+// data-type="text" must order strictly by the canonical string value. Pre-r5
+// fillSingletonSortValue rewrote every date key into a numeric sortValue and
+// blanked str, so all keys compared equal ("") and the sort degenerated to
+// document order. Document order here is 2020,2019,2021; correct text order is
+// 2019,2020,2021.
+func TestSingleKeyTextSortDateKeysOrdersByString(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="xs:date(@v)" data-type="text"/>
+        <xsl:value-of select="@v"/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item v="2020-01-01"/><item v="2019-06-01"/><item v="2021-03-03"/></root>`))
+	require.NoError(t, err)
+
+	result, err := ss.Transform(doc).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, result, ">2019-06-012020-01-012021-03-03<")
+}
+
+// XSLT3-102 r5: same as the date case but for xs:dayTimeDuration keys, which
+// fillSingletonSortValue rewrites through a separate duration branch. Under
+// data-type="text" the canonical string value must drive ordering. value-of
+// outputs the canonical duration string (the same value the sort compares) so
+// the assertion is independent of any lexical-vs-canonical mismatch. Document
+// order is PT3H,PT1H,PT20H; correct text order is PT1H < PT20H < PT3H.
+func TestSingleKeyTextSortDurationKeysOrdersByString(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="xs:dayTimeDuration(@v)" data-type="text"/>
+        <xsl:value-of select="xs:dayTimeDuration(@v)"/><xsl:text>|</xsl:text>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item v="PT3H"/><item v="PT1H"/><item v="PT20H"/></root>`))
+	require.NoError(t, err)
+
+	result, err := ss.Transform(doc).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, result, ">PT1H|PT20H|PT3H|<")
+}
+
+// XSLT3-102 r5: a default multi-key sort whose secondary level is flipped to
+// auto-number mode by an earlier item (an xs:integer key) and whose later item
+// supplies the key as a NODE with an incompatible atomized type (untypedAtomic
+// "zzz", not castable to a number) must raise XTDE1030. Pre-r5 the
+// dataTypeNumberAuto branch only recorded an atom when the singleton item was
+// already an xpath3.AtomicValue, so the node key was silently skipped by
+// validateSortLevelTypes and the inconsistency bypassed the type gate.
+func TestMultiKeySortNumberAutoNodeKeyBypassRaisesXTDE1030(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="@g"/>
+        <xsl:sort select="if (@t='i') then xs:integer(@v) else @v"/>
+        <xsl:value-of select="@v"/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item g="x" t="i" v="5"/><item g="x" t="n" v="zzz"/></root>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(doc).Serialize(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "XTDE1030")
 }
 
 // XSLT3-102 r3: a default-data-type sort mixing xs:dateTimeStamp and xs:dateTime

--- a/xslt3/sort_validate_test.go
+++ b/xslt3/sort_validate_test.go
@@ -218,3 +218,61 @@ func TestMultiKeySortIncompatibleSecondKeyRaisesXTDE1030(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "XTDE1030")
 }
+
+// XSLT3-102 r2: a SECONDARY sort key with explicit data-type="text" stringifies
+// every value before comparison, so mutually incomparable original atomic types
+// (here xs:date vs xs:integer) are perfectly valid and must NOT raise XTDE1030.
+// The per-level type-consistency check only applies to default-data-type levels.
+func TestMultiKeySortTextSecondKeyMixedTypesNoError(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="@g"/>
+        <xsl:sort select="if (@t='d') then xs:date(@v) else xs:integer(@v)" data-type="text"/>
+        <xsl:value-of select="@v"/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item g="x" t="d" v="2020-01-01"/><item g="x" t="n" v="5"/></root>`))
+	require.NoError(t, err)
+
+	result, err := ss.Transform(doc).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, result, "<out")
+}
+
+// XSLT3-102 r2: likewise, a SECONDARY sort key with explicit data-type="number"
+// casts every value to xs:double, so mixed original atomic types (xs:date vs
+// xs:integer here, which belong to different orderability families) are
+// comparable and must NOT raise XTDE1030.
+func TestMultiKeySortNumberSecondKeyMixedTypesNoError(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="@g"/>
+        <xsl:sort select="if (@t='d') then xs:date(@v) else xs:integer(@v)" data-type="number"/>
+        <xsl:value-of select="@v"/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item g="x" t="d" v="2020-01-01"/><item g="x" t="i" v="5"/></root>`))
+	require.NoError(t, err)
+
+	result, err := ss.Transform(doc).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, result, "<out")
+}

--- a/xslt3/sort_validate_test.go
+++ b/xslt3/sort_validate_test.go
@@ -248,6 +248,118 @@ func TestMultiKeySortTextSecondKeyMixedTypesNoError(t *testing.T) {
 	require.Contains(t, result, "<out")
 }
 
+// XSLT3-102 r3: a SINGLE-key sort with explicit data-type="text" stringifies
+// every value, so mutually incomparable original atomic types (xs:date vs
+// xs:integer) are perfectly valid and must NOT raise XTDE1030. The single-key
+// path must skip the type-consistency check for explicit text levels exactly
+// like the multi-key path does.
+func TestSingleKeyTextSortMixedTypesNoError(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="if (@t='d') then xs:date(@v) else xs:integer(@v)" data-type="text"/>
+        <xsl:value-of select="@v"/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item t="d" v="2020-01-01"/><item t="n" v="5"/></root>`))
+	require.NoError(t, err)
+
+	result, err := ss.Transform(doc).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, result, "<out")
+}
+
+// XSLT3-102 r3: a default-data-type sort mixing xs:dateTimeStamp and xs:dateTime
+// must NOT raise XTDE1030. In the repo's XSD 1.1 model xs:dateTimeStamp is a
+// subtype of xs:dateTime and the two are mutually comparable with the value
+// comparison `lt`/`eq` operators, so the consistency check must accept them
+// rather than rejecting on raw type-name inequality.
+func TestSingleKeySortDateTimeStampDateTimeNoError(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="if (@t='s') then xs:dateTimeStamp(@v) else xs:dateTime(@v)"/>
+        <xsl:value-of select="@v"/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item t="s" v="2020-01-01T00:00:00Z"/><item t="d" v="2019-06-01T12:00:00"/></root>`))
+	require.NoError(t, err)
+
+	result, err := ss.Transform(doc).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, result, "2019-06-01T12:00:00")
+}
+
+// XSLT3-102 r3: a default-data-type sort mixing xs:anyURI and xs:string must NOT
+// raise XTDE1030. Both belong to the string comparison family and are mutually
+// comparable, so the consistency check must accept them.
+func TestSingleKeySortAnyURIStringNoError(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="if (@t='u') then xs:anyURI(@v) else string(@v)"/>
+        <xsl:value-of select="@v"/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item t="s" v="zebra"/><item t="u" v="apple"/></root>`))
+	require.NoError(t, err)
+
+	result, err := ss.Transform(doc).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, result, "<out")
+}
+
+// XSLT3-102 r3: a default-data-type single-key sort mixing genuinely
+// incomparable atomic types (xs:date vs xs:integer, different orderability
+// families) must still raise XTDE1030.
+func TestSingleKeySortIncompatibleTypesRaisesXTDE1030(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="if (@t='d') then xs:date(@v) else xs:integer(@v)"/>
+        <xsl:value-of select="@v"/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item t="d" v="2020-01-01"/><item t="n" v="5"/></root>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(doc).Serialize(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "XTDE1030")
+}
+
 // XSLT3-102 r2: likewise, a SECONDARY sort key with explicit data-type="number"
 // casts every value to xs:double, so mixed original atomic types (xs:date vs
 // xs:integer here, which belong to different orderability families) are

--- a/xslt3/sort_validate_test.go
+++ b/xslt3/sort_validate_test.go
@@ -189,3 +189,32 @@ func TestSortInvalidDataTypeRaisesXTDE0030(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "XTDE0030")
 }
+
+// XSLT3-102: in a multi-key xsl:sort, a SECONDARY sort key whose atomic values
+// are of mutually incomparable types across the sorted sequence (here xs:date
+// vs xs:integer) must raise XTDE1030, just as the single-key path does. The
+// primary key is uniform so the failure can only come from the second key.
+func TestMultiKeySortIncompatibleSecondKeyRaisesXTDE1030(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="@g"/>
+        <xsl:sort select="if (@t='d') then xs:date(@v) else xs:integer(@v)"/>
+        <xsl:value-of select="@v"/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item g="x" t="d" v="2020-01-01"/><item g="x" t="n" v="5"/></root>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(doc).Serialize(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "XTDE1030")
+}

--- a/xslt3/sort_validate_test.go
+++ b/xslt3/sort_validate_test.go
@@ -360,6 +360,99 @@ func TestSingleKeySortIncompatibleTypesRaisesXTDE1030(t *testing.T) {
 	require.ErrorContains(t, err, "XTDE1030")
 }
 
+// XSLT3-102 r4: a default-data-type SINGLE-key sort mixing xs:yearMonthDuration
+// and xs:dayTimeDuration must raise XTDE1030. The two duration subtypes define
+// `eq` but NOT `lt` (ordering between them is XPTY0004), so the orderability
+// gate must reject them. Pre-fix this slipped through an equality-based oracle
+// and the values were silently mashed into one numeric domain (months vs
+// seconds) and sorted nonsensically.
+func TestSingleKeySortMixedDurationsRaisesXTDE1030(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="if (@t='y') then xs:yearMonthDuration(@v) else xs:dayTimeDuration(@v)"/>
+        <xsl:value-of select="@v"/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item t="y" v="P1Y"/><item t="d" v="P400D"/></root>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(doc).Serialize(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "XTDE1030")
+}
+
+// XSLT3-102 r4: a default-data-type MULTI-key sort whose SECONDARY key mixes
+// xs:yearMonthDuration and xs:dayTimeDuration must raise XTDE1030 for the same
+// reason as the single-key case: ordering across the two duration subtypes is
+// undefined (XPTY0004), so the orderability gate must reject them.
+func TestMultiKeySortMixedDurationsRaisesXTDE1030(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort select="@g"/>
+        <xsl:sort select="if (@t='y') then xs:yearMonthDuration(@v) else xs:dayTimeDuration(@v)"/>
+        <xsl:value-of select="@v"/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item g="x" t="y" v="P1Y"/><item g="x" t="d" v="P400D"/></root>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(doc).Serialize(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "XTDE1030")
+}
+
+// XSLT3-102 r4: a no-`select` BODY xsl:sort whose sequence-constructor key
+// yields mutually incomparable atomic types across the sequence (xs:date for
+// one item, xs:integer for another) must raise XTDE1030. Pre-fix the body path
+// failed to record the original atomized value, so the per-level type gate
+// (which skips values lacking an atom) silently bypassed the check.
+func TestBodySortMixedIncomparableTypesRaisesXTDE1030(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <out>
+      <xsl:for-each select="root/item">
+        <xsl:sort>
+          <xsl:choose>
+            <xsl:when test="@t='d'"><xsl:sequence select="xs:date(@v)"/></xsl:when>
+            <xsl:otherwise><xsl:sequence select="xs:integer(@v)"/></xsl:otherwise>
+          </xsl:choose>
+        </xsl:sort>
+        <xsl:value-of select="@v"/>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item t="d" v="2020-01-01"/><item t="n" v="5"/></root>`))
+	require.NoError(t, err)
+
+	_, err = ss.Transform(doc).Serialize(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "XTDE1030")
+}
+
 // XSLT3-102 r2: likewise, a SECONDARY sort key with explicit data-type="number"
 // casts every value to xs:double, so mixed original atomic types (xs:date vs
 // xs:integer here, which belong to different orderability families) are

--- a/xslt3/sort_validate_test.go
+++ b/xslt3/sort_validate_test.go
@@ -699,3 +699,96 @@ func TestNumberAutoDateNodeOrdersByValue(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, result, ">2000-06-15|2010-01-01|2019-01-01|2021-01-01|<")
 }
+
+// XSLT3-102 r7: a default single-key sort whose keys are SCHEMA-DERIVED date
+// NODES (a type derived from xs:date) must order by the TYPED date value, not as
+// text. The XTDE1030 validation gate already accepts such derived types (it
+// promotes via xpath3.ValueCompare/PromoteSchemaType), but pre-r7 the
+// comparison-value conversion switched on the EXACT TypeName, so a derived date
+// fell through to a text sort. BCE years discriminate text from value order:
+// lexically "-0044-01-01" < "-0100-01-01" (3rd digit 0<1), but chronologically
+// 100 BCE precedes 44 BCE, so the value order reverses the text order.
+func TestSingleKeySortDerivedDateNodeOrdersByValue(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:import-schema>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:simpleType name="myDate">
+        <xs:restriction base="xs:date"/>
+      </xs:simpleType>
+    </xs:schema>
+  </xsl:import-schema>
+  <xsl:template match="/">
+    <xsl:variable name="ds" as="element()*">
+      <xsl:for-each select="root/item">
+        <xsl:element name="d" type="myDate">
+          <xsl:attribute name="o" select="@v"/>
+          <xsl:value-of select="@v"/>
+        </xsl:element>
+      </xsl:for-each>
+    </xsl:variable>
+    <out>
+      <xsl:for-each select="$ds">
+        <xsl:sort select="."/>
+        <xsl:value-of select="@o"/><xsl:text>|</xsl:text>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item v="-0044-01-01"/><item v="-0100-01-01"/><item v="0050-01-01"/></root>`))
+	require.NoError(t, err)
+
+	result, err := ss.Transform(doc).Serialize(t.Context())
+	require.NoError(t, err)
+	// Chronological value order, NOT the lexical text order
+	// (-0044-01-01|-0100-01-01|0050-01-01).
+	require.Contains(t, result, ">-0100-01-01|-0044-01-01|0050-01-01|<")
+}
+
+// XSLT3-102 r7: same schema-derived xs:date value-ordering requirement applied to
+// a SECONDARY (multi-key) sort level. With a uniform primary key every record ties
+// on level 1, so the derived-date secondary level must break the tie by typed
+// value. Pre-r7 it compared by text, giving the reversed BCE order.
+func TestMultiKeySortDerivedDateNodeSecondaryOrdersByValue(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:import-schema>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:simpleType name="myDate">
+        <xs:restriction base="xs:date"/>
+      </xs:simpleType>
+    </xs:schema>
+  </xsl:import-schema>
+  <xsl:template match="/">
+    <xsl:variable name="ds" as="element()*">
+      <xsl:for-each select="root/item">
+        <xsl:element name="d" type="myDate">
+          <xsl:attribute name="o" select="@v"/>
+          <xsl:value-of select="@v"/>
+        </xsl:element>
+      </xsl:for-each>
+    </xsl:variable>
+    <out>
+      <xsl:for-each select="$ds">
+        <xsl:sort select="'k'"/>
+        <xsl:sort select="."/>
+        <xsl:value-of select="@o"/><xsl:text>|</xsl:text>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item v="-0044-01-01"/><item v="-0100-01-01"/><item v="0050-01-01"/></root>`))
+	require.NoError(t, err)
+
+	result, err := ss.Transform(doc).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, result, ">-0100-01-01|-0044-01-01|0050-01-01|<")
+}

--- a/xslt3/sort_validate_test.go
+++ b/xslt3/sort_validate_test.go
@@ -585,3 +585,117 @@ func TestMultiKeySortNumberSecondKeyMixedTypesNoError(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, result, "<out")
 }
+
+// XSLT3-102 r6: a default single-key sort whose keys are schema/type-annotated
+// xs:dayTimeDuration NODES must order by the TYPED VALUE, not by the string. A
+// node key is atomized for the XTDE1030 gate, but pre-r6 the atomized typed
+// value was NOT fed through the same auto numeric/duration promotion that an
+// atomic singleton receives: fillSingletonSortValue only recorded the node's
+// type, leaving sv as text, and extractNumericSortValue (the NumberAuto branch)
+// only converted already-atomic items. So a typed duration node sorted by its
+// lexical string. Document order PT3H,PT1H,PT20H sorts lexically as
+// PT1H<PT20H<PT3H but by value as PT1H<PT3H<PT20H.
+func TestSingleKeySortDurationNodeOrdersByValue(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <xsl:variable name="ds" as="element()*">
+      <xsl:for-each select="root/item">
+        <xsl:element name="d" type="xs:dayTimeDuration"><xsl:value-of select="@v"/></xsl:element>
+      </xsl:for-each>
+    </xsl:variable>
+    <out>
+      <xsl:for-each select="$ds">
+        <xsl:sort select="."/>
+        <xsl:value-of select="."/><xsl:text>|</xsl:text>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item v="PT3H"/><item v="PT1H"/><item v="PT20H"/></root>`))
+	require.NoError(t, err)
+
+	result, err := ss.Transform(doc).Serialize(t.Context())
+	require.NoError(t, err)
+	// Value order, not lexical PT1H|PT20H|PT3H.
+	require.Contains(t, result, ">PT1H|PT3H|PT20H|<")
+}
+
+// XSLT3-102 r6: same typed-node value-ordering requirement applied to a
+// SECONDARY (multi-key) sort level. With a uniform primary key every record
+// ties on level 1, so the typed xs:dayTimeDuration NODE secondary level must
+// break the tie by typed value. Pre-r6 the secondary level compared the nodes
+// by their lexical strings (PT1H<PT20H<PT3H) instead of by value
+// (PT1H<PT3H<PT20H).
+func TestMultiKeySortDurationNodeSecondaryOrdersByValue(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <xsl:variable name="ds" as="element()*">
+      <xsl:for-each select="root/item">
+        <xsl:element name="d" type="xs:dayTimeDuration"><xsl:value-of select="@v"/></xsl:element>
+      </xsl:for-each>
+    </xsl:variable>
+    <out>
+      <xsl:for-each select="$ds">
+        <xsl:sort select="'k'"/>
+        <xsl:sort select="."/>
+        <xsl:value-of select="."/><xsl:text>|</xsl:text>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item v="PT3H"/><item v="PT1H"/><item v="PT20H"/></root>`))
+	require.NoError(t, err)
+
+	result, err := ss.Transform(doc).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, result, ">PT1H|PT3H|PT20H|<")
+}
+
+// XSLT3-102 r6: a default sort level flipped to auto-number mode by an earlier
+// ATOMIC date item must still sort later schema-typed xs:date NODES by their
+// typed value, not as NaN. Pre-r6 the dataTypeNumberAuto branch ran the node
+// through extractNumericSortValue, which only converts already-atomic items, so
+// the node fell back to parsing its lexical string ("2019-01-01") to a number →
+// NaN, and every date node sorted ahead of the atomic key. The mixed sequence
+// puts the atomic xs:date('2000-06-15') first (flipping the level to
+// number-auto) followed by the typed date nodes; correct value order is
+// 2000-06-15 < 2010 < 2019 < 2021.
+func TestNumberAutoDateNodeOrdersByValue(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xsl:template match="/">
+    <xsl:variable name="dn" as="element()*">
+      <xsl:for-each select="root/item">
+        <xsl:element name="d" type="xs:date"><xsl:value-of select="@v"/></xsl:element>
+      </xsl:for-each>
+    </xsl:variable>
+    <xsl:variable name="mixed" as="item()*" select="(xs:date('2000-06-15'), $dn)"/>
+    <out>
+      <xsl:for-each select="$mixed">
+        <xsl:sort select="."/>
+        <xsl:value-of select="."/><xsl:text>|</xsl:text>
+      </xsl:for-each>
+    </out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<root><item v="2019-01-01"/><item v="2021-01-01"/><item v="2010-01-01"/></root>`))
+	require.NoError(t, err)
+
+	result, err := ss.Transform(doc).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, result, ">2000-06-15|2010-01-01|2019-01-01|2021-01-01|<")
+}


### PR DESCRIPTION
- Multi-key xsl:sort skipped checkSortKeyTypeConsistency, so XTDE1030 was never raised when a secondary key's atomic values were mutually incomparable across the sequence.
- Now applies the existing single-key consistency check to each key in the multi-key node/item/group paths.
- Added a focused test (date vs integer secondary key).