### PR TITLE
reject fixed on prohibited attr in xsd 1.1 extensions

### DIFF
--- a/xsd/attr_extension_prohibited_test.go
+++ b/xsd/attr_extension_prohibited_test.go
@@ -1,0 +1,98 @@
+package xsd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAttrExtensionProhibitedFixed verifies the XSD 1.1 Attribute Declaration
+// Representation OK constraint (a prohibited attribute use must not carry a
+// 'fixed' value constraint) is enforced on the xs:extension paths — both a
+// complexContent extension and a simpleContent extension. These paths warn+skip
+// a prohibited attribute before the ordinary attribute-use check runs, so the
+// constraint is enforced at the skip site. XSD 1.0 tolerates prohibited+fixed
+// everywhere, so the same schemas stay valid there.
+func TestAttrExtensionProhibitedFixed(t *testing.T) {
+	t.Parallel()
+
+	const prohibitedFixed = "The attribute 'fixed' is not allowed when the value of the attribute 'use' is 'prohibited'."
+
+	t.Run("complexContent extension prohibited+fixed", func(t *testing.T) {
+		t.Parallel()
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="base"><xs:sequence/></xs:complexType>
+  <xs:complexType name="derived">
+    <xs:complexContent>
+      <xs:extension base="base">
+        <xs:attribute name="a" type="xs:string" use="prohibited" fixed="x"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:schema>`
+		_, diag, cerr := compileV11(t, schemaXML)
+		require.Error(t, cerr, "v11 must reject prohibited+fixed in a complexContent extension")
+		require.Contains(t, diag, prohibitedFixed)
+
+		_, v10err := compileV10(t, schemaXML)
+		require.NoError(t, v10err, "v10 must accept prohibited+fixed in a complexContent extension")
+	})
+
+	t.Run("simpleContent extension prohibited+fixed", func(t *testing.T) {
+		t.Parallel()
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="derived">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="a" type="xs:string" use="prohibited" fixed="x"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+</xs:schema>`
+		_, diag, cerr := compileV11(t, schemaXML)
+		require.Error(t, cerr, "v11 must reject prohibited+fixed in a simpleContent extension")
+		require.Contains(t, diag, prohibitedFixed)
+
+		_, v10err := compileV10(t, schemaXML)
+		require.NoError(t, v10err, "v10 must accept prohibited+fixed in a simpleContent extension")
+	})
+
+	// A prohibited attribute WITHOUT a fixed value is a legal (if pointless)
+	// declaration in an extension in both versions — no over-rejection.
+	t.Run("complexContent extension prohibited without fixed stays valid", func(t *testing.T) {
+		t.Parallel()
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="base"><xs:sequence/></xs:complexType>
+  <xs:complexType name="derived">
+    <xs:complexContent>
+      <xs:extension base="base">
+        <xs:attribute name="a" type="xs:string" use="prohibited"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:schema>`
+		_, _, cerr := compileV11(t, schemaXML)
+		require.NoError(t, cerr, "v11 must accept prohibited (no fixed) in a complexContent extension")
+
+		_, v10err := compileV10(t, schemaXML)
+		require.NoError(t, v10err, "v10 must accept prohibited (no fixed) in a complexContent extension")
+	})
+
+	t.Run("simpleContent extension prohibited without fixed stays valid", func(t *testing.T) {
+		t.Parallel()
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="derived">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="a" type="xs:string" use="prohibited"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+</xs:schema>`
+		_, _, cerr := compileV11(t, schemaXML)
+		require.NoError(t, cerr, "v11 must accept prohibited (no fixed) in a simpleContent extension")
+
+		_, v10err := compileV10(t, schemaXML)
+		require.NoError(t, v10err, "v10 must accept prohibited (no fixed) in a simpleContent extension")
+	})
+}

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -685,6 +685,15 @@ func (c *compiler) parseComplexContentDerivationBody(ctx context.Context, elem *
 				continue
 			}
 			if kind == DerivationExtension && getAttr(ce, attrUse) == attrValProhibited {
+				// XSD 1.1 Attribute Declaration Representation OK: a prohibited
+				// attribute use must not carry a 'fixed' value constraint. The
+				// prohibited use is otherwise warned+skipped below, so this check
+				// (mirroring checkAttributeUse) is what enforces the constraint on
+				// the extension path. Gated on Version11 so XSD 1.0 stays byte-identical.
+				if c.version == Version11 && hasAttr(ce, attrFixed) {
+					c.schemaError(ctx, schemaParserError(c.diagSource(), ce.Line(), ce.LocalName(), "attribute",
+						"The attribute 'fixed' is not allowed when the value of the attribute 'use' is 'prohibited'."))
+				}
 				if c.filename != "" {
 					c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserWarning(c.filename, ce.Line(), ce.LocalName(), "attribute",
 						"Skipping attribute use prohibition, since it is pointless when extending a type."), helium.ErrorLevelWarning))
@@ -913,6 +922,15 @@ func (c *compiler) parseSimpleContentChildren(ctx context.Context, derivation *h
 				directAttrChild = ae.LocalName()
 			}
 			if kind == DerivationExtension && getAttr(ae, attrUse) == attrValProhibited {
+				// XSD 1.1 Attribute Declaration Representation OK: a prohibited
+				// attribute use must not carry a 'fixed' value constraint. The
+				// prohibited use is otherwise warned+skipped below, so this check
+				// (mirroring checkAttributeUse) is what enforces the constraint on
+				// the extension path. Gated on Version11 so XSD 1.0 stays byte-identical.
+				if c.version == Version11 && hasAttr(ae, attrFixed) {
+					c.schemaError(ctx, schemaParserError(c.diagSource(), ae.Line(), ae.LocalName(), "attribute",
+						"The attribute 'fixed' is not allowed when the value of the attribute 'use' is 'prohibited'."))
+				}
 				if c.filename != "" {
 					c.errorHandler.Handle(ctx, helium.NewLeveledError(schemaParserWarning(c.filename, ae.Line(), ae.LocalName(), "attribute",
 						"Skipping attribute use prohibition, since it is pointless when extending a type."), helium.ErrorLevelWarning))


### PR DESCRIPTION
- Completes the XSD 1.1 "Attribute Declaration Representation OK" check (added in #909): a `use="prohibited"` attribute must not carry `fixed`. The check ran in `checkAttributeUse` and `parseNamedAttributeGroup` but was skipped for a prohibited attribute inside an `xs:extension` (both complexContent `read_types.go:687` and simpleContent `:915` warn-and-skip before the check)
- Adds the same Version11-gated rejection at both extension sites; XSD 1.0 byte-identical
- Note: no W3C conformance-count change (no fixture exercises this) — it makes the check consistent across restriction and extension. Regression test added
