### PR TITLE
reject schema-namespace attributes on components

### DIFF
--- a/xsd/check_schema_attrs.go
+++ b/xsd/check_schema_attrs.go
@@ -1,0 +1,54 @@
+package xsd
+
+import (
+	"context"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/lexicon"
+)
+
+// checkSchemaNamespaceAttrs rejects any attribute in the XML Schema namespace
+// (http://www.w3.org/2001/XMLSchema) appearing on an XSD-namespace schema
+// element. The normative schema-for-schemas declares every schema element's
+// complex type with `<xs:anyAttribute namespace="##other"/>`, so the ONLY
+// attributes permitted are the explicitly-declared unqualified (no-namespace)
+// ones plus foreign attributes from a namespace OTHER than the XSD namespace.
+// An attribute in the XSD namespace itself (e.g. `xsd:type`, `xsd:targetNamespace`)
+// is neither a recognized schema attribute (those are unqualified) nor an
+// admissible foreign attribute, so it is a representation error.
+//
+// This is a version-independent XSD rule, enforced in both 1.0 and 1.1.
+func (c *compiler) checkSchemaNamespaceAttrs(ctx context.Context, root *helium.Element) {
+	if c.filename == "" {
+		return
+	}
+	c.walkSchemaNamespaceAttrs(ctx, root)
+}
+
+func (c *compiler) walkSchemaNamespaceAttrs(ctx context.Context, elem *helium.Element) {
+	if elem.URI() == lexicon.NamespaceXSD {
+		for _, a := range elem.Attributes() {
+			if a.URI() != lexicon.NamespaceXSD {
+				continue
+			}
+			file := c.diagSource()
+			c.schemaError(ctx, schemaParserErrorAttr(file, elem.Line(), elem.LocalName(), elem.LocalName(), a.LocalName(),
+				"Attributes from the schema namespace ('"+lexicon.NamespaceXSD+"') are not allowed on schema components; only unqualified schema attributes and foreign-namespace attributes are permitted."))
+		}
+	}
+
+	for child := range helium.Children(elem) {
+		ce, ok := child.(*helium.Element)
+		if !ok {
+			continue
+		}
+		// Do NOT descend into xs:appinfo / xs:documentation payload: their content
+		// is arbitrary application/human data, not schema components, so an
+		// XSD-namespace attribute embedded there is not governed by the
+		// schema-for-schemas.
+		if ce.URI() == lexicon.NamespaceXSD && (ce.LocalName() == elemAppinfo || ce.LocalName() == elemDocumentation) {
+			continue
+		}
+		c.walkSchemaNamespaceAttrs(ctx, ce)
+	}
+}

--- a/xsd/check_schema_attrs_test.go
+++ b/xsd/check_schema_attrs_test.go
@@ -1,0 +1,72 @@
+package xsd_test
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSchemaNamespaceAttrRejected verifies that an attribute in the XML Schema
+// namespace appearing on a schema-component element is a representation error.
+// The schema-for-schemas allows only unqualified schema attributes plus foreign
+// attributes from a namespace OTHER than the XSD namespace (##other), so an
+// attribute in the XSD namespace itself (e.g. xsd:type, xsd:targetNamespace) is
+// neither and must be rejected. Version-independent (1.0 and 1.1).
+func TestSchemaNamespaceAttrRejected(t *testing.T) {
+	t.Parallel()
+
+	const mainXSD = "s.xsd"
+	const want = "Attributes from the schema namespace"
+
+	compile := func(t *testing.T, body string) string {
+		t.Helper()
+		fsys := fstest.MapFS{mainXSD: &fstest.MapFile{Data: []byte(body)}}
+		doc, err := helium.NewParser().Parse(t.Context(), fsys[mainXSD].Data)
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, cerr := xsd.NewCompiler().Label(mainXSD).ErrorHandler(collector).FS(fsys).Compile(t.Context(), doc)
+		requireCompileResultErr(t, cerr)
+		require.NoError(t, collector.Close())
+		_, errStr := partitionCompileErrors(collector.Errors())
+		return errStr
+	}
+
+	t.Run("xsd:type on complexType and attribute (addB082)", func(t *testing.T) {
+		t.Parallel()
+		errStr := compile(t, `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:attribute name="foo" xsd:type="xsd:string"/>
+  <xsd:complexType name="ct" xsd:type="xsd:integer"/>
+  <xsd:element name="doc" type="ct"/>
+</xsd:schema>`)
+		require.Contains(t, errStr, want)
+	})
+
+	t.Run("xsd:targetNamespace on schema (test64756)", func(t *testing.T) {
+		t.Parallel()
+		errStr := compile(t, `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsd:targetNamespace="http://foobar">
+  <xsd:element name="foo"/>
+</xsd:schema>`)
+		require.Contains(t, errStr, want)
+	})
+
+	t.Run("schema-namespace attribute on notation (notatE002)", func(t *testing.T) {
+		t.Parallel()
+		errStr := compile(t, `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:notation a:b="c" name="jpeg" public="image/jpeg" system="viewer.exe" xmlns:a="http://www.w3.org/2001/XMLSchema"/>
+</xsd:schema>`)
+		require.Contains(t, errStr, want)
+	})
+
+	t.Run("foreign-namespace attribute is allowed", func(t *testing.T) {
+		t.Parallel()
+		errStr := compile(t, `<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:o="urn:other">
+  <xsd:element name="foo" o:note="hi" type="xsd:string"/>
+</xsd:schema>`)
+		require.False(t, strings.Contains(errStr, want),
+			"foreign (non-schema-namespace) attributes must be permitted; got: %q", errStr)
+	})
+}

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -761,6 +761,7 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 	// identity-constraint components. Both are version-independent XSD rules, so
 	// they run in 1.0 and 1.1 alike.
 	c.checkSchemaComponentIDs(ctx, root)
