### PR TITLE
reject hyphen as char-class range endpoint in xsd regex

### DIFF
--- a/internal/xsdregex/regex.go
+++ b/internal/xsdregex/regex.go
@@ -300,15 +300,22 @@ func validateXPathCharClassStructure(class string) error {
 			}
 		}
 		// An interior raw '-' denotes a range operator whose endpoints must be
-		// single characters, never another '-'. A '-' is literal only at the
-		// start of the class (i == first) or immediately before the closing ']'
-		// (runes[i+1] == ']'); an interior '-' whose immediately-preceding or
-		// immediately-following raw char is itself '-' uses a '-' as a range
-		// endpoint, which the XSD/XPath regex grammar forbids. (The '-' of a
-		// '-[' subtraction never trips this: its following char is '[', and the
-		// subtraction itself is validated by validateXPathCharClassSubtraction.)
-		if runes[i] == '-' && i != first && runes[i+1] != ']' {
-			if prevRaw == '-' || runes[i+1] == '-' {
+		// single characters, never another '-'. A '-' is literal (not a range
+		// operator) at the start of the class (i == first) or immediately
+		// before the closing ']' (runes[i+1] == ']'); a '-' immediately before
+		// '[' is the operator of a '-[' character-class subtraction (validated
+		// separately by validateXPathCharClassSubtraction), not a range. An
+		// interior, non-subtraction '-' whose immediately-preceding or
+		// immediately-following raw char is itself a literal '-' uses a '-' as
+		// a range endpoint, which the XSD/XPath regex grammar forbids — except
+		// when that adjacent '-' is itself the operator of a '-[' subtraction
+		// (its own following char is '['), which is a literal dash abutting the
+		// subtraction operator (e.g. the valid base group of '[a--[b]]'), not a
+		// range endpoint.
+		if runes[i] == '-' && i != first && runes[i+1] != ']' && runes[i+1] != '[' {
+			precededByHyphen := prevRaw == '-'
+			followedByHyphen := runes[i+1] == '-' && (i+2 >= len(runes) || runes[i+2] != '[')
+			if precededByHyphen || followedByHyphen {
 				return &regexError{
 					Code:    errCodeFORX0002,
 					Message: fmt.Sprintf("invalid character class: %s", class),

--- a/internal/xsdregex/regex.go
+++ b/internal/xsdregex/regex.go
@@ -299,6 +299,22 @@ func validateXPathCharClassStructure(class string) error {
 				Message: fmt.Sprintf("invalid character class: %s", class),
 			}
 		}
+		// An interior raw '-' denotes a range operator whose endpoints must be
+		// single characters, never another '-'. A '-' is literal only at the
+		// start of the class (i == first) or immediately before the closing ']'
+		// (runes[i+1] == ']'); an interior '-' whose immediately-preceding or
+		// immediately-following raw char is itself '-' uses a '-' as a range
+		// endpoint, which the XSD/XPath regex grammar forbids. (The '-' of a
+		// '-[' subtraction never trips this: its following char is '[', and the
+		// subtraction itself is validated by validateXPathCharClassSubtraction.)
+		if runes[i] == '-' && i != first && runes[i+1] != ']' {
+			if prevRaw == '-' || runes[i+1] == '-' {
+				return &regexError{
+					Code:    errCodeFORX0002,
+					Message: fmt.Sprintf("invalid character class: %s", class),
+				}
+			}
+		}
 		prevRaw = runes[i]
 		i++
 	}

--- a/internal/xsdregex/regex_test.go
+++ b/internal/xsdregex/regex_test.go
@@ -91,6 +91,32 @@ func TestNegatedCharClassUnaffected(t *testing.T) {
 	require.False(t, re.MatchString("a"))
 }
 
+func TestCharClassHyphenRangeEndpoint(t *testing.T) {
+	// In the XSD/XPath regex grammar a '-' is a literal only at the start of a
+	// character class or immediately before the closing ']'. An interior '-'
+	// is a range operator, and its endpoints must be single characters — never
+	// another '-'. Go's RE2 happily accepts '[--z]' (range '-'..'z') and
+	// '[!--]' (range '!'..'-'), so the translator must reject these explicitly.
+	t.Run("reject hyphen as range endpoint", func(t *testing.T) {
+		for _, pat := range []string{`[--z]`, `[!--]`, `[^--z]`, `[a--z]`} {
+			t.Run(pat, func(t *testing.T) {
+				_, err := xsdregex.Compile(pat + "*")
+				require.Error(t, err, "pattern %q must be rejected", pat)
+				require.Contains(t, err.Error(), "invalid character class")
+			})
+		}
+	})
+
+	t.Run("accept valid hyphen neighbors", func(t *testing.T) {
+		for _, pat := range []string{`[+-]`, `[-+]`, `[a-z-+]`} {
+			t.Run(pat, func(t *testing.T) {
+				_, err := xsdregex.Compile(pat + "*")
+				require.NoError(t, err, "pattern %q must be accepted", pat)
+			})
+		}
+	})
+}
+
 func TestDefaultMatchTimeoutAccessors(t *testing.T) {
 	orig := xsdregex.DefaultMatchTimeout()
 	t.Cleanup(func() { xsdregex.SetDefaultMatchTimeout(orig) })

--- a/internal/xsdregex/regex_test.go
+++ b/internal/xsdregex/regex_test.go
@@ -115,6 +115,35 @@ func TestCharClassHyphenRangeEndpoint(t *testing.T) {
 			})
 		}
 	})
+
+	// A literal '-' immediately abutting a '-[' character-class subtraction
+	// operator is part of the base positive group, not a range endpoint, so the
+	// range-endpoint rule must NOT fire on it. '[--[a]]' (base {-} minus {a})
+	// and '[^--[a]]' (negated base {-} minus {a}) are valid and compile.
+	t.Run("accept hyphen abutting subtraction operator", func(t *testing.T) {
+		for _, pat := range []string{`[--[a]]`, `[^--[a]]`} {
+			t.Run(pat, func(t *testing.T) {
+				_, err := xsdregex.Compile(pat + "*")
+				require.NoError(t, err, "pattern %q must be accepted", pat)
+			})
+		}
+	})
+
+	// '[a--[b]]' (base {a,-} minus {b}) is also a valid XSD subtraction, but the
+	// regexp2/RE2 subtraction path passes the class through unexpanded, so the
+	// engine misreads 'a--' as a reverse-order range and rejects it — a
+	// pre-existing limitation, unchanged by this fix. The structural
+	// char-class validator must still NOT be the thing that rejects it: any
+	// error must come from the engine, never an "invalid character class"
+	// FORX0002, proving the range-endpoint rule does not fire on the literal
+	// dash abutting the '-[' operator.
+	t.Run("range-endpoint rule does not fire on subtraction base dash", func(t *testing.T) {
+		_, err := xsdregex.Compile(`[a--[b]]*`)
+		if err != nil {
+			require.NotContains(t, err.Error(), "invalid character class",
+				"structural validator must not reject the subtraction base dash")
+		}
+	})
 }
 
 func TestDefaultMatchTimeoutAccessors(t *testing.T) {


### PR DESCRIPTION
- reject an interior `-` whose neighbor is `-` (e.g. `[--z]`, `[!--]`) in xsd/xpath char classes; RE2 wrongly accepted these as ranges
- fixes W3C XSD 1.1 saxonMeta/Simple.testSet/simple041,simple042