### PR TITLE
reject annotation after type child in element

### DIFF
--- a/xsd/check_elements.go
+++ b/xsd/check_elements.go
@@ -99,6 +99,9 @@ func (c *compiler) checkGlobalElement(ctx context.Context, elem *helium.Element)
 	// Closed attribute-vocabulary check (§3.3.2, version-INDEPENDENT).
 	c.checkElementAttrVocabulary(ctx, elem)
 
+	// Content-model ordering: annotation must be the first child (§3.3.2).
+	c.checkElementContentOrder(ctx, elem)
+
 	// name is required for global elements.
 	if name == "" {
 		c.schemaError(ctx, schemaParserError(c.filename, line, local, "element",
@@ -220,6 +223,46 @@ func (c *compiler) checkElementAttrVocabulary(ctx context.Context, elem *helium.
 		}
 		c.schemaError(ctx, schemaParserError(src, line, local, elemElement,
 			"The attribute '"+attr.LocalName()+"' is not allowed."))
+	}
+}
+
+// checkElementContentOrder enforces the §3.3.2 element content model ordering
+// constraint that an <xs:annotation> must be the FIRST child of an <xs:element>
+// declaration — it may not FOLLOW a recognized content child (<simpleType>,
+// <complexType>, <alternative>, <unique>, <key>, <keyref>). This is
+// version-INDEPENDENT: annotation is the leading term of the element content
+// model in every XSD version ((annotation?, ((simpleType | complexType)?,
+// alternative*, (unique | key | keyref)*))). Only recognized content children set
+// the "saw a non-annotation" state, so a stray/foreign child that helium
+// otherwise tolerates does not trigger the diagnostic. The at-most-one-annotation
+// rule and the annotation's own content model are enforced separately by
+// checkAnnotations.
+func (c *compiler) checkElementContentOrder(ctx context.Context, elem *helium.Element) {
+	sawContentChild := false
+	for child := range helium.Children(elem) {
+		if child.Type() != helium.ElementNode {
+			continue
+		}
+		ce, ok := helium.AsNode[*helium.Element](child)
+		if !ok {
+			continue
+		}
+		if ce.URI() != lexicon.NamespaceXSD {
+			continue
+		}
+		if isXSDElement(ce, elemAnnotation) {
+			if sawContentChild {
+				c.schemaError(ctx, schemaParserError(c.diagSource(), ce.Line(), ce.LocalName(), "element",
+					"The content is not valid. Expected is (annotation?, ((simpleType | complexType)?, (unique | key | keyref)*))."))
+			}
+			continue
+		}
+		switch {
+		case isXSDElement(ce, elemSimpleType), isXSDElement(ce, elemComplexType),
+			isXSDElement(ce, elemAlternative), isXSDElement(ce, elemUnique),
+			isXSDElement(ce, elemKey), isXSDElement(ce, elemKeyRef):
+			sawContentChild = true
+		}
 	}
 }
 
@@ -485,6 +528,9 @@ func (c *compiler) checkLocalElement(ctx context.Context, elem *helium.Element) 
 		// Named local element constraints.
 		// Matches libxml2 ordering: maxOccurs, not-allowed attrs,
 		// block/final value checks, default+fixed, type/content children.
+
+		// Content-model ordering: annotation must be the first child (§3.3.2).
+		c.checkElementContentOrder(ctx, elem)
 
 		// The {name} of a local element declaration must be an NCName (XSD
 		// Structures §3.3.2; xsd:element/@name is of type xs:NCName), exactly as

--- a/xsd/element_annotation_order_test.go
+++ b/xsd/element_annotation_order_test.go
@@ -1,0 +1,160 @@
+package xsd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestElementAnnotationOrder verifies the §3.3.2 element content-model ordering
+// rule: an <xs:annotation> must be the FIRST child of an <xs:element> and may not
+// follow a <simpleType>/<complexType>/identity-constraint child. This is
+// version-INDEPENDENT (annotation is the leading term in every XSD version's
+// element content model). Fixes W3C MS-Element elemQ004/elemQ006.
+func TestElementAnnotationOrder(t *testing.T) {
+	t.Parallel()
+
+	const wantMsg = "The content is not valid. Expected is (annotation?"
+
+	t.Run("rejects", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct {
+			name      string
+			schemaXML string
+		}{
+			{
+				// elemQ004: annotation after an inline simpleType.
+				name: "annotation after simpleType (global)",
+				schemaXML: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="myElem">
+    <xs:simpleType>
+      <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    <xs:annotation>
+      <xs:documentation>after</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+</xs:schema>`,
+			},
+			{
+				// elemQ006: annotation after an inline complexType.
+				name: "annotation after complexType (global)",
+				schemaXML: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="myElem">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="a" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:annotation>
+      <xs:documentation>after</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+</xs:schema>`,
+			},
+			{
+				name: "annotation after complexType (local)",
+				schemaXML: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="child">
+          <xs:complexType/>
+          <xs:annotation>
+            <xs:documentation>after</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`,
+			},
+			{
+				name: "annotation after identity constraint",
+				schemaXML: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="a" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="u">
+      <xs:selector xpath="a"/>
+      <xs:field xpath="."/>
+    </xs:unique>
+    <xs:annotation>
+      <xs:documentation>after</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+</xs:schema>`,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				errs := compileErrorsExact(t, tc.schemaXML)
+				require.Contains(t, errs, wantMsg)
+			})
+		}
+	})
+
+	t.Run("accepts", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct {
+			name      string
+			schemaXML string
+		}{
+			{
+				name: "annotation first, then simpleType",
+				schemaXML: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="myElem">
+    <xs:annotation>
+      <xs:documentation>first</xs:documentation>
+    </xs:annotation>
+    <xs:simpleType>
+      <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>`,
+			},
+			{
+				name: "annotation first, complexType, then IDC",
+				schemaXML: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:annotation>
+      <xs:documentation>first</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="a" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="u">
+      <xs:selector xpath="a"/>
+      <xs:field xpath="."/>
+    </xs:unique>
+  </xs:element>
+</xs:schema>`,
+			},
+			{
+				name: "no annotation, complexType only",
+				schemaXML: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="myElem">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="a" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				errs := compileErrorsExact(t, tc.schemaXML)
+				require.False(t, strings.Contains(errs, wantMsg),
+					"unexpected annotation-order error: %s", errs)
+			})
+		}
+	})
+}


### PR DESCRIPTION
Enforce the §3.3.2 element content-model ordering rule (version-independent): an `<xs:annotation>` must be the FIRST child of an `<xs:element>` and may not follow a `simpleType`/`complexType`/identity-constraint child. Fixes W3C MS-Element false-accepts elemQ004 and elemQ006.