### PR TITLE
fix relaxng data pattern regex engine and length facet applicability

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -13,7 +13,7 @@ xpath1         → helium, internal/lexicon, internal/domutil
 xpath3         → helium, internal/xpath, internal/lexicon, internal/icu, internal/unparsedtext, internal/strcursor, internal/sequence, internal/xsdregex, internal/xmlchar, internal/domutil
 xslt3          → helium, xpath3, xsd, html, internal/iofs, internal/lexicon, internal/sequence, internal/uripath, internal/xpathstream, internal/domutil, xslt3/internal/elements
 xsd            → helium, xpath1, internal/lexicon, internal/xsd/value, internal/xsdregex, internal/uripath, internal/iofs
-relaxng        → helium, internal/lexicon, internal/iofs, internal/iolimit, internal/xsd/value, internal/xmlchar, internal/uripath
+relaxng        → helium, internal/lexicon, internal/iofs, internal/iolimit, internal/xsd/value, internal/xsdregex, internal/xmlchar, internal/uripath
 schematron     → helium, xpath1, internal/xpath, internal/xpath1/number
 xpointer       → helium, xpath1, internal/xmlchar
 c14n           → helium, internal/lexicon, internal/domutil

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -190,7 +190,7 @@ RELAX NG schema compilation and validation.
 - `ValidateError.Output` — libxml2-compatible error string; `ValidateError.Errors` — structured `[]ValidationError`
 - `ValidationError{Filename, Line, Element, Message}` — per-error structured type
 - Files: `relaxng.go` (API + config), `doc.go`, `grammar.go` (data model), `parse.go` (compiler), `parse_check.go` (compile checks), `validate.go` (engine), `errors.go` (error types + formatting)
-- Imports: helium, internal/lexicon, internal/iofs, internal/iolimit, internal/xsd/value, internal/xmlchar, internal/uripath
+- Imports: helium, internal/lexicon, internal/iofs, internal/iolimit, internal/xsd/value, internal/xsdregex, internal/xmlchar, internal/uripath
 - Status: 159/159 golden tests passing
 
 ## html/

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -509,6 +509,7 @@ XSD builtin value validation and comparison, extracted from `xsd/`.
 - **XSDFields(s string) []string** — split on XSD list whitespace
 - **Orderable(builtinLocal string) bool** — whether the primitive value space is ordered (range facets may apply)
 - **IsDecimalFamily(builtinLocal string) bool** — whether the type is xs:decimal or a derived integer (digit facets may apply)
+- **LengthApplicable(builtinLocal string) bool** — whether length/minLength/maxLength facets apply (string-derived, binary, anyURI, QName, NOTATION); shared by relaxng and xsd
 - **CountTotalDigits(value string) int** — significant total-digit count for the totalDigits facet
 - **CountFractionDigits(value string) int** — significant fraction-digit count for the fractionDigits facet
 - Files: `validate.go`, `compare.go`, `facets.go`

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -509,7 +509,8 @@ XSD builtin value validation and comparison, extracted from `xsd/`.
 - **XSDFields(s string) []string** — split on XSD list whitespace
 - **Orderable(builtinLocal string) bool** — whether the primitive value space is ordered (range facets may apply)
 - **IsDecimalFamily(builtinLocal string) bool** — whether the type is xs:decimal or a derived integer (digit facets may apply)
-- **LengthApplicable(builtinLocal string) bool** — whether length/minLength/maxLength facets apply (string-derived, binary, anyURI, QName, NOTATION); shared by relaxng and xsd
+- **LengthApplicable(builtinLocal string) bool** — whether length/minLength/maxLength facets are APPLICABLE/facet-valid (string-derived, binary, anyURI, QName, NOTATION); shared by relaxng and xsd
+- **LengthEnforced(builtinLocal string) bool** — whether an applicable length facet actually CONSTRAINS the value (true for string-derived/binary/anyURI; FALSE for QName/NOTATION, whose length facets are deprecated/non-constraining per XSD 1.1)
 - **CountTotalDigits(value string) int** — significant total-digit count for the totalDigits facet
 - **CountFractionDigits(value string) int** — significant fraction-digit count for the fractionDigits facet
 - Files: `validate.go`, `compare.go`, `facets.go`

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -509,8 +509,7 @@ XSD builtin value validation and comparison, extracted from `xsd/`.
 - **XSDFields(s string) []string** — split on XSD list whitespace
 - **Orderable(builtinLocal string) bool** — whether the primitive value space is ordered (range facets may apply)
 - **IsDecimalFamily(builtinLocal string) bool** — whether the type is xs:decimal or a derived integer (digit facets may apply)
-- **LengthApplicable(builtinLocal string) bool** — whether length/minLength/maxLength facets are APPLICABLE/facet-valid (string-derived, binary, anyURI, QName, NOTATION); shared by relaxng and xsd
-- **LengthEnforced(builtinLocal string) bool** — whether an applicable length facet actually CONSTRAINS the value (true for string-derived/binary/anyURI; FALSE for QName/NOTATION, whose length facets are deprecated/non-constraining per XSD 1.1)
+- **LengthApplicable(builtinLocal string) bool** — whether length/minLength/maxLength facets apply and CONSTRAIN the value (string-derived, binary, anyURI, QName, NOTATION — enforced per XSD 1.0/libxml2 parity); shared by relaxng and xsd
 - **CountTotalDigits(value string) int** — significant total-digit count for the totalDigits facet
 - **CountFractionDigits(value string) int** — significant fraction-digit count for the fractionDigits facet
 - Files: `validate.go`, `compare.go`, `facets.go`

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -459,7 +459,20 @@ names/libraries fail rather than matching by raw equality.
 `length` as well as `minLength`/`maxLength`, computing length by datatype via
 `facetLength`: rune count for string-family types, XML-whitespace token COUNT
 for XSD list builtins (`NMTOKENS`/`IDREFS`/`ENTITIES`), and decoded OCTET count
-for binary (`hexBinary`/`base64Binary`).
+for binary (`hexBinary`/`base64Binary`). The length facets are APPLICABLE only to
+the string-derived family, the binary types, anyURI, QName and NOTATION
+(`value.LengthApplicable`, the shared single-source set in `internal/xsd/value`);
+a length facet on a numeric, boolean or date/time datatype is rejected at COMPILE
+time by `checkDataFacets`.
+
+**Pattern facet.** The `pattern` facet is an XSD/XPath regular expression matched
+through the shared XSD-regex engine (`internal/xsdregex`, the same translator
+`xsd` and `xpath3` use), NOT Go's `regexp` — so XSD-only constructs (`\i`/`\c`
+name-class shorthands, `\p{...}` blocks, character-class subtraction) are honoured
+rather than false-rejected. `checkDataFacets` compiles the pattern once at compile
+time (caching the `*xsdregex.Regexp` on the `param`, guarded by `patternChecked`
+against shared-`<ref>` re-visits); an invalid pattern is a fatal schema error, and
+`validateWithParams` reuses the cached compilation (whole-value anchored).
 
 **Ordering / digit facets.** `validateWithParams` also enforces the range facets
 (`min`/`maxInclusive`, `min`/`maxExclusive`) via `facetOrderingOK` (shared
@@ -476,7 +489,9 @@ which trims NBSP and overflows large bounds into a reject-all). Facet APPLICABIL
 and bound LEXICAL VALIDITY are enforced at COMPILE time by `checkDataFacets`
 (`parse_check.go`, run from the `patternData` case of
 `checkPattern`): an ordering facet on a non-ordered datatype (`!value.Orderable`)
