### PR TITLE
reject xs:group ref to wrong symbol space or dangling

### DIFF
--- a/xsd/group_ref_resolve_test.go
+++ b/xsd/group_ref_resolve_test.go
@@ -1,0 +1,104 @@
+package xsd_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// A <xs:group ref="..."> in a content model must resolve to a globally declared
+// model group (XSD Structures §3.7.2 / src-resolve). A ref naming a component in
+// a different symbol space (a complexType or an attributeGroup of the same name)
+// or a name declared nowhere is a schema-representation error. This is
+// version-independent, so it is enforced under both XSD 1.0 (default) and XSD
+// 1.1. A valid reference — including one to a chameleon / no-namespace imported
+// group — must still compile.
+func TestGroup_RefMustResolveToModelGroup(t *testing.T) {
+	t.Parallel()
+
+	invalid := []struct {
+		name string
+		xml  string
+	}{
+		{
+			// ref names a global attributeGroup (wrong symbol space).
+			name: "ref-to-attributeGroup",
+			xml: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="complexType"><xs:sequence><xs:element name="r1"/></xs:sequence></xs:complexType>
+  <xs:element name="elem"><xs:complexType><xs:complexContent><xs:extension base="complexType">
+    <xs:group ref="attG"/></xs:extension></xs:complexContent></xs:complexType></xs:element>
+  <xs:attributeGroup name="attG"><xs:attribute name="att1"/></xs:attributeGroup>
+</xs:schema>`,
+		},
+		{
+			// ref names a global complexType (wrong symbol space).
+			name: "ref-to-complexType",
+			xml: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="complexType"><xs:sequence><xs:element name="r1"/></xs:sequence></xs:complexType>
+  <xs:element name="elem"><xs:complexType><xs:complexContent><xs:extension base="complexType">
+    <xs:group ref="complexType"/></xs:extension></xs:complexContent></xs:complexType></xs:element>
+</xs:schema>`,
+		},
+		{
+			// ref names a group that does not exist anywhere.
+			name: "dangling-ref",
+			xml: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="A"><xs:group ref="nope"/></xs:complexType>
+  <xs:element name="doc" type="A"/>
+</xs:schema>`,
+		},
+		{
+			// dangling ref nested inside a model group.
+			name: "dangling-ref-nested",
+			xml: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="A"><xs:sequence><xs:group ref="nope"/></xs:sequence></xs:complexType>
+  <xs:element name="doc" type="A"/>
+</xs:schema>`,
+		},
+	}
+	for _, tc := range invalid {
+		t.Run("invalid/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+				schema, errs, cerr := compileWith(t, v, tc.xml)
+				require.ErrorIs(t, cerr, xsd.ErrCompilationFailed, "version=%v must reject unresolved group ref", v)
+				require.Nil(t, schema)
+				require.Contains(t, errs, "does not resolve to a(n) model group definition", "version=%v", v)
+			}
+		})
+	}
+
+	valid := []struct {
+		name string
+		xml  string
+	}{
+		{
+			// ref resolves to a real model group in the same namespace.
+			name: "ref-to-model-group",
+			xml: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="A"><xs:group ref="xyz"/></xs:complexType>
+  <xs:group name="xyz"><xs:sequence><xs:element name="A"/></xs:sequence></xs:group>
+  <xs:element name="doc" type="A"/>
+</xs:schema>`,
+		},
+		{
+			// nested ref resolves to a real model group.
+			name: "nested-ref-to-model-group",
+			xml: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="A"><xs:sequence><xs:group ref="xyz"/></xs:sequence></xs:complexType>
+  <xs:group name="xyz"><xs:sequence><xs:element name="A"/></xs:sequence></xs:group>
+  <xs:element name="doc" type="A"/>
+</xs:schema>`,
+		},
+	}
+	for _, tc := range valid {
+		t.Run("valid/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+				_, errs, cerr := compileWith(t, v, tc.xml)
+				require.NoError(t, cerr, "version=%v must accept a resolvable group ref: %s", v, errs)
+			}
+		})
+	}
+}

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -197,13 +197,41 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 	// placeholder is left empty so the tree stays acyclic; the schema is reported
 	// invalid (circular groups are forbidden in both XSD 1.0 and 1.1).
 	cutGroupRefs := c.checkCircularGroupRefs(ctx)
