### PR TITLE
reject fixed on prohibited attribute use in xsd 1.1

### DIFF
--- a/xsd/check_elements.go
+++ b/xsd/check_elements.go
@@ -523,6 +523,18 @@ func (c *compiler) checkAttributeUse(ctx context.Context, elem *helium.Element) 
 	line := elem.Line()
 	local := elem.LocalName()
 
+	// XSD 1.1 Schema Representation Constraint (Attribute Declaration
+	// Representation OK): a prohibited attribute use must not carry a value
+	// constraint. A prohibited attribute can never appear, so a fixed value is
+	// meaningless. XSD 1.0 tolerates this (the schemas are valid there), so the
+	// check is gated on Version11 to keep 1.0 byte-identical. A `default` on a
+	// prohibited use is already rejected in both versions by the "default requires
+	// use=optional" check below, so only `fixed` needs handling here.
+	if c.version == Version11 && getAttr(elem, attrUse) == attrValProhibited && hasAttr(elem, attrFixed) {
+		c.schemaError(ctx, schemaParserError(c.diagSource(), line, local, "attribute",
+			"The attribute 'fixed' is not allowed when the value of the attribute 'use' is 'prohibited'."))
+	}
+
 	if ref != "" {
 		// ref and name are mutually exclusive.
 		if getAttr(elem, attrName) != "" {

--- a/xsd/read_particles.go
+++ b/xsd/read_particles.go
@@ -107,6 +107,19 @@ func (c *compiler) parseNamedAttributeGroup(ctx context.Context, elem *helium.El
 			// the attribute. libxml2 warns and SKIPS it, so the wildcard still
 			// admits the attribute. Mirror that here (parent type is attributeGroup).
 			if getAttr(ce, attrUse) == attrValProhibited {
+				// XSD 1.1 Schema Representation Constraint (Attribute Declaration
+				// Representation OK): a prohibited attribute use must not carry a
+				// value constraint. The use itself is skipped as pointless (below),
+				// but the fixed-value defect is still a schema error in 1.1. Gated on
+				// Version11 so 1.0 stays byte-identical (default is already rejected
+				// in both versions by checkAttributeUse's "default requires
+				// use=optional" rule, but that path is not reached here — a prohibited
+				// use with default inside a group is silently skipped in 1.0, matching
+				// origin, so only fixed is flagged and only in 1.1).
+				if c.version == Version11 && hasAttr(ce, attrFixed) {
+					c.schemaError(ctx, schemaParserError(c.diagSource(), ce.Line(), ce.LocalName(), "attribute",
+						"The attribute 'fixed' is not allowed when the value of the attribute 'use' is 'prohibited'."))
+				}
 				if c.filename != "" {
 					c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserWarning(c.diagSource(), ce.Line(), ce.LocalName(), "attribute",
 						"Skipping attribute use prohibition, since it is pointless inside an <attributeGroup>."), helium.ErrorLevelWarning))


### PR DESCRIPTION
- XSD 1.1 conformance: a local `xs:attribute` with `use="prohibited"` must not carry a `fixed` value constraint (Attribute Declaration Representation OK) — valid in 1.0, invalid in 1.1
- helium missed this in two paths: `checkAttributeUse` (only checked `default`+use, not `fixed`+prohibited) and `parseNamedAttributeGroup` (skipped prohibited attrs before the check ran)
- Both checks gated on `Version11`; XSD 1.0 stays byte-identical. Fixes Microsoft xsd11 cases attKb009/attKc009/attP029/attP031