-or with an invalid bound, a digit facet on a non-decimal datatype, and a digit-facet
+or with an invalid bound, a digit facet on a non-decimal datatype, a length facet
+on a non-string-derived datatype (`!value.LengthApplicable`), an uncompilable
+`pattern`, and a digit-facet
 bound that is not a valid `xs:positiveInteger` (`totalDigits`) /
 `xs:nonNegativeInteger` (`fractionDigits`) — including an NBSP-padded or
 out-of-range bound — are fatal

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -461,7 +461,8 @@ names/libraries fail rather than matching by raw equality.
 for XSD list builtins (`NMTOKENS`/`IDREFS`/`ENTITIES`), and decoded OCTET count
 for binary (`hexBinary`/`base64Binary`). The length facets are APPLICABLE only to
 the string-derived family, the binary types, anyURI, QName and NOTATION
-(`value.LengthApplicable`, the shared single-source set in `internal/xsd/value`);
+(`value.LengthApplicable` in `internal/xsd/value`, shared with relaxng; xsd's
+`check_facets.go` keeps an equivalent table);
 a length facet on a numeric, boolean or date/time datatype is rejected at COMPILE
 time by `checkDataFacets`.
 

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -464,11 +464,21 @@ the string-derived family, the binary types, anyURI, QName and NOTATION
 (`value.LengthApplicable` in `internal/xsd/value`, shared with relaxng; xsd's
 `check_facets.go` keeps an equivalent table);
 a length facet on a numeric, boolean or date/time datatype is rejected at COMPILE
-time by `checkDataFacets`. Each length bound is itself COMPILE-validated as an
+time by `checkDataFacets`. APPLICABLE is about facet-VALIDITY (may the facet
+appear, is its bound valid), NOT enforcement: on `xs:QName` and `xs:NOTATION` the
+length facets are applicable (so they may appear and the bound is validated) but
+DEPRECATED and NON-CONSTRAINING per XSD 1.1 — a lexically valid QName/NOTATION is
+facet-valid regardless of its rune count. `validateWithParams` gates the actual
+length comparison on `value.LengthEnforced` (true for string-derived/binary/anyURI,
+FALSE for QName/NOTATION), so a multi-rune QName with `maxLength="1"` is ACCEPTED
+rather than rejected, while the bound itself is still compile-validated. Each
+length bound is COMPILE-validated as an
 `xs:nonNegativeInteger` (XSD-collapse normalized, NOT Go `TrimSpace`) so a
 negative, fractional, non-digit, or NBSP-padded bound is a fatal schema error
+(including on QName/NOTATION)
 rather than a facet that silently accepts every value (`minLength="-1"`) or whose
-bound is leniently trimmed. At validation `validateWithParams` parses the bound
+bound is leniently trimmed. At validation, for an ENFORCED type
+`validateWithParams` parses the bound
 with `math/big` (`parseNonNegFacetBound`) and compares against `facetLength` via
 `big.Int.Cmp`, so a huge-but-valid `maxLength` cannot overflow `int` into a
 reject-all.

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -464,21 +464,17 @@ the string-derived family, the binary types, anyURI, QName and NOTATION
 (`value.LengthApplicable` in `internal/xsd/value`, shared with relaxng; xsd's
 `check_facets.go` keeps an equivalent table);
 a length facet on a numeric, boolean or date/time datatype is rejected at COMPILE
-time by `checkDataFacets`. APPLICABLE is about facet-VALIDITY (may the facet
-appear, is its bound valid), NOT enforcement: on `xs:QName` and `xs:NOTATION` the
-length facets are applicable (so they may appear and the bound is validated) but
-DEPRECATED and NON-CONSTRAINING per XSD 1.1 — a lexically valid QName/NOTATION is
-facet-valid regardless of its rune count. `validateWithParams` gates the actual
-length comparison on `value.LengthEnforced` (true for string-derived/binary/anyURI,
-FALSE for QName/NOTATION), so a multi-rune QName with `maxLength="1"` is ACCEPTED
-rather than rejected, while the bound itself is still compile-validated. Each
+time by `checkDataFacets`. On every applicable type the length facets are
+CONSTRAINING — including `xs:QName` and `xs:NOTATION` (XSD 1.0 / libxml2 parity):
+a value whose rune count violates the bound is REJECTED, exactly as the shared xsd
+validator's `facetLength` rejects it (so RELAX NG and xsd cannot diverge — a
+multi-rune QName with `maxLength="1"` fails in both). Each
 length bound is COMPILE-validated as an
 `xs:nonNegativeInteger` (XSD-collapse normalized, NOT Go `TrimSpace`) so a
 negative, fractional, non-digit, or NBSP-padded bound is a fatal schema error
 (including on QName/NOTATION)
 rather than a facet that silently accepts every value (`minLength="-1"`) or whose
-bound is leniently trimmed. At validation, for an ENFORCED type
-`validateWithParams` parses the bound
+bound is leniently trimmed. At validation `validateWithParams` parses the bound
 with `math/big` (`parseNonNegFacetBound`) and compares against `facetLength` via
 `big.Int.Cmp`, so a huge-but-valid `maxLength` cannot overflow `int` into a
 reject-all.

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -464,7 +464,14 @@ the string-derived family, the binary types, anyURI, QName and NOTATION
 (`value.LengthApplicable` in `internal/xsd/value`, shared with relaxng; xsd's
 `check_facets.go` keeps an equivalent table);
 a length facet on a numeric, boolean or date/time datatype is rejected at COMPILE
