### PR TITLE
enforce restricted xpath subset for idc selector/field

### DIFF
--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -1119,7 +1119,7 @@ func (c *compiler) parseIDConstraint(ctx context.Context, elem *helium.Element, 
 	// run), so an invalid schema must fail to compile rather than validate
 	// documents as if no constraint were present.
 	if idc.Selector != "" {
-		compiled, err := compileIDCXPath(idc.Selector, false)
+		compiled, err := compileIDCXPath(idc.Selector, false, idc.Namespaces)
 		if err != nil {
 			c.reportIDCXPathError(ctx, elemSelector, selectorLine, idc.Selector, err)
 		} else {
@@ -1138,7 +1138,7 @@ func (c *compiler) parseIDConstraint(ctx context.Context, elem *helium.Element, 
 			// also emit a redundant "not a valid field expression" diagnostic.
 			continue
 		}
-		compiled, err := compileIDCXPath(f, true)
+		compiled, err := compileIDCXPath(f, true, idc.Namespaces)
 		if err != nil {
 			line := 0
 			if i < len(fieldLines) {
@@ -1383,10 +1383,21 @@ func (c *compiler) reportIDCXPathError(ctx context.Context, kind string, line in
 // steps, function calls, variable references, operators, or predicates that the
 // subset forbids. allowAttribute is true for <field> (which may end in an
 // attribute step) and false for <selector> (where the attribute axis is not
-// permitted).
-func compileIDCXPath(expr string, allowAttribute bool) (*xpath1.Expression, error) {
+// permitted). namespaces is the in-scope namespace context of the identity
+// constraint (prefix → URI); every prefix used in a name test must be bound in
+// it, or the QName has no namespace and the constraint is invalid.
+func compileIDCXPath(expr string, allowAttribute bool, namespaces map[string]string) (*xpath1.Expression, error) {
 	compiled, err := xpath1.Compile(expr)
 	if err != nil {
+		return nil, err
+	}
+	// The AST normalizes the abbreviated syntax ('.' → self::node(), './/' →
+	// self::node()/descendant-or-self::node()/…), which loses the syntactic
+	// distinction the restricted subset grammar draws — an explicit
+	// 'self::node()' or a mid-path './/' looks identical to the permitted '.' /
+	// leading './/'. A lexical check over the raw expression enforces those
+	// syntactic constraints that the AST cannot see.
+	if err := validateIDCXPathLexical(expr); err != nil {
 		return nil, err
 	}
 	// Re-parse to inspect the AST; the expression already compiled, so this
@@ -1395,10 +1406,49 @@ func compileIDCXPath(expr string, allowAttribute bool) (*xpath1.Expression, erro
 	if err != nil {
 		return nil, err
 	}
-	if err := validateIDCXPathSubset(ast, allowAttribute); err != nil {
+	if err := validateIDCXPathSubset(ast, allowAttribute, namespaces); err != nil {
 		return nil, err
 	}
 	return compiled, nil
+}
+
+// validateIDCXPathLexical enforces the syntactic constraints of the restricted
+// identity-constraint XPath subset (XSD Structures 3.11.6) that are lost once the
+// expression is normalized into an AST. The subset uses ONLY the abbreviated
+// syntax for the self and descendant-or-self axes — the literal steps '.' and the
+// leading './/' — never a spelled-out node-type test, and the descendant-or-self
+// step './/' may appear ONLY as the prefix of a path, never mid-path or repeated.
+//
+//   - A '(' can only introduce a node-type test (node()/text()/…) or a function
+//     call; neither is in the subset (the subset's name tests never bear
+//     parentheses), so its presence means the expression escaped the grammar —
+//     notably 'self::node()', which normalizes identically to the permitted '.'.
+//   - The '//' (descendant-or-self) token is permitted only as the leading './/'
+//     of each union path; any other occurrence ('.//.//…', 'a/.//b', a mid-path
+//     '//') is outside the grammar. Only the FIRST '//' may appear, and only
+//     after an optional leading '.' step (XPath permits insignificant whitespace,
+//     so '. //.' and '.// .' are the same leading './/' as './/.').
+func validateIDCXPathLexical(expr string) error {
+	if strings.ContainsRune(expr, '(') {
+		return errors.New("node type tests and function calls are not permitted")
+	}
+	for path := range strings.SplitSeq(expr, "|") {
+		before, after, found := strings.Cut(path, "//")
+		if !found {
+			continue
+		}
+		// Everything before the (leading) '//' may be only whitespace and an
+		// optional single '.' self step; anything else means the '//' is not the
+		// path-leading descendant-or-self step.
+		if prefix := strings.TrimSpace(before); prefix != "" && prefix != "." {
+			return errors.New("the './/' descendant-or-self step is only permitted at the start of a path")
+		}
+		// A second '//' (e.g. './/.//x') is never permitted.
+		if strings.Contains(after, "//") {
+			return errors.New("the './/' descendant-or-self step is only permitted at the start of a path")
+		}
+	}
+	return nil
 }
 
 // validateIDCXPathSubset reports an error if expr falls outside the XSD
@@ -1408,24 +1458,24 @@ func compileIDCXPath(expr string, allowAttribute bool) (*xpath1.Expression, erro
 // prefix, and — for fields only — a trailing attribute step. Anything else
 // (literals, function calls, variables, arithmetic/boolean operators, filter
 // expressions, predicates, absolute paths) is rejected.
-func validateIDCXPathSubset(expr xpath1.Expr, allowAttribute bool) error {
+func validateIDCXPathSubset(expr xpath1.Expr, allowAttribute bool, namespaces map[string]string) error {
 	switch e := expr.(type) {
 	case xpath1.UnionExpr:
-		if err := validateIDCXPathSubset(e.Left, allowAttribute); err != nil {
+		if err := validateIDCXPathSubset(e.Left, allowAttribute, namespaces); err != nil {
 			return err
 		}
-		return validateIDCXPathSubset(e.Right, allowAttribute)
+		return validateIDCXPathSubset(e.Right, allowAttribute, namespaces)
 	case *xpath1.LocationPath:
-		return validateIDCLocationPath(e, allowAttribute)
+		return validateIDCLocationPath(e, allowAttribute, namespaces)
 	case xpath1.LocationPath:
-		return validateIDCLocationPath(&e, allowAttribute)
+		return validateIDCLocationPath(&e, allowAttribute, namespaces)
 	default:
 		return errors.New("the expression is outside the identity-constraint XPath subset")
 	}
 }
 
 // validateIDCLocationPath checks a single location path against the IDC subset.
-func validateIDCLocationPath(lp *xpath1.LocationPath, allowAttribute bool) error {
+func validateIDCLocationPath(lp *xpath1.LocationPath, allowAttribute bool, namespaces map[string]string) error {
 	if lp.Absolute {
 		return errors.New("absolute location paths are not permitted")
 	}
@@ -1443,8 +1493,12 @@ func validateIDCLocationPath(lp *xpath1.LocationPath, allowAttribute bool) error
 				return fmt.Errorf("the %s axis is only permitted as the abbreviated '.' or './/' step", step.Axis)
 			}
 		case xpath1.AxisChild:
-			if _, ok := step.NodeTest.(xpath1.NameTest); !ok {
+			nt, ok := step.NodeTest.(xpath1.NameTest)
+			if !ok {
 				return errors.New("only name tests are permitted on the child axis")
+			}
+			if err := checkIDCNameTestPrefix(nt, namespaces); err != nil {
+				return err
 			}
 		case xpath1.AxisAttribute:
 			if !allowAttribute {
@@ -1453,12 +1507,31 @@ func validateIDCLocationPath(lp *xpath1.LocationPath, allowAttribute bool) error
 			if i != last {
 				return errors.New("the attribute axis is only permitted in the final step")
 			}
-			if _, ok := step.NodeTest.(xpath1.NameTest); !ok {
+			nt, ok := step.NodeTest.(xpath1.NameTest)
+			if !ok {
 				return errors.New("only name tests are permitted on the attribute axis")
+			}
+			if err := checkIDCNameTestPrefix(nt, namespaces); err != nil {
+				return err
 			}
 		default:
 			return fmt.Errorf("the %s axis is not permitted", step.Axis)
 		}
+	}
+	return nil
+}
+
+// checkIDCNameTestPrefix rejects a name test whose namespace prefix is not bound
+// in the identity constraint's in-scope namespace context. A QName in a
+// selector/field XPath is resolved against those namespaces (XSD Structures
+// 3.11.6.1), so an unbound prefix leaves the name unresolvable and the constraint
+// invalid. The reserved 'xml' prefix is always bound.
+func checkIDCNameTestPrefix(nt xpath1.NameTest, namespaces map[string]string) error {
+	if nt.Prefix == "" || nt.Prefix == lexicon.PrefixXML {
+		return nil
+	}
+	if _, ok := namespaces[nt.Prefix]; !ok {
+		return fmt.Errorf("the prefix '%s' is not bound to a namespace", nt.Prefix)
 	}
 	return nil
 }

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -1041,6 +1041,16 @@ func (c *compiler) parseIDConstraint(ctx context.Context, elem *helium.Element, 
 	var fieldLines []int
 	var selectorSeen bool
 
+	// selectorNS / fieldNS capture the in-scope namespace context of the
+	// <selector>/<field> element ITSELF (not the enclosing constraint element),
+	// so the restricted-subset prefix-binding check resolves a name-test prefix
+	// against the selector/field's own namespaces (XSD Structures 3.11.6.1) —
+	// including an xmlns:* declared directly on <xs:selector>/<xs:field>. The
+	// constraint-scoped idc.Namespaces (used by runtime IDC evaluation) is
+	// intentionally left unchanged. fieldNS is parallel to idc.Fields.
+	var selectorNS map[string]string
+	var fieldNS []map[string]string
+
 	// The identity-constraint content model is (annotation?, (selector, field+))
 	// (XSD Structures 3.11.1 / src-identity-constraint). Enforce ORDER and
 	// CARDINALITY with an ordered scan: an OPTIONAL leading <annotation>, then
@@ -1075,6 +1085,7 @@ func (c *compiler) parseIDConstraint(ctx context.Context, elem *helium.Element, 
 			selectorSeen = true
 			idc.SelectorDefaultNS = c.resolveXPathDefaultNS(ce)
 			selectorLine = ce.Line()
+			selectorNS = collectNSContext(ce)
 			idc.Selector = c.idcXPathAttr(ctx, ce, elemSelector)
 		case isXSDElement(ce, elemField):
 			// fields follow the selector.
@@ -1083,6 +1094,7 @@ func (c *compiler) parseIDConstraint(ctx context.Context, elem *helium.Element, 
 			}
 			idc.FieldDefaultNS = append(idc.FieldDefaultNS, c.resolveXPathDefaultNS(ce))
 			fieldLines = append(fieldLines, ce.Line())
+			fieldNS = append(fieldNS, collectNSContext(ce))
 			idc.Fields = append(idc.Fields, c.idcXPathAttr(ctx, ce, elemField))
 		default:
 			// Any other element child is not in the content model. The
@@ -1119,7 +1131,7 @@ func (c *compiler) parseIDConstraint(ctx context.Context, elem *helium.Element, 
 	// run), so an invalid schema must fail to compile rather than validate
 	// documents as if no constraint were present.
 	if idc.Selector != "" {
-		compiled, err := compileIDCXPath(idc.Selector, false, idc.Namespaces)
+		compiled, err := compileIDCXPath(idc.Selector, false, selectorNS)
 		if err != nil {
 			c.reportIDCXPathError(ctx, elemSelector, selectorLine, idc.Selector, err)
 		} else {
@@ -1138,7 +1150,11 @@ func (c *compiler) parseIDConstraint(ctx context.Context, elem *helium.Element, 
 			// also emit a redundant "not a valid field expression" diagnostic.
 			continue
 		}
-		compiled, err := compileIDCXPath(f, true, idc.Namespaces)
+		nsCtx := idc.Namespaces
+		if i < len(fieldNS) {
+			nsCtx = fieldNS[i]
+		}
+		compiled, err := compileIDCXPath(f, true, nsCtx)
 		if err != nil {
 			line := 0
 			if i < len(fieldLines) {

--- a/xsd/validate_idc_errors_test.go
+++ b/xsd/validate_idc_errors_test.go
@@ -233,6 +233,53 @@ func TestIDCXPathSubset(t *testing.T) {
 			require.Empty(t, errs, "a bound-prefix name test must compile clean")
 		})
 	})
+
+	t.Run("prefix declared on selector/field element", func(t *testing.T) {
+		t.Parallel()
+		// Per XSD Structures 3.11.6.1 a selector/field @xpath resolves prefixes
+		// against the SELECTOR/FIELD element's OWN in-scope namespaces, so an
+		// xmlns:* declared directly on <xs:selector>/<xs:field> is in scope and a
+		// name test using it must compile clean. A prefix declared on neither the
+		// selector/field nor an ancestor stays unbound and is still rejected.
+		localNS := func(selectorAttrs, selector, fieldAttrs, field string) string {
+			return `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="id" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="itemKey">
+      <xs:selector ` + selectorAttrs + ` xpath="` + selector + `"/>
+      <xs:field ` + fieldAttrs + ` xpath="` + field + `"/>
+    </xs:unique>
+  </xs:element>
+</xs:schema>`
+		}
+		t.Run("selector prefix", func(t *testing.T) {
+			t.Parallel()
+			// xmlns:p is declared on <xs:selector> itself.
+			_, errs := compileXSD(t, localNS(`xmlns:p="urn:p"`, "p:item | item", "", okField))
+			require.Empty(t, errs, "a prefix declared on the selector element must be in scope")
+		})
+		t.Run("field prefix", func(t *testing.T) {
+			t.Parallel()
+			// xmlns:p is declared on <xs:field> itself.
+			_, errs := compileXSD(t, localNS("", okSelector, `xmlns:p="urn:p"`, "p:id"))
+			require.Empty(t, errs, "a prefix declared on the field element must be in scope")
+		})
+		t.Run("selector-local prefix not in scope for field", func(t *testing.T) {
+			t.Parallel()
+			// A prefix declared only on the selector is NOT in scope for the field,
+			// so it stays unbound there and is rejected.
+			_, errs := compileXSD(t, localNS(`xmlns:p="urn:p"`, "p:item", "", "p:id"))
+			require.Contains(t, errs, "is not a valid field")
+		})
+	})
 }
 
 // TestIDCKeyRefUnresolvedRefer covers an xs:keyref whose @refer names a

--- a/xsd/validate_idc_errors_test.go
+++ b/xsd/validate_idc_errors_test.go
@@ -132,8 +132,14 @@ func TestIDCXPathSubset(t *testing.T) {
 	t.Run("selector rejected", func(t *testing.T) {
 		t.Parallel()
 		// String/number literals, function calls, predicates, the attribute
-		// axis, absolute paths and operators are all outside the subset.
-		for _, sel := range []string{"'literal'", "42", "foo()", "item[@id='x']", "@id", "/item", "item + 1"} {
+		// axis, absolute paths and operators are all outside the subset. The
+		// spelled-out 'self::node()' and a repeated/mid-path './/' normalize to
+		// the same AST as the permitted '.' / leading './/' steps, so they are
+		// caught lexically over the raw expression.
+		for _, sel := range []string{
+			"'literal'", "42", "foo()", "item[@id='x']", "@id", "/item", "item + 1",
+			"self::node()", ".//.//item", ".//item/.//item",
+		} {
 			t.Run(sel, func(t *testing.T) {
 				t.Parallel()
 				_, errs := compileXSD(t, schema(sel, okField))
@@ -146,7 +152,10 @@ func TestIDCXPathSubset(t *testing.T) {
 	t.Run("field rejected", func(t *testing.T) {
 		t.Parallel()
 		// Like selectors, plus a non-final attribute step is out of subset.
-		for _, f := range []string{"'literal'", "string(@id)", "$x", "@id[1]", "@id/item"} {
+		for _, f := range []string{
+			"'literal'", "string(@id)", "$x", "@id[1]", "@id/item",
+			"self::node()", ".//id/.//id",
+		} {
 			t.Run(f, func(t *testing.T) {
 				t.Parallel()
 				_, errs := compileXSD(t, schema(okSelector, f))
@@ -161,13 +170,20 @@ func TestIDCXPathSubset(t *testing.T) {
 		for name, tc := range map[string]struct {
 			selector, field string
 		}{
-			"child name test":    {okSelector, okField},
-			"self step":          {".", okField},
-			"descendant-or-self": {".//item", okField},
-			"wildcard name test": {"*", okField},
-			"union of paths":     {".//item | item", okField},
-			"field self":         {okSelector, "."},
-			"multi-step child":   {"item/item", okField},
+			"child name test":     {okSelector, okField},
+			"self step":           {".", okField},
+			"descendant-or-self":  {".//item", okField},
+			"descendant then dot": {".//.", okField},
+			// XPath permits insignificant whitespace, so '. //.' / '.// .' are
+			// the same leading './/' step as './/.'.
+			"whitespace descendant":       {". //.", okField},
+			"trailing-space descendant":   {".// .", okField},
+			"wildcard name test":          {"*", okField},
+			"union of paths":              {".//item | item", okField},
+			"explicit child axis":         {"child::item", okField},
+			"explicit attribute in field": {okSelector, "attribute::id"},
+			"field self":                  {okSelector, "."},
+			"multi-step child":            {"item/item", okField},
 		} {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
@@ -175,6 +191,47 @@ func TestIDCXPathSubset(t *testing.T) {
 				require.Empty(t, errs, "valid subset XPath must compile clean")
 			})
 		}
+	})
+
+	t.Run("unbound prefix rejected", func(t *testing.T) {
+		t.Parallel()
+		// A QName name test whose prefix is not bound in the constraint's in-scope
+		// namespaces cannot be resolved (XSD Structures 3.11.6.1), so it is a
+		// schema error; a bound prefix (p → urn:p) compiles clean.
+		prefixed := func(selector, field string) string {
+			return `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:p="urn:p">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="id" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="itemKey">
+      <xs:selector xpath="` + selector + `"/>
+      <xs:field xpath="` + field + `"/>
+    </xs:unique>
+  </xs:element>
+</xs:schema>`
+		}
+		t.Run("selector", func(t *testing.T) {
+			t.Parallel()
+			_, errs := compileXSD(t, prefixed("q:item", okField))
+			require.Contains(t, errs, "is not a valid selector")
+		})
+		t.Run("field", func(t *testing.T) {
+			t.Parallel()
+			_, errs := compileXSD(t, prefixed(okSelector, "q:id"))
+			require.Contains(t, errs, "is not a valid field")
+		})
+		t.Run("bound prefix accepted", func(t *testing.T) {
+			t.Parallel()
+			_, errs := compileXSD(t, prefixed("p:item | item", okField))
+			require.Empty(t, errs, "a bound-prefix name test must compile clean")
+		})
 	})
 }
 


### PR DESCRIPTION
- Reject IDC selector/field `@xpath` that escapes the restricted XPath subset (XSD Structures 3.11.6): a spelled-out node-type test (`self::node()`), a repeated/mid-path `.//`, and an unbound namespace prefix in a name test — the AST normalizes abbreviations away, so the syntactic cases are checked lexically over the raw expression.
- Fixes 10 W3C msData/identityConstraint false-accepts (idI010/idI015/idI028/idI038/idI150, idJ011/idJ036/idJ052/idJ056/idJ208); version-independent, no golden flips.
- Whitespace-tolerant leading `.//` (`. //.`, `.// .` stay valid).