### PR TITLE
support XML 1.1 namespace undeclaration + control chars

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -15,7 +15,7 @@ XML parsing, DOM tree, serialization. Entry point for all XML processing.
   - `Parser.ErrorHandler(ErrorHandler)` — sets the handler for validation errors produced during DTD validation (`ValidateDTD`); individual errors are delivered as they occur and `Parse` returns `ErrDTDValidationFailed` on failure. If the handler is an `io.Closer`, it is closed only after the DTD validation pass runs (i.e. when `ValidateDTD` is enabled and the document was parsed); it is not auto-closed for non-validating parses or for parse errors that abort before validation
   - Terminal methods: `Parse(ctx, []byte) → (*Document, error)`, `ParseReader(ctx, io.Reader) → (*Document, error)`, `ParseFile(ctx, string) → (*Document, error)`, `ParseInNodeContext(ctx, Node, []byte) → (Node, error)`, `NewPushParser(ctx) → *PushParser`
 - **NewWriter() → Writer** — create fluent XML writer builder
-  - Writer methods: `Format(bool)`, `IndentString(string)`, `SelfCloseEmptyElements(bool)`, `XMLDeclaration(bool)`, `IncludeDTD(bool)`, `EscapeNonASCII(bool)`, `AllowPrefixUndeclarations(bool)`
+  - Writer methods: `Format(bool)`, `IndentString(string)`, `SelfCloseEmptyElements(bool)`, `XMLDeclaration(bool)`, `IncludeDTD(bool)`, `EscapeNonASCII(bool)`, `AllowPrefixUndeclarations(bool)`, `RejectInvalidChars(bool)` (fail with `ErrInvalidXMLChar` — the XSLT SERE0006 error — instead of replacing an XML-invalid char with U+FFFD; folded into the escape pass, no extra traversal)
   - Terminal method: `WriteTo(io.Writer, Node) → error`
 - **Write(io.Writer, Node) → error** — serialize node with default settings
 - **WriteString(Node) → (string, error)** — serialize node to string with default settings

--- a/.claude/docs/parser-internals.md
+++ b/.claude/docs/parser-internals.md
@@ -65,6 +65,11 @@ State affects parsing rules: e.g., external entity refs forbidden in `psAttribut
 - `nsNrTab []int` — namespace count per element level (parallel to nodeTab); used to pop exact count on element close
 - `spaceTab []int` — xml:space stack (-1=inherit, 0=default, 1=preserve)
 
+### XML 1.1 Version-Gated Relaxations
+`pctx.isXML11()` (`version == "1.1"`, from the XML declaration; absent decl = 1.0) gates two well-formedness relaxations; every non-1.1 document stays byte-identical:
+- **Namespace prefix undeclaration** (`parser_element.go` `validatePrefixedNamespaceDecl`): `xmlns:pfx=""` is accepted only in XML 1.1 and pushes an empty-URI binding onto `nsTab` (undeclaring the prefix); XML 1.0 rejects it ("Empty XML namespace is not allowed"). The reserved `xml`/`xmlns` prefixes are checked before the empty-URI branch, so they can never be undeclared. Applies to both literal and DTD-defaulted namespace declarations. A default-namespace undeclaration (`xmlns=""`) is legal in both versions and is handled separately.
+- **Control-character char references** (`parser_entity_ref.go` `parseCharRef`): a `&#N;`/`&#xN;` reference to a C0/C1 control character (all but U+0000) that the XML 1.0 Char production forbids is accepted in XML 1.1 via `isXML11CharValue` (`parser_content.go`). Only the char-reference value check is relaxed; literal control bytes and XML 1.0 documents are unchanged.
+
 ### SAX & Tree Building
 - `sax` (sax.SAX2Handler) — callbacks (default: TreeBuilder)
 - `doc *Document` — parsed document

--- a/parser_content.go
+++ b/parser_content.go
@@ -261,6 +261,25 @@ func isXMLCharValue(c uint32) bool {
 	return (0x100 <= c && c <= 0xd7ff) || (0xe000 <= c && c <= 0xfffd) || (0x10000 <= c && c <= 0x10ffff)
 }
 
