### PR TITLE
apply XSD 1.1 open content on empty complex types

### DIFF
--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -720,6 +720,16 @@ func (vc *validationContext) validateElementContent(ctx context.Context, elem *h
 func (vc *validationContext) validateContentByType(ctx context.Context, elem *helium.Element, edecl *ElementDecl, td *TypeDef) error {
 	switch td.ContentType {
 	case ContentTypeEmpty:
+		// XSD 1.1 §3.4.2.3.3: an empty explicit content type plus effective open
+		// content (mode != none) becomes element-only with an empty particle plus
+		// the open content, so extra wildcard-matched children are admitted.
+		if vc.version == Version11 && td.OpenContent != nil {
+			mg := td.ContentModel
+			if mg == nil {
+				mg = &ModelGroup{Compositor: CompositorSequence, MinOccurs: 1, MaxOccurs: 1}
+			}
+			return vc.validateContentModelOpen(ctx, elem, mg, td.OpenContent)
+		}
 		return vc.validateEmptyContent(ctx, elem)
 	case ContentTypeSimple:
 		return vc.validateSimpleContent(ctx, elem, edecl, td)

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -714,6 +714,27 @@ func (vc *validationContext) validateElementContent(ctx context.Context, elem *h
 	return nil
 }
 
+// rejectNonWhitespaceText reports a validity error and returns a non-nil error
+// if elem has any non-whitespace text or CDATA child. It is used for element-only
+// content types (including the XSD 1.1 synthesized empty+openContent type), where
+// character content other than whitespace is not allowed.
+func (vc *validationContext) rejectNonWhitespaceText(ctx context.Context, elem *helium.Element) error {
+	for child := range helium.Children(elem) {
+		if child.Type() != helium.TextNode && child.Type() != helium.CDATASectionNode {
+			continue
+		}
+		// Use XSD/XML whitespace (space, tab, CR, LF) only: characters like
+		// NBSP (U+00A0) are NOT ignorable in element-only content, so
+		// strings.TrimSpace (which strips all Unicode space) must not be used.
+		if !xmlchar.IsAllSpace(child.Content()) {
+			msg := "Character content other than whitespace is not allowed because the content type is 'element-only'."
+			vc.reportValidityError(ctx, vc.filename, elem.Line(), elemDisplayName(elem), msg)
+			return fmt.Errorf("text content in element-only type")
+		}
+	}
+	return nil
+}
+
 // validateContentByType validates an element's content against its type's
 // content-type (empty/simple/element-only/mixed). Attribute validation and the
 // XSD 1.1 assertion check are handled by the caller (validateElementContent).
@@ -724,6 +745,11 @@ func (vc *validationContext) validateContentByType(ctx context.Context, elem *he
 		// content (mode != none) becomes element-only with an empty particle plus
 		// the open content, so extra wildcard-matched children are admitted.
 		if vc.version == Version11 && td.OpenContent != nil {
+			// The synthesized type is element-only, so non-whitespace character
+			// content is not allowed even though extra wildcard-matched children are.
+			if err := vc.rejectNonWhitespaceText(ctx, elem); err != nil {
+				return err
+			}
 			mg := td.ContentModel
 			if mg == nil {
 				mg = &ModelGroup{Compositor: CompositorSequence, MinOccurs: 1, MaxOccurs: 1}
@@ -736,18 +762,8 @@ func (vc *validationContext) validateContentByType(ctx context.Context, elem *he
 	case ContentTypeElementOnly, ContentTypeMixed:
 		// For element-only content, non-whitespace text children are not allowed.
 		if td.ContentType == ContentTypeElementOnly {
-			for child := range helium.Children(elem) {
-				if child.Type() == helium.TextNode || child.Type() == helium.CDATASectionNode {
-					// Use XSD/XML whitespace (space, tab, CR, LF) only: characters
-					// like NBSP (U+00A0) are NOT ignorable in element-only content,
-					// so strings.TrimSpace (which strips all Unicode space) must not
-					// be used here.
-					if !xmlchar.IsAllSpace(child.Content()) {
-						msg := "Character content other than whitespace is not allowed because the content type is 'element-only'."
-						vc.reportValidityError(ctx, vc.filename, elem.Line(), elemDisplayName(elem), msg)
-						return fmt.Errorf("text content in element-only type")
-					}
-				}
+			if err := vc.rejectNonWhitespaceText(ctx, elem); err != nil {
+				return err
 			}
 		}
 		if td.ContentModel == nil {

--- a/xsd/version_opencontent_empty_test.go
+++ b/xsd/version_opencontent_empty_test.go
@@ -1,0 +1,60 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVersion11OpenContentEmpty covers XSD 1.1 §3.4.2.3.3: xs:openContent on an
+// otherwise empty complex type (no particle) makes the type element-only with an
+// empty particle plus the open content, so extra wildcard-matched children are
+// admitted. A truly empty type with no open content still rejects children.
+func TestVersion11OpenContentEmpty(t *testing.T) {
+	compile := func(t *testing.T, c xsd.Compiler, s string) *xsd.Schema {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(s))
+		require.NoError(t, err)
+		schema, err := c.Compile(t.Context(), doc)
+		require.NoError(t, err)
+		return schema
+	}
+	validate := func(t *testing.T, schema *xsd.Schema, instance string) error {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(instance))
+		require.NoError(t, err)
+		return xsd.NewValidator(schema).Validate(t.Context(), doc)
+	}
+
+	openOnly := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:openContent mode="interleave">
+        <xs:any namespace="##any" processContents="skip"/>
+      </xs:openContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+	empty := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType/>
+  </xs:element>
+</xs:schema>`
+
+	t.Run("1.1 open-content-only empty type accepts extra child", func(t *testing.T) {
+		t.Parallel()
+		s := compile(t, xsd.NewCompiler().Version(xsd.Version11), openOnly)
+		require.NoError(t, validate(t, s, `<root><extra/></root>`))
+		require.NoError(t, validate(t, s, `<root/>`))
+	})
+
+	t.Run("truly empty type with no open content rejects child", func(t *testing.T) {
+		t.Parallel()
+		s := compile(t, xsd.NewCompiler().Version(xsd.Version11), empty)
+		require.ErrorIs(t, validate(t, s, `<root><extra/></root>`), xsd.ErrValidationFailed)
+		require.NoError(t, validate(t, s, `<root/>`))
+	})
+}

--- a/xsd/version_opencontent_empty_test.go
+++ b/xsd/version_opencontent_empty_test.go
@@ -51,6 +51,16 @@ func TestVersion11OpenContentEmpty(t *testing.T) {
 		require.NoError(t, validate(t, s, `<root/>`))
 	})
 
+	t.Run("1.1 open-content-only empty type rejects non-whitespace text", func(t *testing.T) {
+		t.Parallel()
+		s := compile(t, xsd.NewCompiler().Version(xsd.Version11), openOnly)
+		// The synthesized type is element-only, so character content other than
+		// whitespace is not allowed even though extra elements are admitted.
+		require.ErrorIs(t, validate(t, s, `<root>text</root>`), xsd.ErrValidationFailed)
+		require.ErrorIs(t, validate(t, s, `<root>text<extra/></root>`), xsd.ErrValidationFailed)
+		require.NoError(t, validate(t, s, `<root><extra/></root>`))
+	})
+
 	t.Run("truly empty type with no open content rejects child", func(t *testing.T) {
 		t.Parallel()
 		s := compile(t, xsd.NewCompiler().Version(xsd.Version11), empty)


### PR DESCRIPTION
- Empty (no-particle) complex types with `xs:openContent` (mode != none) were ignoring the open content: `validateContentByType`'s `ContentTypeEmpty` branch returned `validateEmptyContent` before any open-content check, rejecting extra wildcard-matched children.
- Per XSD 1.1 §3.4.2.3.3 an empty explicit content type plus effective open content becomes element-only with an empty particle plus the open content. The branch now routes to `validateContentModelOpen` (synthesizing an empty sequence model group when `ContentModel` is nil) when `version == Version11 && OpenContent != nil`. 1.0 behavior unchanged.