### PR TITLE
match schema-element by substitution group

### DIFF
--- a/xpath3/cast_schema_default_ns_test.go
+++ b/xpath3/cast_schema_default_ns_test.go
@@ -31,6 +31,9 @@ func (nsFooTypeDecls) ValidateCastWithNS(_ context.Context, value, typeName stri
 }
 func (nsFooTypeDecls) ListItemType(typeName string) (string, bool) { return "", false }
 func (nsFooTypeDecls) UnionMemberTypes(typeName string) []string   { return nil }
+func (nsFooTypeDecls) IsSubstitutionGroupMember(memberLocal, memberNS, headLocal, headNS string) bool {
+	return false
+}
 
 // TestCastUnprefixedUserTypeUnderDefaultNS verifies that the cast schema fallback
 // resolves an UNPREFIXED user-defined target type using the ALREADY-RESOLVED

--- a/xpath3/cast_schema_union_test.go
+++ b/xpath3/cast_schema_union_test.go
@@ -98,6 +98,9 @@ func (d unionCastDecls) ValidateCastWithNS(ctx context.Context, value, typeName 
 	return d.ValidateCast(ctx, value, typeName)
 }
 func (unionCastDecls) ListItemType(typeName string) (string, bool) { return "", false }
+func (unionCastDecls) IsSubstitutionGroupMember(memberLocal, memberNS, headLocal, headNS string) bool {
+	return false
+}
 func (unionCastDecls) UnionMemberTypes(typeName string) []string {
 	switch typeName {
 	case testBuiltinUnion:

--- a/xpath3/context.go
+++ b/xpath3/context.go
@@ -73,6 +73,14 @@ type SchemaDeclarations interface {
 	// Both names use the annotation format: "xs:localName" for XSD built-ins,
 	// "Q{ns}localName" for user-defined types.
 	IsSubtypeOf(typeName, baseTypeName string) bool
+	// IsSubstitutionGroupMember reports whether the element (memberLocal, memberNS)
+	// is substitutable for — i.e. a (transitive) member of the substitution group
+	// headed by — the element (headLocal, headNS). It drives the schema-element()
+	// kind test, which matches an element whose name is a member of the head's
+	// substitution group (not merely a type-derivation of the head's type).
+	// Returns false when the schema declares no such head or no such membership,
+	// preserving behavior for callers that are not substitution-group aware.
+	IsSubstitutionGroupMember(memberLocal, memberNS, headLocal, headNS string) bool
 	// ValidateCast checks whether a string value is valid for a user-defined
 	// schema type (including facet constraints). Returns nil if valid or the
 	// type is not found; returns an error if the value violates facets.

--- a/xpath3/eval_path.go
+++ b/xpath3/eval_path.go
@@ -750,21 +750,22 @@ func matchNodeTest(nt NodeTest, n helium.Node, axis AxisType, ec *evalContext) b
 		local, ns := resolveSchemaTestName(test.Name, ec, false)
 		nameMatch := ixpath.LocalNameOf(n) == local && ixpath.NodeNamespaceURI(n) == ns
 		if !nameMatch {
-			// Check substitution group membership: the node's element
-			// must be in the substitution group headed by (local, ns)
-			// and its type annotation must be a subtype of the head's type.
-			headType, headFound := ec.schemaDeclarations.LookupSchemaElement(local, ns)
-			if !headFound {
+			// The node's name is not the head's own name, so it matches only
+			// when the node's element is a member of the substitution group
+			// headed by (local, ns). Substitution-group membership already
+			// requires each member's declared type to derive from the head's
+			// type, so a validated (non-untyped) member satisfies the kind
+			// test; a type-derivation check alone would wrongly admit any
+			// element whose type happens to derive from the head's type
+			// without being substitutable for it.
+			if !ec.schemaDeclarations.IsSubstitutionGroupMember(ixpath.LocalNameOf(n), ixpath.NodeNamespaceURI(n), local, ns) {
 				return false
 			}
 			ann := nodeTypeAnnotation(n, ec)
-			if ann == "" {
-				ann = TypeUntyped
-			}
-			if ann == TypeUntyped {
+			if ann == "" || ann == TypeUntyped {
 				return false
 			}
-			return isSubtypeOf(ann, headType) || ec.schemaDeclarations.IsSubtypeOf(ann, headType)
+			return true
 		}
 		typeName, found := ec.schemaDeclarations.LookupSchemaElement(local, ns)
 		if !found {

--- a/xpath3/eval_path_kindtest_ns_test.go
+++ b/xpath3/eval_path_kindtest_ns_test.go
@@ -32,6 +32,9 @@ func (noNSFooAttrDecls) ValidateCastWithNS(_ context.Context, value, typeName st
 }
 func (noNSFooAttrDecls) ListItemType(typeName string) (string, bool) { return "", false }
 func (noNSFooAttrDecls) UnionMemberTypes(typeName string) []string   { return nil }
+func (noNSFooAttrDecls) IsSubstitutionGroupMember(memberLocal, memberNS, headLocal, headNS string) bool {
+	return false
+}
 
 // predeclaredNSDecls is a minimal SchemaDeclarations that declares one element
 // {NSXS}foo and one attribute {NSXS}foo of type xs:string, where NSXS is the
@@ -71,6 +74,9 @@ func (predeclaredNSDecls) ValidateCastWithNS(_ context.Context, value, typeName 
 }
 func (predeclaredNSDecls) ListItemType(typeName string) (string, bool) { return "", false }
 func (predeclaredNSDecls) UnionMemberTypes(typeName string) []string   { return nil }
+func (predeclaredNSDecls) IsSubstitutionGroupMember(memberLocal, memberNS, headLocal, headNS string) bool {
+	return false
+}
 
 // TestSchemaTestPredeclaredPrefix verifies that schema-element()/
 // schema-attribute() step tests and the equivalent "instance of" tests resolve

--- a/xpath3/eval_schema_element_substgroup_test.go
+++ b/xpath3/eval_schema_element_substgroup_test.go
@@ -1,0 +1,143 @@
+package xpath3_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+const sgTestNS = "urn:t"
+
+// substGroupDecls declares a head element {urn:t}h of type Q{urn:t}HT, a
+// substitution-group member {urn:t}m (type Q{urn:t}MT, derived from HT), and a
+// NON-member {urn:t}e (type Q{urn:t}ET, ALSO derived from HT). Type derivation
+// and substitution-group membership are DELIBERATELY decoupled: e derives from
+// HT but is not a member of h's substitution group. schema-element(H) must key
+// on substitution-group membership, not type derivation, so both the step
+// node-test path (eval_path.go) and the sequence-type / instance-of path
+// (eval_types.go) must reject e and accept m — and must agree with each other.
+type substGroupDecls struct{}
+
+func (substGroupDecls) LookupSchemaElement(local, ns string) (string, bool) {
+	if ns != sgTestNS {
+		return "", false
+	}
+	switch local {
+	case "h":
+		return "Q{urn:t}HT", true
+	case "m":
+		return "Q{urn:t}MT", true
+	case "e":
+		return "Q{urn:t}ET", true
+	}
+	return "", false
+}
+func (substGroupDecls) LookupSchemaAttribute(local, ns string) (string, bool) { return "", false }
+func (substGroupDecls) LookupSchemaType(local, ns string) (string, bool)      { return "", false }
+func (substGroupDecls) IsSubtypeOf(typeName, baseTypeName string) bool {
+	if typeName == baseTypeName {
+		return true
+	}
+	// Both MT and ET derive from HT.
+	switch typeName {
+	case "Q{urn:t}MT", "Q{urn:t}ET":
+		return baseTypeName == "Q{urn:t}HT"
+	}
+	return false
+}
+func (substGroupDecls) ValidateCast(_ context.Context, value, typeName string) error { return nil }
+func (substGroupDecls) ValidateCastWithNS(_ context.Context, value, typeName string, nsMap map[string]string) error {
+	return nil
+}
+func (substGroupDecls) ListItemType(typeName string) (string, bool) { return "", false }
+func (substGroupDecls) UnionMemberTypes(typeName string) []string   { return nil }
+func (substGroupDecls) IsSubstitutionGroupMember(memberLocal, memberNS, headLocal, headNS string) bool {
+	// Only m is substitutable for h; e is not — even though ET derives from HT.
+	return headNS == sgTestNS && headLocal == "h" && memberNS == sgTestNS && memberLocal == "m"
+}
+
+// TestSchemaElementStepAndInstanceOfAgree verifies that the two schema-element()
+// matchers — the step node-test (eval_path.go) and the sequence-type instance-of
+// path (eval_types.go) — give the SAME answer, keying on substitution-group
+// membership rather than type derivation. The member m is selected/true by both;
+// the non-member e, whose type still derives from the head's type, is
+// rejected/false by both.
+func TestSchemaElementStepAndInstanceOfAgree(t *testing.T) {
+	t.Parallel()
+
+	doc := `<root xmlns:t="` + sgTestNS + `"><t:m/><t:e/></root>`
+
+	build := func(t *testing.T) (*helium.Document, map[helium.Node]string) {
+		t.Helper()
+		parsed, err := helium.NewParser().Parse(t.Context(), []byte(doc))
+		require.NoError(t, err)
+		annotations := map[helium.Node]string{}
+		for c := range helium.Children(parsed.DocumentElement()) {
+			elem, ok := helium.AsNode[*helium.Element](c)
+			if !ok {
+				continue
+			}
+			switch elem.LocalName() {
+			case "m":
+				annotations[elem] = "Q{urn:t}MT"
+			case "e":
+				annotations[elem] = "Q{urn:t}ET"
+			}
+		}
+		require.Len(t, annotations, 2, "fixture must annotate both t:m and t:e")
+		return parsed, annotations
+	}
+
+	newEval := func(annotations map[helium.Node]string) xpath3.Evaluator {
+		return xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+			Namespaces(map[string]string{"t": sgTestNS}).
+			TypeAnnotations(annotations).
+			SchemaDeclarations(substGroupDecls{})
+	}
+
+	t.Run("step selects only the substitution-group member", func(t *testing.T) {
+		t.Parallel()
+		parsed, annotations := build(t)
+		compiled, err := xpath3.NewCompiler().Compile(`//schema-element(t:h)`)
+		require.NoError(t, err)
+		r, err := newEval(annotations).Evaluate(t.Context(), compiled, parsed)
+		require.NoError(t, err)
+		nodes, err := r.Nodes()
+		require.NoError(t, err)
+		require.Len(t, nodes, 1, "only t:m (the substitution member) must be selected, not t:e")
+		require.Equal(t, "m", xpath3NodeLocal(nodes[0]))
+	})
+
+	t.Run("instance of true for the member, false for the non-member", func(t *testing.T) {
+		t.Parallel()
+		parsed, annotations := build(t)
+
+		memberOK := xpath3.NewCompiler()
+		compiledMember, err := memberOK.Compile(`//t:m instance of schema-element(t:h)`)
+		require.NoError(t, err)
+		rm, err := newEval(annotations).Evaluate(t.Context(), compiledMember, parsed)
+		require.NoError(t, err)
+		bm, ok := rm.IsBoolean()
+		require.True(t, ok)
+		require.True(t, bm, "t:m is a substitution member of t:h, so instance of must be true")
+
+		compiledNonMember, err := xpath3.NewCompiler().Compile(`//t:e instance of schema-element(t:h)`)
+		require.NoError(t, err)
+		re, err := newEval(annotations).Evaluate(t.Context(), compiledNonMember, parsed)
+		require.NoError(t, err)
+		be, ok := re.IsBoolean()
+		require.True(t, ok)
+		require.False(t, be,
+			"t:e's type derives from t:h's type but t:e is NOT a substitution member, so instance of must be false — agreeing with the step path")
+	})
+}
+
+func xpath3NodeLocal(n helium.Node) string {
+	if e, ok := helium.AsNode[*helium.Element](n); ok {
+		return e.LocalName()
+	}
+	return n.Name()
+}

--- a/xpath3/eval_types.go
+++ b/xpath3/eval_types.go
@@ -919,27 +919,23 @@ func matchesItemType(item Item, test NodeTest, ec *evalContext) bool {
 		// (or a substitution group member — checked separately below).
 		nameMatch := ixpath.LocalNameOf(ni.Node) == local && ixpath.NodeNamespaceURI(ni.Node) == ns
 		if !nameMatch {
-			// Check substitution group membership.
-			if ec.schemaDeclarations == nil {
+			// The node's name is not the head's own name, so it matches only
+			// when the node's element is a member of the substitution group
+			// headed by (local, ns). This mirrors the step node-test path
+			// (eval_path.go): substitution-group membership already requires
+			// each member's declared type to derive from the head's type, so a
+			// validated (non-untyped) member satisfies the kind test, whereas a
+			// bare type-derivation check would wrongly admit an element whose
+			// type happens to derive from the head's type without being
+			// substitutable for it — keeping the two matchers consistent.
+			if !ec.schemaDeclarations.IsSubstitutionGroupMember(ixpath.LocalNameOf(ni.Node), ixpath.NodeNamespaceURI(ni.Node), local, ns) {
 				return false
 			}
-			headType, headFound := ec.schemaDeclarations.LookupSchemaElement(local, ns)
-			if !headFound {
-				return false
-			}
-			// The node's type must be a subtype of the head's type.
 			ann := nodeAnn
-			if ann == "" {
-				ann = TypeUntyped
-			}
-			// Untyped elements do NOT match schema-element().
-			if ann == TypeUntyped {
+			if ann == "" || ann == TypeUntyped {
 				return false
 			}
-			if isSubtypeOf(ann, headType) || ec.schemaDeclarations.IsSubtypeOf(ann, headType) {
-				return true
-			}
-			return false
+			return true
 		}
 		typeName, found := ec.schemaDeclarations.LookupSchemaElement(local, ns)
 		if !found {

--- a/xpath3/id_annotations_test.go
+++ b/xpath3/id_annotations_test.go
@@ -44,6 +44,9 @@ func (idSubtypeDecls) ListItemType(typeName string) (string, bool) {
 func (idSubtypeDecls) UnionMemberTypes(typeName string) []string {
 	return nil
 }
+func (idSubtypeDecls) IsSubstitutionGroupMember(memberLocal, memberNS, headLocal, headNS string) bool {
+	return false
+}
 
 func TestFnIDUsesTypeAnnotationsForIDSubtype(t *testing.T) {
 	doc := mustParseXML(t, `<root id="alpha"/>`)

--- a/xsd/schema_decls.go
+++ b/xsd/schema_decls.go
@@ -186,6 +186,21 @@ func (d schemaDecls) IsSubtypeOf(typeName, baseTypeName string) bool {
 	return false
 }
 
+// IsSubstitutionGroupMember implements xpath3.SchemaDeclarations. It reports
+// whether the element (memberLocal, memberNS) is a transitive member (after
+// block/derivation filtering) of the substitution group headed by
+// (headLocal, headNS), so the schema-element() kind test matches by
+// substitution-group membership rather than mere type-derivation.
+func (d schemaDecls) IsSubstitutionGroupMember(memberLocal, memberNS, headLocal, headNS string) bool {
+	member := QName{Local: memberLocal, NS: memberNS}
+	for _, m := range d.schema.SubstGroupMembers(QName{Local: headLocal, NS: headNS}) {
+		if m.Name == member {
+			return true
+		}
+	}
+	return false
+}
+
 // ValidateCast validates value against a user-defined simple type's facets.
 func (d schemaDecls) ValidateCast(ctx context.Context, value, typeName string) error {
 	return d.validateCast(ctx, value, typeName, nil)

--- a/xslt3/schema_context.go
+++ b/xslt3/schema_context.go
@@ -258,10 +258,10 @@ func (r *schemaRegistry) IsSubtypeOf(typeName, baseTypeName string) bool {
 // the base-type chain (IsSubtypeOf) OR is an ATOMIC member of the baseTypeName
 // union (Type Derivation OK (Simple), §3.16.6.3). It is used for element(*, T) /
 // attribute(*, T) pattern type tests, where a union member matches its union.
-// It is intentionally NOT folded into IsSubtypeOf: the shared derives-from is
-// also used as a substitution-group proxy in xpath3's schema-element step, where
-// admitting union membership would wrongly match an unrelated element whose type
-// happens to be a member of the head element's union type.
+// It is intentionally NOT folded into IsSubtypeOf, which is a strict
+// type-derivation predicate: admitting union membership there would wrongly
+// match an unrelated element whose type happens to be a member of the head
+// element's union type.
 func (r *schemaRegistry) isSubtypeOrUnionMember(typeName, baseTypeName string) bool {
 	if r.IsSubtypeOf(typeName, baseTypeName) {
 		return true
@@ -375,8 +375,10 @@ func (r *schemaRegistry) UnionMemberTypes(typeName string) []string {
 	return members
 }
 
-// IsSubstitutionGroupMember checks if an element (memberLocal, memberNS) is in
-// the substitution group of the head element (headLocal, headNS).
+// IsSubstitutionGroupMember implements xpath3.SchemaDeclarations. It checks if
+// an element (memberLocal, memberNS) is a transitive member (after
+// block/derivation filtering) of the substitution group headed by the element
+// (headLocal, headNS), driving the schema-element() kind test.
 func (r *schemaRegistry) IsSubstitutionGroupMember(memberLocal, memberNS, headLocal, headNS string) bool {
 	headQN := xsd.QName{Local: headLocal, NS: headNS}
 	memberQN := xsd.QName{Local: memberLocal, NS: memberNS}


### PR DESCRIPTION
- add xpath3.SchemaDeclarations.IsSubstitutionGroupMember; schema-element(H) kind test now matches by transitive substitution-group membership instead of the type-derivation proxy (which false-matched non-members sharing a base type)
- all implementers updated; safe no-op (false) default preserves non-schema-aware behavior
- fixes W3C xslt30 validation-0501/0601/0701