+// isXML11CharValue implements the XML 1.1 Char production:
+//
+//	Char ::= [#x1-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+//
+// The C0/C1 control characters (0x1-0x1F, 0x7F-0x9F) the XML 1.0 Char
+// production forbids are valid XML 1.1 characters; only U+0000 is disallowed.
+// XML 1.1 requires the restricted characters to appear as character references
+// rather than literally, so this predicate governs only the char-reference
+// value check.
+func isXML11CharValue(c uint32) bool {
+	if c == 0 {
+		return false
+	}
+	if c < 0x100 {
+		return true
+	}
+	return (0x100 <= c && c <= 0xd7ff) || (0xe000 <= c && c <= 0xfffd) || (0x10000 <= c && c <= 0x10ffff)
+}
+
 var (
 	ErrCDATANotFinished = errors.New("invalid CDATA section (premature end)")
 	ErrCDATAInvalid     = errors.New("invalid CDATA section")

--- a/parser_element.go
+++ b/parser_element.go
@@ -377,6 +377,14 @@ func (pctx *parserCtx) validatePrefixedNamespaceDecl(ctx context.Context, prefix
 		return pctx.namespaceError(ctx, errors.New("reuse of the xmlns namespace name if forbidden"))
 	}
 	if uri == "" {
+		// Namespaces in XML 1.1 §5: a prefixed namespace declaration with an
+		// empty value undeclares the prefix (removes the in-scope binding).
+		// This is well-formed only in an XML 1.1 document; XML 1.0 forbids it.
+		// The reserved xml/xmlns prefixes were already handled above, so they
+		// cannot be undeclared here.
+		if pctx.isXML11() {
+			return nil
+		}
 		return pctx.namespaceError(ctx, fmt.Errorf("xmlns:%s: Empty XML namespace is not allowed", prefix))
 	}
 	u, err := url.Parse(uri)

--- a/parser_entity_ref.go
+++ b/parser_entity_ref.go
@@ -610,7 +610,13 @@ func (ctx *parserCtx) parseCharRef() (r rune, err error) {
 		return
 	}
 
-	if isXMLCharValue(uint32(val)) && val <= unicode.MaxRune {
+	charOK := isXMLCharValue(uint32(val))
+	if !charOK && ctx.isXML11() {
+		// XML 1.1 permits character references to the C0/C1 control
+		// characters the 1.0 Char production forbids (all but U+0000).
+		charOK = isXML11CharValue(uint32(val))
+	}
+	if charOK && val <= unicode.MaxRune {
 		r = val
 		return
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -244,6 +244,48 @@ func TestParseRejectsDuplicateAttribute(t *testing.T) {
 	}
 }
 
+func TestParseXML11PrefixUndeclaration(t *testing.T) {
+	// Namespaces in XML 1.1 §5: a prefixed namespace declaration with an empty
+	// value (xmlns:pfx="") undeclares the prefix. This is well-formed only in an
+	// XML 1.1 document; XML 1.0 forbids it.
+	const undecl = `<doc xmlns:a="http://a/"><para xmlns:a=""/></doc>`
+
+	// XML 1.0: rejected.
+	_, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<?xml version="1.0"?>`+undecl))
+	require.Error(t, err, "XML 1.0 must reject a prefixed namespace undeclaration")
+
+	// No XML declaration defaults to XML 1.0: rejected.
+	_, err = helium.NewParser().Parse(t.Context(), []byte(undecl))
+	require.Error(t, err, "an implicit XML 1.0 document must reject xmlns:pfx=\"\"")
+
+	// XML 1.1: accepted, and the prefix binding is removed on the inner element.
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<?xml version="1.1"?>`+undecl))
+	require.NoError(t, err, "XML 1.1 must accept a prefixed namespace undeclaration")
+
+	para := doc.DocumentElement().FirstChild().(*helium.Element)
+	require.Equal(t, "para", para.Name())
+	var hasUndecl bool
+	for _, ns := range para.Namespaces() {
+		if ns.Prefix() == "a" {
+			require.Equal(t, "", ns.URI(),
+				"the prefix a must be undeclared (empty URI) on the inner element")
+			hasUndecl = true
+		}
+	}
+	require.True(t, hasUndecl, "the undeclaration must be recorded on the inner element")
+
+	// The reserved xml/xmlns prefixes may never be undeclared, even in XML 1.1.
+	for _, input := range []string{
+		`<?xml version="1.1"?><doc xmlns:xml=""/>`,
+		`<?xml version="1.1"?><doc xmlns:xmlns=""/>`,
+	} {
+		_, err := helium.NewParser().Parse(t.Context(), []byte(input))
+		require.Error(t, err, "must reject undeclaring a reserved prefix in %q", input)
+	}
+}
+
 func TestParseNamespace(t *testing.T) {
 	const input = `<?xml version="1.0"?>
 <helium:root xmlns:helium="https://github.com/lestrrat-go/helium">
@@ -3466,6 +3508,28 @@ func TestCharacterReferences(t *testing.T) {
 	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
 	require.NoError(t, err)
 	require.Equal(t, "dec=A hex=B high=\U0001F600", string(doc.DocumentElement().Content()))
+}
+
+func TestParseXML11ControlCharRef(t *testing.T) {
+	t.Parallel()
+
+	// XML 1.1 permits character references to the C0/C1 control characters
+	// (all but U+0000) that the XML 1.0 Char production forbids.
+	doc, err := helium.NewParser().Parse(t.Context(),
+		[]byte(`<?xml version="1.1"?><root>&#7;&#131;&#133;</root>`))
+	require.NoError(t, err, "XML 1.1 must accept control-character references")
+	require.Equal(t, "\u0007\u0083\u0085", string(doc.DocumentElement().Content()))
+
+	// XML 1.0 (and an implicit-1.0 document) must still reject them, and U+0000
+	// is invalid in every XML version.
+	for _, in := range []string{
+		`<?xml version="1.0"?><root>&#7;</root>`,
+		`<root>&#7;</root>`,
+		`<?xml version="1.1"?><root>&#0;</root>`,
+	} {
+		_, err := helium.NewParser().Parse(t.Context(), []byte(in))
+		require.Error(t, err, "must reject %q", in)
+	}
 }
 
 // TestMalformedDocuments exercises well-formedness error branches across the

