### PR TITLE
honor context cancellation in verify reference loop

### DIFF
--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -108,6 +108,12 @@ func verifySignature(ctx context.Context, cfg *verifierConfig, doc *helium.Docum
 	// confirm that the element they intend to consume is actually covered.
 	result := &VerifyResult{Signature: sigElem}
 	for i, ref := range parsed.references {
+		// Honor context cancellation between references: a signature with very
+		// many References must not be digested to completion once the caller's
+		// context is cancelled or its deadline has passed.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		target, err := verifyReference(doc, sigElem, ref, cfg.allowSHA1)
 		if err != nil {
 			return nil, &VerificationError{Reference: i, URI: ref.uri, Err: err}

--- a/xmldsig1/verify_test.go
+++ b/xmldsig1/verify_test.go
@@ -580,3 +580,44 @@ func TestVerifyNilKeySource(t *testing.T) {
 		})
 	})
 }
+
+// TestVerifyHonorsContextCancellation ensures the per-Reference verification
+// loop checks ctx between references: a document with several References must
+// not be digested to completion once the caller's context is cancelled. The
+// StaticKey source ignores ctx and verifyBytes does not check it, so a
+// pre-cancelled context reaches the Reference loop, where cancellation must be
+// observed and surfaced as the context error instead of a full verify.
+func TestVerifyHonorsContextCancellation(t *testing.T) {
+	xml := `<root><a Id="one">first</a><b Id="two">second</b></root>`
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, xml)
+
+	mkRef := func(uri string) xmldsig1.ReferenceConfig {
+		return xmldsig1.ReferenceConfig{
+			URI:             uri,
+			DigestAlgorithm: xmldsig1.DigestSHA256,
+			Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+		}
+	}
+
+	sigElem, err := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(mkRef("#one")).
+		Reference(mkRef("#two")).
+		SignDetached(t.Context(), doc, key)
+	require.NoError(t, err)
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+
+	// Sanity: verifies under a live context.
+	_, err = verifier.Verify(t.Context(), doc)
+	require.NoError(t, err)
+
+	// A context cancelled before verification must abort the Reference loop and
+	// surface the context error rather than completing a full verification.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = verifier.Verify(ctx, doc)
+	require.ErrorIs(t, err, context.Canceled)
+}


### PR DESCRIPTION
- xmldsig1 verifySignature now checks ctx.Err() at the top of each Reference iteration, so a signature with many References is cancellable mid-verify
- adds a multi-reference test asserting a pre-cancelled context returns context.Canceled instead of completing a full verify