### PR TITLE
enforce xs:redefine group self-reference cardinality (src-redefine.6.1)

### DIFF
--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -985,25 +985,44 @@ func (c *compiler) processRedefineOverrides(ctx context.Context, redefineElem *h
 			}
 			// Patch self-reference: find newly-added groupRefs entries referencing qn.
 			if origGroup != nil {
+				// Collect the newly-parsed self-references (a group ref inside the
+				// redefine child whose ref names the redefined group itself).
+				var selfRefs []*ModelGroup
 				for mg, refQN := range c.groupRefs {
 					if existingRefs[mg] {
 						continue
 					}
 					if refQN == qn {
-						// The self-reference resolves to the original group's
-						// content. resolveRefs deletes this entry from groupRefs
-						// before it can run checkAllGroupRef, so the all-group
-						// placement rule (cos-all-limited) would be bypassed for a
-						// redefine that nests an all-group self-reference inside a
-						// sequence/choice. Enforce it here, while the source record
-						// is still available, before the entry is removed.
-						if origGroup.Compositor == CompositorAll {
-							c.checkAllGroupRef(ctx, mg)
-						}
-						mg.Compositor = origGroup.Compositor
-						mg.Particles = origGroup.Particles
-						delete(c.groupRefs, mg)
+						selfRefs = append(selfRefs, mg)
 					}
+				}
+				// src-redefine.6.1.1/6.1.2 (§4.2.3): a <group> child of <redefine>
+				// that references itself must do so exactly ONCE and with
+				// minOccurs = maxOccurs = 1. A group without a self-reference is
+				// governed by clause 6.2 (valid restriction of the original) and is
+				// not constrained here. Version-independent, so enforced in XSD 1.0.
+				if len(selfRefs) > 1 {
+					c.schemaError(ctx, schemaParserError(c.diagSource(), elem.Line(), elem.LocalName(), "group",
+						fmt.Sprintf("src-redefine.6.1.1: The group '%s' redefined inside <redefine> must not reference itself more than once.", qn.Local)))
+				}
+				for _, mg := range selfRefs {
+					if mg.MinOccurs != 1 || mg.MaxOccurs != 1 {
+						c.schemaError(ctx, schemaParserError(c.diagSource(), elem.Line(), elem.LocalName(), "group",
+							fmt.Sprintf("src-redefine.6.1.2: The self-reference to group '%s' inside <redefine> must have minOccurs = maxOccurs = 1.", qn.Local)))
+					}
+					// The self-reference resolves to the original group's content.
+					// resolveRefs deletes this entry from groupRefs before it can
+					// run checkAllGroupRef, so the all-group placement rule
+					// (cos-all-limited) would be bypassed for a redefine that nests
+					// an all-group self-reference inside a sequence/choice. Enforce
+					// it here, while the source record is still available, before the
+					// entry is removed.
+					if origGroup.Compositor == CompositorAll {
+						c.checkAllGroupRef(ctx, mg)
+					}
+					mg.Compositor = origGroup.Compositor
+					mg.Particles = origGroup.Particles
+					delete(c.groupRefs, mg)
 				}
 			}
 		case isXSDElement(elem, elemAttributeGroup):

--- a/xsd/redefine_group_selfref_test.go
+++ b/xsd/redefine_group_selfref_test.go
@@ -1,0 +1,109 @@
+package xsd_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+// src-redefine.6.1.1/6.1.2 (XSD Part 1 §4.2.3): a <group> child of <xs:redefine>
+// that references itself must do so exactly once and with the reference's
+// minOccurs = maxOccurs = 1. A group that does NOT reference itself is governed
+// by clause 6.2 (valid restriction of the original) and is not constrained by
+// this rule. The rule is version-independent, so it is enforced in the default
+// XSD 1.0 compiler. Mirrors W3C msMeta/Schema_w3c.xml schR3/schR4.
+func TestRedefine_GroupSelfReferenceCardinality(t *testing.T) {
+	t.Parallel()
+
+	const baseXSD = "base.xsd"
+	base := &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="g">
+    <xs:choice>
+      <xs:element name="c1" type="xs:int"/>
+      <xs:element name="c2" type="xs:int"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="other">
+    <xs:sequence><xs:element name="o1" type="xs:int"/></xs:sequence>
+  </xs:group>
+</xs:schema>`)}
+
+	for _, tc := range []struct {
+		name    string
+		redef   string
+		wantErr string
+	}{
+		{
+			name: "self-reference with occurrence 1/1 is valid",
+			redef: `<xs:group name="g">
+    <xs:choice>
+      <xs:element name="c1" type="xs:int"/>
+      <xs:group ref="g"/>
+      <xs:element name="c2" type="xs:int"/>
+    </xs:choice>
+  </xs:group>`,
+		},
+		{
+			name: "self-reference with minOccurs=0 is invalid",
+			redef: `<xs:group name="g">
+    <xs:choice>
+      <xs:element name="c1" type="xs:int"/>
+      <xs:group ref="g" minOccurs="0"/>
+      <xs:element name="c2" type="xs:int"/>
+    </xs:choice>
+  </xs:group>`,
+			wantErr: "src-redefine.6.1.2",
+		},
+		{
+			name: "self-reference with maxOccurs=2 is invalid",
+			redef: `<xs:group name="g">
+    <xs:choice>
+      <xs:element name="c1" type="xs:int"/>
+      <xs:group ref="g" maxOccurs="2"/>
+      <xs:element name="c2" type="xs:int"/>
+    </xs:choice>
+  </xs:group>`,
+			wantErr: "src-redefine.6.1.2",
+		},
+		{
+			name: "two self-references are invalid",
+			redef: `<xs:group name="g">
+    <xs:choice>
+      <xs:group ref="g"/>
+      <xs:group ref="g"/>
+    </xs:choice>
+  </xs:group>`,
+			wantErr: "src-redefine.6.1.1",
+		},
+		{
+			name: "no self-reference (references a different group) is not caught by 6.1",
+			redef: `<xs:group name="g">
+    <xs:choice>
+      <xs:element name="c1" type="xs:int"/>
+      <xs:group ref="other"/>
+    </xs:choice>
+  </xs:group>`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			const mainXSD = "main.xsd"
+			fsys := fstest.MapFS{
+				baseXSD: base,
+				mainXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base.xsd">
+    ` + tc.redef + `
+  </xs:redefine>
+</xs:schema>`)},
+			}
+			errStr, err := compileRedefineFS(t, fsys, mainXSD)
+			if tc.wantErr != "" {
+				require.Error(t, err, "expected src-redefine.6.1 rejection")
+				require.Contains(t, errStr, tc.wantErr)
+				return
+			}
+			require.NoError(t, err, "valid redefine must compile; got: %q", errStr)
+		})
+	}
+}


### PR DESCRIPTION
A `<group>` child of `<xs:redefine>` that references its own name must do so exactly once and with the reference's minOccurs = maxOccurs = 1 (§4.2.3 src-redefine.6.1.1/6.1.2). A group without a self-reference stays governed by clause 6.2 and is unaffected. Version-independent, so enforced in the default XSD 1.0 compiler. Rejects W3C msMeta/Schema_w3c.xml schR3/schR4 while keeping the valid self-ref (schH1/H2) and non-self-ref (schR5) redefines accepted.