### PR TITLE
enforce xs:attributeGroup XML representation (§3.6.2)

### DIFF
--- a/xsd/attr_group_repr_test.go
+++ b/xsd/attr_group_repr_test.go
@@ -1,0 +1,145 @@
+package xsd_test
+
+import (
+	"strings"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAttrGroupRepresentation covers the XML representation of an
+// <xs:attributeGroup> (XSD Structures §3.6.2), a version-INDEPENDENT rule
+// enforced by the default (XSD 1.0) compiler:
+//
+//   - a global attributeGroup @name must be a valid xs:NCName;
+//   - a nested attributeGroup (inside a definition, a complexType, or a
+//     derivation body) is a REFERENCE: it must not carry @name (the definition
+//     form) and its content model is (annotation?), so any non-annotation element
+//     child is a schema-representation error;
+//   - a definition's content model is
+//     (annotation?, ((attribute | attributeGroup)*, anyAttribute?)), so a stray
+//     element child (e.g. xs:element) is a schema-representation error.
+//
+// These mirror the W3C xmlschema msMeta AttributeGroup tests attgB002/B003/B004/
+// B006 and attgD012/D037/D038/D039, all of which the schema-for-schemas rejects.
+func TestAttrGroupRepresentation(t *testing.T) {
+	t.Parallel()
+
+	compile := func(t *testing.T, schemaXML string) (bool, string) {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, cerr := xsd.NewCompiler().Label("test.xsd").ErrorHandler(collector).Compile(t.Context(), doc)
+		var msg strings.Builder
+		for _, e := range collector.Errors() {
+			msg.WriteString(e.Error())
+		}
+		return cerr != nil || len(collector.Errors()) > 0, msg.String()
+	}
+
+	t.Run("rejects", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct {
+			name   string
+			schema string
+			want   string
+		}{
+			{
+				name: "attgB006_name_not_ncname",
+				schema: `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+					<xsd:attributeGroup name="0"><xsd:attribute name="att" type="xsd:int"/></xsd:attributeGroup></xsd:schema>`,
+				want: "is not a valid 'xs:NCName'",
+			},
+			{
+				name: "attgB002_nested_definition_in_group",
+				schema: `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+					<xsd:attributeGroup name="G"><xsd:attributeGroup name="abc"><xsd:attribute name="att" type="xsd:int"/></xsd:attributeGroup></xsd:attributeGroup></xsd:schema>`,
+				want: "not allowed on an attributeGroup reference",
+			},
+			{
+				name: "attgB003_nested_definition_in_complextype",
+				schema: `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+					<xsd:complexType name="G"><xsd:attributeGroup name="abc"><xsd:attribute name="att" type="xsd:int"/></xsd:attributeGroup></xsd:complexType></xsd:schema>`,
+				want: "not allowed on an attributeGroup reference",
+			},
+			{
+				name: "attgB004_nested_definition_in_extension",
+				schema: `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+					<xsd:complexType name="base"><xsd:sequence><xsd:element name="e1"/></xsd:sequence></xsd:complexType>
+					<xsd:complexType name="ext"><xsd:complexContent><xsd:extension base="base">
+						<xsd:attributeGroup name="abc"/></xsd:extension></xsd:complexContent></xsd:complexType>
+					<xsd:attributeGroup name="abc"><xsd:attribute name="att" type="xsd:int"/></xsd:attributeGroup></xsd:schema>`,
+				want: "not allowed on an attributeGroup reference",
+			},
+			{
+				name: "attgD037_ref_carries_attribute",
+				schema: `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+					<xsd:attributeGroup name="attG"><xsd:attribute name="att1" type="xsd:int"/></xsd:attributeGroup>
+					<xsd:complexType name="attgRef"><xsd:attributeGroup ref="attG"><xsd:attribute name="gg"/></xsd:attributeGroup></xsd:complexType></xsd:schema>`,
+				want: "restricted to (annotation?)",
+			},
+			{
+				name: "attgD038_ref_carries_nested_ref",
+				schema: `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+					<xsd:attributeGroup name="attG"><xsd:attribute name="att1" type="xsd:int"/></xsd:attributeGroup>
+					<xsd:complexType name="attgRef"><xsd:attributeGroup ref="attG"><xsd:attributeGroup ref="attG"/></xsd:attributeGroup></xsd:complexType></xsd:schema>`,
+				want: "restricted to (annotation?)",
+			},
+			{
+				name: "attgD039_ref_carries_anyattribute",
+				schema: `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+					<xsd:attributeGroup name="attG"><xsd:attribute name="att1" type="xsd:int"/></xsd:attributeGroup>
+					<xsd:complexType name="attgRef"><xsd:attributeGroup ref="attG"><xsd:anyAttribute namespace="##any"/></xsd:attributeGroup></xsd:complexType></xsd:schema>`,
+				want: "restricted to (annotation?)",
+			},
+			{
+				name: "attgD012_stray_element_child",
+				schema: `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+					<xsd:attributeGroup name="attG"><xsd:attribute name="att1" type="xsd:int"/><xsd:element name="e1"/></xsd:attributeGroup></xsd:schema>`,
+				want: "is not allowed in an attributeGroup",
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				rejected, msg := compile(t, tc.schema)
+				require.True(t, rejected, "expected schema to be rejected")
+				require.Contains(t, msg, tc.want)
+			})
+		}
+	})
+
+	t.Run("accepts", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct {
+			name   string
+			schema string
+		}{
+			{
+				name: "valid_definition_and_ref",
+				schema: `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+					<xsd:attributeGroup name="attG"><xsd:attribute name="att1" type="xsd:int"/></xsd:attributeGroup>
+					<xsd:complexType name="attgRef"><xsd:attributeGroup ref="attG"/></xsd:complexType></xsd:schema>`,
+			},
+			{
+				name: "ref_with_annotation_child",
+				schema: `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+					<xsd:attributeGroup name="attG"><xsd:attribute name="att1" type="xsd:int"/></xsd:attributeGroup>
+					<xsd:complexType name="attgRef"><xsd:attributeGroup ref="attG"><xsd:annotation/></xsd:attributeGroup></xsd:complexType></xsd:schema>`,
+			},
+			{
+				name: "definition_with_leading_annotation",
+				schema: `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+					<xsd:attributeGroup name="attG"><xsd:annotation/><xsd:attribute name="att1" type="xsd:int"/></xsd:attributeGroup></xsd:schema>`,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				rejected, msg := compile(t, tc.schema)
+				require.False(t, rejected, "expected schema to compile: %s", msg)
+			})
+		}
+	})
+}

