### PR TITLE
accept literal dash before class subtraction in xsd 1.0 regex

### DIFF
--- a/internal/xsdregex/regex.go
+++ b/internal/xsdregex/regex.go
@@ -1499,8 +1499,11 @@ func checkXSD10ClassRanges(runes []rune, start, end int) error {
 		}
 		if c == '-' {
 			// A '-' is literal at the group start, immediately before the
-			// closing ']' (i+1 == end), or as the '-[' subtraction operator.
-			if i == contentStart || i+1 >= end || runes[i+1] == '[' {
+			// closing ']' (i+1 == end), as the '-[' subtraction operator, or
+			// as a literal member directly abutting the '-[' subtraction (the
+			// first '-' of "--[", e.g. [a-z--[b-z]]).
+			if i == contentStart || i+1 >= end || runes[i+1] == '[' ||
+				(runes[i+1] == '-' && i+2 < end && runes[i+2] == '[') {
 				prevRangeEnd = false
 				i++
 				continue

--- a/internal/xsdregex/regex_test.go
+++ b/internal/xsdregex/regex_test.go
@@ -224,7 +224,7 @@ func TestXSD10CharClassRangeAfterRange(t *testing.T) {
 	})
 
 	t.Run("xsd10 still accepts ordinary multi-range classes", func(t *testing.T) {
-		for _, pat := range []string{`[a-z0-9]`, `[a-z-]`, `[-a-z]`, `[a-c-[b]]`, `[abc-]`, `[+-/]`, `[!-~-]`, `[0-9a-fA-F]`} {
+		for _, pat := range []string{`[a-z0-9]`, `[a-z-]`, `[-a-z]`, `[a-c-[b]]`, `[a-z--[b-z]]`, `[abc-]`, `[+-/]`, `[!-~-]`, `[0-9a-fA-F]`} {
 			t.Run(pat, func(t *testing.T) {
 				_, err := xsdregex.Compile(pat + "*")
 				require.NoError(t, err, "pattern %q must still compile in XSD 1.0", pat)


### PR DESCRIPTION
- XSD 1.0 char-class checker misread the literal `-` abutting the `-[` subtraction operator (the first dash of `--[`) as a range operator after a completed range
- fixes W3C xsd10 msMeta/Regex reF56 (`[a-z--[b-z]]` wrongly rejected at compile); xsd10 314→313, xsd11 unchanged