### PR TITLE
cast/castable to user union and list types

### DIFF
--- a/.claude/docs/xpath3-eval.md
+++ b/.claude/docs/xpath3-eval.md
@@ -253,6 +253,28 @@ sources use the original lexical value, while already-typed sources use the
 accepted member-cast result's lexical form. `cast` returns the atomic value for
 the matching member.
 
+A user-defined LIST target type (resolved via `SchemaDeclarations.ListItemType`)
+casts by tokenization (F&O 3.1 §19.1.2): a string/untypedAtomic source is split on
+XSD whitespace (`xsdListFields`) and each token must be castable to the item type
+through the same schema-aware path, then the whole normalized value validates
+against the list type's own facets via `ValidateCastWithNS`. `castToUserList`
+returns the sequence of per-item atoms (each typed as the item type) for `cast`;
+`castableToUserList` returns the boolean for `castable`. Any other already-typed
+atomic source is not a list literal → not castable (an empty/whitespace-only
+source is the empty list, castable iff the list facets accept zero items). A
+multi-item list-typed operand (e.g. the xslt3 `s:intListType1("1 2 3")`
+constructor, which expands to a sequence of item atoms) is rejected earlier by the
+singleton-cardinality check on the atomized operand, so casting it to the same
+list type is correctly NOT castable (it is a sequence, not a single value).
+
+`AtomicToString` (canonical lexical) normalizes a schema-derived USER-typed atom
+(a non-XSD `TypeName` with a known-XSD `BaseType`) to its builtin base before
+formatting, mirroring `CastAtomic`'s dispatch normalization — so a user-typed
+temporal/binary/QName atom (e.g. a value of a user type derived from `xs:date`)
+stringifies as its canonical XSD lexical (`"2001-01-01"`) rather than the generic
+Go `%v` fallback. This keeps a union target's re-validation lexical correct when
+the accepted member value carries a user type annotation.
+
 When the cast source is itself an already-resolved `QNameValue` (e.g. `data(@q)`
 where the prefix is declared only on the instance node, absent from the
 assertion's static namespace map), `qnameCastLexical` re-validates using the

--- a/xpath3/cast_string.go
+++ b/xpath3/cast_string.go
@@ -28,6 +28,18 @@ func AtomicToString(v AtomicValue) (string, error) {
 
 // atomicToString returns the canonical string representation of an atomic value.
 func atomicToString(v AtomicValue) (string, error) {
+	// A schema-derived USER type annotation (e.g. Q{ns}unrestrictedDate, stamped
+	// onto an atom by a schema-aware cast or the xsd $value binding) is opaque to
+	// the per-type canonical formatters below, which key on the builtin TypeName —
+	// so a user-typed temporal/binary/QName atom would fall through to the generic
+	// Go %v formatter and produce a non-canonical lexical (e.g. time.Time's default
+	// format instead of "2001-01-01"). Normalize such a source to its recorded
+	// builtin BaseType (preserving the Value) so it formats exactly like its base,
+	// mirroring CastAtomic's dispatch normalization. The BaseType must be a KNOWN
+	// XSD builtin and the TypeName a NON-XSD user name; built-in atoms are untouched.
+	if v.TypeName != "" && v.BaseType != "" && IsKnownXSDType(v.BaseType) && !IsKnownXSDType(v.TypeName) {
+		return atomicToString(AtomicValue{TypeName: v.BaseType, Value: v.Value})
+	}
 	switch v.TypeName {
 	case TypeString, TypeAnyURI, TypeUntypedAtomic,
 		TypeNormalizedString, TypeToken, TypeLanguage, TypeName, TypeNCName,

--- a/xpath3/eval_types.go
+++ b/xpath3/eval_types.go
@@ -212,6 +212,12 @@ func evalCastExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContext, e 
 		}
 		return SingleAtomic(result), nil
 	}
+	// A user-defined list type (xs:list) casts to a SEQUENCE of item atoms.
+	if ec != nil && ec.schemaDeclarations != nil {
+		if itemType, ok := ec.schemaDeclarations.ListItemType(targetType); ok {
+			return castToUserList(ctx, ec, av, targetType, itemType)
+		}
+	}
 	result, err := CastAtomic(av, targetType)
 	if err != nil {
 		if result, err = schemaAwareCast(ctx, ec, av, targetType); err != nil {
@@ -272,8 +278,67 @@ func evalCastableExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContext
 		_, castErr := CastAtomic(av, TypeDouble)
 		return SingleBoolean(castErr == nil), nil
 	}
+	// A user-defined list type (xs:list): castable iff a string/untypedAtomic
+	// source tokenizes into tokens each castable to the item type, and the whole
+	// value satisfies the list type's own facets. A multi-item (already-expanded)
+	// list-typed source was rejected by the singleton cardinality check above.
+	if ec != nil && ec.schemaDeclarations != nil {
+		if itemType, ok := ec.schemaDeclarations.ListItemType(targetType); ok {
+			return SingleBoolean(castableToUserList(ctx, ec, av, targetType, itemType)), nil
+		}
+	}
 	_, castErr := schemaAwareCast(ctx, ec, av, targetType)
 	return SingleBoolean(castErr == nil), nil
+}
+
+// castableToUserList reports whether av is castable to a user-defined list type
+// (F&O 3.1 §19.1.2): a string/untypedAtomic source is split on XSD whitespace and
+// each token must be castable to the list's item type, then the whole normalized
+// value must satisfy the list type's own facets (length/pattern). Any other
+// already-typed atomic source is not castable to a list (its lexical is not a list
+// literal). An empty token set (an empty/whitespace-only source) is the empty list,
+// castable iff the list facets accept zero items.
+func castableToUserList(ctx context.Context, ec *evalContext, av AtomicValue, listType, itemType string) bool {
+	if av.TypeName != TypeString && av.TypeName != TypeUntypedAtomic {
+		return false
+	}
+	s, err := AtomicToString(av)
+	if err != nil {
+		return false
+	}
+	for _, tok := range xsdListFields(s) {
+		if _, castErr := schemaAwareCast(ctx, ec, AtomicValue{TypeName: TypeString, Value: tok}, itemType); castErr != nil {
+			return false
+		}
+	}
+	return ec.schemaDeclarations.ValidateCastWithNS(ctx, s, listType, ec.namespaces) == nil
+}
+
+// castToUserList casts a string/untypedAtomic source to a user-defined list type,
+// returning the sequence of item atoms (each typed as the item type). Mirrors
+// castableToUserList's tokenize-and-cast semantics; a token that is not castable
+// to the item type, a non-string source, or a list-facet violation is FORG0001.
+func castToUserList(ctx context.Context, ec *evalContext, av AtomicValue, listType, itemType string) (Sequence, error) {
+	if av.TypeName != TypeString && av.TypeName != TypeUntypedAtomic {
+		return nil, &XPathError{Code: errCodeFORG0001, Message: fmt.Sprintf("cannot cast %s to list type %s", av.TypeName, listType)}
+	}
+	s, err := AtomicToString(av)
+	if err != nil {
+		return nil, err
+	}
+	if vErr := ec.schemaDeclarations.ValidateCastWithNS(ctx, s, listType, ec.namespaces); vErr != nil {
+		return nil, &XPathError{Code: errCodeFORG0001, Message: fmt.Sprintf("cannot cast %q to %s: %v", s, listType, vErr)}
+	}
+	tokens := xsdListFields(s)
+	items := make(ItemSlice, 0, len(tokens))
+	for _, tok := range tokens {
+		cast, castErr := schemaAwareCast(ctx, ec, AtomicValue{TypeName: TypeString, Value: tok}, itemType)
+		if castErr != nil {
+			return nil, &XPathError{Code: errCodeFORG0001, Message: fmt.Sprintf("cannot cast token %q to %s: %v", tok, itemType, castErr)}
+		}
+		items = append(items, cast)
+	}
+	return items, nil
 }
 
 // isValidListCastable checks whether a string value is castable to

--- a/xslt3/schema_constructors.go
+++ b/xslt3/schema_constructors.go
@@ -69,6 +69,15 @@ func (ec *execContext) makeSchemaConstructor(td *xsd.TypeDef) func(context.Conte
 		}
 
 		if baseType == "" || variety != xsd.TypeVarietyAtomic {
+			// A LIST-typed value is a SEQUENCE of item atoms (XDM list semantics),
+			// not a single string atom — so its cardinality and per-item typing
+			// match a real list value (e.g. `s:intListType1("1 2 3")` is three
+			// xs:integer items, not one string, so it is not a singleton).
+			if variety == xsd.TypeVarietyList {
+				if seq, ok := ec.expandSchemaListValue(td, schemaNormalizeLexical(lexical, td)); ok {
+					return seq, nil
+				}
+			}
 			return xpath3.SingleAtomic(xpath3.AtomicValue{
 				TypeName: typeName,
 				Value:    schemaNormalizeLexical(lexical, td),
@@ -80,9 +89,13 @@ func (ec *execContext) makeSchemaConstructor(td *xsd.TypeDef) func(context.Conte
 			return nil, err
 		}
 		// Preserve the actual typed value (e.g., *big.Int for integer types)
-		// so that aggregate functions like sum() can operate on it.
+		// so that aggregate functions like sum() can operate on it. Stamp the
+		// builtin BaseType (the AtomizeItem/schema-aware-cast convention) so the
+		// user-typed atom normalizes to its base for cast dispatch and canonical
+		// string formatting (e.g. a user xs:date atom stringifies as "2001-01-01").
 		return xpath3.SingleAtomic(xpath3.AtomicValue{
 			TypeName: typeName,
+			BaseType: baseType,
 			Value:    cast.Value,
 		}), nil
 	}
@@ -166,6 +179,48 @@ func (ec *execContext) schemaTypeName(uri, local string) string {
 		return xpath3.QAnnotation(uri, local)
 	}
 	return local
+}
+
+// listItemTypeDef returns the item type definition of a list type, following the
+// base-type chain (a restriction of a list keeps the base's item type).
+func listItemTypeDef(listTD *xsd.TypeDef) *xsd.TypeDef {
+	for cur := listTD; cur != nil; cur = cur.BaseType {
+		if cur.Variety == xsd.TypeVarietyList && cur.ItemType != nil {
+			return cur.ItemType
+		}
+	}
+	return nil
+}
+
+// expandSchemaListValue expands a (validated, whitespace-collapsed) list lexical
+// into a sequence of per-item atoms, each typed as the item type — the XDM
+// representation of a list value. It only handles an ATOMIC item type (the common
+// case, e.g. xs:list itemType="xs:integer"); a union/list item type returns ok=false
+// so the caller keeps the single-atom fallback rather than mis-typing the tokens.
+func (ec *execContext) expandSchemaListValue(listTD *xsd.TypeDef, lexical string) (xpath3.Sequence, bool) {
+	itemTD := listItemTypeDef(listTD)
+	if itemTD == nil {
+		return nil, false
+	}
+	itemBuiltin := schemaBuiltinXPathType(itemTD)
+	if itemBuiltin == "" || schemaTypeVariety(itemTD) != xsd.TypeVarietyAtomic {
+		return nil, false
+	}
+	itemName := ec.schemaTypeName(itemTD.Name.NS, itemTD.Name.Local)
+	tokens := strings.Fields(lexical)
+	items := make(xpath3.ItemSlice, 0, len(tokens))
+	for _, tok := range tokens {
+		cast, err := xpath3.CastFromString(tok, itemBuiltin)
+		if err != nil {
+			return nil, false
+		}
+		items = append(items, xpath3.AtomicValue{
+			TypeName: itemName,
+			BaseType: itemBuiltin,
+			Value:    cast.Value,
+		})
+	}
+	return items, true
 }
 
 func schemaTypeVariety(td *xsd.TypeDef) xsd.TypeVariety {


### PR DESCRIPTION
- schema-aware cast/castable to a user-defined union type (normalize a user-typed atom to its builtin base before union re-validation) and user list type (per-item castability + list facets)
- list-type schema constructor expands to a per-item atom sequence; atomic constructor stamps builtin BaseType
- fixes W3C xslt30 castable-005/006