### PR TITLE
Enforce src-import namespace representation rules

### DIFF
--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -796,6 +796,16 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 		}
 	}
 
+	// A present targetNamespace must not be the empty string (§3.1 / Schema
+	// Representation): the absent-namespace case is expressed by OMITTING the
+	// attribute, so an explicit targetNamespace="" is a schema-representation error.
+	// Presence is detected with hasAttr so a genuinely absent targetNamespace stays
+	// valid. Version-independent.
+	if hasAttr(root, attrTargetNamespace) && getAttr(root, attrTargetNamespace) == "" && c.filename != "" {
+		c.schemaError(ctx, schemaParserErrorAttr(c.filename, root.Line(), root.LocalName(), elemSchema, attrTargetNamespace,
+			"The value '' is not valid; the targetNamespace of a schema must not be the empty string."))
+	}
+
 	// First pass: collect all named types and global elements.
 	if err := c.parseSchemaChildren(ctx, root); err != nil {
 		return nil, err

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -269,6 +269,36 @@ func (c *compiler) reportSchemaLoadWarning(ctx context.Context, elem *helium.Ele
 // same diagnostics as a top-level import.
 func (c *compiler) processImport(ctx context.Context, elem *helium.Element) error {
 	ns := getAttr(elem, attrNamespace)
+
+	// src-import (§4.2.6.1 Import Constraints and Semantics): the <xs:import>
+	// @namespace representation constraints, version-independent. A violation is a
+	// schema-representation error, so the invalid import declaration is reported and
+	// skipped (never loaded). Only enforced when a filename is available (the same
+	// gating the other schema-parser diagnostics use).
+	if c.filename != "" {
+		nsPresent := hasAttr(elem, attrNamespace)
+		switch {
+		case nsPresent && ns == "":
+			// An empty @namespace is not a namespace name: the ABSENT namespace is
+			// imported by OMITTING @namespace, never by namespace="".
+			c.schemaError(ctx, schemaParserErrorAttr(c.filename, elem.Line(), elem.LocalName(), elemImport, attrNamespace,
+				"The value '' is not valid; the namespace of an <import> must not be the empty string."))
+			return nil
+		case nsPresent && ns == c.schema.targetNamespace && c.schemaTargetNSSet:
+			// src-import.1.1: @namespace must not match the enclosing schema's own
+			// targetNamespace (a schema does not import its own namespace).
+			c.schemaError(ctx, schemaParserErrorAttr(c.filename, elem.Line(), elem.LocalName(), elemImport, attrNamespace,
+				"The namespace '"+ns+"' must not match the target namespace of the importing schema."))
+			return nil
+		case !nsPresent && !c.schemaTargetNSSet:
+			// src-import.1.2: an <import> without @namespace requires the enclosing
+			// schema to have a targetNamespace.
+			c.schemaError(ctx, schemaParserError(c.filename, elem.Line(), elem.LocalName(), elemImport,
+				"An <import> without a namespace attribute requires the enclosing schema to have a targetNamespace."))
+			return nil
+		}
+	}
+
 	// Record the namespace as import-declared BEFORE any early return, so a
 	// location-less import (and, below, one whose load fails) still marks the
 	// namespace referenceable — its declarations are simply unknown.

--- a/xsd/import_srcimport_test.go
+++ b/xsd/import_srcimport_test.go
@@ -1,0 +1,114 @@
+package xsd_test
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// src-import (§4.2.6.1) constrains the @namespace of an <xs:import>, and a
+// schema's @targetNamespace must not be the empty string. Both are
+// version-independent schema-representation constraints surfaced through the
+// ErrorHandler. These mirror W3C msMeta/Schema_w3c cases schZ014_a (namespace=""),
+// schF4/schZ010 (import of own targetNamespace), schF3 (no-namespace import into a
+// no-targetNamespace schema) and schZ014_b (targetNamespace="").
+func TestCompile_SrcImportNamespaceConstraints(t *testing.T) {
+	compileErrors := func(t *testing.T, fsys fstest.MapFS) string {
+		t.Helper()
+		data, err := fsys.ReadFile(importMainXSD)
+		require.NoError(t, err)
+		doc, err := helium.NewParser().Parse(t.Context(), data)
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, err = xsd.NewCompiler().Label(importMainXSD).ErrorHandler(collector).FS(fsys).Compile(t.Context(), doc)
+		requireCompileResultErr(t, err)
+		var b strings.Builder
+		for _, e := range collector.Errors() {
+			b.WriteString(e.Error())
+		}
+		return b.String()
+	}
+
+	// namespace="" is not a namespace name; the absent namespace is imported by
+	// OMITTING @namespace. Reject (schZ014_a).
+	t.Run("empty import namespace", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			importMainXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import namespace=""/>
+</xs:schema>`)},
+		}
+		require.Contains(t, compileErrors(t, fsys), "must not be the empty string")
+	})
+
+	// src-import.1.1: @namespace must not match the importing schema's own
+	// targetNamespace. Reject (schF4/schZ010).
+	t.Run("import of own targetNamespace", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			importMainXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="urn:main">
+  <xs:import namespace="urn:main"/>
+  <xs:element name="e" type="xs:string"/>
+</xs:schema>`)},
+		}
+		require.Contains(t, compileErrors(t, fsys), "must not match the target namespace")
+	})
+
+	// src-import.1.2: an <import> without @namespace requires the enclosing schema
+	// to have a targetNamespace. Reject (schF3).
+	t.Run("no-namespace import in no-targetNamespace schema", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			importMainXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import schemaLocation="other.xsd"/>
+</xs:schema>`)},
+			importOtherXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="e" type="xs:string"/>
+</xs:schema>`)},
+		}
+		require.Contains(t, compileErrors(t, fsys), "requires the enclosing schema to have a targetNamespace")
+	})
+
+	// A present targetNamespace must not be the empty string. Reject (schZ014_b).
+	t.Run("empty schema targetNamespace", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			importMainXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="">
+</xs:schema>`)},
+		}
+		require.Contains(t, compileErrors(t, fsys), "targetNamespace of a schema must not be the empty string")
+	})
+
+	// Guard against over-rejection: importing a DIFFERENT namespace is valid.
+	t.Run("import of a different namespace is accepted", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			importMainXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="urn:main">
+  <xs:import namespace="urn:other" schemaLocation="other.xsd"/>
+  <xs:element name="e" type="xs:string"/>
+</xs:schema>`)},
+			importOtherXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="urn:other">
+  <xs:element name="o" type="xs:string"/>
+</xs:schema>`)},
+		}
+		require.Empty(t, compileErrors(t, fsys))
+	})
+
+	// Guard against over-rejection: a no-namespace import IS valid when the
+	// enclosing schema has a targetNamespace (imports the absent namespace).
+	t.Run("no-namespace import with a targetNamespace is accepted", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			importMainXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="urn:main">
+  <xs:import schemaLocation="other.xsd"/>
+  <xs:element name="e" type="xs:string"/>
+</xs:schema>`)},
+			importOtherXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="o" type="xs:string"/>
+</xs:schema>`)},
+		}
+		require.Empty(t, compileErrors(t, fsys))
+	})
+}


### PR DESCRIPTION
Reject an `<xs:import>` whose `@namespace` is empty, equals the enclosing schema targetNamespace (src-import.1.1), or is absent while the enclosing schema has no targetNamespace (src-import.1.2), plus a schema `targetNamespace=""`. Version-independent (§4.2.6.1 / §3.1). Fixes W3C msMeta/Schema_w3c false-accepts schZ014_a, schF4, schZ010, schF3, schZ014_b.