### PR TITLE
reject less-restrictive whiteSpace facet restriction

### DIFF
--- a/xsd/check_facets.go
+++ b/xsd/check_facets.go
@@ -1555,10 +1555,26 @@ func (c *compiler) checkBuiltinFixedFacetRestriction(ctx context.Context, td *Ty
 	}
 
 	if fs.WhiteSpace != nil {
-		if fixed, ok := fixedBuiltinWhiteSpace(builtinLocal); ok && *fs.WhiteSpace != fixed {
-			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
-				fmt.Sprintf("The value '%s' of the facet 'whiteSpace' does not match the fixed value '%s' of the base type '%s'.",
-					*fs.WhiteSpace, fixed, typeDisplayName(td.BaseType))))
+		if fixed, ok := fixedBuiltinWhiteSpace(builtinLocal); ok {
+			if *fs.WhiteSpace != fixed {
+				c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+					fmt.Sprintf("The value '%s' of the facet 'whiteSpace' does not match the fixed value '%s' of the base type '%s'.",
+						*fs.WhiteSpace, fixed, typeDisplayName(td.BaseType))))
+			}
+		} else if td.BaseType != nil {
+			// whiteSpace Valid Restriction (§4.3.6): the derived value must not be
+			// LESS restrictive than the base type's effective whiteSpace. The
+			// ordering is preserve < replace < collapse, so a restriction of a
+			// `replace` base (e.g. xs:normalizedString) to `preserve`, or of a
+			// `collapse` base (e.g. xs:token) to `preserve`/`replace`, is a schema
+			// error. Version-independent. (The fixed-builtin case above already
+			// covers the date/time family, which fixes whiteSpace=collapse.)
+			inherited := resolveWhiteSpace(td.BaseType)
+			if whiteSpaceRank(*fs.WhiteSpace) < whiteSpaceRank(inherited) {
+				c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+					fmt.Sprintf("The value '%s' of the facet 'whiteSpace' is less restrictive than the 'whiteSpace' value '%s' of the base type '%s'.",
+						*fs.WhiteSpace, inherited, typeDisplayName(td.BaseType))))
+			}
 		}
 	}
 
@@ -1595,6 +1611,21 @@ func explicitTimezoneApplicable(builtinLocal string) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// whiteSpaceRank orders the three whiteSpace facet values by restrictiveness so a
+// derived value can be compared against the inherited base value (§4.3.6):
+// preserve (0) < replace (1) < collapse (2). An unrecognized value ranks as the
+// least restrictive so it never spuriously rejects a restriction.
+func whiteSpaceRank(v string) int {
+	switch v {
+	case "replace":
+		return 1
+	case "collapse":
+		return 2
+	default: // "preserve" and any unrecognized value
+		return 0
 	}
 }
 

--- a/xsd/facet_whitespace_restriction_test.go
+++ b/xsd/facet_whitespace_restriction_test.go
@@ -1,0 +1,76 @@
+package xsd_test
+
+import (
+	"fmt"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWhiteSpaceValidRestriction verifies whiteSpace Valid Restriction (§4.3.6):
+// the derived whiteSpace facet must not be LESS restrictive than the base type's
+// effective whiteSpace. The ordering is preserve < replace < collapse, so
+// restricting xs:normalizedString (replace) or xs:token (collapse) to preserve is
+// a schema error in BOTH XSD 1.0 and 1.1. This is the root cause behind the
+// msMeta/DataTypes_w3c false-accepts normalizedString_whitespace001 and
+// token_whitespace001.
+func TestWhiteSpaceValidRestriction(t *testing.T) {
+	t.Parallel()
+
+	const wantMsg = "is less restrictive than the 'whiteSpace' value"
+	const tokenBase = "xs:token"
+
+	schemaFor := func(base, ws string) string {
+		return fmt.Sprintf(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="t">
+    <xs:restriction base="%s">
+      <xs:whiteSpace value="%s"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="root" type="t"/>
+</xs:schema>`, base, ws)
+	}
+
+	compile := func(t *testing.T, schemaXML string) (string, error) {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, cerr := xsd.NewCompiler().Label("test.xsd").ErrorHandler(collector).Compile(t.Context(), doc)
+		_, errStr := partitionCompileErrors(collector.Errors())
+		return errStr, cerr
+	}
+
+	reject := []struct{ base, ws string }{
+		{"xs:normalizedString", "preserve"}, // replace base, less restrictive
+		{tokenBase, "preserve"},             // collapse base, less restrictive
+		{tokenBase, "replace"},              // collapse base, less restrictive
+		{"xs:language", "preserve"},         // collapse base (token-derived)
+	}
+	for _, tc := range reject {
+		t.Run(fmt.Sprintf("reject %s whiteSpace=%s", tc.base, tc.ws), func(t *testing.T) {
+			t.Parallel()
+			errStr, cerr := compile(t, schemaFor(tc.base, tc.ws))
+			requireCompileResultErr(t, cerr)
+			require.Contains(t, errStr, wantMsg)
+		})
+	}
+
+	accept := []struct{ base, ws string }{
+		{"xs:string", "preserve"},           // preserve base, equal
+		{"xs:string", "replace"},            // preserve base, more restrictive
+		{"xs:string", "collapse"},           // preserve base, more restrictive
+		{"xs:normalizedString", "replace"},  // replace base, equal
+		{"xs:normalizedString", "collapse"}, // replace base, more restrictive
+		{tokenBase, "collapse"},             // collapse base, equal
+	}
+	for _, tc := range accept {
+		t.Run(fmt.Sprintf("accept %s whiteSpace=%s", tc.base, tc.ws), func(t *testing.T) {
+			t.Parallel()
+			_, cerr := compile(t, schemaFor(tc.base, tc.ws))
+			require.NoError(t, cerr)
+		})
+	}
+}


### PR DESCRIPTION
Enforce whiteSpace Valid Restriction (XSD Part 2 §4.3.6): a derived whiteSpace facet must not be less restrictive than the base type's effective whiteSpace (ordering preserve < replace < collapse). Version-independent. Fixes msMeta/DataTypes_w3c false-accepts normalizedString_whitespace001 and token_whitespace001, plus SimpleType_w3c stZ013/018/019/022/026/027/028.