### PR TITLE
document XSD 1.1 support in READMEs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,6 @@ XML toolkit for Go covering XML parsing, SAX2-style streaming, XPath 3.1,
 XInclude, XSD, Relax NG, and Schematron. Started as a libxml2-style port to
 Go and grew broader native Go APIs and features along the way.
 
-## XSD — Version
-
-The xsd package targets **XSD 1.0** (libxml2 parity). XSD 1.1-only constructs (xs:dateTimeStamp, explicitTimezone, assertions, the §3.16.6.3 union-facets-empty restriction condition) are out of scope; xpath3 is the only XSD 1.1 surface.
-
 ## XPath 3.1 — XSD Version
 
 The xpath3 package targets **XSD 1.1 only**. This means `+INF` is a valid lexical form for xs:double and xs:float, and xs:dateTimeStamp is a recognized type. QT3 tests with `dependency type="xsd-version" value="1.0"` are skipped.

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ go test -tags cgo,libxml2bench -bench=. -benchmem ./bench/
 
 * Core functionality is implemented: XML/HTML parsing, DOM building, SAX2, XPath 1.0, XPath 3.1, Basic XSLT 3.0, XInclude, C14N, RELAX NG, Schematron, XSD, XML Catalog, streaming XML writer, and `encoding/xml` compatibility (`shim` package).
 * Experimental: W3C XML Digital Signatures 1.1 (`xmldsig1`) and XML Encryption 1.1 (`xmlenc1`). These APIs may change and may move to a separate repository.
-* W3C conformance suites: ~22,250 / 22,744 QT3 tests pass for XPath 3.1; ~11,780 / 13,129 W3C tests pass for XSLT 3.0 (skips are XSLT 1.0/2.0 backwards compatibility and other out-of-scope features); XSD 1.1 passes the IBM and Saxon XSD 1.1 test sets of the W3C XML Schema Test Suite (967 test groups, 0 failures).
+* W3C conformance suites: ~22,250 / 22,744 QT3 tests pass for XPath 3.1; ~11,780 / 13,129 W3C tests pass for XSLT 3.0 (skips are XSLT 1.0/2.0 backwards compatibility and other out-of-scope features); XSD 1.1 passes the XSD-1.1-tagged test groups of the W3C XML Schema Test Suite — 967 groups from the IBM, Saxon, Oracle, and W3C-WG collections, 0 failures.
 * libxml2-compat golden tests: core XML parsing 100%, XSD 99.6%, RELAX NG 100%, Schematron 100%, C14N 100%, HTML 100%.
 * XSLT support is intentionally scoped to Basic XSLT 3.0. Backwards compatibility modes for XSLT 1.0/2.0 are not part of the target feature set.
 * A `helium` CLI provides `lint`, `xpath`, `xslt`, `xsd validate`, `relaxng validate`, and `schematron validate` subcommands.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ an embedded example.
 | [`xpath1`](xpath1/README.md) | XPath 1.0 compilation and evaluation. | Includes convenience helpers like `Find` and `Evaluate`. |
 | [`xpath3`](xpath3/README.md) | XPath 3.1 compilation and evaluation. | Includes a compiler, evaluator, maps, arrays, and HOFs. |
 | [`xpointer`](xpointer/README.md) | XPointer evaluation. | Supports shorthand, `element()`, and XPath-backed schemes. |
-| [`xsd`](xsd/README.md) | XML Schema compilation and validation. | XSD 1.0 compiler plus validator APIs. |
+| [`xsd`](xsd/README.md) | XML Schema compilation and validation. | XSD 1.0 (default) and opt-in XSD 1.1 compiler plus validator APIs. |
 | [`xslt3`](xslt3/README.md) | XSLT 3.0 stylesheet compilation and execution. | Targets Basic XSLT 3.0 conformance. |
 
 # `helium` CLI
@@ -235,7 +235,7 @@ go test -tags cgo,libxml2bench -bench=. -benchmem ./bench/
 
 * Core functionality is implemented: XML/HTML parsing, DOM building, SAX2, XPath 1.0, XPath 3.1, Basic XSLT 3.0, XInclude, C14N, RELAX NG, Schematron, XSD, XML Catalog, streaming XML writer, and `encoding/xml` compatibility (`shim` package).
 * Experimental: W3C XML Digital Signatures 1.1 (`xmldsig1`) and XML Encryption 1.1 (`xmlenc1`). These APIs may change and may move to a separate repository.
