### PR TITLE
enforce xs:attribute child content model

### DIFF
--- a/xsd/attr_children_grammar_test.go
+++ b/xsd/attr_children_grammar_test.go
@@ -1,0 +1,123 @@
+package xsd_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAttributeChildrenGrammar covers the schema-representation content model of
+// a non-reference <xs:attribute> (XSD Structures §3.2.2): (annotation?, simpleType?).
+// Version-independent (enforced in the default XSD 1.0 compiler). Mirrors W3C
+// msMeta/Attribute_w3c.xml attI005/attI006/attP001/attP002/attQ006 cases.
+func TestAttributeChildrenGrammar(t *testing.T) {
+	const main = "test.xsd"
+	compile := func(t *testing.T, schema string) string {
+		t.Helper()
+		fsys := fstest.MapFS{main: &fstest.MapFile{Data: []byte(schema)}}
+		return compileFSErrors(t, fsys, main)
+	}
+
+	t.Run("nested xs:attribute child is rejected (attP001)", func(t *testing.T) {
+		schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attribute name="att">
+    <xs:attribute name="att1" type="xs:string"/>
+  </xs:attribute>
+</xs:schema>`
+		require.Contains(t, compile(t, schema), "is not allowed as a child of an attribute declaration")
+	})
+
+	t.Run("xs:element child is rejected (attP002)", func(t *testing.T) {
+		schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attribute name="att">
+    <xs:element name="elem"/>
+  </xs:attribute>
+</xs:schema>`
+		require.Contains(t, compile(t, schema), "is not allowed as a child of an attribute declaration")
+	})
+
+	t.Run("xs:complexType child is rejected (attQ006)", func(t *testing.T) {
+		schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="internationalPrice">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:decimal">
+          <xs:attribute name="currency">
+            <xs:complexType name="foo">
+              <xs:sequence>
+                <xs:element name="e"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:attribute>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		require.Contains(t, compile(t, schema), "is not allowed as a child of an attribute declaration")
+	})
+
+	t.Run("annotation after simpleType is rejected (attI005)", func(t *testing.T) {
+		schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="t">
+    <xs:attribute name="att1">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="AK"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:annotation/>
+    </xs:attribute>
+  </xs:complexType>
+</xs:schema>`
+		require.Contains(t, compile(t, schema), "The annotation must appear before the simpleType")
+	})
+
+	t.Run("two simpleType children are rejected (attI006)", func(t *testing.T) {
+		schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="t">
+    <xs:attribute name="att1">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="AK"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="AL"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:complexType>
+</xs:schema>`
+		require.Contains(t, compile(t, schema), "must not have more than one simpleType")
+	})
+
+	t.Run("valid annotation then simpleType compiles", func(t *testing.T) {
+		schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="t">
+    <xs:attribute name="att1">
+      <xs:annotation><xs:documentation>doc</xs:documentation></xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="AK"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:complexType>
+</xs:schema>`
+		require.Empty(t, compile(t, schema))
+	})
+
+	t.Run("valid plain typed attribute compiles", func(t *testing.T) {
+		schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attribute name="foo" type="xs:string"/>
+  <xs:complexType name="t">
+    <xs:attribute name="bar" type="xs:string"/>
+    <xs:attribute name="baz"/>
+  </xs:complexType>
+</xs:schema>`
+		require.Empty(t, compile(t, schema))
+	})
+}

--- a/xsd/check_elements.go
+++ b/xsd/check_elements.go
@@ -2,6 +2,7 @@ package xsd
 
 import (
 	"context"
+	"fmt"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
@@ -656,6 +657,12 @@ func (c *compiler) checkAttributeUse(ctx context.Context, elem *helium.Element) 
 			}
 		}
 	} else {
+		// XSD Structures §3.2.2: the content of an <xs:attribute> that is NOT a
+		// reference is (annotation?, simpleType?) — at most one annotation which
+		// must be first, at most one simpleType, and no other element children.
+		// Version-INDEPENDENT schema-representation rule (enforced in 1.0 and 1.1).
+		c.checkAttributeChildren(ctx, elem)
+
 		// Attribute name must not be "xmlns".
 		if getAttr(elem, attrName) == lexicon.PrefixXMLNS {
 			c.schemaError(ctx, schemaParserErrorAttr(c.filename, line, local, "attribute", "name",
@@ -742,6 +749,59 @@ func (c *compiler) checkAttributeUse(ctx context.Context, elem *helium.Element) 
 					c.schemaError(ctx, schemaParserError(c.filename, ce.Line(), ce.LocalName(), "attribute",
 						"The attribute 'type' and the <simpleType> child are mutually exclusive."))
 				}
+			}
+		}
+	}
+}
+
+// checkAttributeChildren enforces the schema-representation content model of a
+// non-reference <xs:attribute> (XSD Structures §3.2.2): (annotation?, simpleType?).
+// It reports (does not abort) an annotation that is not first or is duplicated, a
+// second simpleType, and any other XSD-namespace element child (e.g. a nested
+// xs:attribute/xs:element/xs:complexType). Foreign-namespace children are ignored.
+// The type-vs-simpleType mutual-exclusion is enforced separately, so a simpleType
+// child is accepted here as content-model-valid. Version-INDEPENDENT.
+func (c *compiler) checkAttributeChildren(ctx context.Context, elem *helium.Element) {
+	if c.filename == "" {
+		return
+	}
+	local := elem.LocalName()
+
+	var annotationSeen bool
+	var simpleTypeSeen bool
+	var sawNonAnnotation bool
+	for child := range helium.Children(elem) {
+		if child.Type() != helium.ElementNode {
+			continue
+		}
+		ce, ok := helium.AsNode[*helium.Element](child)
+		if !ok {
+			continue
+		}
+		switch {
+		case isXSDElement(ce, elemAnnotation):
+			switch {
+			case annotationSeen:
+				c.schemaError(ctx, schemaParserError(c.diagSource(), ce.Line(), local, "attribute",
+					"An attribute declaration must not have more than one annotation."))
+			case sawNonAnnotation:
+				c.schemaError(ctx, schemaParserError(c.diagSource(), ce.Line(), local, "attribute",
+					"The annotation must appear before the simpleType."))
+			default:
+				annotationSeen = true
+			}
+		case isXSDElement(ce, elemSimpleType):
+			sawNonAnnotation = true
+			if simpleTypeSeen {
+				c.schemaError(ctx, schemaParserError(c.diagSource(), ce.Line(), local, "attribute",
+					"An attribute declaration must not have more than one simpleType."))
+			}
+			simpleTypeSeen = true
+		default:
+			sawNonAnnotation = true
+			if ce.URI() == lexicon.NamespaceXSD {
+				c.schemaError(ctx, schemaParserError(c.diagSource(), ce.Line(), local, "attribute",
+					fmt.Sprintf("The element '%s' is not allowed as a child of an attribute declaration; expected one of annotation or simpleType.", ce.LocalName())))
 			}
 		}
 	}


### PR DESCRIPTION
Enforce the schema-representation content model of a non-reference `<xs:attribute>` (XSD Structures §3.2.2): `(annotation?, simpleType?)`. A stray XSD-namespace element child (nested xs:attribute/xs:element/xs:complexType), a second simpleType, or an annotation after the simpleType is now a schema error. Version-independent (XSD 1.0 and 1.1).

Fixes msMeta/Attribute_w3c false-accepts attI005, attI006, attP001, attP002, attQ006.