--- a/xsd/read_particles.go
+++ b/xsd/read_particles.go
@@ -131,6 +131,18 @@ func (c *compiler) parseNamedAttributeGroup(ctx context.Context, elem *helium.El
 		return fmt.Errorf("xsd: named attributeGroup missing name")
 	}
 
+	// The @name of a global attribute group definition is an xs:NCName (XSD
+	// Structures §3.6.2). A value with a colon (e.g. "a:b") or an otherwise invalid
+	// NCName (e.g. a leading digit like "0") is a schema error; the group is dropped
+	// so it does not enter the target-namespace symbol space under a bogus name.
+	// Version-INDEPENDENT XSD rule, mirroring parseNamedGroup / parseNamedSimpleType.
+	if c.filename != "" && !xmlchar.IsValidNCName(name) {
+		c.schemaError(ctx, schemaParserError(c.diagSource(), elem.Line(),
+			elem.LocalName(), "attributeGroup",
+			"The value '"+name+"' of attribute 'name' is not a valid 'xs:NCName'."))
+		return nil
+	}
+
 	qn := QName{Local: name, NS: c.schema.targetNamespace}
 	// An xs:redefine override that was validated and consumed by the redefine
 	// loop is pre-authorized and skips the report.
@@ -217,6 +229,7 @@ func (c *compiler) parseNamedAttributeGroup(ctx context.Context, elem *helium.El
 		// reaches this point is genuinely circular and is reported and dropped (the
 		// reference is cut to avoid further confusion, matching libxml2).
 		if isXSDElement(ce, elemAttributeGroup) {
+			c.checkAttrGroupRef(ctx, ce)
 			if c.version == Version11 && anyAttributeSeen {
 				reportAfterWildcard(ce)
 				continue
@@ -241,6 +254,18 @@ func (c *compiler) parseNamedAttributeGroup(ctx context.Context, elem *helium.El
 				// the owning group's declaration line.
 				c.attrGroupRefSources[qn] = append(c.attrGroupRefSources[qn], attrGroupSource{line: ce.Line(), source: c.diagSource()})
 			}
+			continue
+		}
+		// The XML representation of an attribute group DEFINITION is
+		// (annotation?, ((attribute | attributeGroup)*, anyAttribute?)) (§3.6.2).
+		// Any other XSD-namespace element child (e.g. a stray xs:element) is a
+		// schema-representation error. annotation and anyAttribute are permitted
+		// content (anyAttribute is silently accepted in XSD 1.0, so it is excused
+		// here rather than flagged). Version-INDEPENDENT XSD rule.
+		if c.filename != "" && ce.URI() == lexicon.NamespaceXSD &&
+			!isXSDElement(ce, elemAnnotation) && !isXSDElement(ce, elemAnyAttribute) {
+			c.schemaError(ctx, schemaParserError(c.diagSource(), ce.Line(), ce.LocalName(), "attributeGroup",
+				fmt.Sprintf("The element '%s' is not allowed in an attributeGroup; content is restricted to (annotation?, ((attribute | attributeGroup)*, anyAttribute?)).", ce.LocalName())))
 		}
 	}
 	c.schema.attrGroups[qn] = attrs
@@ -250,6 +275,39 @@ func (c *compiler) parseNamedAttributeGroup(ctx context.Context, elem *helium.El
 	// IDConstraint.Source).
 	c.attrGroupSources[qn] = attrGroupSource{line: elem.Line(), source: c.diagSource()}
 	return nil
+}
+
+// checkAttrGroupRef enforces the XML representation of an attributeGroup
+// REFERENCE (§3.6.2): a nested <xs:attributeGroup> appearing inside a named
+// attribute group definition, a complexType, or a derivation body is a reference,
+// whose content model is (annotation?) and whose only relevant attribute is 'ref'.
+// A '@name' — the DEFINITION form, which is valid only as a top-level xs:schema or
+// xs:redefine child — is a schema-representation error, as is any non-annotation
+// element child (e.g. a nested xs:attribute/xs:attributeGroup/xs:anyAttribute). The
+// PERMITTED XSD 1.1 circular self-reference uses this reference form (ref only, no
+// name, no content) and is therefore unaffected. Version-INDEPENDENT XSD rule.
+func (c *compiler) checkAttrGroupRef(ctx context.Context, ce *helium.Element) {
+	if c.filename == "" {
+		return
+	}
+	if hasAttr(ce, attrName) {
+		c.schemaError(ctx, schemaParserErrorAttr(c.diagSource(), ce.Line(), ce.LocalName(), "attributeGroup", attrName,
+			"The attribute 'name' is not allowed on an attributeGroup reference; use 'ref'."))
+	}
+	for child := range helium.Children(ce) {
+		if child.Type() != helium.ElementNode {
+			continue
+		}
+		sub, ok := helium.AsNode[*helium.Element](child)
+		if !ok {
+			continue
+		}
+		if isXSDElement(sub, elemAnnotation) {
+			continue
+		}
+		c.schemaError(ctx, schemaParserError(c.diagSource(), sub.Line(), sub.LocalName(), "attributeGroup",
+			fmt.Sprintf("The content of an attributeGroup reference is restricted to (annotation?); the element '%s' is not allowed.", sub.LocalName())))
+	}
 }
 
 func (c *compiler) parseModelGroup(ctx context.Context, elem *helium.Element, compositor ModelGroupKind) (*ModelGroup, error) {

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -348,6 +348,7 @@ func (c *compiler) parseComplexType(ctx context.Context, elem *helium.Element) (
 			if directAttrChild == "" {
 				directAttrChild = ce.LocalName()
 			}
+			c.checkAttrGroupRef(ctx, ce)
 			if hasAttr(ce, attrRef) {
 				qn := c.resolveQName(ctx, ce, getAttr(ce, attrRef))
 				c.recordAttrGroupRef(td, qn, attrGroupRefUseSource{
@@ -731,6 +732,7 @@ func (c *compiler) parseComplexContentDerivationBody(ctx context.Context, elem *
 				reportOrder(ce, fmt.Sprintf("The attribute declaration '%s' must appear before the assertion 'assert'.", ce.LocalName()))
 				continue
 			}
+			c.checkAttrGroupRef(ctx, ce)
 			if hasAttr(ce, attrRef) {
 				qn := c.resolveQName(ctx, ce, getAttr(ce, attrRef))
 				c.recordAttrGroupRef(td, qn, attrGroupRefUseSource{
@@ -958,6 +960,7 @@ func (c *compiler) parseSimpleContentChildren(ctx context.Context, derivation *h
 			if directAttrChild == "" {
 				directAttrChild = ae.LocalName()
 			}
+			c.checkAttrGroupRef(ctx, ae)
 			if hasAttr(ae, attrRef) {
 				qn := c.resolveQName(ctx, ae, getAttr(ae, attrRef))
 				c.recordAttrGroupRef(td, qn, attrGroupRefUseSource{


### PR DESCRIPTION
Enforces the version-independent §3.6.2 schema-representation rules for `<xs:attributeGroup>` that were previously unchecked: a global definition `@name` must be a valid `xs:NCName`; a nested attributeGroup (in a definition, complexType, or derivation body) is a reference whose content model is `(annotation?)` and must not carry `@name`; and a definition rejects stray element children. Fixes W3C msMeta AttributeGroup attgB002/B003/B004/B006 and attgD012/D037/D038/D039 (8 false-accepts → rejected, zero regressions). XSD 1.1 circular attribute-group refs are unaffected.