### PR TITLE
reject misplaced annotation in attributeGroup def

### DIFF
--- a/xsd/attr_group_annotation_order_test.go
+++ b/xsd/attr_group_annotation_order_test.go
@@ -1,0 +1,82 @@
+package xsd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAttrGroupAnnotationOrder verifies the XML representation of an
+// <xs:attributeGroup> DEFINITION content model (annotation?, ((attribute |
+// attributeGroup)*, anyAttribute?)) — §3.6.2: the annotation must PRECEDE the
+// attribute uses. An annotation appearing AFTER the attribute declarations is a
+// schema-representation error (W3C sun AGroupDef annotation00101m3/m6). This is a
+// version-INDEPENDENT rule; it is exercised under the default XSD 1.0 compiler.
+func TestAttrGroupAnnotationOrder(t *testing.T) {
+	t.Parallel()
+
+	const misplaced = "The annotation must appear before the attribute declarations"
+
+	t.Run("annotation after attributes is rejected", func(t *testing.T) {
+		t.Parallel()
+		// documentation-form annotation after the attribute declarations (m3).
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attributeGroup name="G1">
+    <xs:attribute name="c" type="xs:int"/>
+    <xs:attribute name="date" type="xs:date"/>
+    <xs:annotation>
+      <xs:documentation>trailing annotation</xs:documentation>
+    </xs:annotation>
+  </xs:attributeGroup>
+  <xs:complexType name="A">
+    <xs:attributeGroup ref="G1"/>
+  </xs:complexType>
+  <xs:element name="root" type="A"/>
+</xs:schema>`
+		_, errs := compileWithErrors(t, schemaXML)
+		require.Contains(t, errs, misplaced,
+			"an annotation after the attribute declarations must be rejected; got: %q", errs)
+	})
+
+	t.Run("annotation after an attributeGroup ref is rejected", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attributeGroup name="H">
+    <xs:attribute name="x" type="xs:string"/>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="G1">
+    <xs:attributeGroup ref="H"/>
+    <xs:annotation>
+      <xs:documentation>trailing annotation</xs:documentation>
+    </xs:annotation>
+  </xs:attributeGroup>
+  <xs:complexType name="A">
+    <xs:attributeGroup ref="G1"/>
+  </xs:complexType>
+  <xs:element name="root" type="A"/>
+</xs:schema>`
+		_, errs := compileWithErrors(t, schemaXML)
+		require.Contains(t, errs, misplaced,
+			"an annotation after an attributeGroup ref must be rejected; got: %q", errs)
+	})
+
+	t.Run("annotation first is accepted", func(t *testing.T) {
+		t.Parallel()
+		// Leading annotation (valid, mirrors sun annotation00101m1/m4).
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attributeGroup name="G1">
+    <xs:annotation>
+      <xs:documentation>leading annotation</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="c" type="xs:int"/>
+    <xs:attribute name="date" type="xs:date"/>
+  </xs:attributeGroup>
+  <xs:complexType name="A">
+    <xs:attributeGroup ref="G1"/>
+  </xs:complexType>
+  <xs:element name="root" type="A"/>
+</xs:schema>`
+		_, errs := compileWithErrors(t, schemaXML)
+		require.Empty(t, errs, "a leading annotation must be accepted; got: %q", errs)
+	})
+}

--- a/xsd/read_particles.go
+++ b/xsd/read_particles.go
@@ -157,6 +157,11 @@ func (c *compiler) parseNamedAttributeGroup(ctx context.Context, elem *helium.El
 	// rejected. Gated on Version11 (1.0 ignores group wildcards entirely, so its
 	// grammar handling stays byte-identical).
 	var anyAttributeSeen bool
+	// sawContent tracks whether any content particle (attribute, attributeGroup
+	// ref, or anyAttribute wildcard) has been seen, so a later <xs:annotation> can
+	// be flagged: the content model is (annotation?, ...), i.e. the annotation must
+	// PRECEDE the attribute uses. Version-INDEPENDENT XSD rule (§3.6.2).
+	var sawContent bool
 	reportAfterWildcard := func(ce *helium.Element) {
 		c.schemaError(ctx, schemaParserError(c.diagSource(), ce.Line(), ce.LocalName(), "attributeGroup",
 			fmt.Sprintf("The attribute declaration '%s' must appear before the attribute wildcard 'anyAttribute'.", ce.LocalName())))
@@ -169,7 +174,19 @@ func (c *compiler) parseNamedAttributeGroup(ctx context.Context, elem *helium.El
 		if !ok {
 			continue
 		}
+		// annotation? — at most one (checkAnnotations), and it must precede the
+		// attribute uses. An annotation appearing AFTER any content particle
+		// violates the (annotation?, ((attribute | attributeGroup)*, anyAttribute?))
+		// content model. Version-INDEPENDENT XSD rule (§3.6.2).
+		if isXSDElement(ce, elemAnnotation) {
+			if c.filename != "" && sawContent {
+				c.schemaError(ctx, schemaParserError(c.diagSource(), ce.Line(), ce.LocalName(), "attributeGroup",
+					"The annotation must appear before the attribute declarations of an attribute group definition."))
+			}
+			continue
+		}
 		if isXSDElement(ce, elemAttribute) {
+			sawContent = true
 			if c.version == Version11 && anyAttributeSeen {
 				reportAfterWildcard(ce)
 				continue
@@ -208,6 +225,7 @@ func (c *compiler) parseNamedAttributeGroup(ctx context.Context, elem *helium.El
 		// referencing type can intersect it into its effective attribute wildcard.
 		// It must be the final child and unique.
 		if c.version == Version11 && isXSDElement(ce, elemAnyAttribute) {
+			sawContent = true
 			if anyAttributeSeen {
 				c.schemaError(ctx, schemaParserError(c.diagSource(), ce.Line(), ce.LocalName(), "attributeGroup",
 					fmt.Sprintf("An attribute group definition must not have more than one attribute wildcard (found a second '%s').", ce.LocalName())))
@@ -229,6 +247,7 @@ func (c *compiler) parseNamedAttributeGroup(ctx context.Context, elem *helium.El
 		// reaches this point is genuinely circular and is reported and dropped (the
 		// reference is cut to avoid further confusion, matching libxml2).
 		if isXSDElement(ce, elemAttributeGroup) {
+			sawContent = true
 			c.checkAttrGroupRef(ctx, ce)
 			if c.version == Version11 && anyAttributeSeen {
 				reportAfterWildcard(ce)


### PR DESCRIPTION
Enforce the `<xs:attributeGroup>` definition content model `(annotation?, ((attribute | attributeGroup)*, anyAttribute?))` (§3.6.2): the annotation must precede the attribute uses. An annotation after the attribute declarations is now a schema-representation error. Version-independent; fixes W3C sun AGroupDef annotation00101m3/m6 (previously false-accepted under XSD 1.0).