### PR TITLE
enforce xs:annotation schema representation

### DIFF
--- a/xsd/check_annotations.go
+++ b/xsd/check_annotations.go
@@ -1,0 +1,209 @@
+package xsd
+
+import (
+	"context"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/xmlchar"
+)
+
+// checkAnnotations enforces the schema-for-schemas XML representation of
+// <xs:annotation> / <xs:appinfo> / <xs:documentation> (XSD Structures §3.13.2)
+// that the various component parsers do not verify uniformly:
+//
+//   - an xs:annotation's content model is (appinfo | documentation)*: any other
+//     element child (a stray XSD element such as a nested xs:annotation, or a
+//     foreign element) and any non-whitespace character content is an error;
+//   - the only unqualified attribute allowed on xs:annotation is id (foreign
+//     namespaced attributes are allowed);
+//   - xs:appinfo allows only the unqualified attribute source;
+//   - xs:documentation allows only the unqualified attribute source and the
+//     xml:lang attribute, whose value (after xs:language whiteSpace=collapse)
+//     must be a valid xs:language — an empty or whitespace-only value is invalid;
+//   - every XSD element whose content model is (annotation?, ...) admits at most
+//     one xs:annotation child. Only xs:schema admits repeated annotations, so the
+//     "at most one" rule applies to every XSD-namespace element except xs:schema
+//     (and the annotation family itself, whose own content model is checked above).
+//
+// These are version-independent structural constraints, so the walk runs in both
+// XSD 1.0 and 1.1. It mirrors checkNotations / checkSchemaComponentIDs and is
+// invoked on the entry document and every included / imported / redefined /
+// overridden document. It does NOT descend into xs:appinfo / xs:documentation
+// payload, whose content is lax (arbitrary well-formed XML application data, not
+// schema components).
+func (c *compiler) checkAnnotations(ctx context.Context, root *helium.Element) {
+	if c.filename == "" {
+		return
+	}
+	c.walkAnnotations(ctx, root)
+}
+
+func (c *compiler) walkAnnotations(ctx context.Context, elem *helium.Element) {
+	if elem.URI() == lexicon.NamespaceXSD {
+		local := elem.LocalName()
+		switch local {
+		case elemAnnotation:
+			c.checkAnnotationDecl(ctx, elem)
+		case elemSchema, elemRedefine, elemOverride:
+			// xs:schema, xs:redefine and xs:override have the open
+			// (annotation | component)* content model and admit repeated
+			// annotations, so no "at most one" cardinality check applies.
+		default:
+			c.checkAnnotationCardinality(ctx, elem)
+		}
+	}
+
+	for child := range helium.Children(elem) {
+		ce, ok := child.(*helium.Element)
+		if !ok {
+			continue
+		}
+		if ce.URI() == lexicon.NamespaceXSD && (ce.LocalName() == elemAppinfo || ce.LocalName() == elemDocumentation) {
+			continue
+		}
+		c.walkAnnotations(ctx, ce)
+	}
+}
+
+// checkAnnotationCardinality enforces the (annotation?, ...) rule: an XSD element
+// may carry at most one xs:annotation child. A second annotation is a schema
+// error. Position ("must be first") is left to the individual component parsers.
+func (c *compiler) checkAnnotationCardinality(ctx context.Context, elem *helium.Element) {
+	src := c.diagSource()
+	if src == "" {
+		return
+	}
+	seen := false
+	for child := range helium.Children(elem) {
+		ce, ok := child.(*helium.Element)
+		if !ok {
+			continue
+		}
+		if ce.URI() != lexicon.NamespaceXSD || ce.LocalName() != elemAnnotation {
+			continue
+		}
+		if seen {
+			c.schemaError(ctx, schemaParserError(src, ce.Line(), elem.LocalName(), elem.LocalName(),
+				"Only one annotation is allowed. The content is not valid."))
+			return
+		}
+		seen = true
+	}
+}
+
+// checkAnnotationDecl validates a single xs:annotation element: its attributes
+// (only id is allowed) and its (appinfo | documentation)* content model.
+func (c *compiler) checkAnnotationDecl(ctx context.Context, elem *helium.Element) {
+	src := c.diagSource()
+	if src == "" {
+		return
+	}
+	line := elem.Line()
+
+	// Only the unqualified attribute id is allowed; foreign attributes are fine.
+	for _, attr := range elem.Attributes() {
+		if attr.Prefix() != "" {
+			continue
+		}
+		if attr.LocalName() == "id" {
+			continue
+		}
+		c.schemaError(ctx, schemaParserError(src, line, elemAnnotation, elemAnnotation,
+			"The attribute '"+attr.LocalName()+"' is not allowed."))
+	}
+
+	// Content model (appinfo | documentation)*: reject non-whitespace character
+	// content and any element child other than xs:appinfo / xs:documentation.
+	// Report the content-model violation before descending into the appinfo /
+	// documentation children so the diagnostics stay in document order.
+	invalid := false
+	for child := range helium.Children(elem) {
+		switch child.Type() {
+		case helium.TextNode, helium.CDATASectionNode:
+			if !xmlchar.IsAllSpace(child.Content()) {
+				invalid = true
+			}
+		case helium.ElementNode:
+			ce, ok := child.(*helium.Element)
+			if !ok {
+				continue
+			}
+			if ce.URI() == lexicon.NamespaceXSD && (ce.LocalName() == elemAppinfo || ce.LocalName() == elemDocumentation) {
+				continue
+			}
+			invalid = true
+		}
+	}
+	if invalid {
+		c.schemaError(ctx, schemaParserError(src, line, elemAnnotation, elemAnnotation,
+			"The content is not valid. Expected is (appinfo | documentation)*."))
+	}
+
+	for child := range helium.Children(elem) {
+		ce, ok := child.(*helium.Element)
+		if !ok {
+			continue
+		}
+		if ce.URI() != lexicon.NamespaceXSD {
+			continue
+		}
+		switch ce.LocalName() {
+		case elemAppinfo:
+			c.checkAppinfo(ctx, ce, src)
+		case elemDocumentation:
+			c.checkDocumentation(ctx, ce, src)
+		}
+	}
+}
+
+// checkAppinfo validates an xs:appinfo element. Only the unqualified attribute
+// source is allowed; its content is lax and is not inspected.
+func (c *compiler) checkAppinfo(ctx context.Context, elem *helium.Element, src string) {
+	line := elem.Line()
+	for _, attr := range elem.Attributes() {
+		if attr.Prefix() != "" {
+			continue
+		}
+		if attr.LocalName() == attrSource {
+			continue
+		}
+		c.schemaError(ctx, schemaParserError(src, line, elemAppinfo, elemAppinfo,
+			"The attribute '"+attr.LocalName()+"' is not allowed."))
+	}
+}
+
+// checkDocumentation validates an xs:documentation element. Only the unqualified
+// attribute source and the xml:lang attribute are allowed; xml:lang must be a
+// valid xs:language (empty / whitespace-only is invalid). Content is lax.
+func (c *compiler) checkDocumentation(ctx context.Context, elem *helium.Element, src string) {
+	line := elem.Line()
+	langPresent := false
+	var langValue string
+	for _, attr := range elem.Attributes() {
+		name := attr.LocalName()
+		prefix := attr.Prefix()
+		if prefix == lexicon.PrefixXML && name == lexicon.AttrLang {
+			langPresent = true
+			langValue = string(attr.Content())
+			continue
+		}
+		if prefix != "" {
+			continue // other namespaced attributes are allowed
+		}
+		if name == attrSource {
+			continue
+		}
+		c.schemaError(ctx, schemaParserError(src, line, elemDocumentation, elemDocumentation,
+			"The attribute '"+name+"' is not allowed."))
+	}
+
+	if langPresent {
+		collapsed := normalizeWhiteSpace(langValue, "collapse")
+		if !languageRegex.MatchString(collapsed) {
+			c.schemaError(ctx, schemaParserErrorAttr(src, line, elemDocumentation, elemDocumentation,
+				helium.ClarkName(lexicon.NamespaceXML, lexicon.AttrLang),
+				"'"+langValue+"' is not a valid value of the atomic type 'xs:language'."))
+		}
+	}
+}

