### PR TITLE
accept dangling foreign-namespace attribute ref

### DIFF
--- a/xsd/attr_type_ref_kind_test.go
+++ b/xsd/attr_type_ref_kind_test.go
@@ -54,7 +54,9 @@ func TestAttribute_TypeRefKindResolution(t *testing.T) {
 		{"ref-attributegroup", localShell, `<xs:attribute ref="a:ag"/>`, notAttr},
 		{"ref-complextype", localShell, `<xs:attribute ref="a:ct"/>`, notAttr},
 		{"ref-element", localShell, `<xs:attribute ref="a:el"/>`, notAttr},
-		{"ref-undeclared", localShell, `<xs:attribute ref="a:nope"/>`, notAttr},
+		// A dangling ref in the schema's OWN target namespace is a self-reference that
+		// genuinely should resolve — still an error.
+		{"ref-undeclared-selfns", localShell, `<xs:attribute ref="a:nope"/>`, notAttr},
 	}
 	for _, tc := range invalid {
 		t.Run("invalid/"+tc.name, func(t *testing.T) {
@@ -79,6 +81,12 @@ func TestAttribute_TypeRefKindResolution(t *testing.T) {
 		{"type-anysimpletype", localShell, `<xs:attribute name="x" type="xs:anySimpleType"/>`},
 		{"type-inline-simple", localShell, `<xs:attribute name="x"><xs:simpleType><xs:restriction base="xs:string"/></xs:simpleType></xs:attribute>`},
 		{"ref-global-attr", localShell, `<xs:attribute ref="a:ga"/>`},
+		// A ref to a built-in XML-namespace attribute (always implicitly available,
+		// never declared) resolves to no global attribute but must not be rejected.
+		{"ref-xml-builtin", localShell, `<xs:attribute ref="xml:lang"/>`},
+		// A dangling ref into a FOREIGN namespace (e.g. one whose xs:import could not
+		// be loaded) is left lenient rather than over-rejected.
+		{"ref-foreign-namespace", `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:a="urn:a" xmlns:x="urn:unloaded" targetNamespace="urn:a"><xs:import namespace="urn:unloaded"/><xs:complexType name="host"><xs:sequence/>%s</xs:complexType></xs:schema>`, `<xs:attribute ref="x:nope"/>`},
 	}
 	for _, tc := range valid {
 		t.Run("valid/"+tc.name, func(t *testing.T) {

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -1432,7 +1432,24 @@ func (c *compiler) checkAttributeResolution(ctx context.Context) {
 		// is tolerated as a skipped special attribute (a required use of it is instead
 		// left unsatisfied at instance validation). Exempt the whole namespace so
 		// neither form is reported as an unresolvable ref.
-		if qn.NS == lexicon.NamespaceXSI {
+		// The XSI namespace is reserved to the four processor attributes and the XML
+		// namespace provides the built-in xml:lang/base/space/id attributes, which are
+		// always implicitly available and never declared: a ref into either resolves to
+		// no user-declared global attribute by design, so neither is reported.
+		if qn.NS == lexicon.NamespaceXSI || qn.NS == lexicon.NamespaceXML {
+			continue
+		}
+		// A ref that resolves to an EXISTING component of the WRONG symbol space (a
+		// named type, a global element, or an attribute group) is always a src-resolve
+		// error. A ref that resolves to NOTHING is an error only when it is a
+		// self-reference — its namespace is the schema's own target namespace (or the
+		// absent namespace) — where the attribute genuinely should have been declared.
+		// A dangling reference into a FOREIGN namespace is left lenient: that namespace
+		// may be one whose <xs:import> could not be loaded (its declarations unknown),
+		// so flagging it would over-reject valid schemas, matching libxml2 and the
+		// pre-existing tolerant behavior.
+		selfRef := qn.NS == c.schema.targetNamespace || qn.NS == ""
+		if !c.qnameNamesNonAttribute(qn) && !selfRef {
 			continue
 		}
 		src := c.attrRefSources[au]
@@ -1458,6 +1475,26 @@ func (c *compiler) checkAttributeResolution(ctx context.Context) {
 	for _, is := range issues {
 		c.schemaError(ctx, schemaParserErrorAttr(is.source, is.line, elemAttribute, elemAttribute, is.local, is.msg))
 	}
+}
+
+// qnameNamesNonAttribute reports whether qn names an existing schema component
+// that is NOT a global attribute — a named type, a global element, or an
+// attribute group. It is used by the @ref resolution check to distinguish a
+// wrong-symbol-space reference (a src-resolve error) from one that resolves to
+// nothing (left lenient). Only the exact {ns}local lookup is consulted (no
+// chameleon empty-namespace fallback), so a reference that dangles into an
+// unloaded namespace is never treated as wrong-kind.
+func (c *compiler) qnameNamesNonAttribute(qn QName) bool {
+	if _, ok := c.schema.types[qn]; ok {
+		return true
+	}
+	if _, ok := c.schema.elements[qn]; ok {
+		return true
+	}
+	if _, ok := c.schema.attrGroups[qn]; ok {
+		return true
+	}
+	return false
 }
 
 // resolveNamedType resolves a named type reference to its definition, mirroring


### PR DESCRIPTION
- checkAttributeResolution only rejects an @ref that resolves to a wrong-kind component, or a dangling self-reference in the schema's own target/absent namespace
- a dangling @ref into a foreign namespace (built-in xml:*, or a skipped-import namespace) is left lenient — fixes over-rejection of xsts/adhocAddC001/isdefault078