-time by `checkDataFacets`.
+time by `checkDataFacets`. Each length bound is itself COMPILE-validated as an
+`xs:nonNegativeInteger` (XSD-collapse normalized, NOT Go `TrimSpace`) so a
+negative, fractional, non-digit, or NBSP-padded bound is a fatal schema error
+rather than a facet that silently accepts every value (`minLength="-1"`) or whose
+bound is leniently trimmed. At validation `validateWithParams` parses the bound
+with `math/big` (`parseNonNegFacetBound`) and compares against `facetLength` via
+`big.Int.Cmp`, so a huge-but-valid `maxLength` cannot overflow `int` into a
+reject-all.
 
 **Pattern facet.** The `pattern` facet is an XSD/XPath regular expression matched
 through the shared XSD-regex engine (`internal/xsdregex`, the same translator
@@ -484,17 +491,19 @@ for two valid ORDERED operands that are genuinely indeterminate (e.g. mixed-time
 `xs:dateTime`), matching XSD semantics — but a NaN operand is the exception: an
 `xs:float`/`xs:double` NaN instance value OR NaN bound is excluded by the bounding
 facets (`value.IsFloatNaN`), so the facet FAILS rather than slipping through. The
-digit-facet bounds are parsed with `math/big` (`parseDigitFacetBound`, normalizing
-via the XSD collapse whiteSpace facet — NOT Go's `strconv.Atoi`+`strings.TrimSpace`,
-which trims NBSP and overflows large bounds into a reject-all). Facet APPLICABILITY
+digit- and length-facet bounds are parsed with `math/big` (`parseNonNegFacetBound`,
+normalizing via the XSD collapse whiteSpace facet — NOT Go's
+`strconv.Atoi`+`strings.TrimSpace`, which trims NBSP and overflows large bounds
+into a reject-all). Facet APPLICABILITY
 and bound LEXICAL VALIDITY are enforced at COMPILE time by `checkDataFacets`
 (`parse_check.go`, run from the `patternData` case of
 `checkPattern`): an ordering facet on a non-ordered datatype (`!value.Orderable`)
 or with an invalid bound, a digit facet on a non-decimal datatype, a length facet
 on a non-string-derived datatype (`!value.LengthApplicable`), an uncompilable
-`pattern`, and a digit-facet
+`pattern`, a digit-facet
 bound that is not a valid `xs:positiveInteger` (`totalDigits`) /
-`xs:nonNegativeInteger` (`fractionDigits`) — including an NBSP-padded or
+`xs:nonNegativeInteger` (`fractionDigits`), and a length-facet bound that is not a
+valid `xs:nonNegativeInteger` — including an NBSP-padded or
 out-of-range bound — are fatal
 schema errors — which makes the whole grammar unmatchable (`compileSchema`
 replaces `start` with `notAllowed`). `effectiveXSDDatatype` resolves the `<data>`

--- a/internal/xsd/value/facets.go
+++ b/internal/xsd/value/facets.go
@@ -69,45 +69,14 @@ var lengthApplicableTypes = map[string]struct{}{
 // on this keep the length facets off the numeric/decimal family, boolean, float,
 // double and the date/time/duration family, where XSD declares them inapplicable.
 //
-// Applicable is about facet-VALIDITY (may the facet appear, and must its bound be
-// a valid xs:nonNegativeInteger), NOT about whether the facet constrains the
-// value at validation time. For xs:QName and xs:NOTATION the length facets are
-// applicable (so they may appear and the bound is validated) but DEPRECATED and
-// NON-CONSTRAINING per XSD 1.1 — any lexically valid value is facet-valid
-// regardless of its rune length. Use LengthEnforced to gate the actual length
-// comparison.
+// On the applicable types — including xs:QName and xs:NOTATION — the length
+// facets are CONSTRAINING (XSD 1.0 / libxml2 parity): a value whose length (rune
+// count for the string family / QName / NOTATION / anyURI, octet count for the
+// binary types) violates the bound is rejected, the same way the xsd package
+// enforces it (see xsd's facetLength). This keeps relaxng and xsd consistent.
 func LengthApplicable(builtinLocal string) bool {
 	_, ok := lengthApplicableTypes[builtinLocal]
 	return ok
-}
-
-// lengthNoOpTypes is the subset of lengthApplicableTypes whose length facets are
-// DEPRECATED and NON-CONSTRAINING in XSD 1.1: length/minLength/maxLength on
-// xs:QName and xs:NOTATION are facet-valid (applicable, with a validated bound)
-// but never reject a value for its rune count — any lexically valid QName/NOTATION
-// is facet-valid regardless of the bound. Enforcing them as a character count
-// would wrongly reject valid values.
-var lengthNoOpTypes = map[string]struct{}{
-	lexicon.TypeQName:    {},
-	lexicon.TypeNotation: {},
-}
-
-// LengthEnforced reports whether the length facets (length, minLength, maxLength),
-// when present and applicable to builtinLocal, actually CONSTRAIN the value at
-// validation time. It is true for the string-derived, binary and anyURI types,
-// where length is a real rune/octet-count constraint, and FALSE for xs:QName and
-// xs:NOTATION, whose length facets are deprecated and facet-valid but
-// non-constraining (XSD 1.1) — a lexically valid value passes regardless of the
-// bound. Callers must still treat the facet as applicable (LengthApplicable) for
-// facet-validity and bound validation; LengthEnforced only gates the runtime
-// length comparison. A type to which the facet is wholly inapplicable returns
-// false here too (there is nothing to enforce).
-func LengthEnforced(builtinLocal string) bool {
-	if _, ok := lengthApplicableTypes[builtinLocal]; !ok {
-		return false
-	}
-	_, noop := lengthNoOpTypes[builtinLocal]
-	return !noop
 }
 
 // IsDecimalFamily reports whether builtinLocal is in the xs:decimal family

--- a/internal/xsd/value/facets.go
+++ b/internal/xsd/value/facets.go
@@ -68,9 +68,46 @@ var lengthApplicableTypes = map[string]struct{}{
 // maxLength) are applicable to builtinLocal's atomic value space. Callers gating
 // on this keep the length facets off the numeric/decimal family, boolean, float,
 // double and the date/time/duration family, where XSD declares them inapplicable.
+//
+// Applicable is about facet-VALIDITY (may the facet appear, and must its bound be
+// a valid xs:nonNegativeInteger), NOT about whether the facet constrains the
+// value at validation time. For xs:QName and xs:NOTATION the length facets are
+// applicable (so they may appear and the bound is validated) but DEPRECATED and
+// NON-CONSTRAINING per XSD 1.1 — any lexically valid value is facet-valid
+// regardless of its rune length. Use LengthEnforced to gate the actual length
+// comparison.
 func LengthApplicable(builtinLocal string) bool {
 	_, ok := lengthApplicableTypes[builtinLocal]
 	return ok
+}
+
+// lengthNoOpTypes is the subset of lengthApplicableTypes whose length facets are
+// DEPRECATED and NON-CONSTRAINING in XSD 1.1: length/minLength/maxLength on
+// xs:QName and xs:NOTATION are facet-valid (applicable, with a validated bound)
+// but never reject a value for its rune count — any lexically valid QName/NOTATION
+// is facet-valid regardless of the bound. Enforcing them as a character count
+// would wrongly reject valid values.
+var lengthNoOpTypes = map[string]struct{}{
+	lexicon.TypeQName:    {},
+	lexicon.TypeNotation: {},
+}
+
+// LengthEnforced reports whether the length facets (length, minLength, maxLength),
+// when present and applicable to builtinLocal, actually CONSTRAIN the value at
+// validation time. It is true for the string-derived, binary and anyURI types,
+// where length is a real rune/octet-count constraint, and FALSE for xs:QName and
+// xs:NOTATION, whose length facets are deprecated and facet-valid but
+// non-constraining (XSD 1.1) — a lexically valid value passes regardless of the
+// bound. Callers must still treat the facet as applicable (LengthApplicable) for
+// facet-validity and bound validation; LengthEnforced only gates the runtime
+// length comparison. A type to which the facet is wholly inapplicable returns
+// false here too (there is nothing to enforce).
+func LengthEnforced(builtinLocal string) bool {
+	if _, ok := lengthApplicableTypes[builtinLocal]; !ok {
+		return false
+	}
+	_, noop := lengthNoOpTypes[builtinLocal]
+	return !noop
 }
 
 // IsDecimalFamily reports whether builtinLocal is in the xs:decimal family

--- a/internal/xsd/value/facets.go
+++ b/internal/xsd/value/facets.go
@@ -49,6 +49,30 @@ func Orderable(builtinLocal string) bool {
 	return ok
 }
 
+// lengthApplicableTypes is the set of builtin locals on whose atomic value space
+// the length facets (length, minLength, maxLength) are applicable. Per XSD §3.16
+// length measures characters (string family), octets (the binary types) or
+// characters of the lexical/canonical form for anyURI, QName and NOTATION. It is
+// INAPPLICABLE to the numeric/decimal family, boolean, float, double and the
+// date/time/duration family. The string-derived family is enumerated explicitly
+// so the gate does not depend on primitive collapsing.
+var lengthApplicableTypes = map[string]struct{}{
+	lexicon.TypeString: {}, lexicon.TypeNormalizedString: {}, lexicon.TypeToken: {}, "language": {},
+	"Name": {}, "NCName": {}, "ID": {}, lexicon.TypeIDREF: {}, "IDREFS": {},
+	"ENTITY": {}, "ENTITIES": {}, "NMTOKEN": {}, "NMTOKENS": {},
+	lexicon.TypeAnyURI: {}, lexicon.TypeQName: {}, lexicon.TypeNotation: {},
+	"hexBinary": {}, "base64Binary": {},
+}
+
+// LengthApplicable reports whether the length facets (length, minLength,
+// maxLength) are applicable to builtinLocal's atomic value space. Callers gating
+// on this keep the length facets off the numeric/decimal family, boolean, float,
+// double and the date/time/duration family, where XSD declares them inapplicable.
+func LengthApplicable(builtinLocal string) bool {
+	_, ok := lengthApplicableTypes[builtinLocal]
+	return ok
+}
+
 // IsDecimalFamily reports whether builtinLocal is in the xs:decimal family
 // (xs:decimal and its integer derivations). These are the ONLY types on which the
 // digit facets (totalDigits, fractionDigits) are applicable; the facets are

--- a/relaxng/data_facet_pattern_length_test.go
+++ b/relaxng/data_facet_pattern_length_test.go
@@ -94,3 +94,98 @@ func TestDataLengthFacetApplicability(t *testing.T) {
 			"length facet on xs:hexBinary must compile")
 	})
 }
