### PR TITLE
bound xpath3 analyze-string and string-to-codepoints

### DIFF
--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -61,6 +61,8 @@ to `ec.schemaDeclarations.IsSubtypeOf` for user-defined schema types.
 Regex: use Go `regexp` package by default; fall back to `github.com/dlclark/regexp2` for patterns requiring backreferences, character class subtraction, or large quantifiers. Map XPath flags (`i`,`m`,`s`,`x`) to Go equivalents.
 Compiled regexes are cached by pattern + flags pair so repeated literal calls do not repay translation/compilation cost. The cache (`regexLRUCache` in `regex_cache.go`) is a bounded LRU with a 1024-entry cap and least-recently-used eviction, replacing the old unbounded `sync.Map` so many distinct dynamic patterns can no longer grow process memory without limit.
 
+**Resource bounds (XPATH3-102/105).** `string-to-codepoints` charges `fnCountOp` per produced codepoint so a huge input cannot build an item sequence below the node-set cap but above `OpLimit`. `analyze-string` STREAMS its regex matches via `compiledXPathRegex.eachStringSubmatchIndex` (the internal form of the public `Regex.EachSubmatchIndex`) rather than calling `FindAllStringSubmatchIndex` up front: when an op budget is in force it passes `fnRemainingOps(ec)+1` as the match limit and charges `fnCountOp` BEFORE building each match's result nodes, so an input with millions of matches rejects with `ErrOpLimit` (or honors cancellation) without ever materializing the O(matches) index slice. A non-streamable leading-context pattern over an oversized input surfaces `ErrRegexMatchLimit` as-is (errors.Is-compatible); other engine errors map to `FORX0002`.
+
 ### `functions_numeric.go`
 `abs`, `ceiling`, `floor`, `round`, `round-half-to-even`
 

--- a/xpath3/functions_string.go
+++ b/xpath3/functions_string.go
@@ -2,6 +2,7 @@ package xpath3
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -994,28 +995,44 @@ func fnAnalyzeString(ctx context.Context, args []Sequence) (Sequence, error) {
 		return nil, &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("analyze-string: failed to build result: %v", err)}
 	}
 
-	pos := 0
-	matches, err := re.FindAllStringSubmatchIndex(s, -1)
-	if err != nil {
-		return nil, &XPathError{Code: errCodeFORX0002, Message: fmt.Sprintf("regex match failed: %v", err)}
-	}
-	// Charge the op-limit and honor context cancellation once per match: an input
-	// with a huge number of matches would otherwise build the result tree
-	// uncancellable and unaccounted against the op budget.
+	// Stream the matches one at a time instead of materializing every match up
+	// front. An input with a huge number of matches would otherwise allocate the
+	// full match slice (an O(matches) up-front cost) and build the whole result
+	// tree before the op budget or a cancellation could intervene. When an op
+	// budget is in force, cap the enumeration at remaining+1 matches so the
+	// callback observes the one match that exhausts the budget and rejects
+	// without producing the rest; an unbounded budget streams uncapped.
 	ec := getFnContext(ctx)
