### PR TITLE
Enforce whiteSpace valid restriction (XSD Part 2 §4.3.6)

### DIFF
--- a/xsd/check_facets.go
+++ b/xsd/check_facets.go
@@ -1254,6 +1254,7 @@ func (c *compiler) checkFacetSameTypeConsistency(ctx context.Context, td *TypeDe
 // the base type's facets.
 func (c *compiler) checkFacetBaseRestriction(ctx context.Context, td *TypeDef, fs *FacetSet, line int, component string) {
 	c.checkBuiltinFixedFacetRestriction(ctx, td, fs, line, component)
+	c.checkWhiteSpaceValidRestriction(ctx, td, fs, line, component)
 
 	base := baseFacets(td)
 	if base == nil {
@@ -1596,6 +1597,36 @@ func explicitTimezoneApplicable(builtinLocal string) bool {
 	default:
 		return false
 	}
+}
+
+// checkWhiteSpaceValidRestriction enforces the "whiteSpace valid restriction"
+// schema component constraint (XSD Part 2 §4.3.6): a simple type that restricts a
+// base whose effective whiteSpace facet is more restrictive may only tighten,
+// never loosen, that facet. The permitted ordering is preserve → replace →
+// collapse (a derived value may equal or move rightward, never leftward):
+//   - a base whiteSpace of 'collapse' admits only a derived 'collapse';
+//   - a base whiteSpace of 'replace' forbids a derived 'preserve'.
+//
+// This is a version-INDEPENDENT XSD rule (the constraint text is identical in
+// 1.0 and 1.1), so it runs in both. The builtin-fixed-collapse types
+// (xs:date and family) are already reported by checkBuiltinFixedFacetRestriction
+// with a fixed-value message, so they are skipped here to avoid a double report.
+func (c *compiler) checkWhiteSpaceValidRestriction(ctx context.Context, td *TypeDef, fs *FacetSet, line int, component string) {
+	if fs.WhiteSpace == nil || td.BaseType == nil {
+		return
+	}
+	if _, fixed := fixedBuiltinWhiteSpace(builtinBaseLocal(td)); fixed {
+		return
+	}
+
+	baseWS := resolveWhiteSpace(td.BaseType)
+	derived := *fs.WhiteSpace
+	if whiteSpaceRestrictiveness(derived) >= whiteSpaceRestrictiveness(baseWS) {
+		return
+	}
+	c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+		fmt.Sprintf("The value '%s' of the facet 'whiteSpace' is not a valid restriction of the 'whiteSpace' value '%s' of the base type.",
+			derived, baseWS)))
 }
 
 func fixedBuiltinWhiteSpace(builtinLocal string) (string, bool) {

--- a/xsd/facet_whitespace_restriction_test.go
+++ b/xsd/facet_whitespace_restriction_test.go
@@ -1,0 +1,128 @@
+package xsd_test
+
+import (
+	"fmt"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWhiteSpaceValidRestriction verifies the "whiteSpace valid restriction"
+// schema component constraint (XSD Part 2 §4.3.6): a simple type restricting a
+// base with a more restrictive whiteSpace facet may only tighten, never loosen,
+// that facet. The permitted ordering is preserve → replace → collapse (a derived
+// value may equal or move rightward). A base 'collapse' admits only 'collapse';
+// a base 'replace' forbids 'preserve'. This is version-independent, enforced in
+// both XSD 1.0 (the default) and 1.1. (W3C msMeta/SimpleType_w3c stZ013, stZ018,
+// stZ019, stZ022, stZ026-stZ028.)
+func TestWhiteSpaceValidRestriction(t *testing.T) {
+	t.Parallel()
+
+	const (
+		wantMsg    = "is not a valid restriction of the 'whiteSpace' value"
+		wsPreserve = "preserve"
+		wsReplace  = "replace"
+		wsCollapse = "collapse"
+	)
+
+	// Two-step derivation: type_a restricts xs:string with baseWS, then type_b
+	// restricts type_a with derivedWS.
+	chainSchema := func(baseWS, derivedWS string) string {
+		return fmt.Sprintf(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="type_a">
+    <xs:restriction base="xs:string">
+      <xs:whiteSpace value="%s"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="type_b">
+    <xs:restriction base="type_a">
+      <xs:whiteSpace value="%s"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`, baseWS, derivedWS)
+	}
+
+	// Nested-simpleType base (no @base attribute): the inner anonymous simpleType
+	// supplies the base whiteSpace, the outer restriction the derived value.
+	nestedSchema := func(baseWS, derivedWS string) string {
+		return fmt.Sprintf(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="type_c">
+    <xs:restriction>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:whiteSpace value="%s"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:whiteSpace value="%s"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`, baseWS, derivedWS)
+	}
+
+	compile := func(t *testing.T, schemaXML string, v ...xsd.Version) (string, error) {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		compiler := xsd.NewCompiler().Label("test.xsd").ErrorHandler(collector)
+		for _, ver := range v {
+			compiler = compiler.Version(ver)
+		}
+		_, cerr := compiler.Compile(t.Context(), doc)
+		_, errStr := partitionCompileErrors(collector.Errors())
+		return errStr, cerr
+	}
+
+	// Loosening a more-restrictive base whiteSpace is a schema error.
+	invalid := []struct{ baseWS, derivedWS string }{
+		{wsCollapse, wsReplace},  // stZ018
+		{wsCollapse, wsPreserve}, // stZ019
+		{wsReplace, wsPreserve},  // stZ013 type_b, stZ022
+	}
+	for _, tc := range invalid {
+		t.Run(fmt.Sprintf("reject chain %s->%s", tc.baseWS, tc.derivedWS), func(t *testing.T) {
+			t.Parallel()
+			errStr, cerr := compile(t, chainSchema(tc.baseWS, tc.derivedWS))
+			requireCompileResultErr(t, cerr)
+			require.Contains(t, errStr, wantMsg)
+		})
+		t.Run(fmt.Sprintf("reject nested %s->%s", tc.baseWS, tc.derivedWS), func(t *testing.T) {
+			t.Parallel()
+			errStr, cerr := compile(t, nestedSchema(tc.baseWS, tc.derivedWS))
+			requireCompileResultErr(t, cerr)
+			require.Contains(t, errStr, wantMsg)
+		})
+	}
+
+	// Tightening or keeping a base whiteSpace is valid (stZ017/020/021/023-025/029).
+	valid := []struct{ baseWS, derivedWS string }{
+		{wsCollapse, wsCollapse},
+		{wsReplace, wsCollapse},
+		{wsReplace, wsReplace},
+		{wsPreserve, wsCollapse},
+		{wsPreserve, wsReplace}, // stZ013 type_d, stZ029
+		{wsPreserve, wsPreserve},
+	}
+	for _, tc := range valid {
+		t.Run(fmt.Sprintf("accept chain %s->%s", tc.baseWS, tc.derivedWS), func(t *testing.T) {
+			t.Parallel()
+			_, cerr := compile(t, chainSchema(tc.baseWS, tc.derivedWS))
+			require.NoError(t, cerr)
+		})
+		t.Run(fmt.Sprintf("accept nested %s->%s", tc.baseWS, tc.derivedWS), func(t *testing.T) {
+			t.Parallel()
+			_, cerr := compile(t, nestedSchema(tc.baseWS, tc.derivedWS))
+			require.NoError(t, cerr)
+		})
+	}
+
+	// Version-independence: an invalid loosening is rejected under 1.1 too.
+	t.Run("reject under XSD 1.1", func(t *testing.T) {
+		t.Parallel()
+		errStr, cerr := compile(t, chainSchema(wsCollapse, wsPreserve), xsd.Version11)
+		requireCompileResultErr(t, cerr)
+		require.Contains(t, errStr, wantMsg)
+	})
+}

--- a/xsd/simplevalue_core.go
+++ b/xsd/simplevalue_core.go
@@ -87,6 +87,21 @@ func resolveWhiteSpace(td *TypeDef) string {
 	return "collapse"
 }
 
+// whiteSpaceRestrictiveness ranks a whiteSpace facet value by how much it
+// normalizes: preserve (0) < replace (1) < collapse (2). A derived simple type
+// may only keep or increase the rank of its base's whiteSpace (XSD Part 2
+// §4.3.6); it may never decrease it.
+func whiteSpaceRestrictiveness(ws string) int {
+	switch ws {
+	case "preserve":
+		return 0
+	case "replace":
+		return 1
+	default: // collapse
+		return 2
+	}
+}
+
 // normalizeWhiteSpace applies XSD whitespace normalization to a value.
 //   - "preserve": no change
 //   - "replace": replace \t, \n, \r with space


### PR DESCRIPTION
Reject a simple type whose `whiteSpace` facet loosens its base's effective `whiteSpace` (permitted ordering: preserve → replace → collapse; may only tighten or keep). Version-independent XSD rule, enforced in both 1.0 (default) and 1.1.

- Fixes W3C msMeta/SimpleType_w3c false-accepts stZ013, stZ018, stZ019, stZ022, stZ026-stZ028 (both the two-step and nested-simpleType base forms).
- TestGoldenFiles stays byte-identical; valid tightening/equal schemas (stZ017/020/021/023-025/029) still compile.