+
+// TestDataLengthFacetBoundValidity covers RNG-104+105 r2: a length/minLength/
+// maxLength bound must be a valid xs:nonNegativeInteger, validated at COMPILE
+// time with XSD lexical/whitespace rules (not Go's strconv.Atoi + TrimSpace).
+// A negative bound, an NBSP-padded bound, or any non-integer bound is a compile
+// error; and a huge-but-valid bound must NOT overflow int into a reject-all.
+func TestDataLengthFacetBoundValidity(t *testing.T) {
+	t.Parallel()
+
+	const xsd = `datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"`
+
+	mk := func(facet, bound string) string {
+		return `<element name="r" xmlns="http://relaxng.org/ns/structure/1.0" ` + xsd + `>
+  <data type="string"><param name="` + facet + `">` + bound + `</param></data>
+</element>`
+	}
+
+	t.Run("negative minLength is a compile error", func(t *testing.T) {
+		t.Parallel()
+		// Without bound validation, "-1" compiled and then accepted EVERY value
+		// (length >= -1 always holds), silently disabling the facet.
+		require.NotEmpty(t, compileErrorsFor(t, mk("minLength", "-1")),
+			`minLength="-1" must be a compile error, not an accept-all facet`)
+	})
+
+	t.Run("negative length is a compile error", func(t *testing.T) {
+		t.Parallel()
+		require.NotEmpty(t, compileErrorsFor(t, mk("length", "-2")),
+			`length="-2" must be a compile error`)
+	})
+
+	t.Run("negative maxLength is a compile error", func(t *testing.T) {
+		t.Parallel()
+		require.NotEmpty(t, compileErrorsFor(t, mk("maxLength", "-1")),
+			`maxLength="-1" must be a compile error`)
+	})
+
+	t.Run("NBSP-padded bound is a compile error", func(t *testing.T) {
+		t.Parallel()
+		// U+00A0 (NBSP) is NOT XSD whitespace, so it is not collapsed away: the
+		// bound is not a valid xs:nonNegativeInteger. Go's TrimSpace would strip
+		// it and Atoi would accept the digits, which is wrong XSD handling.
+		require.NotEmpty(t, compileErrorsFor(t, mk("minLength", " 3")),
+			"NBSP-padded bound must be a compile error")
+	})
+
+	t.Run("fractional bound is a compile error", func(t *testing.T) {
+		t.Parallel()
+		require.NotEmpty(t, compileErrorsFor(t, mk("maxLength", "3.0")),
+			`maxLength="3.0" must be a compile error`)
+	})
+
+	t.Run("non-digit bound is a compile error", func(t *testing.T) {
+		t.Parallel()
+		require.NotEmpty(t, compileErrorsFor(t, mk("length", "abc")),
+			`length="abc" must be a compile error`)
+	})
+
+	t.Run("XSD-whitespace-padded bound compiles", func(t *testing.T) {
+		t.Parallel()
+		// Leading/trailing XSD whitespace (here a newline + spaces) IS collapsed,
+		// so the bound is the valid xs:nonNegativeInteger "3".
+		require.Empty(t, compileErrorsFor(t, mk("length", "\n  3  ")),
+			"XSD-whitespace-padded bound must compile")
+	})
+
+	t.Run("huge maxLength does not reject valid short values", func(t *testing.T) {
+		t.Parallel()
+		// A bound far beyond int range must compare width-safely: parsing it with
+		// strconv.Atoi overflows and (depending on platform) flips the facet into
+		// a reject-all. A 3-char value must still satisfy this enormous maxLength.
+		huge := "99999999999999999999999999999999999999"
+		require.NoError(t, validateWith(t, mk("maxLength", huge), `<r>abc</r>`),
+			"a huge but valid maxLength must accept a short value, not reject-all")
+	})
+
+	t.Run("huge minLength still rejects short values", func(t *testing.T) {
+		t.Parallel()
+		huge := "99999999999999999999999999999999999999"
+		require.Error(t, validateWith(t, mk("minLength", huge), `<r>abc</r>`),
+			"a huge minLength must reject a short value")
+	})
+
+	t.Run("normal bound still enforces length", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, validateWith(t, mk("length", "3"), `<r>abc</r>`),
+			`length="3" must accept a 3-char value`)
+		require.Error(t, validateWith(t, mk("length", "3"), `<r>ab</r>`),
+			`length="3" must reject a 2-char value`)
+		require.NoError(t, validateWith(t, mk("minLength", "2"), `<r>abc</r>`),
+			`minLength="2" must accept a 3-char value`)
+		require.Error(t, validateWith(t, mk("maxLength", "2"), `<r>abc</r>`),
+			`maxLength="2" must reject a 3-char value`)
+	})
+}

--- a/relaxng/data_facet_pattern_length_test.go
+++ b/relaxng/data_facet_pattern_length_test.go
@@ -95,6 +95,66 @@ func TestDataLengthFacetApplicability(t *testing.T) {
 	})
 }
 
