### PR TITLE
reject unexpected attributes on schema wildcards

### DIFF
--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -275,6 +275,8 @@ func (c *compiler) validateWildcardNamespace(ctx context.Context, elem *helium.E
 }
 
 func (c *compiler) readWildcard(ctx context.Context, elem *helium.Element) *Wildcard {
+	c.checkWildcardAttrs(ctx, elem)
+
 	hasNS := hasAttr(elem, attrNamespace)
 	namespace := getAttr(elem, attrNamespace)
 	if !hasNS {
@@ -314,6 +316,52 @@ func (c *compiler) readWildcard(ctx context.Context, elem *helium.Element) *Wild
 		c.parseNotQName(ctx, elem, wc, getAttr(elem, attrNotQName), isXSDElement(elem, elemAnyAttribute))
 	}
 	return wc
+}
+
+// checkWildcardAttrs enforces the XML representation of an xs:any /
+// xs:anyAttribute wildcard's attributes (XSD §3.10.2). The permitted unqualified
+// attributes are {id, namespace, processContents} for both, PLUS {minOccurs,
+// maxOccurs} for the ELEMENT wildcard xs:any only — an attribute has no
+// occurrence constraint, so minOccurs/maxOccurs on xs:anyAttribute is a schema
+// error. Foreign-namespaced attributes are allowed; an XSD-namespaced attribute
+// or an unexpected unqualified attribute is a schema error.
+//
+// This rule is version-INDEPENDENT for the base attribute set. The 1.1 negated
+// constraints @notNamespace/@notQName are permitted-and-ignored in both versions
+// (in 1.0 they are unrecognized but leniently ignored, keeping the 1.0 path
+// byte-identical to origin). The stricter no-occurs grammar of an xs:openContent
+// wildcard is enforced separately by parseOpenContentWildcard.
+func (c *compiler) checkWildcardAttrs(ctx context.Context, elem *helium.Element) {
+	src := c.diagSource()
+	if src == "" {
+		return
+	}
+	local := elem.LocalName()
+	isAttr := isXSDElement(elem, elemAnyAttribute)
+	line := elem.Line()
+	for _, attr := range elem.Attributes() {
+		switch attr.URI() {
+		case "":
+			switch attr.LocalName() {
+			case "id", attrNamespace, attrProcessContents:
+			case attrMinOccurs, attrMaxOccurs:
+				if isAttr {
+					c.schemaError(ctx, schemaParserErrorAttr(src, line, local, local,
+						attr.LocalName(), "The attribute '"+attr.LocalName()+"' is not allowed on 'anyAttribute'."))
+				}
+			case attrNotNamespace, attrNotQName:
+				// XSD 1.1 negated constraints. In 1.0 they are unrecognized but
+				// leniently IGNORED (the 1.0 path is byte-identical to origin),
+				// so they are permitted-and-ignored in both versions here.
+			default:
+				c.schemaError(ctx, schemaParserErrorAttr(src, line, local, local,
+					attr.LocalName(), "The attribute '"+attr.LocalName()+"' is not allowed."))
+			}
+		case lexicon.NamespaceXSD:
+			c.schemaError(ctx, schemaParserErrorAttr(src, line, local, local,
+				attr.LocalName(), "The attribute '"+attr.LocalName()+"' is not allowed."))
+		}
+	}
 }
 
 // parseNotNamespace parses an xs:any/xs:anyAttribute @notNamespace value (XSD

