### PR TITLE
reject XSD 1.0 ID attribute with value constraint

### DIFF
--- a/xsd/attr_id_value_constraint_test.go
+++ b/xsd/attr_id_value_constraint_test.go
@@ -1,0 +1,78 @@
+package xsd_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// XSD 1.0 "Attribute Declaration Properties Correct" clause 3 (§3.2.6): if an
+// attribute's {type definition} is or is derived from xs:ID there must NOT be a
+// {value constraint} (default or fixed). XSD 1.1 removed this restriction (W3C
+// bug 4077), so the check is version-gated: 1.0 rejects, 1.1 accepts.
+//
+// W3C msMeta/Additional coverage: addB078/A/B (fixed xs:ID attribute) and
+// isDefault060_2/069 (fixed xs:ID attribute inside a named complex type).
+func TestAttribute_IDMustNotHaveValueConstraint(t *testing.T) {
+	t.Parallel()
+
+	const shell = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="myID">
+    <xs:restriction base="xs:ID"/>
+  </xs:simpleType>
+  <xs:complexType name="ct">
+    %s
+  </xs:complexType>
+</xs:schema>`
+
+	rejected := []struct {
+		name string
+		attr string
+	}{
+		{"fixed-on-id", `<xs:attribute name="a" type="xs:ID" fixed="A1"/>`},
+		{"default-on-id", `<xs:attribute name="a" type="xs:ID" default="A1"/>`},
+		{"fixed-on-derived-id", `<xs:attribute name="a" type="myID" fixed="A1"/>`},
+		{"required-fixed-on-id", `<xs:attribute name="a" type="xs:ID" use="required" fixed="A1"/>`},
+	}
+	for _, tc := range rejected {
+		t.Run("invalid10/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			schemaXML := fmt.Sprintf(shell, tc.attr)
+			schema, errs, cerr := compileWith(t, xsd.Version10, schemaXML)
+			require.ErrorIs(t, cerr, xsd.ErrCompilationFailed, "XSD 1.0 must reject an ID attribute with a value constraint")
+			require.Nil(t, schema)
+			require.Contains(t, errs, "there must not be a value constraint")
+		})
+		t.Run("valid11/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			schemaXML := fmt.Sprintf(shell, tc.attr)
+			schema, _, cerr := compileWith(t, xsd.Version11, schemaXML)
+			require.NoError(t, cerr, "XSD 1.1 must accept an ID attribute with a value constraint (bug 4077)")
+			require.NotNil(t, schema)
+		})
+	}
+
+	// A plain xs:ID attribute with no value constraint, and a non-ID attribute
+	// carrying a fixed/default, must still compile under both versions.
+	accepted := []struct {
+		name string
+		attr string
+	}{
+		{"id-no-constraint", `<xs:attribute name="a" type="xs:ID"/>`},
+		{"string-fixed", `<xs:attribute name="a" type="xs:string" fixed="v"/>`},
+		{"idref-fixed", `<xs:attribute name="a" type="xs:IDREF" fixed="A1"/>`},
+	}
+	for _, tc := range accepted {
+		t.Run("accepted/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			schemaXML := fmt.Sprintf(shell, tc.attr)
+			for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+				schema, _, cerr := compileWith(t, v, schemaXML)
+				require.NoError(t, cerr, "version=%v must accept %s", v, tc.name)
+				require.NotNil(t, schema)
+			}
+		})
+	}
+}

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -1756,6 +1756,17 @@ func (c *compiler) checkAttrUseConstraints(ctx context.Context) {
 		if td == nil || td.ContentType != ContentTypeSimple {
 			continue
 		}
+		// XSD 1.0 "Attribute Declaration Properties Correct" clause 3 (§3.2.6): if the
+		// attribute's {type definition} is or is derived from xs:ID there must NOT be a
+		// {value constraint} (default or fixed). builtinBaseLocal returns the first
+		// XSD-namespace ancestor's local name, which is "ID" for xs:ID and any type
+		// restricting it. XSD 1.1 removed this restriction (W3C bug 4077), so the check
+		// is gated to Version10 and the 1.1 path stays byte-identical.
+		if c.version == Version10 && builtinBaseLocal(td) == typeID {
+			msg := "The attribute declaration is or is derived from ID and there must not be a value constraint."
+			c.schemaError(ctx, schemaParserErrorAttr(c.diagSourceOrRecorded(it.src.source), it.src.line, it.src.local, "attribute", it.src.local, msg))
+			continue
+		}
 		// Validate through the version-aware path so a 1.1 schema accepts 1.1-only
 		// lexical forms (e.g. "+INF") in attribute default/fixed constraints. The
 		// version-less (*TypeDef).Validate would build a Version10 context. schema is


### PR DESCRIPTION
- XSD 1.0 au-props-correct.3 (§3.2.6): an attribute whose type is or derives from xs:ID must not carry a default/fixed value constraint; version-gated so XSD 1.1 (bug 4077) still accepts it
- Fixes msMeta/Additional false-accepts addB078/A/B and isDefault060_2/069