### PR TITLE
reject xs:attribute type/ref kind mis-resolution

### DIFF
--- a/xsd/attr_type_ref_kind_test.go
+++ b/xsd/attr_type_ref_kind_test.go
@@ -1,0 +1,94 @@
+package xsd_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// An <xs:attribute>'s @type must resolve to a SIMPLE type definition and its
+// @ref must resolve to a globally-declared ATTRIBUTE (XSD Structures §3.2.2 /
+// src-resolve). A @type naming a complexType (including the ur-type xs:anyType)
+// or a @ref naming a component in a different symbol space (an attributeGroup, a
+// complexType, a global element) or a name declared nowhere is a schema error.
+// Both rules are version-independent, enforced under XSD 1.0 (default) and 1.1.
+func TestAttribute_TypeRefKindResolution(t *testing.T) {
+	t.Parallel()
+
+	// %s is spliced inside <xs:complexType name="host"> so a local attribute use is
+	// legal; every referenceable component is declared at the schema level.
+	const localShell = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:a="urn:a" targetNamespace="urn:a">
+  <xs:attribute name="ga" type="xs:string"/>
+  <xs:element name="el" type="xs:string"/>
+  <xs:complexType name="ct"><xs:sequence/></xs:complexType>
+  <xs:attributeGroup name="ag"><xs:attribute name="q" type="xs:string"/></xs:attributeGroup>
+  <xs:simpleType name="st"><xs:restriction base="xs:string"/></xs:simpleType>
+  <xs:complexType name="host">
+    <xs:sequence/>
+    %s
+  </xs:complexType>
+</xs:schema>`
+
+	// %s is spliced directly under <xs:schema> to exercise a global declaration.
+	const globalShell = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:a="urn:a" targetNamespace="urn:a">
+  <xs:complexType name="ct"><xs:sequence/></xs:complexType>
+  %s
+</xs:schema>`
+
+	const notSimple = "does not resolve to a(n) simple type definition"
+	const notAttr = "does not resolve to a(n) attribute declaration"
+
+	invalid := []struct {
+		name   string
+		shell  string
+		attr   string
+		expect string
+	}{
+		// @type resolving to a complex type (attD002).
+		{"type-complex-local", localShell, `<xs:attribute name="x" type="a:ct"/>`, notSimple},
+		{"type-complex-global", globalShell, `<xs:attribute name="bar" type="a:ct"/>`, notSimple},
+		{"type-anyType", localShell, `<xs:attribute name="x" type="xs:anyType"/>`, notSimple},
+		// @ref resolving to a non-attribute component (attE003/attE004).
+		{"ref-attributegroup", localShell, `<xs:attribute ref="a:ag"/>`, notAttr},
+		{"ref-complextype", localShell, `<xs:attribute ref="a:ct"/>`, notAttr},
+		{"ref-element", localShell, `<xs:attribute ref="a:el"/>`, notAttr},
+		{"ref-undeclared", localShell, `<xs:attribute ref="a:nope"/>`, notAttr},
+	}
+	for _, tc := range invalid {
+		t.Run("invalid/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			schemaXML := fmt.Sprintf(tc.shell, tc.attr)
+			for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+				schema, errs, cerr := compileWith(t, v, schemaXML)
+				require.ErrorIs(t, cerr, xsd.ErrCompilationFailed, "version=%v must reject", v)
+				require.Nil(t, schema)
+				require.Contains(t, errs, tc.expect, "version=%v", v)
+			}
+		})
+	}
+
+	valid := []struct {
+		name  string
+		shell string
+		attr  string
+	}{
+		{"type-user-simple", localShell, `<xs:attribute name="x" type="a:st"/>`},
+		{"type-builtin-simple", localShell, `<xs:attribute name="x" type="xs:integer"/>`},
+		{"type-anysimpletype", localShell, `<xs:attribute name="x" type="xs:anySimpleType"/>`},
+		{"type-inline-simple", localShell, `<xs:attribute name="x"><xs:simpleType><xs:restriction base="xs:string"/></xs:simpleType></xs:attribute>`},
+		{"ref-global-attr", localShell, `<xs:attribute ref="a:ga"/>`},
+	}
+	for _, tc := range valid {
+		t.Run("valid/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			schemaXML := fmt.Sprintf(tc.shell, tc.attr)
+			for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+				schema, errs, cerr := compileWith(t, v, schemaXML)
+				require.NoError(t, cerr, "version=%v must accept: %s", v, errs)
+				require.NotNil(t, schema)
+			}
+		})
+	}
+}

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -146,6 +146,11 @@ type compiler struct {
 	chameleonEligible map[any]struct{}
 	// unresolved attribute references: maps from AttrUse to global attr QName
 	attrRefs map[*AttrUse]QName
+	// source info for every <xs:attribute ref="..."> use, used by the post-resolve
+	// ref-kind check (checkAttributeResolution) so a ref that names a non-attribute
+	// component (attributeGroup/complexType/element) or nothing is reported with a
+	// line number.
+	attrRefSources map[*AttrUse]attrConstraintSource
 	// source info for attribute uses carrying a default/fixed value, used to
 	// validate the constraint value against the attribute's simple type once
 	// all type references are resolved (deferred to resolveRefs).
@@ -614,6 +619,7 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 		itemTypeRefs:              make(map[*TypeDef]QName),
 		chameleonEligible:         make(map[any]struct{}),
 		attrRefs:                  make(map[*AttrUse]QName),
+		attrRefSources:            make(map[*AttrUse]attrConstraintSource),
 		attrUseConstraintSources:  make(map[*AttrUse]attrConstraintSource),
 		attrUseSources:            make(map[*AttrUse]attrConstraintSource),
 		elemDeclConstraintSources: make(map[*ElementDecl]attrConstraintSource),

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -1243,6 +1243,7 @@ func (c *compiler) loadImport(ctx context.Context, location, ns string, importEl
 		itemTypeRefs:              make(map[*TypeDef]QName),
 		chameleonEligible:         make(map[any]struct{}),
 		attrRefs:                  make(map[*AttrUse]QName),
+		attrRefSources:            make(map[*AttrUse]attrConstraintSource),
 		attrUseConstraintSources:  make(map[*AttrUse]attrConstraintSource),
 		attrUseSources:            make(map[*AttrUse]attrConstraintSource),
 		elemDeclConstraintSources: make(map[*ElementDecl]attrConstraintSource),
@@ -1549,6 +1550,15 @@ func (c *compiler) loadImport(ctx context.Context, location, ns string, importEl
 	maps.Copy(c.chameleonEligible, impC.chameleonEligible)
 	c.unionMemberRefs = append(c.unionMemberRefs, impC.unionMemberRefs...)
 	maps.Copy(c.attrRefs, impC.attrRefs)
+	// Merge attribute-ref sources, preserving the originating file so the
+	// ref-kind diagnostic (checkAttributeResolution) cites the file whose line it
+	// carries, not the importing schema.
+	for au, src := range impC.attrRefSources {
+		if src.source == "" {
+			src.source = impC.filename
+		}
+		c.attrRefSources[au] = src
+	}
 	maps.Copy(c.notations, impC.notations)
 	// Merge attribute-use default/fixed constraint sources, preserving the
 	// originating file. An attribute use parsed directly in the imported document

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -240,6 +240,12 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 	// EXISTING group and so is unaffected).
 	c.checkAttrGroupRefsResolve(ctx)
 
+	// Reject an <xs:attribute> whose @type resolves to a complex type or whose @ref
+	// resolves to a non-attribute component (src-resolve / §3.2.2). Both are
+	// component-kind mis-resolutions the lexical QName check cannot catch, and both
+	// are version-independent.
+	c.checkAttributeResolution(ctx)
+
 	// Detect and cut INDIRECT xs:attributeGroup reference cycles (e.g. h -> i,
 	// i -> h) BEFORE any flattening or expansion. A circular attribute-group
 	// reference is disallowed outside <redefine> (XSD §3.6.2 src-attribute_group.3),
@@ -1299,6 +1305,126 @@ func (c *compiler) checkAttrGroupRefsResolve(ctx context.Context) {
 		msg := fmt.Sprintf("The QName value '{%s}%s' does not resolve to a(n) attribute group definition.", d.qn.NS, d.qn.Local)
 		c.schemaError(ctx, schemaParserErrorAttr(d.source, d.line, d.elemLocal, elemAttributeGroup, attrRef, msg))
 	}
+}
+
+// checkAttributeResolution enforces the two component-kind resolution rules on
+// an <xs:attribute> (§3.2.2 / src-resolve), version-INDEPENDENT so it runs in
+// BOTH XSD 1.0 and 1.1:
+//
+//   - the {type definition} named by @type must be a SIMPLE type — a @type that
+//     resolves to a complexType (including the ur-type xs:anyType) is a schema
+//     error (an attribute cannot have complex content); and
+//   - a @ref must resolve to a globally-declared ATTRIBUTE — a ref naming a
+//     component in a DIFFERENT symbol space (an attributeGroup, a complexType, a
+//     global element) or a name declared nowhere is a schema error.
+//
+// Only actual mis-resolutions are reported: a @type that resolves to a simple
+// type (built-in or user), an inline anonymous <xs:simpleType> (au.Type, no
+// TypeName), and a @ref to a real global attribute all pass untouched. A @type
+// that does not resolve at all is left to the existing (missing-type) handling —
+// this check only ADDS the complex-type rejection. In XSD 1.1 a @ref to one of
+// the four reserved xsi: processor attributes resolves to no user-declared global
+// attribute but is legitimate, so it is exempt.
+//
+// Diagnostics are collected and sorted by (source, line, local) so the output is
+// independent of Go map iteration order.
+func (c *compiler) checkAttributeResolution(ctx context.Context) {
+	if c.filename == "" {
+		return
+	}
+
+	type issue struct {
+		source string
+		line   int
+		local  string
+		qn     QName
+		msg    string
+	}
+	var issues []issue
+
+	// Part A: @type must resolve to a simple type. attrUseSources tracks every
+	// non-ref attribute use (a ref use carries no explicit @type here — its
+	// TypeName is copied from the referenced global, which is always simple).
+	for au, src := range c.attrUseSources {
+		if au.TypeName == (QName{}) {
+			continue
+		}
+		td := c.resolveNamedType(au.TypeName)
+		if td == nil || !td.IsComplex {
+			continue
+		}
+		issues = append(issues, issue{
+			source: c.diagSourceOrRecorded(src.source),
+			line:   src.line,
+			local:  src.local,
+			qn:     au.TypeName,
+			msg: fmt.Sprintf("The QName value '{%s}%s' does not resolve to a(n) simple type definition.",
+				au.TypeName.NS, au.TypeName.Local),
+		})
+	}
+
+	// Part B: @ref must resolve to a global attribute declaration.
+	for au, qn := range c.attrRefs {
+		if _, ok := c.schema.globalAttrs[qn]; ok {
+			continue
+		}
+		// An unprefixed ref resolves to the schema's targetNamespace, but the global
+		// attribute may come from a no-targetNamespace (chameleon) imported schema;
+		// mirror the empty-namespace fallback used for element/type/attributeGroup
+		// references so a valid no-NS-import reference is not flagged.
+		if qn.NS != "" {
+			if _, ok := c.schema.globalAttrs[QName{Local: qn.Local}]; ok {
+				continue
+			}
+		}
+		// A ref into the reserved XSI namespace never resolves to a user-declared
+		// global attribute (a schema may not declare an attribute there): the four
+		// processor attributes are provided implicitly, and any other xsi: local name
+		// is tolerated as a skipped special attribute (a required use of it is instead
+		// left unsatisfied at instance validation). Exempt the whole namespace so
+		// neither form is reported as an unresolvable ref.
+		if qn.NS == lexicon.NamespaceXSI {
+			continue
+		}
+		src := c.attrRefSources[au]
+		issues = append(issues, issue{
+			source: c.diagSourceOrRecorded(src.source),
+			line:   src.line,
+			local:  src.local,
+			qn:     qn,
+			msg: fmt.Sprintf("The QName value '{%s}%s' does not resolve to a(n) attribute declaration.",
+				qn.NS, qn.Local),
+		})
+	}
+
+	sort.Slice(issues, func(i, j int) bool {
+		if issues[i].source != issues[j].source {
+			return issues[i].source < issues[j].source
+		}
+		if issues[i].line != issues[j].line {
+			return issues[i].line < issues[j].line
+		}
+		return issues[i].local < issues[j].local
+	})
+	for _, is := range issues {
+		c.schemaError(ctx, schemaParserErrorAttr(is.source, is.line, elemAttribute, elemAttribute, is.local, is.msg))
+	}
+}
+
+// resolveNamedType resolves a named type reference to its definition, mirroring
+// the chameleon empty-namespace fallback used elsewhere: an unprefixed reference
+// resolves to the schema targetNamespace, but the type may come from a
+// no-targetNamespace imported schema.
+func (c *compiler) resolveNamedType(qn QName) *TypeDef {
+	if td, ok := c.schema.types[qn]; ok {
+		return td
+	}
+	if qn.NS != "" {
+		if td, ok := c.schema.types[QName{Local: qn.Local}]; ok {
+			return td
+		}
+	}
+	return nil
 }
 
 // checkCircularAttrGroupRefs detects INDIRECT xs:attributeGroup reference cycles

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -877,6 +877,13 @@ func (c *compiler) parseAttributeUse(ctx context.Context, elem *helium.Element) 
 			}
 		}
 		c.attrRefs[au] = qn
+		// Record the source of every ref use so checkAttributeResolution can cite a
+		// line when the ref does not resolve to a global attribute declaration.
+		c.attrRefSources[au] = attrConstraintSource{
+			line:   elem.Line(),
+			local:  qn.Local,
+			source: c.includeFile,
+		}
 		return au
 	}
 


### PR DESCRIPTION
- `checkAttributeResolution` (link_refs.go, resolveRefs): an `<xs:attribute>` `@type` resolving to a complexType (incl. xs:anyType) or a `@ref` resolving to a non-attribute component (attributeGroup/complexType/element) or nothing is a schema error (§3.2.2 / src-resolve), version-independent.
- XSI-namespace refs stay exempt (four processor attrs + tolerated skipped-special names); inline anonymous simpleType and xs:anySimpleType still accepted.
- Fixes msMeta/Attribute_w3c.xml attD002/attE003/attE004.