### PR TITLE
fix xsd regex IsPrivateUse block to BMP range

### DIFF
--- a/internal/xsdregex/regex.go
+++ b/internal/xsdregex/regex.go
@@ -900,8 +900,10 @@ var unicodeBlocks = map[string]string{
 	"SupplementaryPrivateUseArea-A":        `\x{F0000}-\x{FFFFD}`,
 	"SupplementaryPrivateUseArea-B":        `\x{100000}-\x{10FFFD}`,
 	"Tags":                                 `\x{E0000}-\x{E007F}`,
-	// Composite block: union of PrivateUseArea + SupplementaryPrivateUseArea-A + SupplementaryPrivateUseArea-B
-	"PrivateUse": `\x{E000}-\x{F8FF}\x{F0000}-\x{FFFFD}\x{100000}-\x{10FFFD}`,
+	// The "Private Use" block is the BMP Private Use Area U+E000-U+F8FF. The
+	// supplementary planes are the separate SupplementaryPrivateUseArea-A/-B
+	// blocks, so \p{IsPrivateUse} must NOT match them.
+	"PrivateUse": `\x{E000}-\x{F8FF}`,
 }
 
 // validateXPathRegex checks for patterns that Go's regexp accepts but

--- a/internal/xsdregex/regex_test.go
+++ b/internal/xsdregex/regex_test.go
@@ -233,6 +233,43 @@ func TestXSD10CharClassRangeAfterRange(t *testing.T) {
 	})
 }
 
+func TestPrivateUseBlockBMPOnly(t *testing.T) {
+	// \p{IsPrivateUse} is the BMP Private Use Area U+E000-U+F8FF only. The two
+	// supplementary Private Use planes are the separate
+	// SupplementaryPrivateUseArea-A/-B blocks and must NOT be matched by
+	// \p{IsPrivateUse}. This block table is shared by XSD, Relax NG and XPath, so
+	// lock the boundary down (both bare and inside a character class).
+	bmpLo, bmpHi := string(rune(0xE000)), string(rune(0xF8FF))
+	suppA, suppB := string(rune(0xF0000)), string(rune(0x10FFFD))
+
+	for _, tc := range []struct {
+		name    string
+		pattern string
+		input   string
+		want    bool
+	}{
+		{"bmp-low-matches", `\p{IsPrivateUse}`, bmpLo, true},
+		{"bmp-high-matches", `\p{IsPrivateUse}`, bmpHi, true},
+		{"supp-a-not-matched", `\p{IsPrivateUse}`, suppA, false},
+		{"supp-b-not-matched", `\p{IsPrivateUse}`, suppB, false},
+		{"class-bmp-matches", `[\p{IsPrivateUse}]`, bmpLo, true},
+		{"class-supp-a-not-matched", `[\p{IsPrivateUse}]`, suppA, false},
+		{"supp-a-block-still-matches", `\p{IsSupplementaryPrivateUseArea-A}`, suppA, true},
+		{"supp-b-block-still-matches", `\p{IsSupplementaryPrivateUseArea-B}`, suppB, true},
+		{"neg-bmp-not-matched", `\P{IsPrivateUse}`, bmpLo, false},
+		{"neg-supp-a-matched", `\P{IsPrivateUse}`, suppA, true},
+		{"neg-class-bmp-not-matched", `[^\p{IsPrivateUse}]`, bmpHi, false},
+		{"neg-class-supp-b-matched", `[^\p{IsPrivateUse}]`, suppB, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			re, err := xsdregex.Compile(tc.pattern)
+			require.NoError(t, err, "pattern %q must compile", tc.pattern)
+			require.Equal(t, tc.want, re.MatchString(tc.input),
+				"pattern %q on U+%04X", tc.pattern, []rune(tc.input)[0])
+		})
+	}
+}
+
 func TestDefaultMatchTimeoutAccessors(t *testing.T) {
 	orig := xsdregex.DefaultMatchTimeout()
 	t.Cleanup(func() { xsdregex.SetDefaultMatchTimeout(orig) })


### PR DESCRIPTION
- `\p{IsPrivateUse}` matched the two supplementary Private Use planes; narrow it to the BMP block U+E000-U+F8FF (the SMP planes are the separate SupplementaryPrivateUseArea-A/-B blocks)
- fixes W3C xsd10 msMeta/Regex reL98/reL99/reM98/reN99 (SMP private-use chars wrongly accepted against the block); xsd10 314→310, xsd11 unchanged (0 fail)