### PR TITLE
fix xsi:type union member derivation

### DIFF
--- a/xsd/alternative.go
+++ b/xsd/alternative.go
@@ -438,7 +438,7 @@ func isValidlySubstitutableForDeclaredType(sub, decl *TypeDef, allowError bool) 
 	// Variety/MemberTypes are empty), so reading decl.Variety/decl.MemberTypes
 	// directly would skip the union branch and false-reject a member-derived
 	// alternative. The member check stays strict and recursive (no fallback).
-	if resolveVariety(decl) == TypeVarietyUnion {
+	if resolveVariety(decl) == TypeVarietyUnion && (allowError || unionDerivationHasNoFacets(decl)) {
 		for _, m := range resolveUnionMembers(decl) {
 			if isValidlySubstitutableForDeclaredType(sub, m, allowError) {
 				return true
@@ -446,4 +446,33 @@ func isValidlySubstitutableForDeclaredType(sub, decl *TypeDef, allowError bool) 
 		}
 	}
 	return false
+}
+
+func unionDerivationHasNoFacets(td *TypeDef) bool {
+	for cur := td; cur != nil && resolveVariety(cur) == TypeVarietyUnion; cur = cur.BaseType {
+		if !facetSetEmpty(cur.Facets) {
+			return false
+		}
+	}
+	return true
+}
+
+func facetSetEmpty(fs *FacetSet) bool {
+	if fs == nil {
+		return true
+	}
+	return len(fs.Enumeration) == 0 &&
+		fs.MinInclusive == nil &&
+		fs.MaxInclusive == nil &&
+		fs.MinExclusive == nil &&
+		fs.MaxExclusive == nil &&
+		fs.TotalDigits == nil &&
+		fs.FractionDigits == nil &&
+		fs.Length == nil &&
+		fs.MinLength == nil &&
+		fs.MaxLength == nil &&
+		fs.ExplicitTimezone == nil &&
+		len(fs.Patterns) == 0 &&
+		fs.WhiteSpace == nil &&
+		len(fs.Assertions) == 0
 }

--- a/xsd/alternative.go
+++ b/xsd/alternative.go
@@ -416,13 +416,21 @@ func (c *compiler) checkAltSubstitutability(ctx context.Context) {
 // suite is the safety net — if a real derivation is missed, isDerivedFrom must be
 // extended to cover it rather than reinstating the fallback.
 func isValidlySubstitutable(alt, decl *TypeDef) bool {
-	if alt == nil || decl == nil {
+	return isValidlySubstitutableForDeclaredType(alt, decl, true)
+}
+
+func isXsiTypeDerivedFromDeclared(actual, declared *TypeDef) bool {
+	return isValidlySubstitutableForDeclaredType(actual, declared, false)
+}
+
+func isValidlySubstitutableForDeclaredType(sub, decl *TypeDef, allowError bool) bool {
+	if sub == nil || decl == nil {
 		return true
 	}
-	if isErrorType(alt) {
+	if allowError && isErrorType(sub) {
 		return true
 	}
-	if strictBuiltinAwareDerivedFrom(alt, decl) {
+	if strictBuiltinAwareDerivedFrom(sub, decl) {
 		return true
 	}
 	// Use the variety/members RESOLVED through the base chain: a named type that
@@ -432,7 +440,7 @@ func isValidlySubstitutable(alt, decl *TypeDef) bool {
 	// alternative. The member check stays strict and recursive (no fallback).
 	if resolveVariety(decl) == TypeVarietyUnion {
 		for _, m := range resolveUnionMembers(decl) {
-			if isValidlySubstitutable(alt, m) {
+			if isValidlySubstitutableForDeclaredType(sub, m, allowError) {
 				return true
 			}
 		}

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -1982,13 +1982,13 @@ func (vc *validationContext) resolveXsiType(ctx context.Context, elem *helium.El
 		return nil, fmt.Errorf("xsi:type not found")
 	}
 
-	// Check derivation: xsi:type must be the same as or derived from the declared
-	// type. Use the built-in-aware predicate so a narrowing to a built-in subtype
-	// (e.g. xsi:type="xs:int" over a declared xs:integer) is accepted — the built-in
-	// types are registered without BaseType links, so raw isDerivedFrom would wrongly
-	// reject it. The predicate is STRICT (no permissive simple-vs-simple fallback),
-	// so an unrelated xsi:type (e.g. xs:string over xs:integer) is still rejected.
-	if declaredType != nil && !strictBuiltinAwareDerivedFrom(td, declaredType) {
+	// Check derivation: xsi:type must be the same as or validly substitutable for
+	// the declared type. Use the built-in-aware predicate plus the union-member
+	// rule so a narrowing to a built-in subtype (e.g. xsi:type="xs:int" over a
+	// declared xs:integer) and a member of a declared union are accepted. The
+	// predicate is STRICT (no permissive simple-vs-simple fallback), so an unrelated
+	// xsi:type (e.g. xs:string over xs:integer) is still rejected.
+	if declaredType != nil && !isXsiTypeDerivedFromDeclared(td, declaredType) {
 		msg := fmt.Sprintf("The type definition '%s' is not validly derived from the type definition '%s'.",
 			typeDisplayName(td), typeDisplayName(declaredType))
 		vc.reportValidityError(ctx, vc.filename, elem.Line(), elemDisplayName(elem), msg)

--- a/xsd/validate_elem.go
+++ b/xsd/validate_elem.go
@@ -1088,6 +1088,17 @@ func isDerivationBlocked(derived, base *TypeDef, blocked BlockFlags) bool {
 		}
 		td = td.BaseType
 	}
+	// A declared union can be substituted by one of its member types even though the
+	// member's BaseType chain does not point back to the union. Treat that path as a
+	// restriction for element block enforcement; otherwise block="restriction" on a
+	// union-typed element would be bypassed by xsi:type naming a member.
+	if td != base && blocked&BlockRestriction != 0 && resolveVariety(base) == TypeVarietyUnion {
+		for _, member := range resolveUnionMembers(base) {
+			if isXsiTypeDerivedFromDeclared(derived, member) {
+				return true
+			}
+		}
+	}
 	// The BaseType pointer chain is NOT linked for built-in simple types, so it can
 	// bottom out (td == nil) before reaching a built-in base. ALL built-in
 	// simple-type derivation is by RESTRICTION, so when base is a built-in simple

--- a/xsd/xsi_type_union_test.go
+++ b/xsd/xsi_type_union_test.go
@@ -1,0 +1,84 @@
+package xsd_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersion11XSITypeUnionMember(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://xstest-tns/IBMd3_16v05"
+    xmlns:sv="http://xstest-tns/IBMd3_16v05">
+  <xs:simpleType name="u_string">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[1-9][1-9]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="u_integer">
+    <xs:restriction base="xs:integer">
+      <xs:pattern value="[3-4][3-4]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="u_ncname">
+    <xs:restriction base="xs:NCName">
+      <xs:pattern value="[a-z][x-z]"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="unionAll">
+    <xs:union memberTypes="sv:u_ncname sv:u_integer sv:u_string"/>
+  </xs:simpleType>
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="union_element" type="sv:unionAll" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+	const instanceXML = `<dv:root xmlns:dv="http://xstest-tns/IBMd3_16v05"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <union_element xsi:type="dv:u_string">28</union_element>
+  <union_element xsi:type="dv:u_integer">33</union_element>
+  <union_element xsi:type="dv:u_ncname">az</union_element>
+</dv:root>`
+
+	require.NoError(t, compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version11), schemaXML, instanceXML))
+}
+
+func TestVersion11XSITypeUnionMemberGuards(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="SmallInt">
+    <xs:restriction base="xs:integer">
+      <xs:maxInclusive value="100"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SmallOrBool">
+    <xs:union memberTypes="SmallInt xs:boolean"/>
+  </xs:simpleType>
+  <xs:element name="open" type="SmallOrBool"/>
+  <xs:element name="blocked" type="SmallOrBool" block="restriction"/>
+</xs:schema>`
+
+	const xsiNS = `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"`
+
+	t.Run("unrelated xsi:type is still rejected", func(t *testing.T) {
+		t.Parallel()
+		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version11), schemaXML,
+			`<open `+xsiNS+` xsi:type="xs:string">value</open>`)
+		require.ErrorIs(t, err, xsd.ErrValidationFailed)
+	})
+
+	t.Run("block restriction still rejects union member xsi:type", func(t *testing.T) {
+		t.Parallel()
+		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version11), schemaXML,
+			`<blocked `+xsiNS+` xsi:type="SmallInt">5</blocked>`)
+		require.ErrorIs(t, err, xsd.ErrValidationFailed)
+	})
+}

--- a/xsd/xsi_type_union_test.go
+++ b/xsd/xsi_type_union_test.go
@@ -82,3 +82,90 @@ func TestVersion11XSITypeUnionMemberGuards(t *testing.T) {
 		require.ErrorIs(t, err, xsd.ErrValidationFailed)
 	})
 }
+
+func TestVersion11XSITypeUnionMemberRequiresFacetFreeUnionPath(t *testing.T) {
+	t.Parallel()
+
+	const xsiNS = `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"`
+
+	t.Run("declared union enumeration is not bypassed", func(t *testing.T) {
+		t.Parallel()
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="SmallInt">
+    <xs:restriction base="xs:integer">
+      <xs:maxInclusive value="100"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SmallOrBool">
+    <xs:union memberTypes="SmallInt xs:boolean"/>
+  </xs:simpleType>
+  <xs:simpleType name="OnlyTrue">
+    <xs:restriction base="SmallOrBool">
+      <xs:enumeration value="true"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="open" type="OnlyTrue"/>
+</xs:schema>`
+
+		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version11), schemaXML,
+			`<open `+xsiNS+` xsi:type="SmallInt">5</open>`)
+		require.ErrorIs(t, err, xsd.ErrValidationFailed)
+		require.NoError(t, compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version11), schemaXML,
+			`<open>true</open>`))
+	})
+
+	t.Run("declared union pattern is not bypassed", func(t *testing.T) {
+		t.Parallel()
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="SmallString">
+    <xs:restriction base="xs:string">
+      <xs:maxLength value="10"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StringOrBool">
+    <xs:union memberTypes="SmallString xs:boolean"/>
+  </xs:simpleType>
+  <xs:simpleType name="TStringOrBool">
+    <xs:restriction base="StringOrBool">
+      <xs:pattern value="T.*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="open" type="TStringOrBool"/>
+</xs:schema>`
+
+		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version11), schemaXML,
+			`<open `+xsiNS+` xsi:type="SmallString">abc</open>`)
+		require.ErrorIs(t, err, xsd.ErrValidationFailed)
+		require.NoError(t, compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version11), schemaXML,
+			`<open>T-abc</open>`))
+	})
+
+	t.Run("intervening nested union facet is not bypassed", func(t *testing.T) {
+		t.Parallel()
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="SmallInt">
+    <xs:restriction base="xs:integer">
+      <xs:maxInclusive value="100"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Inner">
+    <xs:union memberTypes="SmallInt xs:boolean"/>
+  </xs:simpleType>
+  <xs:simpleType name="NegativeInner">
+    <xs:restriction base="Inner">
+      <xs:pattern value="-[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Outer">
+    <xs:union memberTypes="NegativeInner xs:string"/>
+  </xs:simpleType>
+  <xs:element name="open" type="Outer"/>
+</xs:schema>`
+
+		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version11), schemaXML,
+			`<open `+xsiNS+` xsi:type="SmallInt">5</open>`)
+		require.ErrorIs(t, err, xsd.ErrValidationFailed)
+		require.NoError(t, compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version11), schemaXML,
+			`<open>-5</open>`))
+	})
+}


### PR DESCRIPTION
- accept xsi:type names that resolve to declared union members
- keep unrelated types and block="restriction" rejected
