### PR TITLE
propagate schema annotations to constructed nodes

### DIFF
--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -667,11 +667,30 @@ func (td *TypeDef) Validate(ctx context.Context, value string, nsMap map[string]
 // This is used by XSLT xsl:type validation where the element is constructed
 // in the result tree and must conform to the given type.
 func (td *TypeDef) ValidateElement(ctx context.Context, elem *helium.Element, schema *Schema) error {
+	return td.ValidateElementAnnotated(ctx, elem, schema, nil)
+}
+
+// ValidateElementAnnotated validates an element's content against this type
+// definition, and — when ann is non-nil — records PSVI type annotations for the
+// element's descendant elements and attributes into *ann, keyed on the LIVE
+// nodes of elem's subtree. The root element's own annotation is the caller's
+// responsibility (it is the type named by the xsl:type/type attribute, not a
+// content-model match). This is used by XSLT xsl:type validation so that later
+// element(*, T) / schema-element() type tests see the schema types of the
+// constructed subtree, not just the root.
+func (td *TypeDef) ValidateElementAnnotated(ctx context.Context, elem *helium.Element, schema *Schema, ann *TypeAnnotations) error {
 	if td == nil {
 		return fmt.Errorf("nil type definition")
 	}
 	collector := &validationErrors{}
-	vc := newValidationContext(schema, &validateConfig{}, "", collector)
+	cfg := &validateConfig{}
+	if ann != nil {
+		if *ann == nil {
+			*ann = make(TypeAnnotations)
+		}
+		cfg.annotations = ann
+	}
+	vc := newValidationContext(schema, cfg, "", collector)
 	err := vc.validateElementContent(ctx, elem, nil, td)
 	if err == nil {
 		return nil

--- a/xslt3/compile_patterns.go
+++ b/xslt3/compile_patterns.go
@@ -1470,8 +1470,26 @@ func matchSchemaAttributeTest(_ context.Context, ec *execContext, t xpath3.Schem
 	if ec.schemaRegistry == nil {
 		return false
 	}
-	_, found := ec.schemaRegistry.LookupAttribute(local, ns)
-	return found
+	declType, found := ec.schemaRegistry.LookupAttribute(local, ns)
+	if !found {
+		return false
+	}
+	// The attribute must have been validated against the GLOBAL declaration's
+	// type: its type annotation must be that type, or derived from it. An
+	// instance attribute whose (e.g. local) declaration gives it an unrelated
+	// type — my:toks declared globally as xs:string but validated as
+	// xs:NMTOKENS on the person element — does not match schema-attribute(N).
+	ann := ""
+	if ec.typeAnnotations != nil {
+		ann = ec.typeAnnotations[node]
+	}
+	if ann == "" || ann == lexicon.XSUntypedAtomic {
+		return false
+	}
+	if ann == declType || ec.schemaRegistry.IsSubtypeOf(ann, declType) {
+		return true
+	}
+	return false
 }
 
 // resolvePatternKindTestName resolves a kind-test name string (used by
@@ -1575,26 +1593,35 @@ func matchNameTest(_ context.Context, ec *execContext, nt xpath3.NameTest, node 
 	if nodeLocal != nt.Local || nodeURI != expectedURI {
 		return false
 	}
-	// XSLT 3.0 §6.6: when mode typed="strict", bare element name patterns
-	// are treated as schema-element() — the element must have been validated
-	// against the schema declaration for that name.
-	if isElem && ec != nil && nt.Prefix != "*" && isTypedStrictMode(ec) {
-		if ec.schemaRegistry == nil {
-			return false
-		}
-		declType, found := ec.schemaRegistry.LookupElement(nodeLocal, nodeURI)
-		if !found {
-			return false
-		}
-		ann := ""
-		if ec.typeAnnotations != nil {
-			ann = ec.typeAnnotations[node]
-		}
-		if ann == "" || ann == lexicon.XSUntyped {
-			return false
-		}
-		if ann != declType && !ec.schemaRegistry.IsSubtypeOf(ann, declType) {
-			return false
+	// XSLT 3.0 §6.6: when the mode is typed (typed="strict" or typed="lax"), a
+	// bare element name pattern whose name is a global element declaration is
+	// treated as an implicit schema-element() — the element must have been
+	// validated against that declaration for the pattern to match. strict and
+	// lax differ in how an untyped / undeclared node is treated: strict rejects
+	// it, lax falls back to a plain by-name match. A TYPED node whose type is
+	// not derived from the declared type never matches in either (e.g. a
+	// constructed element carrying xsl:type="xs:string" for a name declared with
+	// a decimal type).
+	if isElem && ec != nil && nt.Prefix != "*" {
+		strict := isTypedStrictMode(ec)
+		if strict || isTypedLaxMode(ec) {
+			if ec.schemaRegistry == nil {
+				return !strict
+			}
+			declType, found := ec.schemaRegistry.LookupElement(nodeLocal, nodeURI)
+			if !found {
+				return !strict
+			}
+			ann := ""
+			if ec.typeAnnotations != nil {
+				ann = ec.typeAnnotations[node]
+			}
+			if ann == "" || ann == lexicon.XSUntyped {
+				return !strict
+			}
+			if ann != declType && !ec.schemaRegistry.IsSubtypeOf(ann, declType) {
+				return false
+			}
 		}
 	}
 	return true
@@ -1602,16 +1629,30 @@ func matchNameTest(_ context.Context, ec *execContext, nt xpath3.NameTest, node 
 
 // isTypedStrictMode returns true if the current mode has typed="strict" or typed="yes".
 func isTypedStrictMode(ec *execContext) bool {
-	mode := ec.currentMode
-	if md := ec.stylesheet.modeDefs[mode]; md != nil {
+	if md := currentModeDef(ec); md != nil {
 		return md.Typed == validationStrict || md.Typed == lexicon.ValueYes || md.Typed == lexicon.ValueTrue || md.Typed == "1"
 	}
-	if mode == "" {
-		if md := ec.stylesheet.modeDefs[modeDefault]; md != nil {
-			return md.Typed == validationStrict || md.Typed == lexicon.ValueYes || md.Typed == lexicon.ValueTrue || md.Typed == "1"
-		}
+	return false
+}
+
+// isTypedLaxMode returns true if the current mode has typed="lax".
+func isTypedLaxMode(ec *execContext) bool {
+	if md := currentModeDef(ec); md != nil {
+		return md.Typed == validationLax
 	}
 	return false
+}
+
+// currentModeDef returns the mode definition for the current mode, falling back
+// to the default (unnamed) mode definition when the current mode is unnamed.
+func currentModeDef(ec *execContext) *modeDef {
+	if md := ec.stylesheet.modeDefs[ec.currentMode]; md != nil {
+		return md
+	}
+	if ec.currentMode == "" {
+		return ec.stylesheet.modeDefs[modeDefault]
+	}
+	return nil
 }
 
 // matchElementTest checks if a node matches an element() test.
@@ -1784,13 +1825,15 @@ func matchTypeAnnotation(_ context.Context, ec *execContext, node helium.Node, t
 	if xpath3.BuiltinIsSubtypeOf(fullAnn, fullType) {
 		return true
 	}
-	// Check via schema declarations for user-defined types.
+	// Check via schema declarations for user-defined types. An element(*, T) /
+	// attribute(*, T) type test also matches when the node's type is an atomic
+	// member of the union T (isSubtypeOrUnionMember), per Type Derivation OK.
 	if ec != nil && ec.schemaRegistry != nil {
 		// Also try with resolved QName forms
-		if ec.schemaRegistry.IsSubtypeOf(resolvedAnn, resolvedType) {
+		if ec.schemaRegistry.isSubtypeOrUnionMember(resolvedAnn, resolvedType) {
 			return true
 		}
-		return ec.schemaRegistry.IsSubtypeOf(fullAnn, fullType)
+		return ec.schemaRegistry.isSubtypeOrUnionMember(fullAnn, fullType)
 	}
 	return false
 }

--- a/xslt3/execute.go
+++ b/xslt3/execute.go
@@ -443,6 +443,93 @@ func (ec *execContext) transferAnnotationsForCopy(src helium.Node, parent helium
 	}
 }
 
+// idFamilyAnnotation returns node's type annotation when it is xs:ID / xs:IDREF
+// / xs:IDREFS (or a subtype), else "". It consults both the live and the
+// preserved annotation maps so a strip copy of an already-stripped tree keeps
+// the is-id property.
+func (ec *execContext) idFamilyAnnotation(node helium.Node) string {
+	ann := ""
+	if ec.typeAnnotations != nil {
+		ann = ec.typeAnnotations[node]
+	}
+	if ann == "" && ec.preservedIDAnnotations != nil {
+		ann = ec.preservedIDAnnotations[node]
+	}
+	if ann == "" {
+		return ""
+	}
+	if isIDType(ann, ec.schemaRegistry) || isIDRefType(ann, ec.schemaRegistry) || isIDRefsType(ann, ec.schemaRegistry) {
+		return ann
+	}
+	return ""
+}
+
+func (ec *execContext) preserveNodeIDAnnotation(node helium.Node, ann string) {
+	if ec.preservedIDAnnotations == nil {
+		ec.preservedIDAnnotations = make(map[helium.Node]string)
+	}
+	ec.preservedIDAnnotations[node] = ann
+}
+
+// deepPreserveIDAnnotations records the is-id / is-idref(s) property of each
+// source node onto the corresponding copy node in preservedIDAnnotations. Per
+// XDM, validation="strip" removes the type annotation but retains the is-id /
+// is-idrefs properties, so fn:id()/fn:idref() still resolve over the stripped
+// copy. The two subtrees must have the same structure.
+func (ec *execContext) deepPreserveIDAnnotations(src, dst helium.Node) {
+	if ann := ec.idFamilyAnnotation(src); ann != "" {
+		ec.preserveNodeIDAnnotation(dst, ann)
+	}
+	if srcElem, ok := src.(*helium.Element); ok {
+		if dstElem, ok := dst.(*helium.Element); ok {
+			for _, srcAttr := range srcElem.Attributes() {
+				ann := ec.idFamilyAnnotation(srcAttr)
+				if ann == "" {
+					continue
+				}
+				for _, dstAttr := range dstElem.Attributes() {
+					if srcAttr.LocalName() == dstAttr.LocalName() && srcAttr.URI() == dstAttr.URI() {
+						ec.preserveNodeIDAnnotation(dstAttr, ann)
+						break
+					}
+				}
+			}
+		}
+	}
+	srcChild := src.FirstChild()
+	dstChild := dst.FirstChild()
+	for srcChild != nil && dstChild != nil {
+		ec.deepPreserveIDAnnotations(srcChild, dstChild)
+		srcChild = srcChild.NextSibling()
+		dstChild = dstChild.NextSibling()
+	}
+}
+
+// preserveIDAnnotationsForCopy records is-id / is-idrefs properties from a
+// stripped copy's source subtree onto the newly-copied nodes, mirroring
+// transferAnnotationsForCopy's document-vs-single-node structure matching.
+func (ec *execContext) preserveIDAnnotationsForCopy(src, parent, lastBefore helium.Node) {
+	if src.Type() == helium.DocumentNode {
+		var firstNew helium.Node
+		if lastBefore == nil {
+			firstNew = parent.FirstChild()
+		} else {
+			firstNew = lastBefore.NextSibling()
+		}
+		srcChild := src.FirstChild()
+		dstChild := firstNew
+		for srcChild != nil && dstChild != nil {
+			ec.deepPreserveIDAnnotations(srcChild, dstChild)
+			srcChild = srcChild.NextSibling()
+			dstChild = dstChild.NextSibling()
+		}
+		return
+	}
+	if last := parent.LastChild(); last != nil {
+		ec.deepPreserveIDAnnotations(src, last)
+	}
+}
+
 // varScope is a variable scope chain.
 type varScope struct {
 	vars           map[string]xpath3.Sequence

--- a/xslt3/execute_copy.go
+++ b/xslt3/execute_copy.go
@@ -563,6 +563,13 @@ func (ec *execContext) execCopyOf(ctx context.Context, inst *copyOfInst) error {
 					ec.transferAnnotationsForCopy(v.Node, out.current, lastBefore)
 				}
 			} else if effectiveVal == validationStrict || effectiveVal == validationLax || effectiveVal == validationStrip {
+				// validation="strip" removes type annotations but XDM retains
+				// the is-id / is-idrefs properties, so fn:id()/fn:idref() must
+				// still resolve over the stripped copy. Record them BEFORE the
+				// strip removes the source-derived annotations.
+				if effectiveVal == validationStrip {
+					ec.preserveIDAnnotationsForCopy(v.Node, out.current, lastBefore)
+				}
 				// Apply validation/strip to the most recently added node in output.
 				// In sequence mode the copied node lives in pendingItems, not
 				// as a child of out.current.

--- a/xslt3/execute_element.go
+++ b/xslt3/execute_element.go
@@ -187,24 +187,38 @@ func (ec *execContext) execElement(ctx context.Context, inst *elementInst) error
 // when validation="strict" or validation="lax". Returns XTTE1510 when the
 // value is invalid, XTTE1555 when no matching global declaration is found
 // (strict only).
-func (ec *execContext) validateConstructedAttribute(ctx context.Context, localName, nsURI, value, validation string) error {
+// firstNonEmptyType returns explicit if non-empty, else fallback. An explicit
+// type= on xsl:attribute takes precedence over a validation-resolved type.
+func firstNonEmptyType(explicit, fallback string) string {
+	if explicit != "" {
+		return explicit
+	}
+	return fallback
+}
+
+// validateConstructedAttribute validates a computed attribute against the global
+// attribute declaration for its name and returns the resolved type-annotation
+// name so the caller can annotate the attribute node (needed for
+// schema-attribute(N) pattern matching and instance-of tests). typeName is ""
+// when no declaration governs the attribute (lax with no declaration).
+func (ec *execContext) validateConstructedAttribute(ctx context.Context, localName, nsURI, value, validation string) (string, error) {
 	if ec.schemaRegistry == nil {
-		return nil
+		return "", nil
 	}
 	typeName, valid, valErr := ec.schemaRegistry.ValidateAttribute(ctx, localName, nsURI, value)
 	if typeName == "" {
 		// No matching global attribute declaration found.
 		if validation == validationStrict {
-			return dynamicError(errCodeXTTE1555,
+			return "", dynamicError(errCodeXTTE1555,
 				"no schema declaration found for attribute {%s}%s (validation=strict)", nsURI, localName)
 		}
-		return nil // lax: silently skip if no declaration
+		return "", nil // lax: silently skip if no declaration
 	}
 	if !valid || valErr != nil {
-		return dynamicError(errCodeXTTE1510,
+		return "", dynamicError(errCodeXTTE1510,
 			"attribute {%s}%s value %q is not valid for type %s: %v", nsURI, localName, value, typeName, valErr)
 	}
-	return nil
+	return typeName, nil
 }
 
 // validateAndNormalizeElementContent validates the text content of elem against
@@ -230,9 +244,23 @@ func (ec *execContext) validateAndNormalizeElementContent(ctx context.Context, e
 				td, schema := def.TD, def.Schema
 				switch td.ContentType {
 				case xsd.ContentTypeElementOnly, xsd.ContentTypeMixed, xsd.ContentTypeEmpty:
-					if err := td.ValidateElement(ctx, elem, schema); err != nil {
+					var ann xsd.TypeAnnotations
+					if err := td.ValidateElementAnnotated(ctx, elem, schema, &ann); err != nil {
 						lastErr = err
 						continue
+					}
+					// Propagate the PSVI type annotations the content-model
+					// validation assigned to descendant elements and attributes
+					// onto the live result tree, so later element(*, T) /
+					// schema-element() type tests see the subtree's schema types,
+					// not just the root (whose own annotation is set by the
+					// caller from the xsl:type/type attribute). Annotations are
+					// keyed on the live nodes of elem's subtree.
+					for node, typeName := range ann {
+						if node == helium.Node(elem) {
+							continue
+						}
+						ec.annotateNode(node, typeName)
 					}
 					return nil
 				case xsd.ContentTypeSimple:
@@ -810,22 +838,31 @@ func (ec *execContext) execAttribute(ctx context.Context, inst *attributeInst) e
 			attrNS = ns
 		}
 		// Schema validation when validation attribute is set.
+		var valTypeName string
 		if inst.Validation == validationStrict || inst.Validation == validationLax {
-			if err := ec.validateConstructedAttribute(ctx, localName, nsURI, value, inst.Validation); err != nil {
+			tn, err := ec.validateConstructedAttribute(ctx, localName, nsURI, value, inst.Validation)
+			if err != nil {
 				return err
 			}
+			valTypeName = tn
 		}
 		attr, attrErr := out.doc.CreateAttribute(localName, value, attrNS)
 		if attrErr != nil {
 			return attrErr
 		}
 		ni := xpath3.NodeItem{Node: attr}
-		if inst.TypeName != "" {
-			ec.annotateNode(attr, inst.TypeName)
-			ni.TypeAnnotation = inst.TypeName
+		// The explicit type= wins; otherwise a validation-resolved type carries
+		// the annotation so schema-attribute(N) / instance-of see the type.
+		annType := inst.TypeName
+		if annType == "" {
+			annType = valTypeName
+		}
+		if annType != "" {
+			ec.annotateNode(attr, annType)
+			ni.TypeAnnotation = annType
 			// Set ListItemType for list types (built-in or schema-defined).
 			if ec.schemaRegistry != nil {
-				if itemType, ok := ec.schemaRegistry.ListItemType(inst.TypeName); ok {
+				if itemType, ok := ec.schemaRegistry.ListItemType(annType); ok {
 					ni.ListItemType = itemType
 				}
 			}
@@ -888,10 +925,13 @@ func (ec *execContext) execAttribute(ctx context.Context, inst *attributeInst) e
 		localName := resolved.localName
 		nsURI := resolved.nsURI
 		// Schema validation when validation attribute is set.
+		var valTypeName string
 		if inst.Validation == validationStrict || inst.Validation == validationLax {
-			if err := ec.validateConstructedAttribute(ctx, localName, nsURI, value, inst.Validation); err != nil {
+			tn, err := ec.validateConstructedAttribute(ctx, localName, nsURI, value, inst.Validation)
+			if err != nil {
 				return err
 			}
+			valTypeName = tn
 		}
 		// If the prefix is already bound to a different URI on this element,
 		// generate a unique prefix to avoid conflicts.
@@ -911,7 +951,7 @@ func (ec *execContext) execAttribute(ctx context.Context, inst *attributeInst) e
 		// Use literal mode: XSLT evaluation values are plain text
 		// that may contain & from resolved entities.
 		_ = elem.SetLiteralAttributeNS(localName, value, ns)
-		ec.annotateAttr(elem, inst.TypeName, localName, nsURI, value)
+		ec.annotateAttr(elem, firstNonEmptyType(inst.TypeName, valTypeName), localName, nsURI, value)
 		out.noteOutput()
 		return nil
 	}
@@ -920,15 +960,18 @@ func (ec *execContext) execAttribute(ctx context.Context, inst *attributeInst) e
 	// explicit namespace="" that discarded the prefix).
 	localName := resolved.localName
 	// Schema validation for no-namespace attribute.
+	var valTypeName string
 	if inst.Validation == validationStrict || inst.Validation == validationLax {
-		if err := ec.validateConstructedAttribute(ctx, localName, "", value, inst.Validation); err != nil {
+		tn, err := ec.validateConstructedAttribute(ctx, localName, "", value, inst.Validation)
+		if err != nil {
 			return err
 		}
+		valTypeName = tn
 	}
 	// Remove existing attribute with same name to allow replacement
 	elem.RemoveAttribute(localName)
 	_ = elem.SetLiteralAttribute(localName, value)
-	ec.annotateAttr(elem, inst.TypeName, localName, "", value)
+	ec.annotateAttr(elem, firstNonEmptyType(inst.TypeName, valTypeName), localName, "", value)
 	out.noteOutput()
 	return nil
 }

--- a/xslt3/schema_context.go
+++ b/xslt3/schema_context.go
@@ -190,6 +190,13 @@ func (r *schemaRegistry) LookupSchemaType(local, ns string) (baseType string, ok
 // It checks whether typeName is the same as or a subtype of baseTypeName using
 // the annotation format ("xs:localName" for built-ins, "Q{ns}localName" for user-defined).
 func (r *schemaRegistry) IsSubtypeOf(typeName, baseTypeName string) bool {
+	// Canonicalize the XSD-namespace Q{...}local form to xs:local so the
+	// built-in hierarchy and union-member comparisons (which produce xs:local
+	// via xsdTypeNameFromDef) see a consistent spelling regardless of whether
+	// the caller resolved a builtin type through its prefix (Q{XMLSchema}local)
+	// or left it as xs:local.
+	typeName = canonicalizeBuiltinTypeName(typeName)
+	baseTypeName = canonicalizeBuiltinTypeName(baseTypeName)
 	if typeName == baseTypeName {
 		return true
 	}
@@ -202,7 +209,9 @@ func (r *schemaRegistry) IsSubtypeOf(typeName, baseTypeName string) bool {
 		if isBuiltinSubtypeOf(typeName, baseTypeName) {
 			return true
 		}
-		// Also check if baseTypeName is a union type with typeName as a member.
+		// A built-in type is validly derived from a union type that has it (or a
+		// supertype) as a member — e.g. xs:time derives from a union of
+		// xs:date/xs:time/xs:dateTime, so `$t instance of theUnion` holds.
 		if !isXSBuiltin(baseTypeName) {
 			baseLocal, baseNS := splitAnnotationName(baseTypeName)
 			for _, s := range r.schemas {
@@ -232,7 +241,7 @@ func (r *schemaRegistry) IsSubtypeOf(typeName, baseTypeName string) bool {
 		cur := td.BaseType
 		for cur != nil {
 			curName := xsdTypeNameFromDef(cur)
-			if curName == baseTypeName {
+			if canonicalizeBuiltinTypeName(curName) == baseTypeName {
 				return true
 			}
 			if isXSBuiltin(curName) {
@@ -242,20 +251,70 @@ func (r *schemaRegistry) IsSubtypeOf(typeName, baseTypeName string) bool {
 		}
 		return false
 	}
-	// Check if baseTypeName is a union type and typeName is a member type.
+	return false
+}
+
+// isSubtypeOrUnionMember reports whether typeName is derived from baseTypeName by
+// the base-type chain (IsSubtypeOf) OR is an ATOMIC member of the baseTypeName
+// union (Type Derivation OK (Simple), §3.16.6.3). It is used for element(*, T) /
+// attribute(*, T) pattern type tests, where a union member matches its union.
+// It is intentionally NOT folded into IsSubtypeOf: the shared derives-from is
+// also used as a substitution-group proxy in xpath3's schema-element step, where
+// admitting union membership would wrongly match an unrelated element whose type
+// happens to be a member of the head element's union type.
+func (r *schemaRegistry) isSubtypeOrUnionMember(typeName, baseTypeName string) bool {
+	if r.IsSubtypeOf(typeName, baseTypeName) {
+		return true
+	}
+	return r.isUnionMember(typeName, baseTypeName)
+}
+
+// isUnionMember returns true if baseTypeName is a union type having typeName —
+// or a type typeName derives from — among its (transitive) member types.
+//
+// Only ATOMIC member types (and nested unions, walked recursively) confer this
+// derivation: a LIST member does not make a same-typed node match
+// element(*, U) / attribute(*, U). W3C match-232 requires the atomic-member
+// derivation (an xs:integer attribute matches attribute(*, partIntegerUnion)),
+// while match-197 requires that a list-typed element (myListType) does NOT match
+// element(*, listUnionType) even though myListType is a union member.
+func (r *schemaRegistry) isUnionMember(typeName, baseTypeName string) bool {
+	typeName = canonicalizeBuiltinTypeName(typeName)
+	baseTypeName = canonicalizeBuiltinTypeName(baseTypeName)
 	baseLocal, baseNS := splitAnnotationName(baseTypeName)
 	for _, s := range r.schemas {
 		baseTD, found := s.LookupType(baseLocal, baseNS)
 		if !found {
 			continue
 		}
-		if baseTD.Variety == xsd.TypeVarietyUnion {
-			for _, member := range baseTD.MemberTypes {
-				memberName := xsdTypeNameFromDef(member)
-				if typeName == memberName || r.IsSubtypeOf(typeName, memberName) {
-					return true
-				}
+		if baseTD.Variety != xsd.TypeVarietyUnion {
+			continue
+		}
+		for _, member := range baseTD.MemberTypes {
+			if effectiveVarietyIsList(member) {
+				continue
 			}
+			memberName := canonicalizeBuiltinTypeName(xsdTypeNameFromDef(member))
+			if typeName == memberName {
+				return true
+			}
+			if r.IsSubtypeOf(typeName, memberName) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// effectiveVarietyIsList reports whether td's effective variety (following the
+// base-type chain, mirroring the xsd package's resolveVariety) is list.
+func effectiveVarietyIsList(td *xsd.TypeDef) bool {
+	for cur := td; cur != nil; cur = cur.BaseType {
+		switch cur.Variety {
+		case xsd.TypeVarietyList:
+			return true
+		case xsd.TypeVarietyUnion:
+			return false
 		}
 	}
 	return false
@@ -334,6 +393,17 @@ func (r *schemaRegistry) IsSubstitutionGroupMember(memberLocal, memberNS, headLo
 // isXSBuiltin returns true if the annotation name is an xs: built-in type.
 func isXSBuiltin(name string) bool {
 	return len(name) > 3 && name[:3] == "xs:"
+}
+
+// canonicalizeBuiltinTypeName rewrites the XSD-namespace Q{ns}local annotation
+// form to the xs:local form so built-in type comparisons are spelling-agnostic.
+// Non-XSD names are returned unchanged.
+func canonicalizeBuiltinTypeName(name string) string {
+	local, ns := splitAnnotationName(name)
+	if ns == lexicon.NamespaceXSD {
+		return "xs:" + local
+	}
+	return name
 }
 
 // builtinSimpleTypes is the set of xs: built-in simple (atomic/list/union) types


### PR DESCRIPTION
- annotate descendants of xsl:type-validated constructed elements/copies (additive xsd.TypeDef.ValidateElementAnnotated; existing ValidateElement delegates with nil, byte-identical)
- canonicalize builtin type-name spelling, schema-attribute(N) checks instance type, lax implicit schema-element, preserve is-id family across copy validation=strip
- fixes W3C xslt30 match-174/181/210/221/232, copy-5034