### PR TITLE
enforce simpleType type-resolution kind rules in xsd

### DIFF
--- a/xsd/check_facets.go
+++ b/xsd/check_facets.go
@@ -974,6 +974,82 @@ func isAnySimpleTypeDef(td *TypeDef) bool {
 	return td != nil && td.Name.NS == lexicon.NamespaceXSD && td.Name.Local == lexicon.TypeAnySimpleType
 }
 
+// checkSimpleTypeResolution enforces the type-resolution kind rules for simple
+// type definitions (XSD Structures §3.14.6 / Part 2 §2.4), version-INDEPENDENT so
+// it runs in BOTH XSD 1.0 and 1.1:
+//
+//   - a restriction's {base type definition} must be a SIMPLE type definition —
+//     naming a complexType (including the ur-type xs:anyType) is a schema error
+//     (cos-st-restricts.1 / st-props-correct);
+//   - a list's {item type definition} must be a simple type whose variety is
+//     atomic or union — naming a complexType, or another LIST type (a list of
+//     lists is forbidden), is a schema error (cos-list-of-atomic);
+//   - each union {member type definition} must be a simple type — naming a
+//     complexType is a schema error.
+//
+// It walks every parsed simple type, including inline anonymous ones (recorded in
+// typeDefSources); the built-in datatypes are registered separately and never
+// appear there, so they are not re-examined. Complex type definitions are skipped
+// entirely (td.IsComplex) — their derivation rules are enforced elsewhere. The
+// base/item/member type pointers are already resolved by resolveRefs, and cyclic
+// simple types have been rejected before this runs, so the resolveVariety base
+// walk terminates.
+func (c *compiler) checkSimpleTypeResolution(ctx context.Context) {
+	if c.filename == "" {
+		return
+	}
+
+	type entry struct {
+		td  *TypeDef
+		src typeDefSource
+	}
+	var entries []entry
+	for td, src := range c.typeDefSources {
+		if td.IsComplex || td.syntheticComplexBase || td.Name.NS == lexicon.NamespaceXSD {
+			continue
+		}
+		entries = append(entries, entry{td: td, src: src})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].src.line != entries[j].src.line {
+			return entries[i].src.line < entries[j].src.line
+		}
+		if entries[i].td.Name.Local != entries[j].td.Name.Local {
+			return entries[i].td.Name.Local < entries[j].td.Name.Local
+		}
+		return entries[i].src.ordinal < entries[j].src.ordinal
+	})
+
+	qnameOf := func(td *TypeDef) string {
+		return fmt.Sprintf("{%s}%s", td.Name.NS, td.Name.Local)
+	}
+
+	for _, e := range entries {
+		td := e.td
+		component := td.Name.Local
+		if component == "" || e.src.isLocal {
+			component = componentLocalSimpleType
+		}
+		report := func(msg string) {
+			c.schemaError(ctx, schemaComponentError(c.diagSourceOrRecorded(e.src.source), e.src.line,
+				elemSimpleType, component, msg))
+		}
+
+		switch {
+		case td.Derivation == DerivationRestriction && td.BaseType != nil && td.BaseType.IsComplex:
+			report(fmt.Sprintf("The base type '%s' of a simpleType restriction must be a simple type definition.", qnameOf(td.BaseType)))
+		case td.ItemType != nil && td.ItemType.IsComplex:
+			report(fmt.Sprintf("The item type '%s' of a list must be a simple type definition.", qnameOf(td.ItemType)))
+		case td.ItemType != nil && resolveVariety(td.ItemType) == TypeVarietyList:
+			report(fmt.Sprintf("The item type '%s' of a list must not itself be a list type.", qnameOf(td.ItemType)))
+		default:
+			if i := slices.IndexFunc(td.MemberTypes, func(m *TypeDef) bool { return m != nil && m.IsComplex }); i >= 0 {
+				report(fmt.Sprintf("The member type '%s' of a union must be a simple type definition.", qnameOf(td.MemberTypes[i])))
+			}
+		}
+	}
+}
+
 // checkAnySimpleTypeUsage (XSD 1.1) rejects user derivations that restrict the
 // simple ur-type xs:anySimpleType. Per the note in XML Schema Part 2 §2.4.1 (and
 // the resolution of W3C bug 14559) the simple ur-type must not be named as the

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -790,6 +790,13 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 		return nil, ErrCompilationFailed
 	}
 
