### PR TITLE
reject attribute ref into a never-imported namespace

### DIFF
--- a/xsd/attr_type_ref_kind_test.go
+++ b/xsd/attr_type_ref_kind_test.go
@@ -57,6 +57,9 @@ func TestAttribute_TypeRefKindResolution(t *testing.T) {
 		// A dangling ref in the schema's OWN target namespace is a self-reference that
 		// genuinely should resolve — still an error.
 		{"ref-undeclared-selfns", localShell, `<xs:attribute ref="a:nope"/>`, notAttr},
+		// A ref into a FOREIGN namespace that was never imported is illegal — a
+		// component of a non-imported namespace cannot be referenced (schZ011_c).
+		{"ref-unimported-namespace", `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:a="urn:a" xmlns:d="urn:d" targetNamespace="urn:a"><xs:complexType name="host"><xs:sequence/>%s</xs:complexType></xs:schema>`, `<xs:attribute ref="d:d"/>`, notAttr},
 	}
 	for _, tc := range invalid {
 		t.Run("invalid/"+tc.name, func(t *testing.T) {

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -171,6 +171,13 @@ type compiler struct {
 	includeFile  string // currently-included file path (for duplicate element errors)
 	// importedNS tracks which namespaces have been imported and their schema locations.
 	importedNS map[string]string // namespace → schema location
+	// importDeclaredNS records every namespace named by an <xs:import>, regardless of
+	// whether a schema document was actually loaded for it (a location-less import, or
+	// one whose schemaLocation could not be loaded, still counts). Unlike importedNS
+	// (successful loads only), this is the set of namespaces a reference is ALLOWED to
+	// target even when their declarations are unknown, so a dangling ref into an
+	// imported-but-unloadable namespace is not over-rejected.
+	importDeclaredNS map[string]struct{}
 	// importDepth and maxImportDepth bound xs:import recursion. Each sub-compiler
 	// created by loadImport inherits maxImportDepth and stores its own
 	// importDepth = parent.importDepth + 1. A sub-compiler whose depth would
@@ -624,6 +631,7 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 		attrUseSources:            make(map[*AttrUse]attrConstraintSource),
 		elemDeclConstraintSources: make(map[*ElementDecl]attrConstraintSource),
 		importedNS:                make(map[string]string),
+		importDeclaredNS:          make(map[string]struct{}),
 		maxImportDepth:            defaultMaxImportDepth,
 		importActive:              make(map[string]string),
 		includeVisited:            make(map[string]struct{}),

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -268,11 +268,16 @@ func (c *compiler) reportSchemaLoadWarning(ctx context.Context, elem *helium.Ele
 // xs:override nested processor so an import inside an overridden document gets the
 // same diagnostics as a top-level import.
 func (c *compiler) processImport(ctx context.Context, elem *helium.Element) error {
+	ns := getAttr(elem, attrNamespace)
+	// Record the namespace as import-declared BEFORE any early return, so a
+	// location-less import (and, below, one whose load fails) still marks the
+	// namespace referenceable — its declarations are simply unknown.
+	c.importDeclaredNS[ns] = struct{}{}
+
 	loc := getAttr(elem, attrSchemaLocation)
 	if loc == "" {
 		return nil
 	}
-	ns := getAttr(elem, attrNamespace)
 
 	// Check if this namespace was already imported.
 	if prevLoc, ok := c.importedNS[ns]; ok && c.filename != "" {
@@ -1268,6 +1273,7 @@ func (c *compiler) loadImport(ctx context.Context, location, ns string, importEl
 		elemDeclConstraintSources: make(map[*ElementDecl]attrConstraintSource),
 		filename:                  impFilename,
 		importedNS:                make(map[string]string),
+		importDeclaredNS:          make(map[string]struct{}),
 		importDepth:               c.importDepth + 1,
 		maxImportDepth:            c.maxImportDepth,
 		// Share the active import-ancestry set by pointer so the whole import tree
@@ -1477,6 +1483,10 @@ func (c *compiler) loadImport(ctx context.Context, location, ns string, importEl
 	maps.Copy(c.elemRefs, impC.elemRefs)
 	maps.Copy(c.elemRefSources, impC.elemRefSources)
 	maps.Copy(c.typeRefs, impC.typeRefs)
+	// A namespace imported anywhere in the assembly is referenceable everywhere the
+	// merged refs are resolved (the ref check runs on the parent), so union the
+	// import-declared namespaces up.
+	maps.Copy(c.importDeclaredNS, impC.importDeclaredNS)
 	// Offset each imported type's parse-order ordinal past the parent's counter
 	// so ordinals remain globally unique across the merged compilers; otherwise
 	// a parent type and an imported type sharing a source line and an empty name

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -1441,15 +1441,15 @@ func (c *compiler) checkAttributeResolution(ctx context.Context) {
 		}
 		// A ref that resolves to an EXISTING component of the WRONG symbol space (a
 		// named type, a global element, or an attribute group) is always a src-resolve
-		// error. A ref that resolves to NOTHING is an error only when it is a
-		// self-reference — its namespace is the schema's own target namespace (or the
-		// absent namespace) — where the attribute genuinely should have been declared.
-		// A dangling reference into a FOREIGN namespace is left lenient: that namespace
-		// may be one whose <xs:import> could not be loaded (its declarations unknown),
-		// so flagging it would over-reject valid schemas, matching libxml2 and the
-		// pre-existing tolerant behavior.
-		selfRef := qn.NS == c.schema.targetNamespace || qn.NS == ""
-		if !c.qnameNamesNonAttribute(qn) && !selfRef {
+		// error. A ref that resolves to NOTHING is left lenient ONLY when its namespace
+		// was actually imported (`<xs:import namespace="...">`) but its schema document
+		// could not be loaded — the namespace's declarations are then genuinely unknown,
+		// so flagging the ref would over-reject valid schemas (matching libxml2). A ref
+		// into a namespace that was NEVER imported — including the schema's own target
+		// namespace and the absent namespace — is an error: referencing a component of a
+		// non-imported namespace is illegal (src-resolve), and a self-reference should
+		// have been declared. The built-in XML namespace is exempted above.
+		if _, imported := c.importDeclaredNS[qn.NS]; imported && !c.qnameNamesNonAttribute(qn) {
 			continue
 		}
 		src := c.attrRefSources[au]


### PR DESCRIPTION
- a dangling attribute @ref is lenient only when its namespace was declared by an <xs:import> (load may have failed), tracked in a new importDeclaredNS set unioned across sub-compilers
- a ref into a never-imported namespace (incl. the schema's own target/absent namespace) is a src-resolve error; built-in xml: and xsi: stay exempt
- recovers rejection of schZ011_c (ref to un-imported d:d) while keeping xsts/adhocAddC001/isdefault078 valid