+	// Collect every <xs:group ref="..."> that does NOT resolve to a globally
+	// declared model group (a ref naming a component in the wrong symbol space —
+	// a complexType or attributeGroup of the same name — or a name declared
+	// nowhere). Reported after the loop, sorted for deterministic output, so the
+	// invalid schema is rejected instead of silently compiling with empty content.
+	type danglingGroupRef struct {
+		source string
+		line   int
+		local  string
+		qn     QName
+	}
+	var danglingGroups []danglingGroupRef
 	for _, placeholder := range groupRefPlaceholders {
 		if _, isCut := cutGroupRefs[placeholder]; isCut {
 			continue
 		}
 		qn := c.groupRefs[placeholder]
 		grp, ok := c.schema.groups[qn]
+		if !ok && qn.NS != "" {
+			// An unprefixed ref resolves to the schema's targetNamespace, but the
+			// group may come from a chameleon / no-namespace imported schema. Mirror
+			// the empty-namespace fallback used for element/type/attribute-group
+			// references so such a valid reference is not flagged dangling.
+			grp, ok = c.schema.groups[QName{Local: qn.Local}]
+		}
 		if !ok {
+			if c.filename != "" {
+				src := c.groupRefSources[placeholder]
+				danglingGroups = append(danglingGroups, danglingGroupRef{
+					source: c.diagSourceOrRecorded(src.source),
+					line:   src.line,
+					local:  src.local,
+					qn:     qn,
+				})
+			}
 			continue
 		}
 		// Copy the group's content into the placeholder.
@@ -227,6 +255,27 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 			continue
 		}
 		c.checkAllGroupRef(ctx, placeholder)
+	}
+
+	// Report unresolved model-group references (src-resolve / Model Group
+	// Reference Representation OK): a ref to a component in the wrong symbol space
+	// (a complexType or attributeGroup of the same name) or a name declared
+	// nowhere. Version-independent — the resolution rule holds in both XSD 1.0 and
+	// 1.1 (a permitted 1.1 circular ref still resolves to an existing group, so it
+	// never reaches here). Sorted by (source, line, local) so the output is
+	// independent of Go map iteration order.
+	sort.Slice(danglingGroups, func(i, j int) bool {
+		if danglingGroups[i].source != danglingGroups[j].source {
+			return danglingGroups[i].source < danglingGroups[j].source
+		}
+		if danglingGroups[i].line != danglingGroups[j].line {
+			return danglingGroups[i].line < danglingGroups[j].line
+		}
+		return danglingGroups[i].local < danglingGroups[j].local
+	})
+	for _, d := range danglingGroups {
+		msg := fmt.Sprintf("The QName value '{%s}%s' does not resolve to a(n) model group definition.", d.qn.NS, d.qn.Local)
+		c.schemaError(ctx, schemaParserErrorAttr(d.source, d.line, d.local, elemGroup, attrRef, msg))
 	}
 
 	// Reject an xs:attributeGroup ref that does not resolve to a globally-declared


### PR DESCRIPTION
- `checkGroupRefsResolve` (`link_refs.go`): a `<xs:group ref>` must resolve to a globally declared model group; a ref naming a complexType/attributeGroup of the same name (wrong symbol space) or a name declared nowhere is now a schema error, mirroring `checkAttrGroupRefsResolve`.
- Version-independent (both 1.0 and 1.1); chameleon/no-namespace empty-ns fallback preserved so valid imported group refs still compile.
- Fixes Group_w3c false-accepts groupB008/groupB011 (plus schH3, sunData xsd020-3.e cross-suite).