### PR TITLE
reject xs:group name as content-model particle

### DIFF
--- a/xsd/group_ref_repr_test.go
+++ b/xsd/group_ref_repr_test.go
@@ -1,0 +1,103 @@
+package xsd_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// A <xs:group> appearing as a particle inside a content model — directly under
+// an xs:complexType, inside an xs:extension/xs:restriction derivation body, or
+// nested in an xs:sequence/xs:choice/xs:all — is a model group REFERENCE
+// (§3.8.2). Its only naming attribute is 'ref'; a '@name' (the top-level
+// DEFINITION form) is a schema-representation error, as is a missing 'ref'.
+// This is version-independent, so it is enforced under both XSD 1.0 (default)
+// and XSD 1.1. Mirrors W3C xsdtests groupC004-groupC008.
+func TestGroupReference_NameNotAllowedInContentModel(t *testing.T) {
+	t.Parallel()
+
+	const defn = `
+  <xs:group name="xyz">
+    <xs:sequence>
+      <xs:element name="A"/>
+      <xs:element name="B"/>
+    </xs:sequence>
+  </xs:group>`
+
+	// Each %s is the offending <xs:group> particle under test.
+	invalidShells := map[string]string{
+		"direct-complexType": `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="ct">%s</xs:complexType>` + defn + `
+</xs:schema>`,
+		"in-sequence": `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="ct"><xs:sequence minOccurs="0">%s</xs:sequence></xs:complexType>` + defn + `
+</xs:schema>`,
+		"in-choice": `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="ct"><xs:choice minOccurs="0">%s</xs:choice></xs:complexType>` + defn + `
+</xs:schema>`,
+		"in-extension": `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="base"><xs:sequence><xs:element name="A"/></xs:sequence></xs:complexType>
+  <xs:complexType name="ct"><xs:complexContent><xs:extension base="base">%s</xs:extension></xs:complexContent></xs:complexType>` + defn + `
+</xs:schema>`,
+		"in-restriction": `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="base"><xs:sequence minOccurs="0"><xs:element name="A" minOccurs="0"/><xs:element name="B" minOccurs="0"/></xs:sequence></xs:complexType>
+  <xs:complexType name="ct"><xs:complexContent><xs:restriction base="base">%s</xs:restriction></xs:complexContent></xs:complexType>` + defn + `
+</xs:schema>`,
+	}
+
+	// Both the DEFINITION form (a '@name') and a bare <xs:group> (no 'ref') are
+	// representation errors as content-model particles.
+	offenders := map[string]string{
+		"name-form":   `<xs:group name="xyz"/>`,
+		"missing-ref": `<xs:group/>`,
+	}
+
+	for ctx, shell := range invalidShells {
+		for oname, particle := range offenders {
+			t.Run("invalid/"+oname+"/"+ctx, func(t *testing.T) {
+				t.Parallel()
+				schemaXML := fmt.Sprintf(shell, particle)
+				for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+					schema, errs, cerr := compileWith(t, v, schemaXML)
+					require.ErrorIs(t, cerr, xsd.ErrCompilationFailed,
+						"version=%v ctx=%s must reject %s in a content model; errs=%s", v, ctx, particle, errs)
+					require.Nil(t, schema)
+				}
+			})
+		}
+	}
+
+	// A proper <xs:group ref> in an unconditionally-valid position must still
+	// compile (no over-rejection). Extension/restriction add orthogonal
+	// derivation constraints, so the ref form is exercised only where a plain
+	// group reference is always valid.
+	validShells := map[string]string{
+		"direct-complexType": invalidShells["direct-complexType"],
+		"in-sequence":        invalidShells["in-sequence"],
+		"in-choice":          invalidShells["in-choice"],
+	}
+	for ctx, shell := range validShells {
+		t.Run("valid/ref-form/"+ctx, func(t *testing.T) {
+			t.Parallel()
+			schemaXML := fmt.Sprintf(shell, `<xs:group ref="xyz"/>`)
+			for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+				_, errs, cerr := compileWith(t, v, schemaXML)
+				require.NoError(t, cerr,
+					"version=%v ctx=%s must accept a proper <xs:group ref>; errs=%s", v, ctx, errs)
+			}
+		})
+	}
+
+	// A group reference carrying a child annotation is valid content (annotation?).
+	t.Run("valid/ref-with-annotation", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := fmt.Sprintf(invalidShells["in-sequence"],
+			`<xs:group ref="xyz"><xs:annotation><xs:documentation>ok</xs:documentation></xs:annotation></xs:group>`)
+		for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+			_, errs, cerr := compileWith(t, v, schemaXML)
+			require.NoError(t, cerr, "version=%v must accept a group ref with an annotation child; errs=%s", v, errs)
+		}
+	})
+}

--- a/xsd/read_particles.go
+++ b/xsd/read_particles.go
@@ -310,6 +310,54 @@ func (c *compiler) checkAttrGroupRef(ctx context.Context, ce *helium.Element) {
 	}
 }
 
