### PR TITLE
reject unknown attrs on xs:element/xs:attribute

### DIFF
--- a/xsd/check_elements.go
+++ b/xsd/check_elements.go
@@ -96,6 +96,9 @@ func (c *compiler) checkGlobalElement(ctx context.Context, elem *helium.Element)
 	line := elem.Line()
 	local := elem.LocalName()
 
+	// Closed attribute-vocabulary check (§3.3.2, version-INDEPENDENT).
+	c.checkElementAttrVocabulary(ctx, elem)
+
 	// name is required for global elements.
 	if name == "" {
 		c.schemaError(ctx, schemaParserError(c.filename, line, local, "element",
@@ -175,6 +178,85 @@ func (c *compiler) checkGlobalElement(ctx context.Context, elem *helium.Element)
 					"The attribute 'type' and the <simpleType> child are mutually exclusive."))
 			}
 		}
+	}
+}
+
+// elementAttrAllowed reports whether name is a recognized unqualified attribute
+// of an <xs:element> declaration in ANY of its forms — global (topLevelElement),
+// local (localElement), or element reference — across XSD 1.0 and 1.1. Per
+// §3.3.2 the schema-for-schemas gives xs:element a CLOSED attribute set with an
+// `##other` anyAttribute admitting foreign-namespaced attributes; an unqualified
+// attribute outside this vocabulary (e.g. `nullable`, a misspelling of
+// `nillable`, or a random `foo`) is a schema-representation error. Attributes
+// recognized but disallowed for the SPECIFIC form (ref/minOccurs/maxOccurs/form
+// on a global, abstract/substitutionGroup/final on a local, …) are reported by
+// the form-specific checks in checkGlobalElement/checkLocalElement, so this
+// vocabulary predicate is the UNION of every form to avoid double-diagnosing
+// those. targetNamespace and abstract/final/substitutionGroup are included even
+// though a given form/version forbids them, since the goal here is only to reject
+// attributes that belong to NO xs:element form at all.
+func elementAttrAllowed(name string) bool {
+	switch name {
+	case "id", attrName, attrRef, attrType, attrMinOccurs, attrMaxOccurs,
+		attrDefault, attrFixed, attrNillable, attrBlock, attrForm,
+		attrSubstitutionGroup, attrFinal, attrAbstract, attrTargetNamespace:
+		return true
+	}
+	return false
+}
+
+// checkElementAttrVocabulary reports every unqualified attribute on an
+// <xs:element> declaration that is outside the closed §3.3.2 vocabulary.
+// Foreign-namespaced attributes (vc:, xml:, any qualified name) are admitted by
+// the schema-for-schemas `##other` anyAttribute, so only no-namespace attributes
+// are checked. Version-INDEPENDENT.
+func (c *compiler) checkElementAttrVocabulary(ctx context.Context, elem *helium.Element) {
+	line := elem.Line()
+	local := elem.LocalName()
+	src := c.diagSource()
+	for _, attr := range elem.Attributes() {
+		if attr.URI() != "" || elementAttrAllowed(attr.LocalName()) {
+			continue
+		}
+		c.schemaError(ctx, schemaParserError(src, line, local, elemElement,
+			"The attribute '"+attr.LocalName()+"' is not allowed."))
+	}
+}
+
+// attributeAttrAllowed reports whether name is a recognized unqualified attribute
+// of an <xs:attribute> declaration in ANY of its forms — global
+// (topLevelAttribute), local attribute use, or attribute reference — across XSD
+// 1.0 and 1.1. Per §3.2.2 the schema-for-schemas gives xs:attribute a CLOSED
+// attribute set with an `##other` anyAttribute admitting foreign-namespaced
+// attributes; an unqualified attribute outside this vocabulary (e.g. a random
+// `value`) is a schema-representation error. Attributes recognized but disallowed
+// for the SPECIFIC form (use/form/ref on a global, …) are reported by the
+// form-specific checks in checkAttributeUse, so this predicate is the UNION of
+// every form. inheritable/targetNamespace are XSD 1.1 additions kept in the union
+// so 1.1 schemas are not over-rejected.
+func attributeAttrAllowed(name string) bool {
+	switch name {
+	case "id", attrName, attrRef, attrType, attrUse, attrDefault, attrFixed,
+		attrForm, attrTargetNamespace, attrInheritable:
+		return true
+	}
+	return false
+}
+
+// checkAttrVocabulary reports every unqualified attribute on an <xs:attribute>
+// declaration that is outside the closed §3.2.2 vocabulary. Foreign-namespaced
+// attributes are admitted by the schema-for-schemas `##other` anyAttribute, so
+// only no-namespace attributes are checked. Version-INDEPENDENT.
+func (c *compiler) checkAttrVocabulary(ctx context.Context, elem *helium.Element) {
+	line := elem.Line()
+	local := elem.LocalName()
+	src := c.diagSource()
+	for _, attr := range elem.Attributes() {
+		if attr.URI() != "" || attributeAttrAllowed(attr.LocalName()) {
+			continue
+		}
+		c.schemaError(ctx, schemaParserError(src, line, local, "attribute",
+			"The attribute '"+attr.LocalName()+"' is not allowed."))
 	}
 }
 
@@ -302,6 +384,9 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 	name := getAttr(elem, attrName)
 	line := elem.Line()
 	local := elem.LocalName()
+
+	// Closed attribute-vocabulary check (§3.3.2, version-INDEPENDENT).
+	c.checkElementAttrVocabulary(ctx, elem)
 
 	minOcc := getAttr(elem, attrMinOccurs)
 	maxOcc := getAttr(elem, attrMaxOccurs)
