### PR TITLE
Reject duplicate singleton XSD facets

### DIFF
--- a/.claude/docs/libxml2-parity.md
+++ b/.claude/docs/libxml2-parity.md
@@ -63,6 +63,16 @@ Test data: `testdata/libxml2-compat/` (golden files generated from libxml2's xml
 | unsupported spec: XSLT10 | 1 |
 | xsd compiler rejects schema-for-xslt20.xsd attribute-wildcard derivation-by-restriction | 1 |
 
+### W3C XSD 1.1 tests
+
+The heavyweight XSD 1.1 conformance harness lives in the sibling module
+`../helium-w3c-tests` on branch `migrate-xsd11`; run it against this module with
+a local `go.work` pointing at the Helium worktree. Current `TestXSD11W3C` leaf
+count: 967 generated test groups, 504 pass, 463 skipped. The Go JSON stream also
+counts the top-level `TestXSD11W3C`, so the harness summary appears as 968 run /
+505 pass / 463 skip. Persistent skips are tracked in
+`helium-w3c-tests/expectations/xsd11.json` as XSD 1.1 conformance gaps.
+
 ## Parser Limitations
 
 Cross-element redundant namespace redeclarations and entity references in

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -196,6 +196,9 @@ stored on `FacetSet.ExplicitTimezone` with `FacetSet.ExplicitTimezoneFixed`,
 checked at validation time for required or prohibited timezone presence, and
 participates in compile-time restriction checks so `xs:dateTimeStamp` can only
 retain `required` and inherited user `fixed="true"` values cannot be changed.
+`parseFacets` rejects duplicate singleton facets in a single restriction step
+(range, digit, length, whiteSpace, and explicitTimezone facets); only
+`enumeration`, `pattern`, and the XSD 1.1 `assertion` facet are repeatable there.
 Built-in temporal whiteSpace is treated as fixed `collapse`.
 `checkFacetSameTypeConsistency` gates EACH
 facet-family consistency check to the family's applicable type/variety, so it never

--- a/xsd/facet_duplicate_test.go
+++ b/xsd/facet_duplicate_test.go
@@ -1,0 +1,48 @@
+package xsd_test
+
+import (
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDuplicateSingletonFacetsRejected(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="zoned">
+    <xs:restriction base="xs:dateTime">
+      <xs:explicitTimezone value="optional"/>
+      <xs:explicitTimezone value="prohibited"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+	require.NoError(t, err)
+
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	_, err = xsd.NewCompiler().
+		Version(xsd.Version11).
+		Label("test.xsd").
+		ErrorHandler(collector).
+		Compile(t.Context(), doc)
+	_ = collector.Close()
+
+	require.ErrorIs(t, err, xsd.ErrCompilationFailed)
+	errs := compileErrorsString(collector.Errors())
+	require.Contains(t, errs, "facet 'explicitTimezone'")
+	require.Contains(t, errs, "specified more than once")
+}
+
+func compileErrorsString(errs []error) string {
+	var b strings.Builder
+	for _, err := range errs {
+		b.WriteString(err.Error())
+		b.WriteByte('\n')
+	}
+	return b.String()
+}

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -903,6 +903,17 @@ func (c *compiler) parseSimpleType(ctx context.Context, elem *helium.Element) (*
 // parseFacets extracts facet constraints from an xs:restriction element.
 func (c *compiler) parseFacets(ctx context.Context, restriction *helium.Element) *FacetSet {
 	var fs *FacetSet
+	seenSingletonFacets := make(map[string]struct{})
+	duplicateSingletonFacet := func(elem *helium.Element, name string) bool {
+		if _, ok := seenSingletonFacets[name]; !ok {
+			seenSingletonFacets[name] = struct{}{}
+			return false
+		}
+		c.schemaError(ctx, schemaParserError(c.filename, elem.Line(),
+			elem.LocalName(), elem.LocalName(),
+			fmt.Sprintf("It is an error for the facet '%s' to be specified more than once on the same type definition.", name)))
+		return true
+	}
 
 	for child := range helium.Children(restriction) {
 		if child.Type() != helium.ElementNode {
@@ -928,6 +939,9 @@ func (c *compiler) parseFacets(ctx context.Context, restriction *helium.Element)
 			maps.Copy(nsCopy, nsCtx)
 			fs.EnumerationNS = append(fs.EnumerationNS, nsCopy)
 		case facetMinInclusive:
+			if duplicateSingletonFacet(ce, facetMinInclusive) {
+				continue
+			}
 			if fs == nil {
 				fs = &FacetSet{}
 			}
@@ -935,6 +949,9 @@ func (c *compiler) parseFacets(ctx context.Context, restriction *helium.Element)
 			fs.MinInclusiveFixed = c.readFacetFixed(ctx, ce)
 			fs.MinInclusiveNS = captureFacetNS(ce)
 		case facetMaxInclusive:
+			if duplicateSingletonFacet(ce, facetMaxInclusive) {
+				continue
+			}
 			if fs == nil {
 				fs = &FacetSet{}
 			}
@@ -942,6 +959,9 @@ func (c *compiler) parseFacets(ctx context.Context, restriction *helium.Element)
 			fs.MaxInclusiveFixed = c.readFacetFixed(ctx, ce)
 			fs.MaxInclusiveNS = captureFacetNS(ce)
 		case facetMinExclusive:
+			if duplicateSingletonFacet(ce, facetMinExclusive) {
+				continue
+			}
 			if fs == nil {
 				fs = &FacetSet{}
 			}
@@ -949,6 +969,9 @@ func (c *compiler) parseFacets(ctx context.Context, restriction *helium.Element)
 			fs.MinExclusiveFixed = c.readFacetFixed(ctx, ce)
 			fs.MinExclusiveNS = captureFacetNS(ce)
 		case facetMaxExclusive:
+			if duplicateSingletonFacet(ce, facetMaxExclusive) {
+				continue
+			}
 			if fs == nil {
 				fs = &FacetSet{}
 			}
@@ -956,42 +979,63 @@ func (c *compiler) parseFacets(ctx context.Context, restriction *helium.Element)
 			fs.MaxExclusiveFixed = c.readFacetFixed(ctx, ce)
 			fs.MaxExclusiveNS = captureFacetNS(ce)
 		case "totalDigits":
+			if duplicateSingletonFacet(ce, "totalDigits") {
+				continue
+			}
 			if fs == nil {
 				fs = &FacetSet{}
 			}
 			n := parseOccurs(val, 0)
 			fs.TotalDigits = &n
 		case "length":
+			if duplicateSingletonFacet(ce, "length") {
+				continue
+			}
 			if fs == nil {
 				fs = &FacetSet{}
 			}
 			n := parseOccurs(val, 0)
 			fs.Length = &n
 		case "minLength":
+			if duplicateSingletonFacet(ce, "minLength") {
+				continue
+			}
 			if fs == nil {
 				fs = &FacetSet{}
 			}
 			n := parseOccurs(val, 0)
 			fs.MinLength = &n
 		case "maxLength":
+			if duplicateSingletonFacet(ce, "maxLength") {
+				continue
+			}
 			if fs == nil {
 				fs = &FacetSet{}
 			}
 			n := parseOccurs(val, 0)
 			fs.MaxLength = &n
 		case "fractionDigits":
+			if duplicateSingletonFacet(ce, "fractionDigits") {
+				continue
+			}
 			if fs == nil {
 				fs = &FacetSet{}
 			}
 			n := parseOccurs(val, 0)
 			fs.FractionDigits = &n
 		case "whiteSpace":
+			if duplicateSingletonFacet(ce, "whiteSpace") {
+				continue
+			}
 			if fs == nil {
 				fs = &FacetSet{}
 			}
 			fs.WhiteSpace = &val
 		case elemExplicitTimezone:
 			if c.version != Version11 {
+				continue
+			}
+			if duplicateSingletonFacet(ce, elemExplicitTimezone) {
 				continue
 			}
 			if fs == nil {


### PR DESCRIPTION
Reject repeated singleton facet declarations within the same XSD simple type restriction, including XSD 1.1 explicitTimezone. This ungates the W3C XSD 1.1 explicitTimezone cases in helium-w3c-tests migrate-xsd11.