-	for _, m := range matches {
+	findLimit := -1
+	if remaining, bounded := fnRemainingOps(ec); bounded {
+		if n := remaining + 1; n > 0 {
+			findLimit = n
+		}
+	}
+	pos := 0
+	var buildErr error
+	buildFail := func(err error) bool {
+		buildErr = &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("analyze-string: failed to build result: %v", err)}
+		return false
+	}
+	iterErr := re.eachStringSubmatchIndex(s, findLimit, func(m []int) bool {
+		// Charge the op-limit and honor context cancellation BEFORE building any
+		// result nodes for this match: an over-budget or cancelled run stops here
+		// instead of emitting an element first, and the full match slice is never
+		// materialized up front.
 		if err := fnCountOp(ctx, ec); err != nil {
-			return nil, err
+			buildErr = err
+			return false
 		}
 		start, end := m[0], m[1]
 		if start > pos {
 			if err := appendAnalyzeStringTextElement(doc, root, "non-match", s[pos:start]); err != nil {
-				return nil, &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("analyze-string: failed to build result: %v", err)}
+				return buildFail(err)
 			}
 		}
 		matchElem, err := createAnalyzeStringElement(doc, "match")
 		if err != nil {
-			return nil, &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("analyze-string: failed to build result: %v", err)}
+			return buildFail(err)
 		}
 		// Check for groups
 		if len(m) > 2 {
@@ -1027,36 +1044,50 @@ func fnAnalyzeString(ctx context.Context, args []Sequence) (Sequence, error) {
 				}
 				if gs > groupPos {
 					if err := matchElem.AppendText([]byte(s[groupPos:gs])); err != nil {
-						return nil, &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("analyze-string: failed to build result: %v", err)}
+						return buildFail(err)
 					}
 				}
 				groupElem, err := createAnalyzeStringElement(doc, "group")
 				if err != nil {
-					return nil, &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("analyze-string: failed to build result: %v", err)}
+					return buildFail(err)
 				}
 				_ = groupElem.SetLiteralAttribute("nr", fmt.Sprintf("%d", g))
 				if err := groupElem.AppendText([]byte(s[gs:ge])); err != nil {
-					return nil, &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("analyze-string: failed to build result: %v", err)}
+					return buildFail(err)
 				}
 				if err := matchElem.AddChild(groupElem); err != nil {
-					return nil, &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("analyze-string: failed to build result: %v", err)}
+					return buildFail(err)
 				}
 				groupPos = ge
 			}
 			if groupPos < end {
 				if err := matchElem.AppendText([]byte(s[groupPos:end])); err != nil {
-					return nil, &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("analyze-string: failed to build result: %v", err)}
+					return buildFail(err)
 				}
 			}
 		} else {
 			if err := matchElem.AppendText([]byte(s[start:end])); err != nil {
-				return nil, &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("analyze-string: failed to build result: %v", err)}
+				return buildFail(err)
 			}
 		}
 		if err := root.AddChild(matchElem); err != nil {
-			return nil, &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("analyze-string: failed to build result: %v", err)}
+			return buildFail(err)
 		}
 		pos = end