--- a/xsd/wildcard_attrs_test.go
+++ b/xsd/wildcard_attrs_test.go
@@ -1,0 +1,161 @@
+package xsd_test
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWildcardAttrRepresentation covers the version-INDEPENDENT XML representation
+// of an xs:any / xs:anyAttribute wildcard's attributes (XSD §3.10.2): the
+// permitted unqualified attributes are {id, namespace, processContents} for both,
+// plus {minOccurs, maxOccurs} for the ELEMENT wildcard xs:any only. An unexpected
+// unqualified attribute, or minOccurs/maxOccurs on xs:anyAttribute, is a schema
+// error; a foreign-namespaced attribute is allowed. W3C Wildcards_w3c:
+// wildI002/wildI003 (stray attr on xs:any) and wildQ002/wildQ003/wildQ004
+// (occurrence attrs on xs:anyAttribute).
+func TestWildcardAttrRepresentation(t *testing.T) {
+	t.Parallel()
+
+	const notAllowed = "is not allowed"
+
+	compile := func(t *testing.T, src string) string {
+		t.Helper()
+		const mainXSD = "main.xsd"
+		fsys := fstest.MapFS{mainXSD: &fstest.MapFile{Data: []byte(src)}}
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, _ = xsd.NewCompiler().Label(mainXSD).ErrorHandler(collector).FS(fsys).Compile(t.Context(), doc)
+		require.NoError(t, collector.Close())
+		_, errStr := partitionCompileErrors(collector.Errors())
+		return errStr
+	}
+
+	t.Run("stray unqualified attr on xs:any rejected (wildI003)", func(t *testing.T) {
+		t.Parallel()
+		errStr := compile(t, `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="foo">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:any namespace="##other" processContents="lax" foo="bar"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`)
+		require.Contains(t, errStr, notAllowed)
+		require.Contains(t, errStr, "foo")
+	})
+
+	t.Run("unqualified attr alongside foreign attr on xs:any rejected (wildI002)", func(t *testing.T) {
+		t.Parallel()
+		// a:b is a foreign (non-schema) namespaced attribute and is ALLOWED; the
+		// unqualified b="c" is the representation error.
+		errStr := compile(t, `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="foo">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:any namespace="##other" processContents="lax" a:b="c" b="c" xmlns:a="http://foo"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`)
+		require.Contains(t, errStr, notAllowed)
+		require.Contains(t, errStr, "'b'")
+	})
+
+	t.Run("minOccurs on xs:anyAttribute rejected (wildQ002)", func(t *testing.T) {
+		t.Parallel()
+		errStr := compile(t, `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="foo">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:anyAttribute minOccurs="2"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`)
+		require.Contains(t, errStr, notAllowed)
+		require.Contains(t, errStr, "minOccurs")
+	})
+
+	t.Run("maxOccurs on xs:anyAttribute rejected (wildQ003)", func(t *testing.T) {
+		t.Parallel()
+		errStr := compile(t, `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="foo">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:anyAttribute maxOccurs="2"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`)
+		require.Contains(t, errStr, notAllowed)
+		require.Contains(t, errStr, "maxOccurs")
+	})
+
+	t.Run("minOccurs+maxOccurs on xs:anyAttribute rejected (wildQ004)", func(t *testing.T) {
+		t.Parallel()
+		errStr := compile(t, `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="foo">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:anyAttribute minOccurs="2" maxOccurs="unbounded"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`)
+		require.Contains(t, errStr, notAllowed)
+	})
+
+	t.Run("minOccurs+maxOccurs on xs:any compiles clean (no over-rejection)", func(t *testing.T) {
+		t.Parallel()
+		errStr := compile(t, `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="foo">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:any id="w" namespace="##other" processContents="lax" minOccurs="1" maxOccurs="2"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`)
+		require.False(t, strings.Contains(errStr, notAllowed),
+			"a well-formed xs:any must compile clean; got: %q", errStr)
+	})
+
+	t.Run("plain xs:anyAttribute compiles clean (no over-rejection)", func(t *testing.T) {
+		t.Parallel()
+		errStr := compile(t, `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="foo">
+    <xs:complexType>
+      <xs:anyAttribute id="w" namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`)
+		require.False(t, strings.Contains(errStr, notAllowed),
+			"a well-formed xs:anyAttribute must compile clean; got: %q", errStr)
+	})
+
+	t.Run("foreign-namespaced attr on wildcard allowed", func(t *testing.T) {
+		t.Parallel()
+		errStr := compile(t, `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:a="urn:a">
+  <xs:element name="foo">
+    <xs:complexType>
+      <xs:anyAttribute namespace="##other" processContents="lax" a:custom="x"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`)
+		require.False(t, strings.Contains(errStr, notAllowed),
+			"a foreign-namespaced attribute must be allowed; got: %q", errStr)
+	})
+}


### PR DESCRIPTION
Enforce the version-independent XML representation of xs:any / xs:anyAttribute wildcard attributes (XSD §3.10.2): the permitted unqualified attributes are {id, namespace, processContents} for both, plus {minOccurs, maxOccurs} for the element wildcard xs:any only. An unexpected unqualified attribute, or minOccurs/maxOccurs on xs:anyAttribute, is now a schema error; foreign-namespaced attributes stay allowed and the 1.1 negated constraints notNamespace/notQName remain permitted-and-ignored in 1.0.

Fixes W3C Wildcards_w3c false-accepts wildI002, wildI003, wildQ002, wildQ003, wildQ004.