### PR TITLE
enforce simpleContent base kind (src-ct.2)

### DIFF
--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -53,7 +53,13 @@ type compiler struct {
 	parser             *helium.Parser // parser governing parse policy for nested include/import/redefine schemas
 	// unresolved type references: maps from element/type QName to the type ref string
 	typeRefs map[*TypeDef]QName
-	elemRefs map[*ElementDecl]QName
+	// recoveryBaseTypes marks the placeholder TypeDefs inserted when a @base/
+	// itemType/memberTypes reference does not resolve (reportUnresolvedTypeRef).
+	// Downstream derivation checks (checkSimpleContentBase) skip a derivation
+	// whose base is such a placeholder — the unresolved ref was already reported,
+	// so the base kind is unknown and any further diagnostic would be spurious.
+	recoveryBaseTypes map[*TypeDef]bool
+	elemRefs          map[*ElementDecl]QName
 	// unresolved xs:alternative (conditional type assignment) @type references,
 	// resolved in resolveRefs. A slice (not a map) so nil-append works without
 	// per-compiler initialization.
@@ -589,6 +595,7 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 		fsys:                      fsys,
 		parser:                    parser,
 		typeRefs:                  make(map[*TypeDef]QName),
+		recoveryBaseTypes:         make(map[*TypeDef]bool),
 		elemRefs:                  make(map[*ElementDecl]QName),
 		elemRefSources:            make(map[*ElementDecl]elemRefSource),
 		groupRefs:                 make(map[*ModelGroup]QName),

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -108,6 +108,10 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 			c.reportUnresolvedTypeRef(ctx, td, qn)
 			base = &TypeDef{Name: qn, ContentType: ContentTypeSimple}
 			c.schema.types[qn] = base
+			if c.recoveryBaseTypes == nil {
+				c.recoveryBaseTypes = make(map[*TypeDef]bool)
+			}
+			c.recoveryBaseTypes[base] = true
 		}
 		td.BaseType = base
 	}
@@ -167,6 +171,11 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 			}
 		}
 	}
+
+	// Enforce src-ct.2 (Complex Type Definition Representation OK): a
+	// <xs:simpleContent> derivation's base type must be of the right kind. Runs
+	// after the base types above are resolved.
+	c.checkSimpleContentBase(ctx)
 
 	// Resolve group references — replace placeholder content with actual group content.
 	//
@@ -717,6 +726,95 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 			c.checkUPA(ctx, t.td, t.src)
 		}
 	}
+}
+
+// checkSimpleContentBase enforces src-ct.2 (Complex Type Definition
+// Representation OK, XSD §3.4.2): when a complex type uses <xs:simpleContent>,
+// the base type resolved by the derivation's @base must have the right KIND and
+// content. This is version-INDEPENDENT — the same constraint holds in XSD 1.0
+// and 1.1 — so it runs in both. Called from resolveRefs after base types are
+// resolved.
+//
+//	extension:   base must be a simple type, OR a complex type whose {content
+//	             type} is a simple type. (clauses 2.1, 2.2)
+//	restriction: base must be a complex type whose {content type} is a simple
+//	             type, OR a complex type whose content is mixed with an emptiable
+//	             particle AND the restriction carries a nested <xs:simpleType>.
+//	             A simple-type base is invalid for a restriction — clause 2.2 is
+//	             extension-only. (clauses 2.1, 2.3)
+func (c *compiler) checkSimpleContentBase(ctx context.Context) {
+	if c.filename == "" {
+		return
+	}
+	tds := make([]*TypeDef, 0, len(c.typeRefs))
+	for td := range c.typeRefs {
+		if td.IsSimpleContent && td.BaseType != nil {
+			tds = append(tds, td)
+		}
+	}
+	sort.Slice(tds, func(i, j int) bool {
+		si, sj := c.typeDefSources[tds[i]], c.typeDefSources[tds[j]]
+		if si.line != sj.line {
+			return si.line < sj.line
+		}
+		return si.ordinal < sj.ordinal
+	})
+	for _, td := range tds {
+		base := td.BaseType
+		if c.recoveryBaseTypes[base] {
+			continue // base ref did not resolve; already reported
+		}
+		baseIsSimpleType := !base.IsComplex
+		baseIsSimpleContent := base.IsComplex && base.ContentType == ContentTypeSimple
+		var ok bool
+		switch td.Derivation {
+		case DerivationExtension:
+			ok = baseIsSimpleType || baseIsSimpleContent
+		case DerivationRestriction:
+			switch {
+			case baseIsSimpleContent:
+				ok = true
+			case base.IsComplex && base.ContentType == ContentTypeMixed &&
+				contentModelEmptiable(base.ContentModel) && td.scHasSimpleTypeChild:
+				ok = true
+			case base.Name.NS == lexicon.NamespaceXSD && base.Name.Local == typeAnySimpleType:
+				// xs:anySimpleType is the simple ur-type; a simpleContent restriction
+				// may base on it and define a fresh simple content via a nested
+				// <xs:simpleType>. (A non-narrowing restriction that leaves the content
+				// as xs:anySimpleType is rejected separately by checkAnySimpleTypeUsage
+				// in 1.1.)
+				ok = true
+			}
+		}
+		if ok {
+			continue
+		}
+		src, srcOK := c.typeDefSources[td]
+		if !srcOK {
+			continue
+		}
+		component := componentLocalComplexType
+		if !src.isLocal {
+			component = "complex type '" + td.Name.Local + "'"
+		}
+		var msg string
+		if td.Derivation == DerivationExtension {
+			msg = "The base type of a 'simpleContent' extension must be a simple type or a complex type with simple content."
+		} else {
+			msg = "The base type of a 'simpleContent' restriction must be a complex type with simple content."
+		}
+		c.schemaError(ctx, schemaComponentError(c.diagSourceOrRecorded(src.source), src.line, "complexType", component, msg))
+	}
+}
+
+// contentModelEmptiable reports whether a complex type's content model can match
+// the empty sequence (src-ct.2.3 "emptiable particle"). A nil model group (e.g.
+// xs:anyType, or an attribute-only content type) is emptiable.
+func contentModelEmptiable(mg *ModelGroup) bool {
+	if mg == nil {
+		return true
+	}
+	return particleEmptiable(&Particle{Term: mg, MinOccurs: mg.MinOccurs, MaxOccurs: mg.MaxOccurs})
 }
 
 // expandAttrGroupUses returns the effective attribute uses contributed by the

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -999,6 +999,13 @@ func (c *compiler) parseSimpleContentChildren(ctx context.Context, derivation *h
 		}
 	}
 
