### PR TITLE
scope override templates to using package

### DIFF
--- a/xslt3/execute_templates.go
+++ b/xslt3/execute_templates.go
@@ -429,7 +429,14 @@ func (ec *execContext) executeTemplate(ctx context.Context, tmpl *template, node
 	// so package-private functions are visible.
 	savedFnsNS := ec.cachedFnsNS
 	savedPackage := ec.currentPackage
-	if tmpl.OwnerPackage != nil && tmpl.OwnerPackage != ec.currentPackage {
+	// Override templates (OriginalTemplate != nil) run in the main stylesheet
+	// context so that strip-space and other package-scoped rules from the
+	// using package apply, not the used package's rules (mirrors
+	// execCallTemplate).
+	if tmpl.OriginalTemplate != nil {
+		ec.cachedFnsNS = nil
+		ec.currentPackage = nil
+	} else if tmpl.OwnerPackage != nil && tmpl.OwnerPackage != ec.currentPackage {
 		ec.cachedFnsNS = nil // force rebuild with new package scope
 		ec.currentPackage = tmpl.OwnerPackage
 	}


### PR DESCRIPTION
- executeTemplate now resets currentPackage for override templates (OriginalTemplate != nil), so package-scoped strip-space rules from the using package apply (mirrors execCallTemplate)
- fixes W3C xslt30 document-2401/2402