### PR TITLE
enforce disallowed-substitutions superset in particle restriction

### DIFF
--- a/xsd/restriction_block_test.go
+++ b/xsd/restriction_block_test.go
@@ -1,0 +1,86 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestElementRestrictionDisallowedSubstitutions covers Particle Valid
+// (Restriction) NameAndTypeOK clause 3.2.4 (§3.9.6): a derived element
+// declaration's {disallowed substitutions} (the @block value) must be a SUPERSET
+// of the base element declaration's. A restriction may tighten the disallowed set
+// but never loosen it. The rule is version-INDEPENDENT and exercised here in the
+// default (XSD 1.0) compiler, mirroring W3C msData/particles particlesIg007-016
+// and particlesL014-L027.
+func TestElementRestrictionDisallowedSubstitutions(t *testing.T) {
+	const head = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="urn:t" xmlns:t="urn:t" elementFormDefault="qualified">`
+
+	// base type carries a single element "e" with the given @block; the derived
+	// type restricts it with the given @block on "e".
+	mk := func(baseBlock, derBlock string) string {
+		be := `<xs:element name="e"`
+		if baseBlock != "" {
+			be += ` block="` + baseBlock + `"`
+		}
+		be += `/>`
+		de := `<xs:element name="e"`
+		if derBlock != "" {
+			de += ` block="` + derBlock + `"`
+		}
+		de += `/>`
+		return head + `
+  <xs:complexType name="base"><xs:choice>` + be + `</xs:choice></xs:complexType>
+  <xs:complexType name="der"><xs:complexContent>
+    <xs:restriction base="t:base"><xs:choice>` + de + `</xs:choice></xs:restriction>
+  </xs:complexContent></xs:complexType>
+  <xs:element name="doc" type="t:der"/>
+</xs:schema>`
+	}
+
+	compile := func(t *testing.T, src string) error {
+		t.Helper()
+		doc, perr := helium.NewParser().Parse(t.Context(), []byte(src))
+		require.NoError(t, perr)
+		_, err := xsd.NewCompiler().Compile(t.Context(), doc)
+		return err
+	}
+
+	const (
+		all = "#all"
+		ext = "extension"
+		res = "restriction"
+		sub = "substitution"
+	)
+	tests := []struct {
+		name      string
+		baseBlock string
+		derBlock  string
+		wantErr   bool
+	}{
+		{"all restricted to extension is invalid", all, ext, true},
+		{"all restricted to restriction is invalid", all, res, true},
+		{"extension restricted to substitution is invalid", ext, sub, true},
+		{"substitution restricted to restriction is invalid", sub, res, true},
+		{"substitution restricted to absent is invalid", sub, "", true},
+		{"extension restricted to all is valid", ext, all, false},
+		{"extension restricted to extension is valid", ext, ext, false},
+		{"substitution restricted to all is valid", sub, all, false},
+		{"absent base with substitution derived is valid", "", sub, false},
+		{"both absent is valid", "", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := compile(t, mk(tc.baseBlock, tc.derBlock))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/xsd/restriction_particle.go
+++ b/xsd/restriction_particle.go
@@ -233,6 +233,16 @@ func elementRestrictsElement(ctx context.Context, r *Particle, rt *ElementDecl, 
 	if version == Version11 && !typeTablesEquivalent(elementAlternatives(rt, schema), elementAlternatives(bt, schema)) {
 		return false
 	}
+	// Particle Valid (Restriction), NameAndTypeOK clause 3.2.4 (§3.9.6,
+	// version-INDEPENDENT): R's declaration's {disallowed substitutions} must be a
+	// SUPERSET of B's. In flag terms every block bit set on the base element must
+	// also be set on the derived element — a restriction may TIGHTEN the disallowed
+	// set but never LOOSEN it (e.g. a base block="#all" cannot be restricted by a
+	// derived block="extension"). Both Block values already fold in blockDefault
+	// when the attribute is absent, so the comparison is on the effective sets.
+	if bt.Block&^rt.Block != 0 {
+		return false
+	}
 	// A base element that is fixed forces the derived element to carry the same
 	// fixed value; a base that is not nillable forbids the derived from becoming
 	// nillable. These are tightening rules — only flag the clear widening cases.


### PR DESCRIPTION
- Particle Valid (Restriction) NameAndTypeOK 3.2.4 (§3.9.6): a derived element's {disallowed substitutions} (@block) must be a superset of the base element's; version-independent.
- Fixes 15 XSD 1.0 false-accepts in msData/particles (particlesIg007-016, particlesL014-L027); no valid particle restriction newly rejected.