+	// Record whether a simpleContent RESTRICTION carried a nested <xs:simpleType>
+	// child (src-ct.2 clause 2.3); consumed by checkSimpleContentBase. Version-
+	// independent: the base-kind constraint holds in both XSD 1.0 and 1.1.
+	if kind == DerivationRestriction && simpleTypeSeen {
+		td.scHasSimpleTypeChild = true
+	}
+
 	// XSD 1.1: a simpleContent RESTRICTION narrows the base content type via a
 	// nested <xs:simpleType> OR direct facets. Capture the resulting effective
 	// content simple type so validateSimpleContent checks the text against the

--- a/xsd/schema.go
+++ b/xsd/schema.go
@@ -333,6 +333,12 @@ type TypeDef struct {
 	// inherited through derived simpleContent types.
 	IsSimpleContent bool
 
+	// scHasSimpleTypeChild records that a <xs:simpleContent> RESTRICTION carried a
+	// nested <xs:simpleType> child. It is consulted by checkSimpleContentBase for
+	// src-ct.2 clause 2.3: a restriction of a complex type whose content is mixed
+	// with an emptiable particle is valid ONLY when such a simpleType is present.
+	scHasSimpleTypeChild bool
+
 	// openContentExplicit records that an <xs:openContent> child (of ANY mode,
 	// including mode="none") was present on this complex type's definition. It
 	// distinguishes an explicit mode="none" (OpenContent nil, default suppressed)

--- a/xsd/simplecontent_base_test.go
+++ b/xsd/simplecontent_base_test.go
@@ -1,0 +1,108 @@
+package xsd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSimpleContentBase locks src-ct.2 (Complex Type Definition Representation
+// OK, XSD Structures §3.4.2): a <xs:simpleContent> derivation's @base must be of
+// the right KIND and content. The rule is version-INDEPENDENT, so the DEFAULT
+// (1.0) compiler must reject the invalid forms while still accepting the valid
+// canonical ones. Invalid cases mirror W3C msData/complexType ctD001/ctD004/
+// ctE003/ctE004/ctK002/ctM001, which helium's 1.0 mode used to accept.
+func TestSimpleContentBase(t *testing.T) {
+	t.Parallel()
+
+	wrap := func(body string) string {
+		return `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">` + body + `</xs:schema>`
+	}
+
+	invalid := map[string]string{
+		// ctD001: restriction whose base is a simple type (clause 2.2 is extension-only).
+		"restriction base is builtin simple type": wrap(`
+  <xs:complexType name="fooType">
+    <xs:simpleContent><xs:restriction base="xs:string"/></xs:simpleContent>
+  </xs:complexType>`),
+		// ctM001: restriction whose base is a user simple type.
+		"restriction base is user simple type": wrap(`
+  <xs:simpleType name="myType"><xs:restriction base="xs:string"/></xs:simpleType>
+  <xs:complexType name="fooType">
+    <xs:simpleContent><xs:restriction base="myType"><xs:length value="5"/></xs:restriction></xs:simpleContent>
+  </xs:complexType>`),
+		// ctD004: restriction whose base is xs:anyType (mixed+emptiable) but the
+		// restriction carries no nested <xs:simpleType> (clause 2.3 requires one).
+		"restriction base is anyType without simpleType child": wrap(`
+  <xs:complexType name="fooType">
+    <xs:simpleContent><xs:restriction base="xs:anyType"/></xs:simpleContent>
+  </xs:complexType>`),
+		// ctE003: extension whose base is a complex type with complex content.
+		"extension base has complex content": wrap(`
+  <xs:complexType name="myType">
+    <xs:sequence><xs:element name="a" type="xs:string"/></xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="fooType">
+    <xs:simpleContent><xs:extension base="myType"/></xs:simpleContent>
+  </xs:complexType>`),
+		// ctE004: extension whose base is xs:anyType (mixed complex content).
+		"extension base is anyType": wrap(`
+  <xs:complexType name="fooType">
+    <xs:simpleContent><xs:extension base="xs:anyType"/></xs:simpleContent>
+  </xs:complexType>`),
+		// ctK002: extension whose base is a mixed complex type (invalid at the
+		// intermediate type, so the whole schema is invalid).
+		"extension base is mixed complex type": wrap(`
+  <xs:complexType name="myCT" mixed="true">
+    <xs:sequence><xs:element name="a" type="xs:string" minOccurs="0"/></xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="myType">
+    <xs:simpleContent><xs:extension base="myCT"/></xs:simpleContent>
+  </xs:complexType>`),
+	}
+
+	valid := map[string]string{
+		"extension base is builtin simple type": wrap(`
+  <xs:complexType name="fooType">
+    <xs:simpleContent><xs:extension base="xs:string"><xs:attribute name="a" type="xs:string"/></xs:extension></xs:simpleContent>
+  </xs:complexType>`),
+		"extension base is complex simple-content type": wrap(`
+  <xs:complexType name="base"><xs:simpleContent><xs:extension base="xs:string"/></xs:simpleContent></xs:complexType>
+  <xs:complexType name="fooType">
+    <xs:simpleContent><xs:extension base="base"><xs:attribute name="a" type="xs:string"/></xs:extension></xs:simpleContent>
+  </xs:complexType>`),
+		"restriction base is complex simple-content type": wrap(`
+  <xs:complexType name="base"><xs:simpleContent><xs:extension base="xs:string"/></xs:simpleContent></xs:complexType>
+  <xs:complexType name="fooType">
+    <xs:simpleContent><xs:restriction base="base"><xs:maxLength value="5"/></xs:restriction></xs:simpleContent>
+  </xs:complexType>`),
+		// Clause 2.3: restriction of a mixed+emptiable complex base WITH a nested
+		// <xs:simpleType> is valid.
+		"restriction of mixed emptiable base with simpleType child": wrap(`
+  <xs:complexType name="base" mixed="true">
+    <xs:sequence><xs:element name="a" type="xs:string" minOccurs="0"/></xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="fooType">
+    <xs:simpleContent>
+      <xs:restriction base="base">
+        <xs:simpleType><xs:restriction base="xs:string"><xs:maxLength value="5"/></xs:restriction></xs:simpleType>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>`),
+	}
+
+	for name, schema := range invalid {
+		t.Run("invalid/"+name, func(t *testing.T) {
+			t.Parallel()
+			_, err := compileV10(t, schema)
+			require.Error(t, err, "XSD 1.0 must reject: %s", name)
+		})
+	}
+	for name, schema := range valid {
+		t.Run("valid/"+name, func(t *testing.T) {
+			t.Parallel()
+			_, err := compileV10(t, schema)
+			require.NoError(t, err, "XSD 1.0 must accept: %s", name)
+		})
+	}
+}


### PR DESCRIPTION
- XSD 1.0 (version-independent) now rejects a `<xs:simpleContent>` derivation whose @base is the wrong kind per src-ct.2 §3.4.2: an extension base must be a simple type or a complex type with simple content; a restriction base must be a complex type with simple content (or a mixed+emptiable complex type with a nested `<xs:simpleType>`).
- Fixes 6 W3C msMeta/ComplexType false-accepts (ctD001/ctD004/ctE003/ctE004/ctK002/ctM001); 0 valid ComplexType cases regress.
- `xs:anySimpleType` restriction base kept valid (existing 1.1 nested-simpleType allowance).