### PR TITLE
ci: pin conformance harness ref + stamp full provenance

### DIFF
--- a/.github/workflows/conformance-run.yml
+++ b/.github/workflows/conformance-run.yml
@@ -19,6 +19,10 @@ on:
         description: Run performance-gated slow tests (sets HELIUM_SLOW_TESTS=1)
         type: boolean
         default: false
+      harness_ref:
+        description: helium-w3c-tests (harness) git ref to check out (commit/tag/branch). Defaults to main so callers that do not pin (e.g. release.yml) keep tracking the harness tip.
+        type: string
+        default: main
 
 permissions:
   contents: read
@@ -42,12 +46,14 @@ jobs:
 
       # The conformance harness lives in helium-w3c-tests, whose go.mod uses
       # `replace github.com/lestrrat-go/helium => ../helium`, so the helium
-      # checkout above must sit as a sibling directory next to it.
+      # checkout above must sit as a sibling directory next to it. harness_ref
+      # defaults to main; a caller may pin an exact commit/tag for a
+      # reproducible audit run.
       - name: Check out helium-w3c-tests (sibling harness)
         uses: actions/checkout@v4
         with:
           repository: lestrrat-go/helium-w3c-tests
-          ref: main
+          ref: ${{ inputs.harness_ref }}
           path: helium-w3c-tests
 
       - name: Set up Go
@@ -70,6 +76,22 @@ jobs:
         working-directory: helium-w3c-tests
         run: go run ./cmd/w3cgen fetch "$FETCH_SUITE"
 
+      # Capture the full provenance of this run so the emitted summary stands
+      # alone: which helium (code under test) commit, which helium-w3c-tests
+      # (harness) commit, which Go toolchain, and whether slow tests ran.
+      - name: Collect provenance
+        run: |
+          {
+            echo "HELIUM_COMMIT=$(git -C helium rev-parse HEAD)"
+            echo "HARNESS_COMMIT=$(git -C helium-w3c-tests rev-parse HEAD)"
+            echo "GO_VERSION=$(go version)"
+            if [ -n "$HELIUM_SLOW_TESTS" ]; then
+              echo "RUN_MODE=slow (HELIUM_SLOW_TESTS=1)"
+            else
+              echo "RUN_MODE=default"
+            fi
+          } >> "$GITHUB_ENV"
+
       - name: Run conformance suite
         working-directory: helium-w3c-tests
         run: |
@@ -77,6 +99,10 @@ jobs:
           go run ./cmd/w3ctest \
             -out "test-results/${SUITE}-junit.xml" \
             -summary "test-results/${SUITE}-summary.md" \
+            -helium-commit "$HELIUM_COMMIT" \
+            -harness-commit "$HARNESS_COMMIT" \
+            -go-version "$GO_VERSION" \
+            -mode "$RUN_MODE" \
             "$SUITE"
 
       - name: Upload conformance results

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -21,6 +21,10 @@ on:
         description: Run performance-gated slow tests (sets HELIUM_SLOW_TESTS=1)
         type: boolean
         default: false
+      harness_ref:
+        description: helium-w3c-tests (harness) git ref to pin (commit/tag/branch); use for an audit/release run. Nightly stays on main.
+        type: string
+        default: main
   # Nightly full run of the XSLT 3.0 suite with slow tests enabled.
   schedule:
     - cron: "0 6 * * *"
@@ -36,3 +40,6 @@ jobs:
       # with slow tests on. For a manual run, honor the dispatch inputs.
       suite: ${{ inputs.suite || 'xslt30' }}
       slow: ${{ github.event_name == 'schedule' || inputs.slow || false }}
+      # Nightly/scheduled has no inputs, so this resolves to main; a manual run
+      # may pin an exact harness commit/tag for a reproducible audit run.
+      harness_ref: ${{ inputs.harness_ref || 'main' }}


### PR DESCRIPTION
Reviewer ask #1. Adds a harness_ref workflow_dispatch input (default main) threaded through conformance.yml into the reusable conformance-run.yml, so an audit/release run can pin an exact helium-w3c-tests commit/tag while the nightly stays on main (the release gate omits it and defaults to main). Adds a Collect provenance step in conformance-run.yml that stamps the summary header with all of: helium commit, harness commit, upstream w3c/xslt30-test commit, Go version, run mode, and the pass/skip/fail/total totals (new cmd/w3ctest flags -harness-commit/-go-version/-mode). Workflow + summary-header provenance only; no conformance outcomes change. Companion generator change: lestrrat-go/helium-w3c-tests#feat-conformance-provenance.