### PR TITLE
atomize simpleContent-union source nodes; scope module namespaces

### DIFF
--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -1347,6 +1347,26 @@ func effectiveContentSimpleType(td *TypeDef) *TypeDef {
 	return effectiveContentSimpleTypeRec(td, make(map[*TypeDef]struct{}))
 }
 
+// EffectiveContentSimpleType returns the effective simple type that constrains
+// the text content of td. For a simpleContent COMPLEX type it walks through the
+// simpleContent derivation to the underlying simpleType/builtin (composing any
+// facet-only restriction), so a caller ATOMIZING a node typed with td sees the
+// narrowed content type — its list/union/QName variety — rather than the raw
+// complex type. A non-simpleContent type (a plain simple type or an element-only
+// complex type) is returned unchanged. It mirrors the internal atomization the
+// xsd assert/$value path uses, so an external adapter (xslt3's schema registry)
+// atomizes a simpleContent-over-union node through the same active member.
+func (td *TypeDef) EffectiveContentSimpleType() *TypeDef {
+	return effectiveContentSimpleType(td)
+}
+
+// ResolveUnionMembers returns the member type definitions of td's effective
+// union variety, walking the base chain (a facet-only restriction of a union
+// carries the members on an ancestor). It returns nil when td is not a union.
+func (td *TypeDef) ResolveUnionMembers() []*TypeDef {
+	return resolveUnionMembers(td)
+}
+
 func effectiveContentSimpleTypeRec(td *TypeDef, visited map[*TypeDef]struct{}) *TypeDef {
 	if td == nil || !td.IsSimpleContent {
 		return td

--- a/xslt3/compile_imports.go
+++ b/xslt3/compile_imports.go
@@ -3,6 +3,7 @@ package xslt3
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path"
 	"slices"
 	"strings"
@@ -13,6 +14,79 @@ import (
 	"github.com/lestrrat-go/helium/xpath3"
 	"github.com/lestrrat-go/helium/xsd"
 )
+
+// enterModuleNamespaceScope establishes the compilation namespace scope for an
+// imported/included module root: it snapshots c.nsBindings and c.localExcludes,
+// seeds c.nsBindings with the module root's in-scope namespaces (so the module's
+// literal result elements see ITS declarations, not a sibling module's), and adds
+// the module root's exclude-result-prefixes / extension-element-prefixes to the
+// exclusion set (resolved to URIs against the module root's own namespaces, per
+// XSLT 3.0 §11.1.3). The returned function restores both maps. Without this, an
+// imported module's root namespaces would leak into later-compiled siblings and
+// its exclude-result-prefixes would be ignored, so literal result elements emit
+// spurious namespace declarations.
+func (c *compiler) enterModuleNamespaceScope(root *helium.Element) func() {
+	savedNS := c.nsBindings
+	savedExcludes := c.localExcludes
+
+	inScope := inScopeNamespaces(root)
+	newBindings := make(map[string]string, len(savedNS)+len(inScope))
+	maps.Copy(newBindings, savedNS)
+	// The module root's in-scope namespaces override any inherited binding.
+	maps.Copy(newBindings, inScope)
+	c.nsBindings = newBindings
+
+	newExcludes := c.moduleResultPrefixExcludes(root, inScope, savedExcludes)
+	if newExcludes != nil {
+		c.localExcludes = newExcludes
+	}
+
+	return func() {
+		c.nsBindings = savedNS
+		c.localExcludes = savedExcludes
+	}
+}
+
+// moduleResultPrefixExcludes resolves a module root's exclude-result-prefixes and
+// extension-element-prefixes to the set of namespace URIs to exclude from result
+// trees, unioned onto base. inScope is the module root's in-scope namespaces.
+// Returns nil when the module declares neither attribute (so the caller keeps the
+// existing exclusion map).
+func (c *compiler) moduleResultPrefixExcludes(root *helium.Element, inScope map[string]string, base map[string]struct{}) map[string]struct{} {
+	erp := getAttr(root, "exclude-result-prefixes")
+	eep := getAttr(root, "extension-element-prefixes")
+	if erp == "" && eep == "" {
+		return nil
+	}
+	out := make(map[string]struct{}, len(base)+4)
+	maps.Copy(out, base)
+	addPrefix := func(prefix string) {
+		if prefix == lexicon.ModeDefault {
+			if uri, ok := inScope[""]; ok && uri != "" {
+				out[uri] = struct{}{}
+			}
+			return
+		}
+		if uri, ok := inScope[prefix]; ok && uri != "" {
+			out[uri] = struct{}{}
+		}
+	}
+	if erp == lexicon.ModeAll {
+		for _, uri := range inScope {
+			if uri != "" {
+				out[uri] = struct{}{}
+			}
+		}
+	} else if erp != "" {
+		for prefix := range strings.FieldsSeq(erp) {
+			addPrefix(prefix)
+		}
+	}
+	for prefix := range strings.FieldsSeq(eep) {
+		addPrefix(prefix)
+	}
+	return out
+}
 
 func (c *compiler) compileImport(ctx context.Context, elem *helium.Element) error {
 	if err := c.validateXSLTAttrs(ctx, elem, map[string]struct{}{
@@ -158,6 +232,13 @@ func (c *compiler) collectIncludeImports(ctx context.Context, elem *helium.Eleme
 	c.moduleRoot = embeddedModuleRoot(root)
 	defer func() { c.moduleRoot = savedModuleRoot }()
 
+	// Seed the module root's namespaces into a SCOPED nsBindings so this phase's
+	// namespace-alias/nested-import processing resolves prefixes against the
+	// included module's own declarations, then restore on return so they do not
+	// leak into later-compiled sibling modules. collectNamespaces still populates
+	// c.stylesheet.namespaces (global, for XPath QName resolution).
+	restoreNS := c.enterModuleNamespaceScope(root)
+	defer restoreNS()
 	c.collectNamespaces(ctx, root)
 
 	// Process namespace-alias declarations from the included module.
@@ -339,6 +420,11 @@ func (c *compiler) compileIncludeTemplates(ctx context.Context, elem *helium.Ele
 	savedModuleRoot := c.moduleRoot
 	c.moduleRoot = embeddedModuleRoot(root)
 	defer func() { c.moduleRoot = savedModuleRoot }()
+
+	// Establish the included module's namespace scope for its template phase: its
+	// root namespaces (so literal result elements declare ITS namespaces, not the
+	// including module's) and its exclude-result-prefixes / extension-element-prefixes.
+	defer c.enterModuleNamespaceScope(root)()
 
 	savedDefaultMode := c.defaultMode
 	if dm := getAttr(root, "default-mode"); dm != "" {
@@ -876,12 +962,15 @@ func (c *compiler) loadExternalStylesheet(ctx context.Context, baseURI, href str
 		c.minImportPrec = c.importPrec
 		savedInsideImport := c.insideImport
 		c.insideImport = true
+		restoreNS := c.enterModuleNamespaceScope(importedRoot)
 		c.collectNamespaces(ctx, importedRoot)
 		if err := c.compileTopLevel(ctx, importedRoot); err != nil {
+			restoreNS()
 			c.minImportPrec = savedMinImportPrec
 			c.insideImport = savedInsideImport
 			return err
 		}
+		restoreNS()
 		c.minImportPrec = savedMinImportPrec
 		c.insideImport = savedInsideImport
 		c.importPrec++
@@ -890,10 +979,13 @@ func (c *compiler) loadExternalStylesheet(ctx context.Context, baseURI, href str
 		// Inherit minImportPrec from the including module so that
 		// xsl:apply-imports in included templates searches the
 		// including module's full import tree.
+		restoreNS := c.enterModuleNamespaceScope(importedRoot)
 		c.collectNamespaces(ctx, importedRoot)
 		if err := c.compileTopLevel(ctx, importedRoot); err != nil {
+			restoreNS()
 			return err
 		}
+		restoreNS()
 	}
 	return nil
 }

--- a/xslt3/execute_misc.go
+++ b/xslt3/execute_misc.go
@@ -12,6 +12,26 @@ import (
 	"github.com/lestrrat-go/helium/xpath3"
 )
 
+// analyzeStringSelectTypeOK reports whether an atomized select value is usable as
+// the xs:string input of xsl:analyze-string: xs:string / xs:anyURI /
+// xs:untypedAtomic, or a schema-defined simple type derived from xs:string (whose
+// BaseType is xs:string, so its string-backed value substitutes for xs:string).
+func analyzeStringSelectTypeOK(av xpath3.AtomicValue) bool {
+	switch av.TypeName {
+	case xpath3.TypeString, xpath3.TypeUntypedAtomic, xpath3.TypeAnyURI:
+		return true
+	}
+	// A user-defined simple type carries its built-in base in BaseType; accept it
+	// when that base is (or derives from) xs:string.
+	if av.BaseType == xpath3.TypeString || av.BaseType == xpath3.TypeAnyURI {
+		return true
+	}
+	if av.BaseType != "" && xpath3.BuiltinIsSubtypeOf(av.BaseType, xpath3.TypeString) {
+		return true
+	}
+	return false
+}
+
 func (ec *execContext) execAnalyzeString(ctx context.Context, inst *analyzeStringInst) error {
 	// Evaluate the select expression
 	result, err := ec.evalXPath(ctx, inst.Select, ec.contextNode)
@@ -38,8 +58,12 @@ func (ec *execContext) execAnalyzeString(ctx context.Context, inst *analyzeStrin
 	if err != nil {
 		return dynamicError(errCodeXPTY0004, "xsl:analyze-string select must be xs:string: %v", err)
 	}
-	// Reject non-string atomic types (xs:integer, etc.)
-	if av.TypeName != xpath3.TypeString && av.TypeName != xpath3.TypeUntypedAtomic && av.TypeName != xpath3.TypeAnyURI {
+	// Accept xs:string, xs:anyURI, xs:untypedAtomic, and any schema type derived
+	// from xs:string (a user simple type such as StandardDate atomizes to a
+	// string-backed value whose BaseType is xs:string — subtype substitution makes
+	// it a valid xs:string for the analyze-string select). Reject genuinely
+	// non-string atomic types (xs:integer, etc.).
+	if !analyzeStringSelectTypeOK(av) {
 		return dynamicError(errCodeXPTY0004, "xsl:analyze-string select must be xs:string, got %s", av.TypeName)
 	}
 	input, err := xpath3.AtomicToString(av)

--- a/xslt3/schema_context.go
+++ b/xslt3/schema_context.go
@@ -346,11 +346,26 @@ func (r *schemaRegistry) ValidateCastWithNS(ctx context.Context, value, typeName
 	return td.Validate(ctx, value, nsMap)
 }
 
+// atomizationTypeDef resolves the TypeDef whose variety/members/item type drive
+// ATOMIZATION of a node annotated with typeName. A simpleContent COMPLEX type
+// resolves to its EFFECTIVE content simple type (xsd.TypeDef.EffectiveContentSimpleType),
+// so a node typed as a simpleContent extension/restriction of a list/union — e.g.
+// a Date element typed DateType (simpleContent extension of a union) — atomizes
+// through the narrowed content type's members, matching the xsd data()/$value
+// path. A non-simpleContent type is returned unchanged.
+func (r *schemaRegistry) atomizationTypeDef(typeName string) (*xsd.TypeDef, bool) {
+	td, _, found := r.LookupTypeDef(typeName)
+	if !found || td == nil {
+		return nil, false
+	}
+	return td.EffectiveContentSimpleType(), true
+}
+
 // ListItemType implements xpath3.SchemaDeclarations.
 // For list types, returns the item type name in annotation format.
 func (r *schemaRegistry) ListItemType(typeName string) (string, bool) {
-	td, _, found := r.LookupTypeDef(typeName)
-	if !found {
+	td, ok := r.atomizationTypeDef(typeName)
+	if !ok {
 		return "", false
 	}
 	// Walk up the type chain to find the list variety.
@@ -364,12 +379,18 @@ func (r *schemaRegistry) ListItemType(typeName string) (string, bool) {
 
 // UnionMemberTypes implements xpath3.SchemaDeclarations.
 func (r *schemaRegistry) UnionMemberTypes(typeName string) []string {
-	td, _, found := r.LookupTypeDef(typeName)
-	if !found || td == nil || td.Variety != xsd.TypeVarietyUnion {
+	td, ok := r.atomizationTypeDef(typeName)
+	if !ok || td == nil {
 		return nil
 	}
-	members := make([]string, 0, len(td.MemberTypes))
-	for _, member := range td.MemberTypes {
+	// Resolve the union members through the base chain (a facet-only restriction
+	// of a union carries the members on an ancestor).
+	memberDefs := td.ResolveUnionMembers()
+	if len(memberDefs) == 0 {
+		return nil
+	}
+	members := make([]string, 0, len(memberDefs))
+	for _, member := range memberDefs {
 		members = append(members, xsdTypeNameFromDef(member))
 	}
 	return members


### PR DESCRIPTION
Fixes W3C xslt30 validation-0202. Three root causes: the xslt3 schemaRegistry atomization adapter now resolves union/list members through the effective content simple type (so a simpleContent complex type extending a union reports its members and `data(Date) instance of StandardDate` works); `xsl:analyze-string` accepts an `xs:string`-derived select type; and an imported/included module root's namespace bindings are scoped so they no longer leak onto later siblings' result elements. xsd changes are additive exported accessors, XSD 1.0 byte-identical. Full xslt30 suite 12345 pass / 0 fail. Companion test-repo unskip: lestrrat-go/helium-w3c-tests#feat-xslt3-validation-0201.