+	// Enforce the simple-type type-resolution kind rules (a restriction base, a
+	// list item type, or a union member type must resolve to a SIMPLE type — not a
+	// complexType/xs:anyType — and a list item type must not itself be a list).
+	// Version-independent; runs after the circular check so the base-chain walk
+	// terminates.
+	c.checkSimpleTypeResolution(ctx)
+
 	// Check facet consistency after refs are resolved (base types are available).
 	c.checkFacetConsistency(ctx)
 

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -1064,6 +1064,11 @@ func (c *compiler) parseSimpleContentRestrictionType(ctx context.Context, deriva
 			Derivation:  DerivationRestriction,
 			BaseType:    owner,
 			Facets:      fs,
+			// This synthetic content simple type deliberately bases on the owning
+			// simpleContent COMPLEX type (its base chain resolves to the builtin
+			// content base). It is a compiler artifact, not a source-level simpleType
+			// restriction, so the simple-type kind check must not flag its complex base.
+			syntheticComplexBase: true,
 		}
 		c.recordTypeDefSource(syn, derivation.Line(), true, elemSimpleType)
 		return syn

--- a/xsd/schema.go
+++ b/xsd/schema.go
@@ -339,6 +339,13 @@ type TypeDef struct {
 	// from an absent <xs:openContent> (OpenContent nil, schema-level
 	// <xs:defaultOpenContent> may still apply). Set at parse time (read_types).
 	openContentExplicit bool
+	// syntheticComplexBase marks a compiler-synthesized content simple type
+	// (parseSimpleContentRestrictionType) that deliberately bases on its owning
+	// simpleContent COMPLEX type to compose the restriction's direct facets over
+	// the base content type. It is not a source-level simpleType restriction, so
+	// checkSimpleTypeResolution skips it — the complex base is intentional here.
+	syntheticComplexBase bool
+
 	// pendingDefaultOpenContent is the schema-level <xs:defaultOpenContent> active
 	// in THIS type's own schema document at parse time, captured only when the type
 	// has no explicit <xs:openContent>. Default open content is per-document

--- a/xsd/simpletype_resolution_test.go
+++ b/xsd/simpletype_resolution_test.go
@@ -1,0 +1,69 @@
+package xsd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSimpleTypeResolution exercises the simple-type type-resolution kind rules
+// (XSD Structures §3.14.6 / Part 2 §2.4), enforced version-independently in the
+// default (XSD 1.0) compiler: a restriction {base type definition}, a list {item
+// type definition}, and each union {member type definition} must resolve to a
+// SIMPLE type — a complexType or the ur-type xs:anyType is a schema error — and a
+// list item type must not itself be a list. Mirrors W3C msMeta/SimpleType_w3c
+// groups stC003/stD019/stE018/stI004/stJ003/stJ019/stK003, each a former
+// false-accept.
+func TestSimpleTypeResolution(t *testing.T) {
+	t.Parallel()
+
+	const head = `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">`
+	const tail = `</xsd:schema>`
+	const simpleContentCT = `<xsd:complexType name="ct"><xsd:simpleContent><xsd:extension base="xsd:integer"/></xsd:simpleContent></xsd:complexType>`
+
+	t.Run("rejects", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct {
+			name   string
+			schema string
+		}{
+			{"restriction-base-anyType", `<xsd:simpleType name="t"><xsd:restriction base="xsd:anyType"/></xsd:simpleType>`},
+			{"restriction-base-complex", simpleContentCT + `<xsd:simpleType name="t"><xsd:restriction base="ct"/></xsd:simpleType>`},
+			{"list-item-complex", simpleContentCT + `<xsd:simpleType name="t"><xsd:list itemType="ct"/></xsd:simpleType>`},
+			{"union-member-complex", simpleContentCT + `<xsd:simpleType name="t"><xsd:union memberTypes="ct"/></xsd:simpleType>`},
+			{"union-member-complex-second", simpleContentCT + `<xsd:simpleType name="t"><xsd:union memberTypes="xsd:string ct"/></xsd:simpleType>`},
+			{"list-item-list-named", `<xsd:simpleType name="l"><xsd:list itemType="xsd:string"/></xsd:simpleType><xsd:simpleType name="t"><xsd:list itemType="l"/></xsd:simpleType>`},
+			{"list-item-list-inline-derived", `<xsd:simpleType name="l"><xsd:list><xsd:simpleType><xsd:restriction base="xsd:integer"/></xsd:simpleType></xsd:list></xsd:simpleType><xsd:simpleType name="t"><xsd:list itemType="l"/></xsd:simpleType>`},
+			{"local-restriction-base-complex", simpleContentCT + `<xsd:element name="e"><xsd:complexType><xsd:sequence><xsd:element name="c"><xsd:simpleType><xsd:restriction base="ct"/></xsd:simpleType></xsd:element></xsd:sequence></xsd:complexType></xsd:element>`},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				require.NotEmpty(t, compileSchemaErrors(t, head+tc.schema+tail),
+					"expected %s to be rejected", tc.name)
+			})
+		}
+	})
+
+	t.Run("accepts", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct {
+			name   string
+			schema string
+		}{
+			{"restriction-base-builtin", `<xsd:simpleType name="t"><xsd:restriction base="xsd:string"><xsd:maxLength value="5"/></xsd:restriction></xsd:simpleType>`},
+			{"restriction-base-anySimpleType", `<xsd:simpleType name="t"><xsd:restriction base="xsd:anySimpleType"/></xsd:simpleType>`},
+			{"restriction-base-user-list", `<xsd:simpleType name="l"><xsd:list itemType="xsd:string"/></xsd:simpleType><xsd:simpleType name="t"><xsd:restriction base="l"><xsd:length value="2"/></xsd:restriction></xsd:simpleType>`},
+			{"list-item-builtin", `<xsd:simpleType name="t"><xsd:list itemType="xsd:integer"/></xsd:simpleType>`},
+			{"list-item-user-atomic", `<xsd:simpleType name="a"><xsd:restriction base="xsd:integer"/></xsd:simpleType><xsd:simpleType name="t"><xsd:list itemType="a"/></xsd:simpleType>`},
+			{"list-item-union", `<xsd:simpleType name="u"><xsd:union memberTypes="xsd:string xsd:integer"/></xsd:simpleType><xsd:simpleType name="t"><xsd:list itemType="u"/></xsd:simpleType>`},
+			{"union-members-builtin", `<xsd:simpleType name="t"><xsd:union memberTypes="xsd:string xsd:integer"/></xsd:simpleType>`},
+			{"union-member-user-list", `<xsd:simpleType name="l"><xsd:list itemType="xsd:string"/></xsd:simpleType><xsd:simpleType name="t"><xsd:union memberTypes="l xsd:string"/></xsd:simpleType>`},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				require.Empty(t, compileSchemaErrors(t, head+tc.schema+tail),
+					"expected %s to compile cleanly", tc.name)
+			})
+		}
+	})
+}


### PR DESCRIPTION
- Reject a simpleType whose restriction `base`, list `itemType`, or union `memberType` resolves to a complexType (including `xs:anyType`), and a list `itemType` that itself resolves to a list type (§3.14.6 / Part 2 §2.4)
- Version-independent `checkSimpleTypeResolution` run after the circular-simple-type check; synthetic simpleContent content-simple-types (whose complex base is intentional) are skipped
- Fixes W3C SimpleType false-accepts stC003/stD019/stE018/stI004/stJ003/stJ019/stK003