### PR TITLE
reject XSD 1.0 ID element with value constraint

### DIFF
--- a/xsd/element_id_value_constraint_test.go
+++ b/xsd/element_id_value_constraint_test.go
@@ -1,0 +1,79 @@
+package xsd_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// XSD 1.0 "Element Declaration Properties Correct" clause 4 (§3.3.6): if an
+// element's {type definition} is or is derived from xs:ID there must NOT be a
+// {value constraint} (default or fixed). This is the element counterpart of the
+// attribute rule au-props-correct.3. XSD 1.1 removed the restriction (W3C bug
+// 4077), so the check is version-gated: 1.0 rejects, 1.1 accepts.
+//
+// W3C sunData/ElemDecl/valueConstraint/valueConstraint01001m coverage:
+// m2/m3 (fixed/default on an xs:ID element) and m5/m6 (fixed/default on an
+// element whose type restricts xs:ID); Saxon Id id014/id015 confirm the 1.1
+// relaxation.
+func TestElement_IDMustNotHaveValueConstraint(t *testing.T) {
+	t.Parallel()
+
+	const shell = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="myID">
+    <xs:restriction base="xs:ID"/>
+  </xs:simpleType>
+  %s
+</xs:schema>`
+
+	rejected := []struct {
+		name string
+		elem string
+	}{
+		{"fixed-on-id", `<xs:element name="e" type="xs:ID" fixed="A1"/>`},
+		{"default-on-id", `<xs:element name="e" type="xs:ID" default="A1"/>`},
+		{"fixed-on-derived-id", `<xs:element name="e" type="myID" fixed="A1"/>`},
+		{"default-on-derived-id", `<xs:element name="e" type="myID" default="A1"/>`},
+	}
+	for _, tc := range rejected {
+		t.Run("invalid10/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			schemaXML := fmt.Sprintf(shell, tc.elem)
+			schema, errs, cerr := compileWith(t, xsd.Version10, schemaXML)
+			require.ErrorIs(t, cerr, xsd.ErrCompilationFailed, "XSD 1.0 must reject an ID element with a value constraint")
+			require.Nil(t, schema)
+			require.Contains(t, errs, "there must not be a value constraint")
+		})
+		t.Run("valid11/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			schemaXML := fmt.Sprintf(shell, tc.elem)
+			schema, _, cerr := compileWith(t, xsd.Version11, schemaXML)
+			require.NoError(t, cerr, "XSD 1.1 must accept an ID element with a value constraint (bug 4077)")
+			require.NotNil(t, schema)
+		})
+	}
+
+	// A plain xs:ID element with no value constraint, and a non-ID element
+	// carrying a fixed/default, must still compile under both versions.
+	accepted := []struct {
+		name string
+		elem string
+	}{
+		{"id-no-constraint", `<xs:element name="e" type="xs:ID"/>`},
+		{"string-fixed", `<xs:element name="e" type="xs:string" fixed="v"/>`},
+		{"idref-fixed", `<xs:element name="e" type="xs:IDREF" fixed="A1"/>`},
+	}
+	for _, tc := range accepted {
+		t.Run("accepted/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			schemaXML := fmt.Sprintf(shell, tc.elem)
+			for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
+				schema, _, cerr := compileWith(t, v, schemaXML)
+				require.NoError(t, cerr, "version=%v must accept %s", v, tc.name)
+				require.NotNil(t, schema)
+			}
+		})
+	}
+}

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -502,6 +502,12 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 	// and 1.1 (sources are recorded unconditionally).
 	c.checkElementDeclConstraints(ctx)
 
+	// XSD 1.0 e-props-correct.4 (§3.3.6): an element declaration whose type is or
+	// is derived from xs:ID must not carry a value constraint. Kept as a distinct
+	// pass from checkElementDeclConstraints (value-space validation) so the two
+	// concerns stay independent. XSD 1.1 removed the rule (W3C bug 4077).
+	c.checkElementIDValueConstraints(ctx)
+
 	// Topologically order extension types so each base type is merged before
 	// the types that derive from it (the merge reads the base's finalized
 	// content model and attributes).
@@ -2219,6 +2225,48 @@ func (c *compiler) checkElementDeclConstraints(ctx context.Context) {
 			msg := fmt.Sprintf("The value '%s' is not a valid value of the atomic type '%s'.", *val, typeDisplayName(effectiveContentSimpleType(std)))
 			c.schemaError(ctx, schemaElemDeclError(c.diagSourceOrRecorded(it.src.source), it.src.line, it.src.local, msg))
 		}
+	}
+}
+
+// checkElementIDValueConstraints enforces XSD 1.0 e-props-correct.4 (§3.3.6): if
+// an element declaration's {type definition} is or is derived from xs:ID, there
+// must not be a {value constraint} (default or fixed). This mirrors the attribute
+// rule au-props-correct.3 (checkAttrUseConstraints). builtinBaseLocal returns the
+// first XSD-namespace ancestor's local name — "ID" for xs:ID and any simple type
+// restricting it. Gated to Version10; XSD 1.1 removed the rule (W3C bug 4077), so
+// the 1.1 path is byte-identical.
+func (c *compiler) checkElementIDValueConstraints(ctx context.Context) {
+	if c.filename == "" || c.version != Version10 {
+		return
+	}
+	type pending struct {
+		decl *ElementDecl
+		src  attrConstraintSource
+	}
+	items := make([]pending, 0, len(c.elemDeclConstraintSources))
+	for decl, src := range c.elemDeclConstraintSources {
+		items = append(items, pending{decl: decl, src: src})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].src.line != items[j].src.line {
+			return items[i].src.line < items[j].src.line
+		}
+		return items[i].src.local < items[j].src.local
+	})
+
+	for _, it := range items {
+		if it.decl.Default == nil && it.decl.Fixed == nil {
+			continue
+		}
+		std := effectiveDeclType(it.decl, c.schema)
+		if std == nil {
+			continue
+		}
+		if builtinBaseLocal(std) != typeID {
+			continue
+		}
+		msg := "The element declaration is or is derived from ID and there must not be a value constraint."
+		c.schemaError(ctx, schemaElemDeclError(c.diagSourceOrRecorded(it.src.source), it.src.line, it.src.local, msg))
 	}
 }
 


### PR DESCRIPTION
Enforce XSD 1.0 e-props-correct.4 (§3.3.6): an element declaration whose type is or is derived from xs:ID must not carry a default/fixed value constraint — the element counterpart of the existing attribute rule au-props-correct.3. Gated to Version10 (XSD 1.1 removed the rule, W3C bug 4077); the 1.1 path is byte-identical. Fixes sunData/ElemDecl valueConstraint01001m2/m3/m5/m6 false-accepts.