+	c.checkSchemaNamespaceAttrs(ctx, root)
 	c.checkIDConstraintPlacement(ctx, root)
 	c.checkNotations(ctx, root)
 	c.checkAnnotations(ctx, root)

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -557,6 +557,7 @@ func (c *compiler) loadInclude(ctx context.Context, location string, includeElem
 	// recur across documents). Runs after conditional-inclusion pruning so
 	// vc-excluded components' @ids don't count.
 	c.checkSchemaComponentIDs(ctx, incRoot)
+	c.checkSchemaNamespaceAttrs(ctx, incRoot)
 	c.checkIDConstraintPlacement(ctx, incRoot)
 	c.checkNotations(ctx, incRoot)
 	c.checkAnnotations(ctx, incRoot)
@@ -832,6 +833,7 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 	// THIS redefined document (a fresh per-document scope). Runs after
 	// conditional-inclusion pruning.
 	c.checkSchemaComponentIDs(ctx, incRoot)
+	c.checkSchemaNamespaceAttrs(ctx, incRoot)
 	c.checkIDConstraintPlacement(ctx, incRoot)
 	c.checkNotations(ctx, incRoot)
 	c.checkAnnotations(ctx, incRoot)
@@ -1486,6 +1488,7 @@ func (c *compiler) loadImport(ctx context.Context, location, ns string, importEl
 	// rules are version-independent, so enforce them on the imported document in
 	// 1.0 and 1.1 alike.
 	impC.checkSchemaComponentIDs(ctx, impRoot)
+	impC.checkSchemaNamespaceAttrs(ctx, impRoot)
 	impC.checkIDConstraintPlacement(ctx, impRoot)
 	impC.checkNotations(ctx, impRoot)
 	impC.checkAnnotations(ctx, impRoot)

--- a/xsd/override.go
+++ b/xsd/override.go
@@ -431,6 +431,7 @@ func (c *compiler) overrideLoadTarget(ctx context.Context, location string, srcE
 	// conditional-inclusion pruning. xs:override is Version11-only.
 	if c.version == Version11 {
 		c.checkSchemaComponentIDs(ctx, incRoot)
+		c.checkSchemaNamespaceAttrs(ctx, incRoot)
 	}
 	c.checkIDConstraintPlacement(ctx, incRoot)
 	c.checkNotations(ctx, incRoot)


### PR DESCRIPTION
Reject any attribute in the XML Schema namespace (e.g. `xsd:type`, `xsd:targetNamespace`) appearing on a schema-component element. The schema-for-schemas permits only unqualified schema attributes plus foreign attributes from a namespace other than the XSD namespace (`##other`), so an XSD-namespace attribute is a representation error. Version-independent (1.0 and 1.1).

Fixes W3C msMeta Additional_w3c false-accepts addB082 and test64756, plus Notations notatE002. Zero over-rejection across 15470 corpus schemas.