### PR TITLE
accept consistent length with minLength/maxLength

### DIFF
--- a/xsd/check_facets.go
+++ b/xsd/check_facets.go
@@ -1126,11 +1126,14 @@ func (c *compiler) checkAnySimpleTypeUsage(ctx context.Context) {
 
 // checkFacetMutualExclusion checks that mutually exclusive facets are not
 // both specified on the same type definition.
+//
+// The min/maxInclusive-vs-min/maxExclusive pairs ARE mutually exclusive (a bound
+// cannot be both inclusive and exclusive). The length family, by contrast, is NOT
+// mutually exclusive: per XSD Part 2 §4.3.1/§4.3.2/§4.3.3 a `length` facet may
+// co-occur with `minLength`/`maxLength` as long as the values are consistent
+// (minLength ≤ length ≤ maxLength). That consistency — including inherited
+// min/maxLength bounds — is enforced by checkFacetSameTypeConsistency, not here.
 func (c *compiler) checkFacetMutualExclusion(ctx context.Context, fs *FacetSet, line int, component string) {
-	if fs.Length != nil && (fs.MinLength != nil || fs.MaxLength != nil) {
-		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
-			"It is an error for both 'length' and either of 'minLength' or 'maxLength' to be specified on the same type definition."))
-	}
 	if fs.MaxInclusive != nil && fs.MaxExclusive != nil {
 		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
 			"It is an error for both 'maxInclusive' and 'maxExclusive' to be specified."))
@@ -1162,9 +1165,31 @@ func (c *compiler) checkFacetSameTypeConsistency(ctx context.Context, td *TypeDe
 	// NOTATION). On any other type the length facets are inapplicable and already
 	// rejected as "not allowed", so this check must not run there.
 	lengthFacetsApplicable := variety == TypeVarietyList || (variety == TypeVarietyAtomic && lengthApplicable)
-	if lengthFacetsApplicable && fs.MinLength != nil && fs.MaxLength != nil && *fs.MinLength > *fs.MaxLength {
-		c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
-			"It is an error for the value of 'minLength' to be greater than the value of 'maxLength'."))
+	if lengthFacetsApplicable {
+		if fs.MinLength != nil && fs.MaxLength != nil && *fs.MinLength > *fs.MaxLength {
+			c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+				"It is an error for the value of 'minLength' to be greater than the value of 'maxLength'."))
+		}
+
+		// length/minLength/maxLength co-occurrence is PERMITTED (XSD Part 2
+		// §4.3.1/§4.3.2/§4.3.3) as long as the values are consistent. A `length`
+		// facet is an error only if it falls outside the EFFECTIVE min/maxLength
+		// bounds — the tightest of the type's OWN min/maxLength and any inherited
+		// from the base chain (a derived `length` must lie within a base's
+		// min/maxLength). A genuinely conflicting length (< effective minLength or
+		// > effective maxLength) is rejected; a consistent one (e.g. length=5 with
+		// minLength=1) is accepted.
+		effMin, effMax := effectiveLengthBounds(td)
+		if length := effectiveLengthFacet(td); length != nil {
+			if effMin != nil && *length < *effMin {
+				c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+					"It is an error for the value of 'length' to be less than the value of 'minLength'."))
+			}
+			if effMax != nil && *length > *effMax {
+				c.schemaError(ctx, schemaComponentError(c.filename, line, "simpleType", component,
+					"It is an error for the value of 'length' to be greater than the value of 'maxLength'."))
+			}
+		}
 	}
 
 	// Digit consistency (fractionDigits > totalDigits). The digit facets are
@@ -1248,6 +1273,41 @@ func (c *compiler) checkFacetSameTypeConsistency(ctx context.Context, td *TypeDe
 				"It is an error for the value of 'minInclusive' to be greater than or equal to the value of 'maxExclusive'."))
 		}
 	}
+}
+
+// effectiveLengthFacet returns the effective `length` facet value for td: its own
+// `length` if present, otherwise the nearest inherited one from the base chain. A
+// derived `length` must equal a base `length` (enforced in checkFacetBaseRestriction),
+// so any value in the chain is equivalent for the consistency comparison.
+func effectiveLengthFacet(td *TypeDef) *int {
+	for cur := range baseChain(td) {
+		if cur == nil || cur.Facets == nil {
+			continue
+		}
+		if cur.Facets.Length != nil {
+			return cur.Facets.Length
+		}
+	}
+	return nil
+}
+
+// effectiveLengthBounds returns the effective (minLength, maxLength) for td: the
+// TIGHTEST of the type's own facets and every min/maxLength inherited from the base
+// chain (the largest minLength, the smallest maxLength). Either may be nil when no
+// such facet appears anywhere in the chain.
+func effectiveLengthBounds(td *TypeDef) (minLen, maxLen *int) {
+	for cur := range baseChain(td) {
+		if cur == nil || cur.Facets == nil {
+			continue
+		}
+		if cur.Facets.MinLength != nil && (minLen == nil || *cur.Facets.MinLength > *minLen) {
+			minLen = cur.Facets.MinLength
+		}
+		if cur.Facets.MaxLength != nil && (maxLen == nil || *cur.Facets.MaxLength < *maxLen) {
+			maxLen = cur.Facets.MaxLength
+		}
+	}
+	return minLen, maxLen
 }
 
 // checkFacetBaseRestriction checks that facet values properly narrow (not widen)

