### PR TITLE
enforce xs:attribute type/ref QName validity in xsd

### DIFF
--- a/xsd/attr_type_ref_qname_test.go
+++ b/xsd/attr_type_ref_qname_test.go
@@ -1,0 +1,87 @@
+package xsd_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// The `type` and `ref` attributes of <xs:attribute> are of type xs:QName
+// (XSD Structures §3.2.2). A present value that is not a lexically valid QName
+// (a leading colon `:_`, a leading digit `123`, or the empty string on `ref`)
+// is a schema-representation error. Additionally, a top-level (global)
+// attribute declaration is typed by the schema-for-schemas `topLevelAttribute`,
+// which omits `ref`, so a `ref` on a global attribute declaration is a schema
+// error. All of these are version-independent, enforced under both XSD 1.0
+// (default) and XSD 1.1.
+func TestAttribute_TypeRefMustBeQName(t *testing.T) {
+	t.Parallel()
+
+	// %s is spliced inside an <xs:complexType> so a local attribute use is legal.
+	const localShell = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:a="urn:a" targetNamespace="urn:a">
+  <xs:attribute name="ga" type="xs:string"/>
+  <xs:complexType name="ct">
+    %s
+  </xs:complexType>
+</xs:schema>`
+
+	// %s is spliced directly under <xs:schema> to exercise a global declaration.
+	const globalShell = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:a="urn:a" targetNamespace="urn:a">
+  <xs:attribute name="ga" type="xs:string"/>
+  %s
+</xs:schema>`
+
+	const notQName = "not a valid QName"
+
+	invalid := []struct {
+		name   string
+		shell  string
+		attr   string
+		expect string
+	}{
+		// @type an invalid QName (attD005/attD006).
+		{"type-leading-colon", localShell, `<xs:attribute name="x" type=":_"/>`, notQName},
+		{"type-leading-digit", localShell, `<xs:attribute name="x" type="123"/>`, notQName},
+		{"type-leading-colon-global", globalShell, `<xs:attribute name="x" type=":_"/>`, notQName},
+		// @ref an invalid QName (attE005) or present-but-empty (attE007).
+		{"ref-leading-colon", localShell, `<xs:attribute ref=":_"/>`, notQName},
+		{"ref-empty", localShell, `<xs:attribute ref=""/>`, notQName},
+		// ref on a global attribute declaration (attKa010/attP003).
+		{"ref-on-global", globalShell, `<xs:attribute ref="a:ga"/>`, "The attribute 'ref' is not allowed."},
+	}
+	for _, tc := range invalid {
+		t.Run("invalid/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			schemaXML := fmt.Sprintf(tc.shell, tc.attr)
+			for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+				schema, errs, cerr := compileWith(t, v, schemaXML)
+				require.ErrorIs(t, cerr, xsd.ErrCompilationFailed, "version=%v must reject", v)
+				require.Nil(t, schema)
+				require.Contains(t, errs, tc.expect, "version=%v", v)
+			}
+		})
+	}
+
+	valid := []struct {
+		name  string
+		shell string
+		attr  string
+	}{
+		{"prefixed-builtin-type", localShell, `<xs:attribute name="x" type="xs:integer"/>`},
+		{"unprefixed-builtin-type", localShell, `<xs:attribute name="x" type="string" xmlns="http://www.w3.org/2001/XMLSchema"/>`},
+		{"local-ref-to-global", localShell, `<xs:attribute ref="a:ga"/>`},
+	}
+	for _, tc := range valid {
+		t.Run("valid/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			schemaXML := fmt.Sprintf(tc.shell, tc.attr)
+			for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+				schema, errs, cerr := compileWith(t, v, schemaXML)
+				require.NoError(t, cerr, "version=%v must accept: %s", v, errs)
+				require.NotNil(t, schema)
+			}
+		})
+	}
+}

--- a/xsd/check_elements.go
+++ b/xsd/check_elements.go
@@ -582,6 +582,25 @@ func (c *compiler) checkAttributeUse(ctx context.Context, elem *helium.Element) 
 		}
 	}
 
+	// Schema Representation Constraint on the `ref` attribute of <xs:attribute>
+	// (version-INDEPENDENT — enforced in BOTH XSD 1.0 and 1.1, §3.2.2). A
+	// top-level (global) attribute declaration is typed by the schema-for-schemas
+	// `topLevelAttribute`, which omits `ref` (like `use`/`form`), so a `ref` on a
+	// global attribute is a schema error. And `xs:attribute/@ref` is an xs:QName,
+	// so a present value that is not a lexically valid QName (empty `ref=""`, a
+	// leading-colon `:_`, a leading-digit `123`, …) is a schema-representation
+	// error; without this an empty/malformed ref slips past prefix resolution and
+	// silently resolves as an unprefixed reference.
+	if hasAttr(elem, attrRef) {
+		switch {
+		case isGlobalAttributeDecl(elem):
+			c.schemaError(ctx, schemaParserError(c.diagSource(), line, local, "attribute",
+				"The attribute 'ref' is not allowed."))
+		case !xmlchar.IsValidQName(ref):
+			c.reportInvalidQNameValue(ctx, elem, ref)
+		}
+	}
+
 	if ref != "" {
 		// ref and name are mutually exclusive.
 		if getAttr(elem, attrName) != "" {
@@ -697,6 +716,17 @@ func (c *compiler) checkAttributeUse(ctx context.Context, elem *helium.Element) 
 				c.schemaError(ctx, schemaParserError(c.filename, line, local, "attribute",
 					"The value of the attribute 'use' must be 'optional' if the attribute 'default' is present."))
 			}
+		}
+
+		// The `type` attribute of <xs:attribute> is an xs:QName (§3.2.2), so a
+		// present value that is not a lexically valid QName (a leading-colon `:_`,
+		// a leading-digit `123`, …) is a schema-representation error. Without this
+		// such a value slips past prefix resolution and silently resolves as an
+		// unprefixed reference. (Version-INDEPENDENT — enforced in 1.0 and 1.1. A
+		// syntactically valid @type that resolves to a non-simple-type component is
+		// a separate, resolution-time check.)
+		if t := getAttr(elem, attrType); t != "" && !xmlchar.IsValidQName(t) {
+			c.reportInvalidQNameValue(ctx, elem, t)
 		}
 
 		// type and inline simpleType are mutually exclusive.


### PR DESCRIPTION
- `xs:attribute/@type` and `@ref` are xs:QName (§3.2.2): a present malformed value (leading colon `:_`, leading digit `123`, empty `ref=""`) is now a schema-representation error, version-independent
- `@ref` on a global (top-level) attribute declaration is rejected (schema-for-schemas `topLevelAttribute` omits `ref`)
- fixes Attribute_w3c false-accepts attD005/attD006/attE005/attE007/attKa010/attP003