### PR TITLE
reject element ref/type into non-imported namespace

### DIFF
--- a/xsd/alternative.go
+++ b/xsd/alternative.go
@@ -428,7 +428,7 @@ func (c *compiler) resolveAltTypeRefs(ctx context.Context) {
 		if !ok {
 			if c.filename != "" && !c.deprecatedDatatypeQName(ref.qn) {
 				msg := fmt.Sprintf("The QName value '{%s}%s' does not resolve to a(n) type definition.", ref.qn.NS, ref.qn.Local)
-				c.schemaError(ctx, schemaElemDeclErrorAttr(c.diagSourceOrRecorded(ref.source), ref.line, ref.elemName, attrType, msg))
+				c.schemaError(ctx, schemaElemDeclErrorAttr(c.diagSourceOrRecorded(ref.source), ref.line, ref.elemName, msg))
 			}
 			td = &TypeDef{Name: ref.qn, ContentType: ContentTypeSimple}
 		}
@@ -549,7 +549,7 @@ func (c *compiler) checkAltSubstitutability(ctx context.Context) {
 			}
 			msg := fmt.Sprintf("The type alternative's type '{%s}%s' is not validly substitutable for the declared type '{%s}%s' of the element declaration.",
 				alt.Type.Name.NS, alt.Type.Name.Local, declType.Name.NS, declType.Name.Local)
-			c.schemaError(ctx, schemaElemDeclErrorAttr(c.diagSourceOrRecorded(alt.Source), alt.Line, elemAlternative, attrType, msg))
+			c.schemaError(ctx, schemaElemDeclErrorAttr(c.diagSourceOrRecorded(alt.Source), alt.Line, elemAlternative, msg))
 		}
 	}
 }

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -178,6 +178,16 @@ type compiler struct {
 	// target even when their declarations are unknown, so a dangling ref into an
 	// imported-but-unloadable namespace is not over-rejected.
 	importDeclaredNS map[string]struct{}
+	// docImportedNS records, per DECLARING document filename, the set of namespaces
+	// that document imported DIRECTLY via its own <xs:import> elements (keyed by
+	// c.filename at the time the import was processed; xs:include shares the
+	// compiler but carries the included document's filename, so an include's import
+	// is attributed to the included document, not the including one). Unlike
+	// importDeclaredNS this is NOT unioned up from sub-compilers, so it distinguishes
+	// a namespace a document imported directly from one only reachable transitively.
+	// Used by the src-resolve check that rejects a reference into a namespace the
+	// referencing document did not directly import.
+	docImportedNS map[string]map[string]struct{}
 	// importDepth and maxImportDepth bound xs:import recursion. Each sub-compiler
 	// created by loadImport inherits maxImportDepth and stores its own
 	// importDepth = parent.importDepth + 1. A sub-compiler whose depth would
@@ -632,6 +642,7 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 		elemDeclConstraintSources: make(map[*ElementDecl]attrConstraintSource),
 		importedNS:                make(map[string]string),
 		importDeclaredNS:          make(map[string]struct{}),
+		docImportedNS:             make(map[string]map[string]struct{}),
 		maxImportDepth:            defaultMaxImportDepth,
 		importActive:              make(map[string]string),
 		includeVisited:            make(map[string]struct{}),

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -303,6 +303,18 @@ func (c *compiler) processImport(ctx context.Context, elem *helium.Element) erro
 	// location-less import (and, below, one whose load fails) still marks the
 	// namespace referenceable — its declarations are simply unknown.
 	c.importDeclaredNS[ns] = struct{}{}
+	// Record the import against the DECLARING document (keyed by its filename), so
+	// the non-imported-namespace reference check can tell a namespace a document
+	// imported DIRECTLY from one merely reachable transitively through another
+	// document's import. Includes share this compiler but carry the included
+	// document's c.filename here, so an include's import is not attributed to the
+	// including document.
+	if c.filename != "" {
+		if c.docImportedNS[c.filename] == nil {
+			c.docImportedNS[c.filename] = make(map[string]struct{})
+		}
+		c.docImportedNS[c.filename][ns] = struct{}{}
+	}
 
 	loc := getAttr(elem, attrSchemaLocation)
 	if loc == "" {
@@ -1304,6 +1316,7 @@ func (c *compiler) loadImport(ctx context.Context, location, ns string, importEl
 		filename:                  impFilename,
 		importedNS:                make(map[string]string),
 		importDeclaredNS:          make(map[string]struct{}),
+		docImportedNS:             make(map[string]map[string]struct{}),
 		importDepth:               c.importDepth + 1,
 		maxImportDepth:            c.maxImportDepth,
 		// Share the active import-ancestry set by pointer so the whole import tree

--- a/xsd/elem_ref_ns_import_test.go
+++ b/xsd/elem_ref_ns_import_test.go
@@ -1,0 +1,160 @@
+package xsd_test
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestElementRefNonImportedNamespace verifies src-resolve §3.3.2: an
+// <xs:element> @type or @ref into a namespace that the entry schema document did
+// not DIRECTLY import is a schema error, even when that namespace's components
+// are present in the assembly because ANOTHER document imported it transitively
+// (W3C Element_w3c elemZ006/elemZ007, Schema_w3c schZ004/schZ005). A reference
+// into a directly-imported namespace, the entry document's own targetNamespace,
+// a self-namespace reference inside an imported sub-document, and the built-in
+// xml: namespace all still compile. The rule is version-independent.
+func TestElementRefNonImportedNamespace(t *testing.T) {
+	t.Parallel()
+
+	const (
+		nsResolveErr = "does not resolve to a(n)"
+		fileMain     = "ern_main.xsd"
+		fileA        = "ern_a.xsd"
+		fileB        = "ern_b.xsd"
+		fileInc      = "ern_inc.xsd"
+	)
+
+	compile := func(t *testing.T, fsys fstest.MapFS) (string, error) {
+		t.Helper()
+		data, err := fsys.ReadFile(fileMain)
+		require.NoError(t, err)
+		doc, err := helium.NewParser().Parse(t.Context(), data)
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, cerr := xsd.NewCompiler().Label(fileMain).ErrorHandler(collector).FS(fsys).Compile(t.Context(), doc)
+		require.NoError(t, collector.Close())
+		var sb strings.Builder
+		for _, e := range collector.Errors() {
+			sb.WriteString(e.Error())
+			sb.WriteString("\n")
+		}
+		return sb.String(), cerr
+	}
+
+	// bDoc declares targetNamespace "urn:b" with both a type and a global element.
+	bDoc := &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:b">
+  <xs:complexType name="b"><xs:sequence><xs:element name="b"/></xs:sequence></xs:complexType>
+  <xs:element name="b"/>
+</xs:schema>`)}
+
+	t.Run("type into transitively-imported ns via import rejects", func(t *testing.T) {
+		t.Parallel()
+		// main imports urn:a only; a.xsd imports urn:b. main references {urn:b}b.
+		fsys := fstest.MapFS{
+			fileMain: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="urn:m" xmlns:a="urn:a" xmlns:b="urn:b">
+  <xs:import namespace="urn:a" schemaLocation="ern_a.xsd"/>
+  <xs:complexType name="ct"><xs:sequence>
+    <xs:element name="a" type="a:a"/>
+    <xs:element name="b" type="b:b"/>
+  </xs:sequence></xs:complexType>
+</xs:schema>`)},
+			fileA: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:a">
+  <xs:import namespace="urn:b" schemaLocation="ern_b.xsd"/>
+  <xs:complexType name="a"><xs:sequence><xs:element name="a"/></xs:sequence></xs:complexType>
+</xs:schema>`)},
+			fileB: bDoc,
+		}
+		errs, cerr := compile(t, fsys)
+		require.Error(t, cerr, "must reject a @type into a non-directly-imported namespace")
+		require.Contains(t, errs, "{urn:b}b")
+		require.Contains(t, errs, nsResolveErr)
+		require.NotContains(t, errs, "{urn:a}a", "a directly-imported reference must not be flagged")
+	})
+
+	t.Run("ref into transitively-imported ns via include rejects", func(t *testing.T) {
+		t.Parallel()
+		// main includes inc.xsd (same targetNamespace); inc.xsd imports urn:b.
+		// main itself does NOT import urn:b, so ref="b:b" is illegal.
+		fsys := fstest.MapFS{
+			fileMain: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="urn:m" xmlns:m="urn:m" xmlns:b="urn:b">
+  <xs:include schemaLocation="ern_inc.xsd"/>
+  <xs:complexType name="ct"><xs:sequence>
+    <xs:element ref="m:a"/>
+    <xs:element ref="b:b"/>
+  </xs:sequence></xs:complexType>
+</xs:schema>`)},
+			fileInc: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:m">
+  <xs:import namespace="urn:b" schemaLocation="ern_b.xsd"/>
+  <xs:element name="a"/>
+</xs:schema>`)},
+			fileB: bDoc,
+		}
+		errs, cerr := compile(t, fsys)
+		require.Error(t, cerr, "must reject a @ref into a non-directly-imported namespace")
+		require.Contains(t, errs, "{urn:b}b")
+		require.Contains(t, errs, nsResolveErr)
+		require.NotContains(t, errs, "{urn:m}a", "an own-targetNamespace reference must not be flagged")
+	})
+
+	t.Run("directly imported ns compiles", func(t *testing.T) {
+		t.Parallel()
+		fsys := fstest.MapFS{
+			fileMain: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="urn:m" xmlns:b="urn:b">
+  <xs:import namespace="urn:b" schemaLocation="ern_b.xsd"/>
+  <xs:complexType name="ct"><xs:sequence>
+    <xs:element name="b" type="b:b"/>
+    <xs:element ref="b:b"/>
+  </xs:sequence></xs:complexType>
+</xs:schema>`)},
+			fileB: bDoc,
+		}
+		_, cerr := compile(t, fsys)
+		require.NoError(t, cerr, "a directly-imported reference must compile")
+	})
+
+	t.Run("sub-document self-namespace reference is not over-rejected", func(t *testing.T) {
+		t.Parallel()
+		// A reference inside an IMPORTED sub-document into that document's own
+		// targetNamespace is legal; the entry-only scoping of the check must not
+		// flag it even though urn:a is import-declared and the entry document
+		// would not resolve a self-reference against it.
+		fsys := fstest.MapFS{
+			fileMain: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="urn:m" xmlns:a="urn:a">
+  <xs:import namespace="urn:a" schemaLocation="ern_a.xsd"/>
+  <xs:element name="root" type="a:ct"/>
+</xs:schema>`)},
+			fileA: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="urn:a" xmlns:a="urn:a">
+  <xs:simpleType name="st"><xs:restriction base="xs:string"/></xs:simpleType>
+  <xs:complexType name="ct"><xs:sequence>
+    <xs:element name="v" type="a:st"/>
+  </xs:sequence></xs:complexType>
+</xs:schema>`)},
+		}
+		_, cerr := compile(t, fsys)
+		require.NoError(t, cerr, "a self-namespace reference in an imported sub-document must compile")
+	})
+
+	t.Run("xml namespace type compiles", func(t *testing.T) {
+		t.Parallel()
+		fsys := fstest.MapFS{
+			fileMain: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace" targetNamespace="urn:m">
+  <xs:complexType name="ct"><xs:sequence>
+    <xs:element name="s" type="xs:string"/>
+  </xs:sequence></xs:complexType>
+</xs:schema>`)},
+		}
+		_, cerr := compile(t, fsys)
+		require.NoError(t, cerr)
+	})
+}

--- a/xsd/errors.go
+++ b/xsd/errors.go
@@ -98,9 +98,11 @@ func schemaElemDeclError(file string, line int, declName, msg string) string {
 	return fmt.Sprintf("%s:%d: element element: Schemas parser error : element decl. '%s': %s\n", file, line, declName, msg)
 }
 
-// schemaElemDeclErrorAttr formats a schema compilation error for an element declaration attribute:
+// schemaElemDeclErrorAttr formats a schema compilation error for an element
+// declaration's @type attribute (the only element-declaration attribute this
+// diagnostic is emitted for):
 //
-//	{file}:{line}: element element: Schemas parser error : element decl. '{name}', attribute '{attr}': {msg}\n
-func schemaElemDeclErrorAttr(file string, line int, declName, attr, msg string) string {
-	return fmt.Sprintf("%s:%d: element element: Schemas parser error : element decl. '%s', attribute '%s': %s\n", file, line, declName, attr, msg)
+//	{file}:{line}: element element: Schemas parser error : element decl. '{name}', attribute 'type': {msg}\n
+func schemaElemDeclErrorAttr(file string, line int, declName, msg string) string {
+	return fmt.Sprintf("%s:%d: element element: Schemas parser error : element decl. '%s', attribute '%s': %s\n", file, line, declName, attrType, msg)
 }

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -15,6 +15,18 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 	// Two passes: the first pass resolves type-name refs and may leave
 	// element-to-element refs with nil Type (because the target global element
 	// hasn't had its own type resolved yet). The second pass picks those up.
+	// Snapshot the REAL (loaded) element and type components before the loops
+	// below install any recovery placeholders for dangling refs, so the
+	// non-imported-namespace check can tell a reference that resolves to a
+	// genuine component from one that merely got a placeholder.
+	realElems := make(map[QName]struct{}, len(c.schema.elements))
+	for qn := range c.schema.elements {
+		realElems[qn] = struct{}{}
+	}
+	realTypes := make(map[QName]struct{}, len(c.schema.types))
+	for qn := range c.schema.types {
+		realTypes[qn] = struct{}{}
+	}
 	for range 2 {
 		for edecl, qn := range c.elemRefs {
 			if edecl.Type != nil {
@@ -80,7 +92,7 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 				// silently compile and validate as if the type existed.
 				if src, hasSrc := c.elemRefSources[edecl]; hasSrc && c.filename != "" && !c.deprecatedDatatypeQName(qn) {
 					msg := fmt.Sprintf("The QName value '{%s}%s' does not resolve to a(n) type definition.", qn.NS, qn.Local)
-					c.schemaError(ctx, schemaElemDeclErrorAttr(c.diagSourceOrRecorded(src.source), src.line, src.elemName, attrType, msg))
+					c.schemaError(ctx, schemaElemDeclErrorAttr(c.diagSourceOrRecorded(src.source), src.line, src.elemName, msg))
 				}
 				td = &TypeDef{Name: qn, ContentType: ContentTypeSimple}
 				c.schema.types[qn] = td
@@ -88,6 +100,10 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 			edecl.Type = td
 		}
 	}
+
+	// Reject an entry-document element @type/@ref into a namespace the entry
+	// document did not directly import (src-resolve §3.3.2).
+	c.checkNonImportedNamespaceRefs(ctx, realElems, realTypes)
 
 	// Resolve XSD 1.1 conditional-type-assignment alternative @type references.
 	c.resolveAltTypeRefs(ctx)
@@ -1522,6 +1538,105 @@ func (c *compiler) qnameNamesNonAttribute(qn QName) bool {
 		return true
 	}
 	return false
+}
+
+// checkNonImportedNamespaceRefs enforces src-resolve §3.3.2: a reference to a
+// component of a namespace that the referencing schema document did not DIRECTLY
+// import is illegal, even when that namespace's components happen to be present
+// in the assembly because ANOTHER document imported it (transitive import does
+// not make a namespace referenceable — W3C Element_w3c/Schema_w3c elemZ006/Z007,
+// schZ004/Z005). The check is version-INDEPENDENT.
+//
+// It is deliberately CONSERVATIVE to avoid over-rejecting valid multi-file
+// schemas, and only fires for a reference that:
+//   - originates in the ENTRY document (its recorded source is c.filename) — a
+//     reference inside an imported/included sub-document is left alone (that
+//     document has its own import context we do not re-check here);
+//   - resolves to a REAL loaded component (in realElems/realTypes), not a
+//     placeholder installed for a dangling ref (those keep the existing
+//     "does not resolve" handling and its import-declared leniency);
+//   - targets a namespace that genuinely requires an import — not the absent
+//     namespace, not the XML/XSI built-in namespaces, and not the entry
+//     document's own targetNamespace;
+//   - targets a namespace that WAS import-declared somewhere in the assembly
+//     (importDeclaredNS) yet was NOT directly imported by the entry document
+//     (docImportedNS[c.filename]).
+//
+// From the entry document's perspective the QName does not resolve, so it
+// reuses the same "does not resolve to a(n) …" diagnostic as a truly-dangling
+// ref. Diagnostics are sorted by (source, line, local) for deterministic output.
+func (c *compiler) checkNonImportedNamespaceRefs(ctx context.Context, realElems, realTypes map[QName]struct{}) {
+	if c.filename == "" {
+		return
+	}
+
+	type issue struct {
+		line  int
+		local string
+		isRef bool
+		src   elemRefSource
+		qn    QName
+	}
+	var issues []issue
+
+	for edecl, qn := range c.elemRefs {
+		src, ok := c.elemRefSources[edecl]
+		if !ok {
+			continue
+		}
+		if c.diagSourceOrRecorded(src.source) != c.filename {
+			continue
+		}
+		if qn.NS == "" || qn.NS == lexicon.NamespaceXML || qn.NS == lexicon.NamespaceXSI {
+			continue
+		}
+		if qn.NS == c.schema.targetNamespace {
+			continue
+		}
+		// Only a namespace that was import-declared somewhere but not directly by
+		// this document is a violation; anything else is left to the existing
+		// resolution handling.
+		if _, declared := c.importDeclaredNS[qn.NS]; !declared {
+			continue
+		}
+		if directImports, ok := c.docImportedNS[c.filename]; ok {
+			if _, imported := directImports[qn.NS]; imported {
+				continue
+			}
+		}
+		var resolved bool
+		if edecl.IsRef {
+			_, resolved = realElems[qn]
+		} else {
+			_, resolved = realTypes[qn]
+		}
+		if !resolved {
+			continue
+		}
+		issues = append(issues, issue{line: src.line, local: src.elemName, isRef: edecl.IsRef, src: src, qn: qn})
+	}
+
+	sort.Slice(issues, func(i, j int) bool {
+		si := c.diagSourceOrRecorded(issues[i].src.source)
+		sj := c.diagSourceOrRecorded(issues[j].src.source)
+		if si != sj {
+			return si < sj
+		}
+		if issues[i].line != issues[j].line {
+			return issues[i].line < issues[j].line
+		}
+		return issues[i].local < issues[j].local
+	})
+	for _, is := range issues {
+		source := c.diagSourceOrRecorded(is.src.source)
+		if is.isRef {
+			msg := fmt.Sprintf("The QName value '{%s}%s' does not resolve to a(n) element declaration.", is.qn.NS, is.qn.Local)
+			c.schemaError(ctx, schemaParserErrorAttr(source, is.line, is.local, elemElement, attrRef, msg))
+			continue
+		}
+		msg := fmt.Sprintf("The QName value '{%s}%s' does not resolve to a(n) type definition.", is.qn.NS, is.qn.Local)
+		c.schemaError(ctx, schemaElemDeclErrorAttr(source, is.line, is.local, msg))
+	}
 }
 
 // resolveNamedType resolves a named type reference to its definition, mirroring


### PR DESCRIPTION
src-resolve §3.3.2: an `<xs:element>` @type or @ref into a namespace the entry schema document did not directly import is a schema error, even when that namespace's components are present because another document imported it transitively. Tracks per-document imports and rejects an entry-document reference resolving to a real component in an import-declared but not directly-imported namespace. Fixes W3C Element_w3c elemZ006/elemZ007 and Schema_w3c schZ004/schZ005; TestGoldenFiles green and no over-rejection across the 305 expected-valid Element_w3c/Schema_w3c schemas.