--- a/xsd/check_annotations_test.go
+++ b/xsd/check_annotations_test.go
@@ -1,0 +1,151 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAnnotationSchemaRepresentation exercises the schema-for-schemas XML
+// representation of xs:annotation / xs:appinfo / xs:documentation (XSD Structures
+// §3.13.2), enforced by the version-independent checkAnnotations DOM walk. These
+// constructs were previously accepted (false-accept) because the attribute /
+// content-model checks only ran for annotations nested in an element's inline
+// type and never for schema-level or leaf-host annotations.
+func TestAnnotationSchemaRepresentation(t *testing.T) {
+	t.Parallel()
+
+	compile := func(t *testing.T, schemaXML string) bool {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, gotErr := xsd.NewCompiler().Label("test.xsd").ErrorHandler(collector).Compile(t.Context(), doc)
+		return gotErr != nil
+	}
+
+	for _, tc := range []struct {
+		name       string
+		schema     string
+		wantReject bool
+	}{
+		{
+			name: "annotation with arbitrary attribute",
+			schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:annotation foo="bar"/>
+</xs:schema>`,
+			wantReject: true,
+		},
+		{
+			name: "annotation containing nested annotation",
+			schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:annotation>
+    <xs:annotation><xs:documentation>x</xs:documentation></xs:annotation>
+    <xs:documentation>y</xs:documentation>
+  </xs:annotation>
+</xs:schema>`,
+			wantReject: true,
+		},
+		{
+			name: "annotation containing stray XSD element",
+			schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:annotation><xs:element name="stray"/></xs:annotation>
+</xs:schema>`,
+			wantReject: true,
+		},
+		{
+			name: "documentation empty xml:lang",
+			schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:annotation><xs:documentation source="urn:x" xml:lang=""/></xs:annotation>
+</xs:schema>`,
+			wantReject: true,
+		},
+		{
+			name: "documentation whitespace xml:lang",
+			schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:annotation><xs:documentation xml:lang=" "/></xs:annotation>
+</xs:schema>`,
+			wantReject: true,
+		},
+		{
+			name: "appinfo with disallowed attribute",
+			schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:annotation><xs:appinfo id="a"/></xs:annotation>
+</xs:schema>`,
+			wantReject: true,
+		},
+		{
+			name: "documentation with disallowed attribute",
+			schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:annotation><xs:documentation frob="x"/></xs:annotation>
+</xs:schema>`,
+			wantReject: true,
+		},
+		{
+			name: "two annotations under element",
+			schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="foo">
+    <xs:annotation><xs:documentation>a</xs:documentation></xs:annotation>
+    <xs:annotation><xs:documentation>b</xs:documentation></xs:annotation>
+  </xs:element>
+</xs:schema>`,
+			wantReject: true,
+		},
+		{
+			name: "two annotations under attribute",
+			schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attribute name="att" type="xs:string">
+    <xs:annotation><xs:documentation>a</xs:documentation></xs:annotation>
+    <xs:annotation><xs:documentation>b</xs:documentation></xs:annotation>
+  </xs:attribute>
+</xs:schema>`,
+			wantReject: true,
+		},
+		// Valid annotations must still compile.
+		{
+			name: "valid annotation appinfo documentation with source and lang",
+			schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:annotation id="a">
+    <xs:appinfo source="urn:app"><Anything/></xs:appinfo>
+    <xs:documentation source="urn:doc" xml:lang="en">Free text.</xs:documentation>
+  </xs:annotation>
+  <xs:element name="foo" type="xs:string"/>
+</xs:schema>`,
+			wantReject: false,
+		},
+		{
+			name: "valid single annotation under element",
+			schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="foo">
+    <xs:annotation><xs:documentation>ok</xs:documentation></xs:annotation>
+    <xs:complexType><xs:sequence/></xs:complexType>
+  </xs:element>
+</xs:schema>`,
+			wantReject: false,
+		},
+		{
+			name: "valid multiple annotations under schema",
+			schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:annotation><xs:documentation>one</xs:documentation></xs:annotation>
+  <xs:annotation><xs:documentation>two</xs:documentation></xs:annotation>
+  <xs:element name="foo" type="xs:string"/>
+</xs:schema>`,
+			wantReject: false,
+		},
+		{
+			name: "valid appinfo with arbitrary content",
+			schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:annotation><xs:appinfo><foo bar="baz"><nested/></foo></xs:appinfo></xs:annotation>
+  <xs:element name="foo" type="xs:string"/>
+</xs:schema>`,
+			wantReject: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.wantReject, compile(t, tc.schema))
+		})
+	}
+}

--- a/xsd/check_elements.go
+++ b/xsd/check_elements.go
@@ -2,7 +2,6 @@ package xsd
 
 import (
 	"context"
-	"strings"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
@@ -773,110 +772,4 @@ func (c *compiler) localAttributeUnderNonAnyTypeRestriction(ctx context.Context,
 func isContentDerivationRestriction(elem *helium.Element) bool {
 	parent, ok := helium.AsNode[*helium.Element](elem.Parent())
 	return ok && (isXSDElement(parent, elemSimpleContent) || isXSDElement(parent, elemComplexContent))
-}
-
-// checkAnnotation validates an xs:annotation element and its children.
-func (c *compiler) checkAnnotation(ctx context.Context, elem *helium.Element) {
-	if c.filename == "" {
-		return
-	}
-	line := elem.Line()
-	local := elem.LocalName()
-
-	// Check for disallowed attributes on annotation (only id is allowed).
-	for _, attr := range elem.Attributes() {
-		name := attr.LocalName()
-		if attr.Prefix() != "" {
-			continue // namespaced attributes are allowed
-		}
-		if name == "id" {
-			continue
-		}
-		c.schemaError(ctx, schemaParserError(c.filename, line, local, "annotation",
-			"The attribute '"+name+"' is not allowed."))
-	}
-
-	// Check for invalid content (non-element children like text nodes).
-	hasInvalidContent := false
-	for child := range helium.Children(elem) {
-		if child.Type() == helium.TextNode {
-			text := strings.TrimSpace(string(child.Content()))
-			if text != "" {
-				hasInvalidContent = true
-				break
-			}
-		}
-	}
-	if hasInvalidContent {
-		c.schemaError(ctx, schemaParserError(c.filename, line, local, "annotation",
-			"The content is not valid. Expected is (appinfo | documentation)*."))
-	}
-
-	// Check children (appinfo, documentation).
-	for child := range helium.Children(elem) {
-		if child.Type() != helium.ElementNode {
-			continue
-		}
-		ce, ok := helium.AsNode[*helium.Element](child)
-		if !ok {
-			continue
-		}
-		if isXSDElement(ce, elemAppinfo) {
-			c.checkAppinfo(ctx, ce)
-		} else if isXSDElement(ce, elemDocumentation) {
-			c.checkDocumentation(ctx, ce)
-		}
-	}
-}
-
-// checkAppinfo validates an xs:appinfo element.
-func (c *compiler) checkAppinfo(ctx context.Context, elem *helium.Element) {
-	line := elem.Line()
-	local := elem.LocalName()
-
-	// Only "source" is allowed (no id).
-	for _, attr := range elem.Attributes() {
-		name := attr.LocalName()
-		if attr.Prefix() != "" {
-			continue
-		}
-		if name == attrSource {
-			continue
-		}
-		c.schemaError(ctx, schemaParserError(c.filename, line, local, "appinfo",
-			"The attribute '"+name+"' is not allowed."))
-	}
-}
-
-// checkDocumentation validates an xs:documentation element.
-func (c *compiler) checkDocumentation(ctx context.Context, elem *helium.Element) {
-	line := elem.Line()
-	local := elem.LocalName()
-
-	// Only "source" and "xml:lang" are allowed (no id).
-	// Check disallowed attributes first, then validate xml:lang value.
-	var langValue string
-	for _, attr := range elem.Attributes() {
-		name := attr.LocalName()
-		prefix := attr.Prefix()
-		if prefix != "" && prefix != lexicon.PrefixXML {
-			continue // other namespaced attributes are allowed
-		}
-		if prefix == lexicon.PrefixXML && name == lexicon.AttrLang {
-			langValue = string(attr.Content())
-			continue
-		}
-		if name == attrSource {
-			continue
-		}
-		c.schemaError(ctx, schemaParserError(c.filename, line, local, "documentation",
-			"The attribute '"+name+"' is not allowed."))
-	}
-
-	// Validate xml:lang value after attribute checks.
-	if langValue != "" && !languageRegex.MatchString(langValue) {
-		c.schemaError(ctx, schemaParserErrorAttr(c.filename, line, local, "documentation",
-			helium.ClarkName(lexicon.NamespaceXML, lexicon.AttrLang),
-			"'"+langValue+"' is not a valid value of the atomic type 'xs:language'."))
-	}
 }

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -731,6 +731,7 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 	c.checkSchemaComponentIDs(ctx, root)
 	c.checkIDConstraintPlacement(ctx, root)
 	c.checkNotations(ctx, root)
+	c.checkAnnotations(ctx, root)
 
 	// Parse blockDefault attribute.
 	if v := getAttr(root, attrBlockDefault); v != "" {

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -486,6 +486,7 @@ func (c *compiler) loadInclude(ctx context.Context, location string, includeElem
 	c.checkSchemaComponentIDs(ctx, incRoot)
 	c.checkIDConstraintPlacement(ctx, incRoot)
 	c.checkNotations(ctx, incRoot)
+	c.checkAnnotations(ctx, incRoot)
 
 	// Parse the included schema's declarations into the current compiler.
 	// (Conditional inclusion already ran above, before the TNS check.)
@@ -760,6 +761,7 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 	c.checkSchemaComponentIDs(ctx, incRoot)
 	c.checkIDConstraintPlacement(ctx, incRoot)
 	c.checkNotations(ctx, incRoot)
+	c.checkAnnotations(ctx, incRoot)
 
 	// Parse the included schema's declarations into the current compiler.
 	// (Conditional inclusion already ran above, before the TNS check.)
@@ -1391,6 +1393,7 @@ func (c *compiler) loadImport(ctx context.Context, location, ns string, importEl
 	impC.checkSchemaComponentIDs(ctx, impRoot)
 	impC.checkIDConstraintPlacement(ctx, impRoot)
 	impC.checkNotations(ctx, impRoot)
+	impC.checkAnnotations(ctx, impRoot)
 
 	if err := impC.parseSchemaChildren(ctx, impRoot); err != nil {
 		return err

--- a/xsd/override.go
+++ b/xsd/override.go
@@ -434,6 +434,7 @@ func (c *compiler) overrideLoadTarget(ctx context.Context, location string, srcE
 	}
 	c.checkIDConstraintPlacement(ctx, incRoot)
 	c.checkNotations(ctx, incRoot)
+	c.checkAnnotations(ctx, incRoot)
 
 	// Target namespace compatibility: same rule as xs:include (W3C over016/017). A
 	// referenced document with no targetNamespace is a chameleon and adopts the

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -547,8 +547,6 @@ func (c *compiler) readElementType(ctx context.Context, elem *helium.Element, de
 			continue
 		}
 		switch {
-		case isXSDElement(ce, elemAnnotation):
-			c.checkAnnotation(ctx, ce)
 		case isXSDElement(ce, elemComplexType):
 			td, err := c.parseComplexType(ctx, ce)
 			if err != nil {


### PR DESCRIPTION
- Add version-independent `checkAnnotations` DOM walk enforcing §3.13.2: xs:annotation content model `(appinfo|documentation)*`, allowed attributes (annotation {id}, appinfo {source}, documentation {source, xml:lang} with a valid xs:language), and at most one annotation child per host (schema/redefine/override excepted).
- Fixes 12 XSD 1.0 false-accepts in msMeta/Annotations_w3c.xml (annotB001/B005/B006/B007/B009/B010/B015/B019/B020, annotF001/F003/F009).