+// TestDataLengthFacetQNameNoOp covers RNG-104+105 r3: the length facets
+// (length, minLength, maxLength) are APPLICABLE to xs:QName and xs:NOTATION (so
+// the bound must still be a valid xs:nonNegativeInteger, validated at compile
+// time), but per XSD 1.1 they are DEPRECATED and NON-CONSTRAINING on those two
+// types — any lexically valid value is facet-valid regardless of its rune count.
+// So a multi-rune QName must NOT be rejected by maxLength/minLength/length, while
+// an invalid bound is still a compile error and string-type enforcement is
+// unaffected.
+func TestDataLengthFacetQNameNoOp(t *testing.T) {
+	t.Parallel()
+
+	const xsd = `datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"`
+
+	mk := func(typ, facet, bound string) string {
+		return `<element name="r" xmlns="http://relaxng.org/ns/structure/1.0" ` + xsd + `>
+  <data type="` + typ + `"><param name="` + facet + `">` + bound + `</param></data>
+</element>`
+	}
+
+	t.Run("maxLength does not constrain a QName", func(t *testing.T) {
+		t.Parallel()
+		// "abc" is a 3-rune lexically valid QName. maxLength="1" would reject it if
+		// enforced as a character count, but the facet is non-constraining here.
+		require.NoError(t, validateWith(t, mk("QName", "maxLength", "1"), `<r>abc</r>`),
+			`maxLength on xs:QName must be a no-op, not a rune-count constraint`)
+	})
+
+	t.Run("minLength does not constrain a QName", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, validateWith(t, mk("QName", "minLength", "100"), `<r>abc</r>`),
+			`minLength on xs:QName must be a no-op`)
+	})
+
+	t.Run("length does not constrain a QName", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, validateWith(t, mk("QName", "length", "1"), `<r>abc</r>`),
+			`length on xs:QName must be a no-op`)
+	})
+
+	t.Run("maxLength does not constrain a NOTATION", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, validateWith(t, mk("NOTATION", "maxLength", "1"), `<r>abc</r>`),
+			`maxLength on xs:NOTATION must be a no-op`)
+	})
+
+	t.Run("length facet on QName still compiles", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, compileErrorsFor(t, mk("QName", "length", "1")),
+			"length facet on xs:QName is applicable and must compile")
+	})
+
+	t.Run("invalid bound on QName is still a compile error", func(t *testing.T) {
+		t.Parallel()
+		// The bound itself must remain a valid xs:nonNegativeInteger even though the
+		// facet does not constrain the value (the r2 bound check is kept).
+		require.NotEmpty(t, compileErrorsFor(t, mk("QName", "maxLength", "-1")),
+			`maxLength="-1" on xs:QName must still be a compile error`)
+	})
+}
+
 // TestDataLengthFacetBoundValidity covers RNG-104+105 r2: a length/minLength/
 // maxLength bound must be a valid xs:nonNegativeInteger, validated at COMPILE
 // time with XSD lexical/whitespace rules (not Go's strconv.Atoi + TrimSpace).

--- a/relaxng/data_facet_pattern_length_test.go
+++ b/relaxng/data_facet_pattern_length_test.go
@@ -1,0 +1,96 @@
+package relaxng_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDataPatternFacetXSDRegex covers RNG-104: a <data> pattern facet must be
+// evaluated with the XSD/XPath regular-expression engine (internal/xsdregex),
+// not Go's regexp package, so XSD-only constructs such as the \i (XML
+// name-start) and \c (XML name) character-class shorthands are honoured rather
+// than false-rejected.
+func TestDataPatternFacetXSDRegex(t *testing.T) {
+	t.Parallel()
+
+	const xsd = `datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"`
+
+	schema := `<element name="r" xmlns="http://relaxng.org/ns/structure/1.0" ` + xsd + `>
+  <data type="string"><param name="pattern">\i\c*</param></data>
+</element>`
+
+	t.Run("accepts a valid XML name", func(t *testing.T) {
+		t.Parallel()
+		// "_foo-bar" is a valid XML Name (\i name-start, then \c* name chars). Go's
+		// regexp engine errors on the \i/\c escapes and so wrongly rejected this.
+		require.NoError(t, validateWith(t, schema, `<r>_foo-bar</r>`),
+			`\i\c* must accept a valid XML name`)
+	})
+
+	t.Run("rejects a non-name value", func(t *testing.T) {
+		t.Parallel()
+		// "1abc" starts with a digit, which is not an XML name-start character, so
+		// it must not match \i\c*.
+		require.Error(t, validateWith(t, schema, `<r>1abc</r>`),
+			`\i\c* must reject a value whose first char is not a name-start char`)
+	})
+
+	t.Run("unicode property class", func(t *testing.T) {
+		t.Parallel()
+		// \p{Lu} (an uppercase-letter category) is another XSD-regex construct Go's
+		// engine does not accept.
+		s := `<element name="r" xmlns="http://relaxng.org/ns/structure/1.0" ` + xsd + `>
+  <data type="string"><param name="pattern">\p{Lu}+</param></data>
+</element>`
+		require.NoError(t, validateWith(t, s, `<r>ABC</r>`), `\p{Lu}+ must accept "ABC"`)
+		require.Error(t, validateWith(t, s, `<r>abc</r>`), `\p{Lu}+ must reject "abc"`)
+	})
+}
+
+// TestDataLengthFacetApplicability covers RNG-105: the length facets (length,
+// minLength, maxLength) are applicable only to string-derived, binary, anyURI,
+// QName and NOTATION datatypes. Applying one to a numeric/boolean/date datatype
+// is a schema error and must be reported at compile time, matching the XSD
+// facet-applicability rules.
+func TestDataLengthFacetApplicability(t *testing.T) {
+	t.Parallel()
+
+	const xsd = `datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"`
+
+	mk := func(typ, facet string) string {
+		return `<element name="r" xmlns="http://relaxng.org/ns/structure/1.0" ` + xsd + `>
+  <data type="` + typ + `"><param name="` + facet + `">3</param></data>
+</element>`
+	}
+
+	t.Run("length on integer is a compile error", func(t *testing.T) {
+		t.Parallel()
+		require.NotEmpty(t, compileErrorsFor(t, mk("integer", "length")),
+			"length facet on xs:integer must be a compile error")
+	})
+
+	t.Run("minLength on boolean is a compile error", func(t *testing.T) {
+		t.Parallel()
+		require.NotEmpty(t, compileErrorsFor(t, mk("boolean", "minLength")),
+			"minLength facet on xs:boolean must be a compile error")
+	})
+
+	t.Run("maxLength on date is a compile error", func(t *testing.T) {
+		t.Parallel()
+		require.NotEmpty(t, compileErrorsFor(t, mk("date", "maxLength")),
+			"maxLength facet on xs:date must be a compile error")
+	})
+
+	t.Run("length on string is allowed", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, compileErrorsFor(t, mk("string", "length")),
+			"length facet on xs:string must compile")
+	})
+
+	t.Run("length on hexBinary is allowed", func(t *testing.T) {
+		t.Parallel()
+		require.Empty(t, compileErrorsFor(t, mk("hexBinary", "length")),
+			"length facet on xs:hexBinary must compile")
+	})
+}