-* W3C conformance suites: ~22,250 / 22,744 QT3 tests pass for XPath 3.1; ~11,780 / 13,129 W3C tests pass for XSLT 3.0 (skips are XSLT 1.0/2.0 backwards compatibility and other out-of-scope features).
+* W3C conformance suites: ~22,250 / 22,744 QT3 tests pass for XPath 3.1; ~11,780 / 13,129 W3C tests pass for XSLT 3.0 (skips are XSLT 1.0/2.0 backwards compatibility and other out-of-scope features); XSD 1.1 passes the IBM and Saxon XSD 1.1 test sets of the W3C XML Schema Test Suite (967 test groups, 0 failures).
 * libxml2-compat golden tests: core XML parsing 100%, XSD 99.6%, RELAX NG 100%, Schematron 100%, C14N 100%, HTML 100%.
 * XSLT support is intentionally scoped to Basic XSLT 3.0. Backwards compatibility modes for XSLT 1.0/2.0 are not part of the target feature set.
 * A `helium` CLI provides `lint`, `xpath`, `xslt`, `xsd validate`, `relaxng validate`, and `schematron validate` subcommands.

--- a/xsd/README.md
+++ b/xsd/README.md
@@ -12,9 +12,10 @@ root `<xs:schema>` when the version is not set explicitly). XSD 1.1 support
 includes assertions, conditional type assignment, open content, wildcard
 `notNamespace`/`notQName`, `xs:all` relaxations, `xs:override`, document-wide
 xs:ID/xs:IDREF/xs:ENTITY value-space validation, and identity-constraint
-scoping. It passes the IBM and Saxon XSD 1.1 test sets of the W3C XML Schema
-Test Suite (967 test groups, 0 failures); the suite's XSD 1.0-era collections
-(Microsoft, NIST, Sun) are not part of that run.
+scoping. It passes the XSD-1.1-tagged test groups of the W3C XML Schema Test
+Suite — 967 groups from the IBM, Saxon, Oracle, and W3C-WG collections, 0
+failures. The suite's XSD 1.0-era collections (Microsoft, NIST, Sun, Boeing)
+contribute no 1.1 tests and are not part of that run.
 
 <!-- INCLUDE(examples/xsd_validate_example_test.go) -->
 ```go

--- a/xsd/README.md
+++ b/xsd/README.md
@@ -4,6 +4,18 @@ The `xsd` package compiles XML Schema documents and validates XML instances.
 
 Import path: `github.com/lestrrat-go/helium/xsd`
 
+## Schema version
+
+The compiler targets **XSD 1.0** by default. **XSD 1.1** is opt-in via
+`Compiler.Version(xsd.Version11)` (or a `vc:minVersion="1.1"` attribute on the
+root `<xs:schema>` when the version is not set explicitly). XSD 1.1 support
+includes assertions, conditional type assignment, open content, wildcard
+`notNamespace`/`notQName`, `xs:all` relaxations, `xs:override`, document-wide
+xs:ID/xs:IDREF/xs:ENTITY value-space validation, and identity-constraint
+scoping. It passes the IBM and Saxon XSD 1.1 test sets of the W3C XML Schema
+Test Suite (967 test groups, 0 failures); the suite's XSD 1.0-era collections
+(Microsoft, NIST, Sun) are not part of that run.
+
 <!-- INCLUDE(examples/xsd_validate_example_test.go) -->
 ```go
 package examples_test


### PR DESCRIPTION
- README + xsd/README: XSD 1.0 (default) and opt-in XSD 1.1 (`Compiler.Version(Version11)`); XSD 1.1 passes the IBM and Saxon XSD 1.1 test sets of the W3C XML Schema Test Suite (967 groups, 0 failures)
- Remove the stale CLAUDE.md "XSD — Version" section that claimed xsd is XSD 1.0-only with 1.1 out of scope — it contradicted the "XSD — Version Toggle" section and the shipped 1.1 implementation