--- a/parserctx.go
+++ b/parserctx.go
@@ -227,6 +227,13 @@ func (ctx *parserCtx) pushNS(prefix, uri string) {
 	ctx.nsTab.Push(prefix, uri)
 }
 
+// isXML11 reports whether the document being parsed declared XML version 1.1
+// in its XML declaration. Used to gate XML 1.1-only well-formedness relaxations
+// such as namespace prefix undeclaration (xmlns:pfx="").
+func (ctx *parserCtx) isXML11() bool {
+	return ctx.version == "1.1"
+}
+
 const (
 	cbEntityDecl = iota
 	cbGetParameterEntity

--- a/writer.go
+++ b/writer.go
@@ -38,13 +38,14 @@ const xmlTextNoEnc = "textnoenc"
 // escapeNonASCII flag, XHTML detection) lives in a writeSession created
 // inside each terminal method.
 type Writer struct {
-	format            bool
-	indentString      string
-	skipDTD           bool
-	noEmpty           bool
-	noDecl            bool
-	noEscapeNonASCII  bool
-	allowPrefixUndecl bool // emit xmlns:prefix="" undeclarations (XML 1.1)
+	format             bool
+	indentString       string
+	skipDTD            bool
+	noEmpty            bool
+	noDecl             bool
+	noEscapeNonASCII   bool
+	allowPrefixUndecl  bool // emit xmlns:prefix="" undeclarations (XML 1.1)
+	rejectInvalidChars bool // error (SERE0006) instead of replacing XML-invalid chars
 }
 
 // writeSession holds the mutable state for a single serialization pass.
@@ -226,6 +227,17 @@ func (w Writer) EscapeNonASCII(v bool) Writer {
 // may be emitted.
 func (w Writer) AllowPrefixUndeclarations(v bool) Writer {
 	w.allowPrefixUndecl = v
+	return w
+}
+
+// RejectInvalidChars controls how the writer handles a character that is not
+// valid in the target XML version (e.g. a C0/C1 control character in XML 1.0
+// output). When false (the default) such a character is replaced with U+FFFD;
+// when true the write fails with ErrInvalidXMLChar (the XSLT/XQuery
+// serialization error SERE0006). This detection is folded into the existing
+// text/attribute escaping pass, so it adds no extra traversal.
+func (w Writer) RejectInvalidChars(v bool) Writer {
+	w.rejectInvalidChars = v
 	return w
 }
 
@@ -444,7 +456,7 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 				return err
 			}
 		} else {
-			if err := escapeText(out, c, false, d.escapeNonASCII); err != nil {
+			if err := escapeText(out, c, false, d.escapeNonASCII, d.rejectInvalidChars); err != nil {
 				return err
 			}
 		}
@@ -553,7 +565,7 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 			for achld := range Children(attr) {
 				count++
 				if achld.Type() == TextNode {
-					if err := escapeAttrValue(out, rawContent(achld), d.escapeNonASCII); err != nil {
+					if err := escapeAttrValue(out, rawContent(achld), d.escapeNonASCII, d.rejectInvalidChars); err != nil {
 						return err
 					}
 				} else {

--- a/writer_dtd.go
+++ b/writer_dtd.go
@@ -379,7 +379,7 @@ func (d *writeSession) dumpAttributeDecl(out io.Writer, n *AttributeDecl) error 
 
 	if n.defvalue != "" {
 		d.writeString(out, ` "`)
-		d.check(escapeAttrValue(out, []byte(n.defvalue), d.escapeNonASCII))
+		d.check(escapeAttrValue(out, []byte(n.defvalue), d.escapeNonASCII, d.rejectInvalidChars))
 		d.writeString(out, `"`)
 	}
 	d.writeString(out, ">\n")
@@ -436,7 +436,7 @@ func (d *writeSession) dumpNs(out io.Writer, ns *Namespace) error {
 	if _, err := io.WriteString(out, `="`); err != nil {
 		return err
 	}
-	if err := escapeAttrValue(out, []byte(ns.href), d.escapeNonASCII); err != nil {
+	if err := escapeAttrValue(out, []byte(ns.href), d.escapeNonASCII, d.rejectInvalidChars); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(out, `"`); err != nil {

--- a/writer_escape.go
+++ b/writer_escape.go
@@ -1,6 +1,7 @@
 package helium
 
 import (
+	"errors"
 	"io"
 	"strings"
 	"unicode/utf8"
@@ -10,6 +11,12 @@ var (
 	qch_dquote = []byte{'"'}
 	qch_quote  = []byte{'\''}
 )
+
+// ErrInvalidXMLChar is returned by the writer when a character in the tree is
+// not valid in the target XML version and the writer is configured to reject
+// (rather than replace) such characters via Writer.RejectInvalidChars. It maps
+// to the XSLT/XQuery serialization error SERE0006.
+var ErrInvalidXMLChar = errors.New("character is not valid in the target XML version")
 
 func dumpQuotedString(out io.Writer, s string) error {
 	dqi := strings.IndexByte(s, qch_dquote[0])
@@ -104,7 +111,7 @@ func isInCharacterRange(r rune) bool {
 		r >= 0x10000 && r <= 0x10FFFF
 }
 
-func escapeAttrValue(w io.Writer, s []byte, escapeNonASCII bool) error {
+func escapeAttrValue(w io.Writer, s []byte, escapeNonASCII, rejectInvalidChars bool) error {
 	var esc []byte
 	var hbuf [8]byte
 	last := 0
@@ -127,6 +134,14 @@ func escapeAttrValue(w io.Writer, s []byte, escapeNonASCII bool) error {
 		case '\t':
 			esc = esc_tab
 		default:
+			// A character outside the XML character range (e.g. a C0/C1 control
+			// char) is a serialization error when rejection is enabled — checked
+			// before the escapeNonASCII char-reference branch so it is caught
+			// regardless of that setting. A malformed UTF-8 byte decodes to
+			// U+FFFD, which is IN range, so it is not a version error here.
+			if rejectInvalidChars && !isInCharacterRange(r) {
+				return ErrInvalidXMLChar
+			}
 			if escapeNonASCII && !(0x20 <= r && r < 0x80) { //nolint:staticcheck
 				if r < 0x100 {
 					esc = hexCharRef(&hbuf, r)
@@ -159,7 +174,7 @@ func escapeAttrValue(w io.Writer, s []byte, escapeNonASCII bool) error {
 	return nil
 }
 
-func escapeText(w io.Writer, s []byte, escapeNewline bool, escapeNonASCII bool) error {
+func escapeText(w io.Writer, s []byte, escapeNewline, escapeNonASCII, rejectInvalidChars bool) error {
 	var esc []byte
 	var hbuf [8]byte
 	last := 0
@@ -181,6 +196,14 @@ func escapeText(w io.Writer, s []byte, escapeNewline bool, escapeNonASCII bool) 
 		case '\r':
 			esc = esc_cr
 		default:
+			// A character outside the XML character range (e.g. a C0/C1 control
+			// char) is a serialization error when rejection is enabled — checked
+			// before the escapeNonASCII char-reference branch so it is caught
+			// regardless of that setting. A malformed UTF-8 byte decodes to
+			// U+FFFD, which is IN range, so it is not a version error here.
+			if rejectInvalidChars && !isInCharacterRange(r) {
+				return ErrInvalidXMLChar
+			}
 			if escapeNonASCII && !(r == '\t' || (0x20 <= r && r < 0x80)) { //nolint:staticcheck
 				if r < 0x100 {
 					esc = hexCharRef(&hbuf, r)

--- a/writer_test.go
+++ b/writer_test.go
@@ -1145,6 +1145,56 @@ func TestWriterOptions(t *testing.T) {
 	require.Contains(t, buf.String(), "&#")
 }
 
+func TestWriterRejectInvalidChars(t *testing.T) {
+	t.Parallel()
+
+	// A C0 control character (U+0007) is invalid in XML 1.0. By default the
+	// writer replaces it with U+FFFD; with RejectInvalidChars it fails with
+	// ErrInvalidXMLChar (the SERE0006 serialization error).
+	textDoc := func() *helium.Document {
+		d := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+		r := d.CreateElement("r")
+		require.NoError(t, d.AddChild(r))
+		require.NoError(t, r.AppendText([]byte("a\x07b")))
+		return d
+	}
+
+	// Default (with EscapeNonASCII off, matching the xslt3 XML path): the
+	// control char is replaced with U+FFFD and no error is raised.
+	var buf bytes.Buffer
+	require.NoError(t, helium.NewWriter().EscapeNonASCII(false).WriteTo(&buf, textDoc()))
+	require.Contains(t, buf.String(), "\uFFFD")
+
+	// RejectInvalidChars rejects the control char regardless of the
+	// EscapeNonASCII setting (the check runs before char-reference escaping).
+	buf.Reset()
+	err := helium.NewWriter().RejectInvalidChars(true).WriteTo(&buf, textDoc())
+	require.ErrorIs(t, err, helium.ErrInvalidXMLChar)
+	buf.Reset()
+	err = helium.NewWriter().EscapeNonASCII(false).RejectInvalidChars(true).WriteTo(&buf, textDoc())
+	require.ErrorIs(t, err, helium.ErrInvalidXMLChar)
+
+	// A control char in an attribute value is rejected too (escaping covers
+	// attribute values, not only text nodes).
+	attrDoc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	r := attrDoc.CreateElement("r")
+	require.NoError(t, attrDoc.AddChild(r))
+	_, err = r.SetAttribute("v", "x\x07y")
+	require.NoError(t, err)
+	buf.Reset()
+	err = helium.NewWriter().RejectInvalidChars(true).WriteTo(&buf, attrDoc)
+	require.ErrorIs(t, err, helium.ErrInvalidXMLChar)
+
+	// A valid document still serializes cleanly with rejection enabled.
+	okDoc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	e := okDoc.CreateElement("r")
+	require.NoError(t, okDoc.AddChild(e))
+	require.NoError(t, e.AppendText([]byte("plain text\tok")))
+	buf.Reset()
+	require.NoError(t, helium.NewWriter().RejectInvalidChars(true).WriteTo(&buf, okDoc))
+	require.Contains(t, buf.String(), "plain text\tok")
+}
+
 // TestWriteStringWithoutDTD verifies WriteString on a programmatically built doc.
 func TestWriteStringWithoutDTD(t *testing.T) {
 	t.Parallel()

--- a/writer_xhtml.go
+++ b/writer_xhtml.go
@@ -225,7 +225,7 @@ func (d *writeSession) dumpXHTMLAttrList(out io.Writer, e *Element) error {
 			for achld := range Children(attr) {
 				if achld.Type() == TextNode {
 					// Read-only escape pass: use the internal slice without a copy.
-					d.check(escapeAttrValue(out, rawContent(achld), d.escapeNonASCII))
+					d.check(escapeAttrValue(out, rawContent(achld), d.escapeNonASCII, d.rejectInvalidChars))
 				} else {
 					d.check(d.writeNode(out, achld))
 				}
@@ -236,17 +236,17 @@ func (d *writeSession) dumpXHTMLAttrList(out io.Writer, e *Element) error {
 
 	if nameAttr != nil && idAttr == nil && xhtmlNameIDElements[localName] {
 		d.writeString(out, ` id="`)
-		d.check(escapeAttrValue(out, nameAttr.Content(), d.escapeNonASCII))
+		d.check(escapeAttrValue(out, nameAttr.Content(), d.escapeNonASCII, d.rejectInvalidChars))
 		d.writeString(out, `"`)
 	}
 
 	if langAttr != nil && xmlLangAttr == nil {
 		d.writeString(out, ` xml:lang="`)
-		d.check(escapeAttrValue(out, langAttr.Content(), d.escapeNonASCII))
+		d.check(escapeAttrValue(out, langAttr.Content(), d.escapeNonASCII, d.rejectInvalidChars))
 		d.writeString(out, `"`)
 	} else if xmlLangAttr != nil && langAttr == nil {
 		d.writeString(out, ` lang="`)
-		d.check(escapeAttrValue(out, xmlLangAttr.Content(), d.escapeNonASCII))
+		d.check(escapeAttrValue(out, xmlLangAttr.Content(), d.escapeNonASCII, d.rejectInvalidChars))
 		d.writeString(out, `"`)
 	}
 	return d.err

--- a/xslt3/errors.go
+++ b/xslt3/errors.go
@@ -22,6 +22,7 @@ const (
 	errCodeSEPM0009 = "SEPM0009" // omit-xml-declaration conflicts with standalone/doctype
 	errCodeSEPM0010 = "SEPM0010" // undeclare-prefixes="yes" requires XML 1.1
 	errCodeSEPM0016 = "SEPM0016" // invalid serialization parameter value
+	errCodeSERE0006 = "SERE0006" // character invalid for the output XML version
 	errCodeSERE0012 = "SERE0012" // invalid character in text
 	errCodeSERE0014 = "SERE0014" // invalid character in comment or PI
 	errCodeSERE0015 = "SERE0015" // invalid character in namespace

--- a/xslt3/output.go
+++ b/xslt3/output.go
@@ -586,49 +586,7 @@ func validateSerializationParams(outDef *OutputDef, doc *helium.Document) error 
 		}
 	}
 
-	// SERE0006: a character in the result tree that is not valid in the output
-	// XML version. Only the XML/XHTML methods emit an XML declaration; the XML
-	// 1.0 Char production forbids the C0/C1 control characters that XML 1.1
-	// permits as character references, so serializing such content as XML 1.0
-	// (the default when version is unset or "1.0") is a serialization error.
-	if (method == methodXML || method == methodXHTML) && outDef.Version != "1.1" {
-		if err := checkXML10Chars(doc); err != nil {
-			return err
-		}
-	}
-
 	return nil
-}
-
-// checkXML10Chars reports a SERE0006 serialization error when the result tree
-// contains character data that is a valid XML 1.1 character but not a valid
-// XML 1.0 character (the C0/C1 control characters other than tab, LF and CR).
-func checkXML10Chars(doc *helium.Document) error {
-	var firstErr error
-	_ = helium.Walk(doc, helium.NodeWalkerFunc(func(n helium.Node) error {
-		if n.Type() != helium.TextNode && n.Type() != helium.CDATASectionNode {
-			return nil
-		}
-		for _, r := range string(n.Content()) {
-			if !isXML10Char(r) {
-				firstErr = dynamicError(errCodeSERE0006,
-					"character U+%04X is not valid in XML 1.0 output", r)
-				return firstErr
-			}
-		}
-		return nil
-	}))
-	return firstErr
-}
-
-// isXML10Char implements the XML 1.0 Char production:
-//
-//	Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
-func isXML10Char(r rune) bool {
-	return r == 0x9 || r == 0xA || r == 0xD ||
-		(r >= 0x20 && r <= 0xD7FF) ||
-		(r >= 0xE000 && r <= 0xFFFD) ||
-		(r >= 0x10000 && r <= 0x10FFFF)
 }
 
 // countRootElements counts the number of element children of the document root.

--- a/xslt3/output.go
+++ b/xslt3/output.go
@@ -586,7 +586,49 @@ func validateSerializationParams(outDef *OutputDef, doc *helium.Document) error 
 		}
 	}
 
+	// SERE0006: a character in the result tree that is not valid in the output
+	// XML version. Only the XML/XHTML methods emit an XML declaration; the XML
+	// 1.0 Char production forbids the C0/C1 control characters that XML 1.1
+	// permits as character references, so serializing such content as XML 1.0
+	// (the default when version is unset or "1.0") is a serialization error.
+	if (method == methodXML || method == methodXHTML) && outDef.Version != "1.1" {
+		if err := checkXML10Chars(doc); err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+// checkXML10Chars reports a SERE0006 serialization error when the result tree
+// contains character data that is a valid XML 1.1 character but not a valid
+// XML 1.0 character (the C0/C1 control characters other than tab, LF and CR).
+func checkXML10Chars(doc *helium.Document) error {
+	var firstErr error
+	_ = helium.Walk(doc, helium.NodeWalkerFunc(func(n helium.Node) error {
+		if n.Type() != helium.TextNode && n.Type() != helium.CDATASectionNode {
+			return nil
+		}
+		for _, r := range string(n.Content()) {
+			if !isXML10Char(r) {
+				firstErr = dynamicError(errCodeSERE0006,
+					"character U+%04X is not valid in XML 1.0 output", r)
+				return firstErr
+			}
+		}
+		return nil
+	}))
+	return firstErr
+}
+
+// isXML10Char implements the XML 1.0 Char production:
+//
+//	Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+func isXML10Char(r rune) bool {
+	return r == 0x9 || r == 0xA || r == 0xD ||
+		(r >= 0x20 && r <= 0xD7FF) ||
+		(r >= 0xE000 && r <= 0xFFFD) ||
+		(r >= 0x10000 && r <= 0x10FFFF)
 }
 
 // countRootElements counts the number of element children of the document root.

--- a/xslt3/output_xml.go
+++ b/xslt3/output_xml.go
@@ -1,6 +1,7 @@
 package xslt3
 
 import (
+	"errors"
 	"io"
 	"strings"
 
@@ -45,7 +46,10 @@ func serializeXML(w io.Writer, doc *helium.Document, outDef *OutputDef, charMap 
 			return err
 		}
 	}
-	writer := helium.NewWriter().EscapeNonASCII(false)
+	// This path only handles XML 1.0-family output (needsXML11 is false above),
+	// so a character invalid in XML 1.0 is a SERE0006 serialization error. The
+	// check is folded into the writer's existing escape pass (no extra traversal).
+	writer := helium.NewWriter().EscapeNonASCII(false).RejectInvalidChars(true)
 	if outDef.Indent {
 		writer = writer.Format(true)
 	}
@@ -59,7 +63,7 @@ func serializeXML(w io.Writer, doc *helium.Document, outDef *OutputDef, charMap 
 	if needStandalone || needStripNewline {
 		var buf strings.Builder
 		if err := writer.WriteTo(&buf, doc); err != nil {
-			return err
+			return xmlInvalidCharError(err)
 		}
 		out := buf.String()
 		if needStandalone {
@@ -73,7 +77,17 @@ func serializeXML(w io.Writer, doc *helium.Document, outDef *OutputDef, charMap 
 		_, err := io.WriteString(w, out)
 		return err
 	}
-	return writer.WriteTo(w, doc)
+	return xmlInvalidCharError(writer.WriteTo(w, doc))
+}
+
+// xmlInvalidCharError maps the writer's ErrInvalidXMLChar sentinel to the
+// XSLT serialization error SERE0006, passing every other error (and nil)
+// through unchanged.
+func xmlInvalidCharError(err error) error {
+	if err != nil && errors.Is(err, helium.ErrInvalidXMLChar) {
+		return dynamicError(errCodeSERE0006, "%s", err.Error())
+	}
+	return err
 }
 
 // injectStandalone inserts standalone="yes" or standalone="no" into the

--- a/xslt3/output_xml.go
+++ b/xslt3/output_xml.go
@@ -19,7 +19,11 @@ func serializeXML(w io.Writer, doc *helium.Document, outDef *OutputDef, charMap 
 	// producing only comments and text), use the stream-based serializer
 	// which does not inject newlines between top-level children.
 	noDocElem := doc.DocumentElement() == nil
-	if len(charMap) > 0 || hasDOEMarkers(doc) || isNonUTF8 || len(outDef.CDATASections) > 0 || (outDef.Indent && len(outDef.SuppressIndentation) > 0) || noDocElem {
+	// The stream-based serializer honors the XML 1.1 output-version declaration
+	// and the undeclare-prefixes namespace-undeclaration output; the default
+	// helium.Writer path does neither, so route to it when either applies.
+	needsXML11 := outDef.UndeclarePrefixes || (outDef.Version != "" && outDef.Version != lexicon.XSLTVersion10)
+	if len(charMap) > 0 || hasDOEMarkers(doc) || isNonUTF8 || len(outDef.CDATASections) > 0 || (outDef.Indent && len(outDef.SuppressIndentation) > 0) || noDocElem || needsXML11 {
 		return serializeXMLWithCharMap(w, doc, outDef, charMap)
 	}
 	// Set encoding on the document so the XML declaration includes it.
@@ -117,7 +121,13 @@ func serializeXMLWithCharMapInner(w io.Writer, doc *helium.Document, outDef *Out
 		if enc == "" {
 			enc = lexicon.EncodingUTF8U
 		}
-		if err := sw.StartDocument(lexicon.XSLTVersion10, enc, ""); err != nil {
+		// The output XML version defaults to 1.0; xsl:output/@version="1.1"
+		// selects an XML 1.1 declaration.
+		xmlVersion := lexicon.XSLTVersion10
+		if outDef.Version == "1.1" {
+			xmlVersion = outDef.Version
+		}
+		if err := sw.StartDocument(xmlVersion, enc, ""); err != nil {
 			return err
 		}
 	}
@@ -154,8 +164,9 @@ func serializeXMLWithCharMapInner(w io.Writer, doc *helium.Document, outDef *Out
 	}
 
 	ictx := &xmlIndentCtx{
-		indent:      outDef.Indent,
-		suppressSet: suppressSet,
+		indent:            outDef.Indent,
+		suppressSet:       suppressSet,
+		undeclarePrefixes: outDef.UndeclarePrefixes,
 	}
 
 	err := serializeXMLNodeWithCharMap(&sw, doc, charMap, cdataSet, enc, outDef.NormalizationForm, ictx)
@@ -172,6 +183,11 @@ type xmlIndentCtx struct {
 	depth       int
 	suppressSet map[string]struct{}
 	suppressed  bool // true when inside a suppress-indentation element
+	// undeclarePrefixes enables serialization of XML 1.1 prefixed namespace
+	// undeclarations (xmlns:pfx="") from empty-URI namespace declarations in the
+	// result tree. A default-namespace undeclaration (xmlns="") is always
+	// serialized regardless (it is valid in XML 1.0).
+	undeclarePrefixes bool
 }
 
 func (ic *xmlIndentCtx) writeIndent(sw *stream.Writer) error {
@@ -280,6 +296,12 @@ func serializeXMLNodeWithCharMap(sw *stream.Writer, n helium.Node, charMap map[r
 						return err
 					}
 				} else {
+					// A prefixed namespace undeclaration (empty URI) is an XML 1.1
+					// construct; emit it only when undeclare-prefixes is enabled,
+					// otherwise the prefix is simply left undeclared in the output.
+					if ns.URI() == "" && !ictx.undeclarePrefixes {
+						continue
+					}
 					if err := sw.WriteAttribute("xmlns:"+ns.Prefix(), ns.URI()); err != nil {
 						return err
 					}

--- a/xslt3/serialize_bench_test.go
+++ b/xslt3/serialize_bench_test.go
@@ -1,0 +1,39 @@
+package xslt3_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xslt3"
+)
+
+// BenchmarkSerializeResultXML measures the default XML-method serialization
+// path (version unset → XML 1.0) over a document with many text nodes. It
+// guards against reintroducing an extra whole-tree traversal for XML-version
+// character validation: the SERE0006 check is folded into the writer's escape
+// pass, so this benchmark should match the plain-serialization fast path.
+func BenchmarkSerializeResultXML(b *testing.B) {
+	const textNodes = 20000
+	var sb strings.Builder
+	sb.WriteString("<root>")
+	for range textNodes {
+		sb.WriteString("<item>lorem ipsum dolor sit amet consectetur</item>")
+	}
+	sb.WriteString("</root>")
+
+	doc, err := helium.NewParser().Parse(b.Context(), []byte(sb.String()))
+	if err != nil {
+		b.Fatalf("parse: %v", err)
+	}
+	outDef := &xslt3.OutputDef{Method: "xml"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if err := xslt3.SerializeResult(io.Discard, doc, outDef); err != nil {
+			b.Fatalf("serialize: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
- parser accepts xmlns:pfx="" as an undeclaration in XML 1.1 (reserved xml/xmlns still rejected); accepts XML 1.1 control-char refs in char data
- xslt3 XML 1.1 serialization: emit version="1.1" and xmlns:pfx="" under undeclare-prefixes; SERE0006 for XML-1.0-invalid chars in non-1.1 output
- all gated on version==1.1; XML 1.0 byte-identical
- fixes W3C xslt30 xml-version-026/027/028/031/032/035/037/039/042