@@ -547,6 +632,9 @@ func (c *compiler) checkAttributeUse(ctx context.Context, elem *helium.Element) 
 	ref := getAttr(elem, attrRef)
 	line := elem.Line()
 	local := elem.LocalName()
+
+	// Closed attribute-vocabulary check (§3.2.2, version-INDEPENDENT).
+	c.checkAttrVocabulary(ctx, elem)
 
 	// XSD 1.1 Schema Representation Constraint (Attribute Declaration
 	// Representation OK): a prohibited attribute use must not carry a value

--- a/xsd/element_attr_vocabulary_test.go
+++ b/xsd/element_attr_vocabulary_test.go
@@ -1,0 +1,83 @@
+package xsd_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// §3.3.2 / §3.2.2: xs:element and xs:attribute declarations have a CLOSED
+// attribute vocabulary with an `##other` anyAttribute admitting only
+// foreign-namespaced attributes. An unknown UNQUALIFIED (no-namespace) attribute
+// is a schema-representation error, while vc:/xml:/other-namespace attributes and
+// every legitimate xs attribute are accepted. Version-INDEPENDENT.
+func TestElementAttribute_ClosedAttrVocabulary(t *testing.T) {
+	t.Parallel()
+
+	const shell = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
+    xmlns:foo="urn:foo" targetNamespace="urn:t" xmlns:t="urn:t">
+  %s
+</xs:schema>`
+
+	invalid := []struct {
+		name string
+		body string
+	}{
+		// elemK007: nullable is a misspelling of nillable on a global element.
+		{"global-nullable", `<xs:element name="foo" nullable="true"/>`},
+		// elemN006: a random unqualified attribute on a global element.
+		{"global-foo", `<xs:element name="myElem" type="xs:string" foo="bar"/>`},
+		// A random unqualified attribute on a local element.
+		{"local-foo", `<xs:complexType name="ct"><xs:sequence><xs:element name="e" type="xs:string" bogus="1"/></xs:sequence></xs:complexType>`},
+		// A random unqualified attribute on an element ref.
+		{"ref-foo", `<xs:element name="g" type="xs:string"/><xs:complexType name="ct"><xs:sequence><xs:element ref="t:g" bogus="1"/></xs:sequence></xs:complexType>`},
+		// An attribute-only attribute (use) on an element is unknown to xs:element.
+		{"element-use", `<xs:element name="e2" type="xs:string" use="optional"/>`},
+		// attH001: a random unqualified attribute on a local attribute.
+		{"attr-value", `<xs:complexType name="ct"><xs:attribute name="a" value="string" use="optional"/></xs:complexType>`},
+		// A random unqualified attribute on a global attribute.
+		{"global-attr-foo", `<xs:attribute name="ga" type="xs:string" foo="bar"/>`},
+	}
+	for _, tc := range invalid {
+		t.Run("invalid/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			schemaXML := fmt.Sprintf(shell, tc.body)
+			for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+				schema, errs, cerr := compileWith(t, v, schemaXML)
+				require.ErrorIs(t, cerr, xsd.ErrCompilationFailed, "version=%v must reject unknown attribute: %s", v, errs)
+				require.Nil(t, schema)
+				require.Contains(t, errs, "is not allowed", "version=%v", v)
+			}
+		})
+	}
+
+	valid := []struct {
+		name string
+		body string
+	}{
+		// A global element carrying its full legitimate attribute set plus
+		// foreign-namespace (vc:, xml:, other) attributes.
+		{"global-full", `<xs:element name="g" type="xs:string" id="g1" default="x" nillable="true" abstract="false" final="restriction" block="extension" vc:minVersion="1.1" xml:lang="en" foo:bar="baz"/>`},
+		// A local element with occurs/form/ref legitimate attributes.
+		{"local-full", `<xs:complexType name="ct"><xs:sequence><xs:element name="e" type="xs:string" minOccurs="0" maxOccurs="2" fixed="v" nillable="true" block="extension" form="qualified" id="e1" vc:minVersion="1.1"/></xs:sequence></xs:complexType>`},
+		// An element ref with its legitimate attribute set.
+		{"ref-full", `<xs:element name="h" type="xs:string"/><xs:complexType name="ct"><xs:sequence><xs:element ref="t:h" minOccurs="0" maxOccurs="1" id="r1" vc:minVersion="1.1"/></xs:sequence></xs:complexType>`},
+		// A global attribute with its legitimate attribute set + foreign attrs.
+		{"global-attr-full", `<xs:attribute name="ga" type="xs:string" id="ga1" default="x" vc:minVersion="1.1" xml:lang="en"/>`},
+		// A local attribute use with its legitimate attribute set + foreign attrs.
+		{"local-attr-full", `<xs:complexType name="ct"><xs:attribute name="a" type="xs:string" use="optional" default="x" form="qualified" id="a1" vc:minVersion="1.1" foo:bar="baz"/></xs:complexType>`},
+	}
+	for _, tc := range valid {
+		t.Run("valid/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			schemaXML := fmt.Sprintf(shell, tc.body)
+			for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+				_, errs, cerr := compileWith(t, v, schemaXML)
+				require.NoError(t, cerr, "version=%v must accept legitimate + foreign attributes: %s", v, errs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Reject an unknown unqualified attribute on `<xs:element>`/`<xs:attribute>` per the closed §3.3.2/§3.2.2 vocabulary (version-independent); foreign-namespaced (vc:/xml:/other) attrs stay allowed via `##other`
- Fixes W3C elemK007, elemN006, attH001, attJ017 (all expected-invalid, previously accepted)