### PR TITLE
fix schematron value-of scalar string conversion

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -14,7 +14,7 @@ xpath3         → helium, internal/xpath, internal/lexicon, internal/icu, inter
 xslt3          → helium, xpath3, xsd, html, internal/iofs, internal/lexicon, internal/sequence, internal/uripath, internal/xpathstream, internal/domutil, xslt3/internal/elements
 xsd            → helium, xpath1, internal/lexicon, internal/xsd/value, internal/xsdregex, internal/uripath, internal/iofs
 relaxng        → helium, internal/lexicon, internal/iofs, internal/iolimit, internal/xsd/value, internal/xmlchar, internal/uripath
-schematron     → helium, xpath1, internal/xpath
+schematron     → helium, xpath1, internal/xpath, internal/xpath1/number
 xpointer       → helium, xpath1, internal/xmlchar
 c14n           → helium, internal/lexicon, internal/domutil
 xmldsig1       → helium, c14n, internal/lexicon, internal/domutil
@@ -55,7 +55,7 @@ c14n, xpath1, xpath3, html, catalog, relaxng, stream, xmlenc1
 xmldsig1 (root + c14n + internal/lexicon)
 
 ## Composition layer (depends on processing)
-xsd (root + xpath1 + internal/lexicon), xpointer (root + xpath1 + internal/xmlchar), schematron (root + xpath1 + internal/xpath), xinclude (root + xpointer + internal/encoding + internal/iofs + internal/lexicon), xslt3 (root + xpath3 + xsd + html + internal/elements), shim (root + stream)
+xsd (root + xpath1 + internal/lexicon), xpointer (root + xpath1 + internal/xmlchar), schematron (root + xpath1 + internal/xpath + internal/xpath1/number), xinclude (root + xpointer + internal/encoding + internal/iofs + internal/lexicon), xslt3 (root + xpath3 + xsd + html + internal/elements), shim (root + stream)
 
 ## Application layer
 internal/cli/heliumcmd (CLI implementation)

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -254,7 +254,7 @@ Schematron schema compilation and validation.
 - Supports: schema, pattern, rule, assert, report, let, name, value-of
 - Variable bindings via `<let>` and `<param>`
 - Files: `schematron.go` (API + config), `schema.go` (data model), `parse.go` (compilation), `validate.go` (validation), `errors.go` (error types + formatting)
-- Imports: helium, internal/xpath, xpath1/
+- Imports: helium, internal/xpath, xpath1/, internal/xpath1/number
 
 ## catalog/
 

--- a/schematron/schematron_test.go
+++ b/schematron/schematron_test.go
@@ -718,7 +718,8 @@ func TestValueOfInterpolation(t *testing.T) {
 
 		collected, err := validateAndCollect(t, schema, doc)
 		require.ErrorIs(t, err, schematron.ErrValidationFailed)
-		require.Contains(t, collected[0].Message, "result is True")
+		// XPath 1.0 string(boolean): true() converts to "true" (lowercase).
+		require.Contains(t, collected[0].Message, "result is true")
 	})
 
 	t.Run("boolean false", func(t *testing.T) {
@@ -735,7 +736,45 @@ func TestValueOfInterpolation(t *testing.T) {
 
 		collected, err := validateAndCollect(t, schema, doc)
 		require.ErrorIs(t, err, schematron.ErrValidationFailed)
-		require.Contains(t, collected[0].Message, "result is False")
+		// XPath 1.0 string(boolean): false() converts to "false" (lowercase).
+		require.Contains(t, collected[0].Message, "result is false")
+	})
+
+	t.Run("number formatting", func(t *testing.T) {
+		t.Parallel()
+		// XPath 1.0 string(number) lexical forms (xmlXPathFormatNumber):
+		// integers carry no decimal point or exponent, special values use
+		// the "NaN"/"Infinity"/"-Infinity" spellings, and negative zero
+		// renders as "0". Go's default %g formatting diverges on all of these.
+		for _, tc := range []struct {
+			name   string
+			expr   string
+			expect string
+		}{
+			{"large integer", "1234567", "n=1234567"},
+			{"decimal", "3 div 2", "n=1.5"},
+			{"NaN", "0 div 0", "n=NaN"},
+			{"positive infinity", "1 div 0", "n=Infinity"},
+			{"negative infinity", "-1 div 0", "n=-Infinity"},
+			{"negative zero", "-1 * 0", "n=0"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				schema, errs := compileTestSchema(t, `<schema xmlns="http://purl.oclc.org/dsdl/schematron">
+					<pattern><rule context="item">
+						<assert test="false()">n=<value-of select="`+tc.expr+`"/></assert>
+					</rule></pattern>
+				</schema>`)
+				require.Equal(t, "", errs)
+
+				doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root><item/></root>`))
+				require.NoError(t, err)
+
+				collected, err := validateAndCollect(t, schema, doc)
+				require.ErrorIs(t, err, schematron.ErrValidationFailed)
+				require.Contains(t, collected[0].Message, tc.expect)
+			})
+		}
 	})
 
 	t.Run("nodeset string-value", func(t *testing.T) {

--- a/schematron/validate.go
+++ b/schematron/validate.go
@@ -8,6 +8,7 @@ import (
 
 	helium "github.com/lestrrat-go/helium"
 	ixpath "github.com/lestrrat-go/helium/internal/xpath"
+	"github.com/lestrrat-go/helium/internal/xpath1/number"
 	"github.com/lestrrat-go/helium/xpath1"
 )
 
@@ -231,12 +232,16 @@ func xpathResultToString(r *xpath1.Result) string {
 	case xpath1.StringResult:
 		return r.String
 	case xpath1.NumberResult:
-		return fmt.Sprintf("%g", r.Number)
+		// XPath 1.0 string(number): reuse the canonical xmlXPathFormatNumber
+		// port (integers without a decimal point, "NaN"/"Infinity"/"-Infinity",
+		// no trailing ".0") instead of Go's default formatting.
+		return number.ToString(r.Number)
 	case xpath1.BooleanResult:
+		// XPath 1.0 string(boolean): "true"/"false" (lowercase).
 		if r.Bool {
-			return "True"
+			return "true"
 		}
-		return "False"
+		return "false"
 	case xpath1.NodeSetResult:
 		if len(r.NodeSet) == 0 {
 			return ""


### PR DESCRIPTION
- route value-of number/boolean stringification through xpath1's xmlXPathFormatNumber port + lowercase true/false (XPath 1.0 string()) instead of Go %g / "True"/"False"
- fixes Infinity/-Infinity/NaN spellings, large-integer decimal-free form, negative zero
- add number-formatting subtests; update boolean subtests to lowercase