--- a/relaxng/data_facet_pattern_length_test.go
+++ b/relaxng/data_facet_pattern_length_test.go
@@ -95,15 +95,14 @@ func TestDataLengthFacetApplicability(t *testing.T) {
 	})
 }
 
-// TestDataLengthFacetQNameNoOp covers RNG-104+105 r3: the length facets
-// (length, minLength, maxLength) are APPLICABLE to xs:QName and xs:NOTATION (so
-// the bound must still be a valid xs:nonNegativeInteger, validated at compile
-// time), but per XSD 1.1 they are DEPRECATED and NON-CONSTRAINING on those two
-// types — any lexically valid value is facet-valid regardless of its rune count.
-// So a multi-rune QName must NOT be rejected by maxLength/minLength/length, while
-// an invalid bound is still a compile error and string-type enforcement is
+// TestDataLengthFacetQNameEnforced covers RNG-104+105 r4: the length facets
+// (length, minLength, maxLength) on xs:QName and xs:NOTATION are CONSTRAINING
+// (XSD 1.0 / libxml2 parity, matching the shared xsd validator's facetLength), not
+// a no-op. A value whose rune count violates the bound is REJECTED exactly as the
+// xsd package rejects it, while an in-bounds value is accepted, the bound is still
+// compile-validated as an xs:nonNegativeInteger, and string-type enforcement is
 // unaffected.