+		return true
+	})
+	if buildErr != nil {
+		return nil, buildErr
+	}
+	if iterErr != nil {
+		// A leading-context pattern that cannot stream is bounded to xpath3's
+		// full-context allocation ceiling; surface that resource condition as-is
+		// so errors.Is(err, ErrRegexMatchLimit) keeps working. Any other engine
+		// error maps to FORX0002 like the former FindAllStringSubmatchIndex path.
+		if errors.Is(iterErr, ErrRegexMatchLimit) {
+			return nil, iterErr
+		}
+		return nil, &XPathError{Code: errCodeFORX0002, Message: fmt.Sprintf("regex match failed: %v", iterErr)}
 	}
 	if pos < len(s) {
 		if err := appendAnalyzeStringTextElement(doc, root, "non-match", s[pos:]); err != nil {

--- a/xpath3/functions_string.go
+++ b/xpath3/functions_string.go
@@ -228,7 +228,7 @@ func isValidXML11Codepoint(cp int) bool {
 	return false
 }
 
-func fnStringToCodepoints(_ context.Context, args []Sequence) (Sequence, error) {
+func fnStringToCodepoints(ctx context.Context, args []Sequence) (Sequence, error) {
 	s, err := coerceArgToString(args[0])
 	if err != nil {
 		return nil, err
@@ -236,10 +236,21 @@ func fnStringToCodepoints(_ context.Context, args []Sequence) (Sequence, error) 
 	if s == "" {
 		return validNilSequence, nil
 	}
-	runes := []rune(s)
-	result := make(ItemSlice, len(runes))
-	for i, r := range runes {
-		result[i] = AtomicValue{TypeName: TypeInteger, Value: big.NewInt(int64(r))}
+	// Build the codepoint sequence one item per character, charging the op-limit
+	// and honoring context cancellation before each append (and capping the
+	// length at maxNodes). A huge input string would otherwise materialize an
+	// unbounded item sequence in one shot, ignoring both budgets.
+	ec := getFnContext(ctx)
+	maxNodes := fnMaxNodes(ec)
+	var result ItemSlice
+	for _, r := range s {
+		if err := fnCountOp(ctx, ec); err != nil {
+			return nil, err
+		}
+		if len(result) >= maxNodes {
+			return nil, ErrNodeSetLimit
+		}
+		result = append(result, AtomicValue{TypeName: TypeInteger, Value: big.NewInt(int64(r))})
 	}
 	return result, nil
 }
@@ -943,7 +954,7 @@ func matchesXPathEmptyLine(s string) bool {
 	return s == "" || strings.HasPrefix(s, "\n") || strings.Contains(s, "\n\n")
 }
 
-func fnAnalyzeString(_ context.Context, args []Sequence) (Sequence, error) {
+func fnAnalyzeString(ctx context.Context, args []Sequence) (Sequence, error) {
 	s, err := coerceArgToString(args[0])
 	if err != nil {
 		return nil, err
@@ -988,7 +999,14 @@ func fnAnalyzeString(_ context.Context, args []Sequence) (Sequence, error) {
 	if err != nil {
 		return nil, &XPathError{Code: errCodeFORX0002, Message: fmt.Sprintf("regex match failed: %v", err)}
 	}
+	// Charge the op-limit and honor context cancellation once per match: an input
+	// with a huge number of matches would otherwise build the result tree
+	// uncancellable and unaccounted against the op budget.
+	ec := getFnContext(ctx)
 	for _, m := range matches {
+		if err := fnCountOp(ctx, ec); err != nil {
+			return nil, err
+		}
 		start, end := m[0], m[1]
 		if start > pos {
 			if err := appendAnalyzeStringTextElement(doc, root, "non-match", s[pos:start]); err != nil {

--- a/xpath3/functions_string_bound_test.go
+++ b/xpath3/functions_string_bound_test.go
@@ -1,0 +1,88 @@
+package xpath3_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// Finding XPATH3-105: fn:string-to-codepoints builds the full codepoint
+// sequence one item per input character. That construction must charge the
+// evaluator op-limit so a huge input string cannot materialize an unbounded
+// item sequence below the node-set cap but above the configured op budget.
+func TestStringToCodepoints_LargeOpLimited(t *testing.T) {
+	const n = 200_000
+	doc := mustParseXML(t, "<root/>")
+
+	compiled, err := xpath3.NewCompiler().Compile("string-to-codepoints($s)")
+	require.NoError(t, err)
+
+	_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Variables(map[string]xpath3.Sequence{"s": xpath3.SingleString(strings.Repeat("x", n))}).
+		OpLimit(1000).
+		Evaluate(t.Context(), compiled, doc)
+	require.ErrorIs(t, err, xpath3.ErrOpLimit)
+}
+
+// Finding XPATH3-105: the codepoint-building loop must consult the context so a
+// cancellation that lands after evaluation begins aborts promptly instead of
+// scanning the whole input string.
+func TestStringToCodepoints_LargeCancellable(t *testing.T) {
+	const n = 200_000
+	doc := mustParseXML(t, "<root/>")
+
+	compiled, err := xpath3.NewCompiler().Compile("string-to-codepoints($s)")
+	require.NoError(t, err)
+
+	const cancelAfter = 500
+	ctx := &cancelAfterNContext{cancelAfter: cancelAfter}
+
+	_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Variables(map[string]xpath3.Sequence{"s": xpath3.SingleString(strings.Repeat("x", n))}).
+		Evaluate(ctx, compiled, doc)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, ctx.calls, n,
+		"string-to-codepoints must bail on cancellation, not scan the whole string")
+}
+
+// Finding XPATH3-102: fn:analyze-string iterates the regex matches and builds a
+// result tree element per match. That loop must charge the evaluator op-limit so
+// an input with a huge number of matches cannot build an unbounded result tree
+// below the node-set cap but above the configured op budget.
+func TestAnalyzeString_LargeOpLimited(t *testing.T) {
+	const n = 200_000
+	doc := mustParseXML(t, "<root/>")
+
+	compiled, err := xpath3.NewCompiler().Compile("analyze-string($s, 'a')")
+	require.NoError(t, err)
+
+	_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Variables(map[string]xpath3.Sequence{"s": xpath3.SingleString(strings.Repeat("a", n))}).
+		OpLimit(1000).
+		Evaluate(t.Context(), compiled, doc)
+	require.ErrorIs(t, err, xpath3.ErrOpLimit)
+}
+
+// Finding XPATH3-102: the analyze-string match loop must consult the context so
+// a cancellation that lands after evaluation begins aborts the tree build
+// promptly instead of emitting an element for every match first.
+func TestAnalyzeString_LargeCancellable(t *testing.T) {
+	const n = 200_000
+	doc := mustParseXML(t, "<root/>")
+
+	compiled, err := xpath3.NewCompiler().Compile("analyze-string($s, 'a')")
+	require.NoError(t, err)
+
+	const cancelAfter = 500
+	ctx := &cancelAfterNContext{cancelAfter: cancelAfter}
+
+	_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Variables(map[string]xpath3.Sequence{"s": xpath3.SingleString(strings.Repeat("a", n))}).
+		Evaluate(ctx, compiled, doc)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, ctx.calls, n,
+		"analyze-string must bail on cancellation, not emit an element per match")
+}

--- a/xpath3/functions_string_bound_test.go
+++ b/xpath3/functions_string_bound_test.go
@@ -2,6 +2,7 @@ package xpath3_test
 
 import (
 	"context"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -85,4 +86,44 @@ func TestAnalyzeString_LargeCancellable(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.Less(t, ctx.calls, n,
 		"analyze-string must bail on cancellation, not emit an element per match")
+}
+
+// Finding XPATH3-102 (r2): rejecting on the op-limit is not enough — the match
+// enumeration itself must STREAM so it never materializes the full O(matches)
+// index slice up front. With a tight OpLimit over millions of matches the call
+// must reject after charging ~OpLimit ops while allocating only a small bounded
+// amount of memory, far below the tens of MB a FindAllStringSubmatchIndex over
+// every match would need. Measuring the TotalAlloc delta proves the up-front
+// match slice is gone: a pre-fix build that enumerates all matches first blows
+// well past this ceiling regardless of where the op charge later fires.
+func TestAnalyzeString_LargeOpLimitedDoesNotMaterializeAllMatches(t *testing.T) {
+	const n = 4_000_000
+	doc := mustParseXML(t, "<root/>")
+
+	compiled, err := xpath3.NewCompiler().Compile("analyze-string($s, 'a')")
+	require.NoError(t, err)
+
+	input := strings.Repeat("a", n)
+
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	_, err = xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+		Variables(map[string]xpath3.Sequence{"s": xpath3.SingleString(input)}).
+		OpLimit(1000).
+		Evaluate(t.Context(), compiled, doc)
+	require.ErrorIs(t, err, xpath3.ErrOpLimit)
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	// FindAllStringSubmatchIndex over n single-char matches materializes an
+	// [][]int with n entries (each a 2-int slice) — at least n*(24+16) bytes,
+	// > 150MB for n=4M. Streaming and stopping at the OpLimit allocates only the
+	// ~1000 result elements, well under this 32MB ceiling.
+	const ceiling = 32 << 20
+	delta := after.TotalAlloc - before.TotalAlloc
+	require.Less(t, delta, uint64(ceiling),
+		"analyze-string must stream matches, not materialize the full O(matches) index slice; allocated %d bytes over %d matches", delta, n)
 }


### PR DESCRIPTION
- XPATH3-102: fn:analyze-string charges the op-limit and checks ctx cancellation per match in the result-tree build loop.
- XPATH3-105: fn:string-to-codepoints charges the op-limit, honors ctx, and caps at maxNodes while building the codepoint sequence item-by-item.