### PR TITLE
ci: make slow xslt30 conformance suite release-gating

### DIFF
--- a/.github/workflows/conformance-run.yml
+++ b/.github/workflows/conformance-run.yml
@@ -1,0 +1,110 @@
+name: Conformance run
+
+# Reusable conformance run. Clones this helium ref plus the sibling
+# helium-w3c-tests harness, fetches the pinned upstream fixtures for one W3C
+# suite, runs it (optionally with the performance-gated slow tests enabled) and
+# fails when the suite reports any failures.
+#
+# Invoked by conformance.yml (nightly/manual entrypoint) and by release.yml
+# (the release-gating slow xslt30 run). Kept as a single source of truth so the
+# checkout/fetch/run logic is not duplicated.
+on:
+  workflow_call:
+    inputs:
+      suite:
+        description: Conformance suite to run (xslt30, qt3, xsd11, xsd10)
+        type: string
+        default: xslt30
+      slow:
+        description: Run performance-gated slow tests (sets HELIUM_SLOW_TESTS=1)
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      SUITE: ${{ inputs.suite }}
+      # HELIUM_SLOW_TESTS is treated as "enabled" whenever it is non-empty, so
+      # it must be left EMPTY (never "0") when slow tests are off.
+      HELIUM_SLOW_TESTS: ${{ inputs.slow && '1' || '' }}
+    steps:
+      # Check out this helium repo at the triggering ref (the code under test).
+      # No repository:/ref: so it uses the ref the calling workflow ran against.
+      - name: Check out helium (code under test)
+        uses: actions/checkout@v4
+        with:
+          path: helium
+
+      # The conformance harness lives in helium-w3c-tests, whose go.mod uses
+      # `replace github.com/lestrrat-go/helium => ../helium`, so the helium
+      # checkout above must sit as a sibling directory next to it.
+      - name: Check out helium-w3c-tests (sibling harness)
+        uses: actions/checkout@v4
+        with:
+          repository: lestrrat-go/helium-w3c-tests
+          ref: main
+          path: helium-w3c-tests
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: helium/go.mod
+          cache-dependency-path: helium-w3c-tests/go.sum
+
+      # The xsd10 run reuses the xsd11 upstream source checkout; only qt3,
+      # xslt30 and xsd11 are fetchable suite names.
+      - name: Resolve fetch suite
+        working-directory: helium-w3c-tests
+        run: |
+          case "$SUITE" in
+            xsd10) echo "FETCH_SUITE=xsd11" >> "$GITHUB_ENV" ;;
+            *)     echo "FETCH_SUITE=$SUITE" >> "$GITHUB_ENV" ;;
+          esac
+
+      - name: Fetch pinned suite fixtures
+        working-directory: helium-w3c-tests
+        run: go run ./cmd/w3cgen fetch "$FETCH_SUITE"
+
+      - name: Run conformance suite
+        working-directory: helium-w3c-tests
+        run: |
+          mkdir -p test-results
+          go run ./cmd/w3ctest \
+            -out "test-results/${SUITE}-junit.xml" \
+            -summary "test-results/${SUITE}-summary.md" \
+            "$SUITE"
+
+      - name: Upload conformance results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.suite }}-conformance-results
+          path: |
+            helium-w3c-tests/test-results/*-junit.xml
+            helium-w3c-tests/test-results/*-summary.md
+          if-no-files-found: warn
+
+      # Gate on the reported failure COUNT, not merely the runner exit code: a
+      # non-zero <testsuites failures="N"> fails the job even if the harness
+      # exited 0. The run step above already exits non-zero on a failing suite,
+      # so this only ever confirms a green run or catches a stray exit-0 report.
+      - name: Enforce zero conformance failures
+        working-directory: helium-w3c-tests
+        run: |
+          report="test-results/${SUITE}-junit.xml"
+          if [ ! -f "$report" ]; then
+            echo "conformance report $report not found" >&2
+            exit 1
+          fi
+          failures=$(grep -o 'failures="[0-9]\+"' "$report" | head -1 | grep -o '[0-9]\+')
+          failures=${failures:-unknown}
+          echo "$SUITE conformance failures: $failures"
+          if [ "$failures" != "0" ]; then
+            echo "conformance suite $SUITE reported $failures failure(s)" >&2
+            exit 1
+          fi

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -3,7 +3,8 @@ name: Conformance
 # Runs the heavyweight W3C conformance suites on demand against this helium ref.
 # These are not run on ordinary pushes/PRs because they clone large upstream
 # fixture sets and, with the performance-gated slow tests enabled, can take many
-# minutes.
+# minutes. The actual checkout/fetch/run logic lives in the reusable
+# conformance-run.yml, shared with the release-gating slow xslt30 run.
 on:
   workflow_dispatch:
     inputs:
@@ -29,69 +30,9 @@ permissions:
 
 jobs:
   conformance:
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    env:
+    uses: ./.github/workflows/conformance-run.yml
+    with:
       # For a scheduled run there are no inputs: default to the xslt30 suite
       # with slow tests on. For a manual run, honor the dispatch inputs.
-      SUITE: ${{ inputs.suite || 'xslt30' }}
-      # HELIUM_SLOW_TESTS is treated as "enabled" whenever it is non-empty, so
-      # it must be left EMPTY (never "0") when slow tests are off.
-      HELIUM_SLOW_TESTS: ${{ (github.event_name == 'schedule' || inputs.slow) && '1' || '' }}
-    steps:
-      # Check out this helium repo at the triggering ref (the code under test).
-      # No repository:/ref: so it uses the branch the workflow_dispatch runs
-      # against.
-      - name: Check out helium (code under test)
-        uses: actions/checkout@v4
-        with:
-          path: helium
-
-      # The conformance harness lives in helium-w3c-tests, whose go.mod uses
-      # `replace github.com/lestrrat-go/helium => ../helium`, so the helium
-      # checkout above must sit as a sibling directory next to it.
-      - name: Check out helium-w3c-tests (sibling harness)
-        uses: actions/checkout@v4
-        with:
-          repository: lestrrat-go/helium-w3c-tests
-          ref: main
-          path: helium-w3c-tests
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: helium/go.mod
-          cache-dependency-path: helium-w3c-tests/go.sum
-
-      # The xsd10 run reuses the xsd11 upstream source checkout; only qt3,
-      # xslt30 and xsd11 are fetchable suite names.
-      - name: Resolve fetch suite
-        working-directory: helium-w3c-tests
-        run: |
-          case "$SUITE" in
-            xsd10) echo "FETCH_SUITE=xsd11" >> "$GITHUB_ENV" ;;
-            *)     echo "FETCH_SUITE=$SUITE" >> "$GITHUB_ENV" ;;
-          esac
-
-      - name: Fetch pinned suite fixtures
-        working-directory: helium-w3c-tests
-        run: go run ./cmd/w3cgen fetch "$FETCH_SUITE"
-
-      - name: Run conformance suite
-        working-directory: helium-w3c-tests
-        run: |
-          mkdir -p test-results
-          go run ./cmd/w3ctest \
-            -out "test-results/${SUITE}-junit.xml" \
-            -summary "test-results/${SUITE}-summary.md" \
-            "$SUITE"
-
-      - name: Upload conformance results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.SUITE }}-conformance-results
-          path: |
-            helium-w3c-tests/test-results/*-junit.xml
-            helium-w3c-tests/test-results/*-summary.md
-          if-no-files-found: warn
+      suite: ${{ inputs.suite || 'xslt30' }}
+      slow: ${{ github.event_name == 'schedule' || inputs.slow || false }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,19 @@ permissions:
   contents: write
 
 jobs:
+  # Release-gating conformance run: the full slow XSLT 3.0 suite must pass with
+  # zero failures before anything is published. goreleaser needs: this job, so a
+  # red slow run blocks the release even though the tag is already pushed.
+  conformance-gate:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/conformance-run.yml
+    with:
+      suite: xslt30
+      slow: true
+
   goreleaser:
+    needs: conformance-gate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,36 @@
+# Releasing
+
+## Conformance gate
+
+A release cannot be tagged/published unless the slow XSLT 3.0 conformance suite
+passes with **0 failures**. The full slow suite is **release-gating, not
+PR-gating**: the heavyweight W3C conformance suites are never run on ordinary
+pushes or pull requests (they clone large upstream fixture sets and, with the
+performance-gated slow tests enabled, take many minutes), so they must not block
+day-to-day PR CI.
+
+### How it is enforced
+
+`.github/workflows/release.yml` (triggered by pushing a `v*` tag) has a
+`conformance-gate` job that runs the reusable `.github/workflows/conformance-run.yml`
+with `suite: xslt30` and `slow: true` (which sets `HELIUM_SLOW_TESTS=1`). The
+`goreleaser` publish job declares `needs: conformance-gate`, so the release
+artifacts and GitHub release are **not** published when the slow suite reports
+any failure.
+
+The reusable run gates on the reported failure **count**: after running the
+suite it reads `<testsuites failures="N">` from the JUnit report and fails the
+job when `N` is not `0`, in addition to the harness's own non-zero exit on a
+failing run. A skipped or absent report also fails the gate.
+
+Because `release.yml` is triggered by a tag push, the tag itself may already
+exist in the repository when the gate runs, but **no release is published**
+until the gate is green. Re-run the release workflow (or push a corrected tag)
+once the conformance suite passes.
+
+### Running the suite manually
+
+The same reusable workflow backs the nightly/manual `Conformance` workflow.
+Trigger it from the Actions tab (`workflow_dispatch`), choosing the suite and
+whether to enable slow tests; it also runs nightly against `xslt30` with slow
+tests on.


### PR DESCRIPTION
Reviewer ask #3. Extracts conformance.yml's checkout-both-repos + run logic into a reusable conformance-run.yml (workflow_call) that both the nightly/dispatch entrypoint and a new release gate invoke. release.yml gains a conformance-gate job (slow xslt30) that goreleaser needs:, so a non-zero failure count blocks publication (a JUnit failures=N parse hard-fails on N!=0). The slow suite stays OFF PR CI (workflow_call/schedule/dispatch only). RELEASING.md documents the policy: no release unless the slow XSLT 3.0 suite passes 0-fail; release-gating, not PR-gating.