### PR TITLE
document xsd11 conformance count after ungates

### DIFF
--- a/.claude/docs/libxml2-parity.md
+++ b/.claude/docs/libxml2-parity.md
@@ -68,9 +68,13 @@ Test data: `testdata/libxml2-compat/` (golden files generated from libxml2's xml
 The heavyweight XSD 1.1 conformance harness lives in the sibling module
 `../helium-w3c-tests` on branch `migrate-xsd11`; run it against this module with
 a local `go.work` pointing at the Helium worktree. Current `TestXSD11W3C` leaf
-count: 967 generated test groups, 540 pass, 427 skipped. The Go JSON stream also
-counts the top-level `TestXSD11W3C`, so the harness summary appears as 968 run /
-541 pass / 427 skip. Persistent skips are tracked in
+count at `helium-w3c-tests` `migrate-xsd11` commit `6651985`: 967 generated
+test groups, 549 pass, 418 skipped, verified against Helium commit `ba773001`
+with `GOWORK=$PWD/.tmp/go.work.docs-6651985 go run ./cmd/w3ctest -out
+.tmp/xsd11-junit-docs-6651985-ba773001.xml xsd11` (JUnit: `tests="967"`
+`failures="0"` `skipped="418"`). The Go JSON stream also counts the top-level
+`TestXSD11W3C`, so its harness summary appears as 968 run / 550 pass / 418
+skip. Persistent skips are tracked in
 `helium-w3c-tests/expectations/xsd11.json` as XSD 1.1 conformance gaps.
 
 ## Parser Limitations

--- a/.claude/docs/libxml2-parity.md
+++ b/.claude/docs/libxml2-parity.md
@@ -69,9 +69,9 @@ The heavyweight XSD 1.1 conformance harness lives in the sibling module
 `../helium-w3c-tests` on branch `migrate-xsd11`; run it against this module with
 a local `go.work` pointing at the Helium worktree. Current `TestXSD11W3C` leaf
 count at `helium-w3c-tests` `migrate-xsd11` commit `6651985`: 967 generated
-test groups, 549 pass, 418 skipped, verified against Helium commit `ba773001`
+test groups, 549 pass, 418 skipped, verified against Helium commit `fc141e44`
 with `GOWORK=$PWD/.tmp/go.work.docs-6651985 go run ./cmd/w3ctest -out
-.tmp/xsd11-junit-docs-6651985-ba773001.xml xsd11` (JUnit: `tests="967"`
+.tmp/xsd11-junit-review-875-fc141e44.xml xsd11` (JUnit: `tests="967"`
 `failures="0"` `skipped="418"`). The Go JSON stream also counts the top-level
 `TestXSD11W3C`, so its harness summary appears as 968 run / 550 pass / 418
 skip. Persistent skips are tracked in


### PR DESCRIPTION
## Summary
- update the XSD 1.1 W3C conformance cache after helium-w3c-tests migrate-xsd11 commit 6651985
- record 549 passing leaf groups and 418 skips, with the top-level Go JSON count noted as 550/418

## Tests
- go test ./xsd -count=1