--- a/xsd/facet_length_minlength_test.go
+++ b/xsd/facet_length_minlength_test.go
@@ -1,0 +1,104 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFacetLengthMinMaxCoOccurrence verifies that a `length` facet may co-occur
+// with `minLength`/`maxLength` when the values are consistent (XSD Part 2
+// §4.3.1/§4.3.2/§4.3.3): minLength ≤ length ≤ maxLength is accepted, while a
+// genuine numeric conflict is still rejected. Version-independent (default 1.0).
+func TestFacetLengthMinMaxCoOccurrence(t *testing.T) {
+	compile := func(t *testing.T, s string) error {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(s))
+		require.NoError(t, err)
+		_, cerr := xsd.NewCompiler().Compile(t.Context(), doc)
+		return cerr
+	}
+
+	wrap := func(facets string) string {
+		return `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="t">
+    <xs:restriction base="xs:NMTOKENS">
+` + facets + `
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="e" type="t"/>
+</xs:schema>`
+	}
+
+	t.Run("length with consistent minLength accepts", func(t *testing.T) {
+		t.Parallel()
+		s := wrap(`<xs:length value="5"/><xs:minLength value="1"/>`)
+		require.NoError(t, compile(t, s))
+	})
+
+	t.Run("length with consistent maxLength accepts", func(t *testing.T) {
+		t.Parallel()
+		s := wrap(`<xs:length value="5"/><xs:maxLength value="10"/>`)
+		require.NoError(t, compile(t, s))
+	})
+
+	t.Run("length equal to minLength and maxLength accepts", func(t *testing.T) {
+		t.Parallel()
+		s := wrap(`<xs:length value="5"/><xs:minLength value="5"/><xs:maxLength value="5"/>`)
+		require.NoError(t, compile(t, s))
+	})
+
+	t.Run("length less than minLength rejects", func(t *testing.T) {
+		t.Parallel()
+		s := wrap(`<xs:length value="1"/><xs:minLength value="5"/>`)
+		require.ErrorIs(t, compile(t, s), xsd.ErrCompilationFailed)
+	})
+
+	t.Run("length greater than maxLength rejects", func(t *testing.T) {
+		t.Parallel()
+		s := wrap(`<xs:length value="10"/><xs:maxLength value="5"/>`)
+		require.ErrorIs(t, compile(t, s), xsd.ErrCompilationFailed)
+	})
+
+	t.Run("minLength greater than maxLength rejects", func(t *testing.T) {
+		t.Parallel()
+		s := wrap(`<xs:minLength value="10"/><xs:maxLength value="5"/>`)
+		require.ErrorIs(t, compile(t, s), xsd.ErrCompilationFailed)
+	})
+
+	t.Run("length alone accepts", func(t *testing.T) {
+		t.Parallel()
+		s := wrap(`<xs:length value="5"/>`)
+		require.NoError(t, compile(t, s))
+	})
+
+	t.Run("derived length outside inherited minLength rejects", func(t *testing.T) {
+		t.Parallel()
+		s := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="base">
+    <xs:restriction base="xs:NMTOKENS"><xs:minLength value="5"/></xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="derived">
+    <xs:restriction base="base"><xs:length value="2"/></xs:restriction>
+  </xs:simpleType>
+  <xs:element name="e" type="derived"/>
+</xs:schema>`
+		require.ErrorIs(t, compile(t, s), xsd.ErrCompilationFailed)
+	})
+
+	t.Run("derived length within inherited minLength accepts", func(t *testing.T) {
+		t.Parallel()
+		s := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="base">
+    <xs:restriction base="xs:NMTOKENS"><xs:minLength value="2"/></xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="derived">
+    <xs:restriction base="base"><xs:length value="5"/></xs:restriction>
+  </xs:simpleType>
+  <xs:element name="e" type="derived"/>
+</xs:schema>`
+		require.NoError(t, compile(t, s))
+	})
+}

--- a/xsd/xsd_test.go
+++ b/xsd/xsd_test.go
@@ -1404,18 +1404,34 @@ func TestFacetConsistency(t *testing.T) {
 		require.Contains(t, errs, "'minLength' to be greater than the value of 'maxLength'")
 	})
 
-	t.Run("length_with_minLength", func(t *testing.T) {
+	t.Run("length_with_consistent_minLength_accepted", func(t *testing.T) {
 		t.Parallel()
+		// length=5 with minLength=3 is CONSISTENT (3 ≤ 5): the co-occurrence is
+		// permitted per XSD Part 2 §4.3.1, so no length/minLength error is raised.
 		errs := compileWithErrors(t, `<?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:simpleType name="badType">
+  <xs:simpleType name="goodType">
     <xs:restriction base="xs:string">
       <xs:length value="5"/>
       <xs:minLength value="3"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>`)
-		require.Contains(t, errs, "both 'length' and either of 'minLength' or 'maxLength'")
+		require.NotContains(t, errs, "'length'")
+	})
+
+	t.Run("length_less_than_minLength_rejected", func(t *testing.T) {
+		t.Parallel()
+		errs := compileWithErrors(t, `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="badType">
+    <xs:restriction base="xs:string">
+      <xs:length value="3"/>
+      <xs:minLength value="5"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>`)
+		require.Contains(t, errs, "'length' to be less than the value of 'minLength'")
 	})
 
 	t.Run("maxInclusive_with_maxExclusive", func(t *testing.T) {


### PR DESCRIPTION
`checkFacetMutualExclusion` unconditionally rejected a simple type carrying `length` together with `minLength`/`maxLength`. Per XSD Part 2 §4.3.1/§4.3.2/§4.3.3 that co-occurrence is permitted when consistent (minLength ≤ length ≤ maxLength, including inherited bounds). The check now rejects only a genuine numeric conflict. Fixes DataTypes_w3c NMTOKENS_length006 and IDREFS_length006 (length=5 with minLength=1). Version-independent.