+// checkContentModelGroupRef enforces the XML representation of a model group
+// REFERENCE (§3.8.2): a <xs:group> appearing as a particle inside a content
+// model — directly under an xs:complexType, inside an xs:extension/xs:restriction
+// derivation body, or nested in an xs:sequence/xs:choice/xs:all — is a reference,
+// whose only naming attribute is 'ref' and whose content model is (annotation?).
+// A '@name' — the DEFINITION form, valid only as a top-level xs:schema /
+// xs:redefine / xs:override child — is a schema-representation error, as is a
+// missing 'ref' or any non-annotation element child. It returns true when the
+// reference is well-formed (a non-empty 'ref', no 'name'), so the caller records
+// the group ref; false (having reported the error) otherwise. Version-INDEPENDENT
+// XSD rule.
+func (c *compiler) checkContentModelGroupRef(ctx context.Context, ce *helium.Element) bool {
+	ref := getAttr(ce, attrRef)
+	if c.filename == "" {
+		// Representation diagnostics need a source label; preserve the legacy
+		// behavior (record only a non-empty ref) when none is available.
+		return ref != ""
+	}
+	ok := true
+	if hasAttr(ce, attrName) {
+		c.schemaError(ctx, schemaParserErrorAttr(c.diagSource(), ce.Line(), ce.LocalName(), "group", attrName,
+			"The attribute 'name' is not allowed on a model group reference; use 'ref'."))
+		ok = false
+	}
+	if !hasAttr(ce, attrRef) {
+		c.schemaError(ctx, schemaParserErrorAttr(c.diagSource(), ce.Line(), ce.LocalName(), "group", attrRef,
+			"A model group reference must have a 'ref' attribute."))
+		ok = false
+	}
+	// content model (annotation?): no non-annotation element children.
+	for child := range helium.Children(ce) {
+		if child.Type() != helium.ElementNode {
+			continue
+		}
+		sub, isElem := helium.AsNode[*helium.Element](child)
+		if !isElem {
+			continue
+		}
+		if isXSDElement(sub, elemAnnotation) {
+			continue
+		}
+		c.schemaError(ctx, schemaParserError(c.diagSource(), sub.Line(), sub.LocalName(), "group",
+			fmt.Sprintf("The content of a model group reference is restricted to (annotation?); the element '%s' is not allowed.", sub.LocalName())))
+		ok = false
+	}
+	return ok && ref != ""
+}
+
 func (c *compiler) parseModelGroup(ctx context.Context, elem *helium.Element, compositor ModelGroupKind) (*ModelGroup, error) {
 	// An xs:all compositor has special occurrence constraints (XSD Part 1
 	// §3.8.6 / cos-all-limited): its own minOccurs must be 0 or 1, its maxOccurs
@@ -481,6 +529,9 @@ func (c *compiler) parseModelGroup(ctx context.Context, elem *helium.Element, co
 			// downstream in checkAllGroupRef.
 			if compositor == CompositorAll && c.version != Version11 {
 				reportStray(ce)
+				continue
+			}
+			if !c.checkContentModelGroupRef(ctx, ce) {
 				continue
 			}
 			ref := getAttr(ce, attrRef)

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -236,6 +236,9 @@ func (c *compiler) parseComplexType(ctx context.Context, elem *helium.Element) (
 				td.ContentType = ContentTypeElementOnly
 			}
 		case isXSDElement(ce, elemGroup):
+			if !c.checkContentModelGroupRef(ctx, ce) {
+				continue
+			}
 			ref := getAttr(ce, attrRef)
 			if ref != "" {
 				c.validateOccursAttrs(ctx, ce)
@@ -674,6 +677,9 @@ func (c *compiler) parseComplexContentDerivationBody(ctx context.Context, elem *
 				td.ContentType = ContentTypeElementOnly
 			}
 		case isXSDElement(ce, elemGroup):
+			if !c.checkContentModelGroupRef(ctx, ce) {
+				continue
+			}
 			ref := getAttr(ce, attrRef)
 			if ref != "" {
 				c.validateOccursAttrs(ctx, ce)


### PR DESCRIPTION
A `<xs:group>` used as a content-model particle (directly under `xs:complexType`, in an `xs:extension`/`xs:restriction` body, or nested in `xs:sequence`/`xs:choice`/`xs:all`) is a model group REFERENCE (§3.8.2): its only naming attribute is `ref`. The three particle-dispatch sites silently dropped a `<xs:group>` lacking a non-empty `ref`, so the DEFINITION form `<xs:group name=...>` (and a bare `<xs:group>`) was false-accepted. New `checkContentModelGroupRef` rejects a `@name`, a missing `ref`, and a non-annotation child. Version-independent.

Fixes W3C xsdtests groupC004-groupC008. groupO024/O026 (group ref in `xs:element`/`xs:any`) and groupA008/groupB007 are distinct causes, left for follow-up.