-func TestDataLengthFacetQNameNoOp(t *testing.T) {
+func TestDataLengthFacetQNameEnforced(t *testing.T) {
 	t.Parallel()
 
 	const xsd = `datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"`
@@ -114,30 +113,36 @@ func TestDataLengthFacetQNameNoOp(t *testing.T) {
 </element>`
 	}
 
-	t.Run("maxLength does not constrain a QName", func(t *testing.T) {
+	t.Run("maxLength constrains a QName", func(t *testing.T) {
 		t.Parallel()
-		// "abc" is a 3-rune lexically valid QName. maxLength="1" would reject it if
-		// enforced as a character count, but the facet is non-constraining here.
-		require.NoError(t, validateWith(t, mk("QName", "maxLength", "1"), `<r>abc</r>`),
-			`maxLength on xs:QName must be a no-op, not a rune-count constraint`)
+		// "abc" is a 3-rune lexically valid QName; maxLength="1" rejects it, the same
+		// way the xsd validator rejects an out-of-space QName length facet.
+		require.Error(t, validateWith(t, mk("QName", "maxLength", "1"), `<r>abc</r>`),
+			`maxLength on xs:QName must reject a longer value (XSD 1.0 parity)`)
 	})
 
-	t.Run("minLength does not constrain a QName", func(t *testing.T) {
+	t.Run("maxLength accepts an in-bounds QName", func(t *testing.T) {
 		t.Parallel()
-		require.NoError(t, validateWith(t, mk("QName", "minLength", "100"), `<r>abc</r>`),
-			`minLength on xs:QName must be a no-op`)
+		require.NoError(t, validateWith(t, mk("QName", "maxLength", "3"), `<r>abc</r>`),
+			`maxLength on xs:QName must accept an in-bounds value`)
 	})
 
-	t.Run("length does not constrain a QName", func(t *testing.T) {
+	t.Run("minLength constrains a QName", func(t *testing.T) {
 		t.Parallel()
-		require.NoError(t, validateWith(t, mk("QName", "length", "1"), `<r>abc</r>`),
-			`length on xs:QName must be a no-op`)
+		require.Error(t, validateWith(t, mk("QName", "minLength", "100"), `<r>abc</r>`),
+			`minLength on xs:QName must reject a too-short value`)
 	})
 
-	t.Run("maxLength does not constrain a NOTATION", func(t *testing.T) {
+	t.Run("length constrains a QName", func(t *testing.T) {
 		t.Parallel()
-		require.NoError(t, validateWith(t, mk("NOTATION", "maxLength", "1"), `<r>abc</r>`),
-			`maxLength on xs:NOTATION must be a no-op`)
+		require.Error(t, validateWith(t, mk("QName", "length", "1"), `<r>abc</r>`),
+			`length on xs:QName must reject a value of a different length`)
+	})
+
+	t.Run("maxLength constrains a NOTATION", func(t *testing.T) {
+		t.Parallel()
+		require.Error(t, validateWith(t, mk("NOTATION", "maxLength", "1"), `<r>abc</r>`),
+			`maxLength on xs:NOTATION must reject a longer value`)
 	})
 
 	t.Run("length facet on QName still compiles", func(t *testing.T) {
@@ -148,8 +153,8 @@ func TestDataLengthFacetQNameNoOp(t *testing.T) {
 
 	t.Run("invalid bound on QName is still a compile error", func(t *testing.T) {
 		t.Parallel()
-		// The bound itself must remain a valid xs:nonNegativeInteger even though the
-		// facet does not constrain the value (the r2 bound check is kept).
+		// The bound itself must remain a valid xs:nonNegativeInteger (the r2 bound
+		// check is kept).
 		require.NotEmpty(t, compileErrorsFor(t, mk("QName", "maxLength", "-1")),
 			`maxLength="-1" on xs:QName must still be a compile error`)
 	})

--- a/relaxng/grammar.go
+++ b/relaxng/grammar.go
@@ -1,5 +1,7 @@
 package relaxng
 
+import "github.com/lestrrat-go/helium/internal/xsdregex"
+
 // Grammar is a compiled RELAX NG schema, analogous to [xsd.Schema].
 // (libxml2: xmlRelaxNGPtr)
 type Grammar struct {
@@ -70,6 +72,14 @@ type dataType struct {
 type param struct {
 	name  string
 	value string
+
+	// compiledPattern is the XSD-regex compilation of a "pattern" facet's value,
+	// populated once at compile time (checkDataFacets) so validation reuses it
+	// instead of recompiling per value. patternChecked guards that one-time work
+	// (and its error report) against a data pattern reached more than once through
+	// shared <ref> definitions.
+	compiledPattern *xsdregex.Regexp
+	patternChecked  bool
 }
 
 // nameClassKind enumerates name class types.

--- a/relaxng/parse_check.go
+++ b/relaxng/parse_check.go
@@ -6,6 +6,7 @@ import (
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/xsd/value"
+	"github.com/lestrrat-go/helium/internal/xsdregex"
 )
 
 // ruleFlags tracks ancestor context for forbidden-pattern-nesting checks.
@@ -216,6 +217,30 @@ func (c *compiler) checkDataFacets(ctx context.Context, pat *pattern) {
 	}
 	for _, p := range pat.params {
 		switch p.name {
+		case "pattern":
+			// The pattern facet is an XSD/XPath regular expression. Compile it once
+			// with the shared XSD-regex engine (xsdregex) so XSD-only constructs (\i,
+			// \c, \p{...}, character-class subtraction, …) are honoured and an invalid
+			// pattern is a fatal schema error rather than a silent runtime no-op or a
+			// false rejection. The compilation is cached on the param for validation.
+			if p.patternChecked {
+				continue
+			}
+			p.patternChecked = true
+			re, err := xsdregex.Compile(p.value)
+			if err != nil {
+				c.addPatternError(ctx, pat, fmt.Sprintf("value '%s' for facet 'pattern' is not a valid regular expression", p.value))
+				continue
+			}
+			p.compiledPattern = re
+		case "length", "minLength", "maxLength":
+			// Length facets apply only to string-derived, binary, anyURI, QName and
+			// NOTATION datatypes (value.LengthApplicable). Applying one to a numeric,
+			// boolean or date/time datatype is a schema error, mirroring XSD's
+			// facet-applicability rules so RELAX NG and XSD agree.
+			if !value.LengthApplicable(typeName) {
+				c.addPatternError(ctx, pat, fmt.Sprintf("facet '%s' is not allowed on the datatype '%s'", p.name, typeName))
+			}
 		case "minInclusive", "maxInclusive", "minExclusive", "maxExclusive":
 			if !value.Orderable(typeName) {
 				c.addPatternError(ctx, pat, fmt.Sprintf("facet '%s' is not allowed on the non-ordered datatype '%s'", p.name, typeName))

--- a/relaxng/parse_check.go
+++ b/relaxng/parse_check.go
@@ -240,6 +240,17 @@ func (c *compiler) checkDataFacets(ctx context.Context, pat *pattern) {
 			// facet-applicability rules so RELAX NG and XSD agree.
 			if !value.LengthApplicable(typeName) {
 				c.addPatternError(ctx, pat, fmt.Sprintf("facet '%s' is not allowed on the datatype '%s'", p.name, typeName))
+				continue
+			}
+			// The bound must itself be a valid xs:nonNegativeInteger. Validate here
+			// with XSD whitespace/lexical rules (value.Normalize collapses only XSD
+			// whitespace — NOT Go's TrimSpace, which would accept NBSP — and
+			// value.ValidateBuiltin enforces the digit lexical and the >=0 range), so
+			// an out-of-space bound (negative, fractional, non-digit, NBSP-padded)
+			// is a fatal compile error rather than being parsed leniently at
+			// validation time and turning the facet into a no-op or reject-all.
+			if value.ValidateBuiltin(value.Normalize(p.value, "nonNegativeInteger"), "nonNegativeInteger") != nil {
+				c.addPatternError(ctx, pat, fmt.Sprintf("value '%s' for facet '%s' is not a valid 'nonNegativeInteger'", p.value, p.name))
 			}
 		case "minInclusive", "maxInclusive", "minExclusive", "maxExclusive":
 			if !value.Orderable(typeName) {

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -2151,10 +2151,11 @@ func validateXSDType(typeName, text string, params []*param) int {
 // The parameter is named text (not value) so the internal/xsd/value package
 // stays reachable for the ordering-facet comparisons below.
 //
-// The length facets (length/minLength/maxLength) are measured via facetLength,
-// EXCEPT on xs:QName/xs:NOTATION, where they are applicable but deprecated and
-// non-constraining (XSD 1.1) — value.LengthEnforced gates the comparison so any
-// lexically valid QName/NOTATION passes regardless of the bound;
+// The length facets (length/minLength/maxLength) are measured via facetLength on
+// every applicable type — including xs:QName and xs:NOTATION, where they are
+// CONSTRAINING (XSD 1.0 / libxml2 parity, matching the xsd package's facetLength)
+// rather than a no-op, so RELAX NG rejects an out-of-length QName/NOTATION exactly
+// as the shared xsd validator does;
 // the ordering facets (min/maxInclusive, min/maxExclusive) are evaluated through
 // the shared XSD value engine (value.Compare) so RELAX NG and XSD agree on the
 // value space (e.g. xs:integer "5" really is less than "10"); and the digit
@@ -2189,13 +2190,6 @@ func validateWithParams(text, typeName string, params []*param) int {
 				return -1
 			}
 		case "length":
-			// On xs:QName/xs:NOTATION the length facets are applicable (the bound was
-			// validated at compile time) but DEPRECATED and non-constraining per XSD
-			// 1.1: any lexically valid value passes regardless of its rune count, so
-			// skip the comparison rather than counting runes (value.LengthEnforced).
-			if !value.LengthEnforced(typeName) {
-				continue
-			}
 			// The bound is compile-time validated as an xs:nonNegativeInteger and
 			// parsed width-safely (big.Int) so a huge-but-valid bound is compared
 			// faithfully rather than overflowing int into a reject-all.
@@ -2208,9 +2202,6 @@ func validateWithParams(text, typeName string, params []*param) int {
 				return -1
 			}
 		case "minLength":
-			if !value.LengthEnforced(typeName) {
-				continue
-			}
 			n, ok := parseNonNegFacetBound(p.value)
 			if !ok {
 				return -1
@@ -2220,9 +2211,6 @@ func validateWithParams(text, typeName string, params []*param) int {
 				return -1
 			}
 		case "maxLength":
-			if !value.LengthEnforced(typeName) {
-				continue
-			}
 			n, ok := parseNonNegFacetBound(p.value)
 			if !ok {
 				return -1

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
-	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/xsd/value"
+	"github.com/lestrrat-go/helium/internal/xsdregex"
 )
 
 // validator holds state during document validation.
@@ -2157,10 +2157,13 @@ func validateXSDType(typeName, text string, params []*param) int {
 // the shared XSD value engine (value.Compare) so RELAX NG and XSD agree on the
 // value space (e.g. xs:integer "5" really is less than "10"); and the digit
 // facets (totalDigits, fractionDigits) are measured via value.CountTotalDigits/
-// CountFractionDigits on the xs:decimal family. Facet applicability — an ordering
-// facet on a non-ordered type, a digit facet on a non-decimal type, and bound
-// validity — is enforced at compile time (checkDataFacets), so the grammar is
-// already unmatchable when an inapplicable facet is present. Any other param name
+// CountFractionDigits on the xs:decimal family; and the pattern facet is matched
+// through the shared XSD-regex engine (xsdregex) so XSD-only constructs (\i, \c,
+// \p{...}, …) are honoured. Facet applicability — an ordering facet on a
+// non-ordered type, a digit facet on a non-decimal type, a length facet on a
+// non-string-derived type, and bound/pattern validity — is enforced at compile
+// time (checkDataFacets), so the grammar is already unmatchable when an
+// inapplicable or invalid facet is present. Any other param name
 // — enumeration, whiteSpace, or an unknown facet — is unsupported and fails
 // closed: it cannot be silently accepted, which would let a <data> match values
 // the facet was meant to reject.
@@ -2168,8 +2171,19 @@ func validateWithParams(text, typeName string, params []*param) int {
 	for _, p := range params {
 		switch p.name {
 		case "pattern":
-			matched, err := regexp.MatchString("^(?:"+p.value+")$", text)
-			if err != nil || !matched {
+			// The pattern facet is an XSD/XPath regular expression, anchored to the
+			// whole value. Use the compilation cached at compile time (checkDataFacets);
+			// fall back to compiling here for robustness if it was not pre-compiled. A
+			// pattern that cannot compile fails closed.
+			re := p.compiledPattern
+			if re == nil {
+				compiled, err := xsdregex.Compile(p.value)
+				if err != nil {
+					return -1
+				}
+				re = compiled
+			}
+			if !re.MatchString(text) {
 				return -1
 			}
 		case "length":

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -2151,7 +2151,10 @@ func validateXSDType(typeName, text string, params []*param) int {
 // The parameter is named text (not value) so the internal/xsd/value package
 // stays reachable for the ordering-facet comparisons below.
 //
-// The length facets (length/minLength/maxLength) are measured via facetLength;
+// The length facets (length/minLength/maxLength) are measured via facetLength,
+// EXCEPT on xs:QName/xs:NOTATION, where they are applicable but deprecated and
+// non-constraining (XSD 1.1) — value.LengthEnforced gates the comparison so any
+// lexically valid QName/NOTATION passes regardless of the bound;
 // the ordering facets (min/maxInclusive, min/maxExclusive) are evaluated through
 // the shared XSD value engine (value.Compare) so RELAX NG and XSD agree on the
 // value space (e.g. xs:integer "5" really is less than "10"); and the digit
@@ -2186,6 +2189,13 @@ func validateWithParams(text, typeName string, params []*param) int {
 				return -1
 			}
 		case "length":
+			// On xs:QName/xs:NOTATION the length facets are applicable (the bound was
+			// validated at compile time) but DEPRECATED and non-constraining per XSD
+			// 1.1: any lexically valid value passes regardless of its rune count, so
+			// skip the comparison rather than counting runes (value.LengthEnforced).
+			if !value.LengthEnforced(typeName) {
+				continue
+			}
 			// The bound is compile-time validated as an xs:nonNegativeInteger and
 			// parsed width-safely (big.Int) so a huge-but-valid bound is compared
 			// faithfully rather than overflowing int into a reject-all.
@@ -2198,6 +2208,9 @@ func validateWithParams(text, typeName string, params []*param) int {
 				return -1
 			}
 		case "minLength":
+			if !value.LengthEnforced(typeName) {
+				continue
+			}
 			n, ok := parseNonNegFacetBound(p.value)
 			if !ok {
 				return -1
@@ -2207,6 +2220,9 @@ func validateWithParams(text, typeName string, params []*param) int {
 				return -1
 			}
 		case "maxLength":
+			if !value.LengthEnforced(typeName) {
+				continue
+			}
 			n, ok := parseNonNegFacetBound(p.value)
 			if !ok {
 				return -1

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/big"
 	"slices"
-	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -2187,30 +2186,33 @@ func validateWithParams(text, typeName string, params []*param) int {
 				return -1
 			}
 		case "length":
-			n, err := strconv.Atoi(strings.TrimSpace(p.value))
-			if err != nil {
+			// The bound is compile-time validated as an xs:nonNegativeInteger and
+			// parsed width-safely (big.Int) so a huge-but-valid bound is compared
+			// faithfully rather than overflowing int into a reject-all.
+			n, ok := parseNonNegFacetBound(p.value)
+			if !ok {
 				return -1
 			}
 			length, ok := facetLength(text, typeName)
-			if !ok || length != n {
+			if !ok || big.NewInt(int64(length)).Cmp(n) != 0 {
 				return -1
 			}
 		case "minLength":
-			n, err := strconv.Atoi(strings.TrimSpace(p.value))
-			if err != nil {
+			n, ok := parseNonNegFacetBound(p.value)
+			if !ok {
 				return -1
 			}
 			length, ok := facetLength(text, typeName)
-			if !ok || length < n {
+			if !ok || big.NewInt(int64(length)).Cmp(n) < 0 {
 				return -1
 			}
 		case "maxLength":
-			n, err := strconv.Atoi(strings.TrimSpace(p.value))
-			if err != nil {
+			n, ok := parseNonNegFacetBound(p.value)
+			if !ok {
 				return -1
 			}
 			length, ok := facetLength(text, typeName)
-			if !ok || length > n {
+			if !ok || big.NewInt(int64(length)).Cmp(n) > 0 {
 				return -1
 			}
 		case "minInclusive":
@@ -2236,7 +2238,7 @@ func validateWithParams(text, typeName string, params []*param) int {
 			// validation, so count its significant digits and reject when they exceed
 			// the bound. The bound is parsed with big.Int so an arbitrarily large
 			// xs:positiveInteger does not overflow into a reject-all.
-			n, ok := parseDigitFacetBound(p.value)
+			n, ok := parseNonNegFacetBound(p.value)
 			if !ok || !value.IsDecimalFamily(typeName) {
 				return -1
 			}
@@ -2244,7 +2246,7 @@ func validateWithParams(text, typeName string, params []*param) int {
 				return -1
 			}
 		case "fractionDigits":
-			n, ok := parseDigitFacetBound(p.value)
+			n, ok := parseNonNegFacetBound(p.value)
 			if !ok || !value.IsDecimalFamily(typeName) {
 				return -1
 			}
@@ -2310,15 +2312,16 @@ func facetOrderingOK(text, facetBound, typeName string, accept func(int) bool) b
 	return accept(cmp)
 }
 
-// parseDigitFacetBound parses a totalDigits/fractionDigits facet bound into a
+// parseNonNegFacetBound parses an integer facet bound — totalDigits,
+// fractionDigits, or the length family (length/minLength/maxLength) — into a
 // big.Int. The bound is compile-time validated (checkDataFacets) as a valid
-// xs:positiveInteger (totalDigits) or xs:nonNegativeInteger (fractionDigits),
-// so by the time validation runs it is a well-formed integer lexical with only
-// XSD whitespace; it is normalized (XSD collapse — NOT Go's unicode-space
-// trimming, which would accept NBSP) before parsing. A big.Int is used rather
-// than strconv.Atoi so an arbitrarily large bound is compared faithfully instead
-// of overflowing int and collapsing into a reject-all.
-func parseDigitFacetBound(s string) (*big.Int, bool) {
+// xs:positiveInteger (totalDigits) or xs:nonNegativeInteger (fractionDigits and
+// the length facets), so by the time validation runs it is a well-formed integer
+// lexical with only XSD whitespace; it is normalized (XSD collapse — NOT Go's
+// unicode-space trimming, which would accept NBSP) before parsing. A big.Int is
+// used rather than strconv.Atoi so an arbitrarily large bound is compared
+// faithfully instead of overflowing int and collapsing into a reject-all.
+func parseNonNegFacetBound(s string) (*big.Int, bool) {
 	n, ok := new(big.Int).SetString(value.Normalize(s, "nonNegativeInteger"), 10)
 	return n, ok
 }


### PR DESCRIPTION
- route the `<data>` `pattern` facet through the shared XSD-regex engine (`internal/xsdregex`) instead of Go's `regexp`, so XSD-only constructs (`\i`, `\c`, `\p{...}`) are honoured rather than false-rejected; cached at compile time, invalid pattern is now a schema error
- reject `length`/`minLength`/`maxLength` at compile time on datatypes where they are inapplicable (numeric/boolean/date), via shared `value.LengthApplicable`