### PR TITLE
reject @name on local complexType

### DIFF
--- a/xsd/alternative.go
+++ b/xsd/alternative.go
@@ -302,7 +302,7 @@ func (c *compiler) parseInlineAlternativeType(ctx context.Context, elem *helium.
 		}
 		switch {
 		case isXSDElement(ce, elemComplexType):
-			td, err := c.parseComplexType(ctx, ce)
+			td, err := c.parseComplexType(ctx, ce, true)
 			return td, true, err
 		case isXSDElement(ce, elemSimpleType):
 			td, err := c.parseSimpleType(ctx, ce, true)

--- a/xsd/local_complextype_name_test.go
+++ b/xsd/local_complextype_name_test.go
@@ -1,0 +1,81 @@
+package xsd_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// A LOCAL (anonymous/inline) xs:complexType — nested in an xs:element or an
+// xs:alternative — must NOT carry a @name (XSD Structures §3.4.2: localComplexType
+// has no {name}). This is version-independent, so it is enforced under both XSD
+// 1.0 (default) and XSD 1.1. W3C ComplexType_w3c ctA042. A top-level named
+// complexType and an anonymous local complexType without @name still compile.
+func TestLocalComplexType_MustNotHaveName(t *testing.T) {
+	t.Parallel()
+
+	// ctA042: a local complexType inside an xs:element carries @name="fooType".
+	const named = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="myElement">
+    <xs:complexType name="fooType">
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:attribute name="attrTest"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+	t.Run("invalid/named-local", func(t *testing.T) {
+		t.Parallel()
+		for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+			schema, errs, cerr := compileWith(t, v, named)
+			require.ErrorIs(t, cerr, xsd.ErrCompilationFailed, "version=%v must reject named local complexType", v)
+			require.Nil(t, schema)
+			require.Contains(t, errs, "A local complexType definition must not have a 'name' attribute.", "version=%v", v)
+		}
+	})
+
+	// An anonymous local complexType (no @name) must still compile.
+	const anon = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="myElement">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:attribute name="attrTest"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+	t.Run("valid/anonymous-local", func(t *testing.T) {
+		t.Parallel()
+		for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+			_, errs, cerr := compileWith(t, v, anon)
+			require.NoError(t, cerr, "version=%v must accept anonymous local complexType: %s", v, errs)
+		}
+	})
+
+	// A top-level named complexType is legitimate.
+	const global = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="fooType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="attrTest"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:element name="myElement" type="fooType"/>
+</xs:schema>`
+
+	t.Run("valid/global-named", func(t *testing.T) {
+		t.Parallel()
+		for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+			_, errs, cerr := compileWith(t, v, global)
+			require.NoError(t, cerr, "version=%v must accept top-level named complexType: %s", v, errs)
+		}
+	})
+}

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -596,7 +596,7 @@ func (c *compiler) readElementType(ctx context.Context, elem *helium.Element, de
 		}
 		switch {
 		case isXSDElement(ce, elemComplexType):
-			td, err := c.parseComplexType(ctx, ce)
+			td, err := c.parseComplexType(ctx, ce, true)
 			if err != nil {
 				return err
 			}

--- a/xsd/read_types.go
+++ b/xsd/read_types.go
@@ -41,7 +41,7 @@ func (c *compiler) parseNamedComplexType(ctx context.Context, elem *helium.Eleme
 		return nil
 	}
 
-	td, err := c.parseComplexType(ctx, elem)
+	td, err := c.parseComplexType(ctx, elem, false)
 	if err != nil {
 		return err
 	}
@@ -124,9 +124,20 @@ func (c *compiler) recordAttrGroupRef(td *TypeDef, qn QName, src attrGroupRefUse
 	c.attrGroupRefUseSources[td] = append(c.attrGroupRefUseSources[td], src)
 }
 
-func (c *compiler) parseComplexType(ctx context.Context, elem *helium.Element) (*TypeDef, error) {
+func (c *compiler) parseComplexType(ctx context.Context, elem *helium.Element, local bool) (*TypeDef, error) {
 	td := &TypeDef{IsComplex: true}
 	c.recordTypeDefSource(td, elem.Line(), true, elem.LocalName())
+
+	// A LOCAL (anonymous/inline) xs:complexType — one whose parent is an element
+	// or an xs:alternative — must NOT carry a @name (XSD Structures §3.4.2:
+	// localComplexType has no {name}). Only a top-level complexType (child of
+	// xs:schema/xs:redefine/xs:override) is named. Version-independent XSD rule;
+	// report-and-continue so the body still parses.
+	if local && hasAttr(elem, attrName) && c.filename != "" {
+		c.schemaError(ctx, schemaComponentError(c.diagSource(), elem.Line(),
+			elem.LocalName(), componentLocalComplexType,
+			"A local complexType definition must not have a 'name' attribute."))
+	}
 
 	// The @block and @final attributes on a complexType are both of type
 	// (#all | List of (extension | restriction)) (XSD Structures §3.4.2). Neither


### PR DESCRIPTION
A local (anonymous/inline) `xs:complexType` — nested in an `xs:element` or `xs:alternative` — must not carry a `@name` (§3.4.2: localComplexType has no {name}). `parseComplexType` now takes a `local` flag and reports a schema error when a local complexType has `@name`, mirroring the existing local-simpleType rule. Version-independent. Fixes W3C ComplexType_w3c ctA042.
