### PR TITLE
ci: PR drift-check for the xslt30 skip ledger

### DIFF
--- a/.github/workflows/conformance-ledger.yml
+++ b/.github/workflows/conformance-ledger.yml
@@ -1,0 +1,53 @@
+name: Conformance Ledger
+
+# Fast, fixture-free drift-check for the checked-in XSLT 3.0 conformance skip
+# ledger (helium-w3c-tests expectations/xslt30-skip-ledger.json +
+# xslt30-skip-counts.json). It regenerates the ledger in memory from the real
+# skip sources and fails on any of the five drift conditions documented on
+# TestXSLT30SkipLedger. It does NOT clone the ~215M upstream fixtures and does
+# not run any transform, so it is safe to run on every PR (unlike the heavy
+# conformance.yml suite).
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      tests_ref:
+        description: helium-w3c-tests ref to check the ledger against
+        type: string
+        default: main
+
+permissions:
+  contents: read
+
+jobs:
+  ledger:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # helium at the triggering ref (the code under test), as a sibling of the
+      # harness so helium-w3c-tests' `replace => ../helium` resolves.
+      - name: Check out helium (code under test)
+        uses: actions/checkout@v4
+        with:
+          path: helium
+
+      - name: Check out helium-w3c-tests (skip ledger + drift-check)
+        uses: actions/checkout@v4
+        with:
+          repository: lestrrat-go/helium-w3c-tests
+          ref: ${{ inputs.tests_ref || 'main' }}
+          path: helium-w3c-tests
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: helium/go.mod
+          cache-dependency-path: helium-w3c-tests/go.sum
+
+      # No `w3cgen fetch` step: the ledger drift-check reads only the generated
+      # in-memory case tables and expectations/xslt30.json, never the fixtures.
+      - name: Check skip ledger for drift
+        working-directory: helium-w3c-tests
+        run: go test ./xslt3 -run TestXSLT30SkipLedger -v

--- a/.github/workflows/conformance-ledger.yml
+++ b/.github/workflows/conformance-ledger.yml
@@ -7,6 +7,15 @@ name: Conformance Ledger
 # TestXSLT30SkipLedger. It does NOT clone the ~215M upstream fixtures and does
 # not run any transform, so it is safe to run on every PR (unlike the heavy
 # conformance.yml suite).
+#
+# Known limitation: this check runs on helium PRs against helium-w3c-tests@main.
+# By project policy CI lives in helium, not helium-w3c-tests, so a helium-w3c-tests
+# PR that edits a skip source (the w3cImplicitSkips map, expectations/xslt30.json,
+# a generated Skip field, or the slow-test lists) without regenerating the ledger
+# is NOT gated on that PR — the drift surfaces on the next helium PR instead.
+# Contributors editing skip sources in helium-w3c-tests must run
+# `go test ./xslt3 -run TestXSLT30SkipLedger -update-ledger` (or `go generate ./xslt3`)
+# and commit the regenerated ledger alongside the change.
 on:
   pull_request:
   push:

--- a/xslt3/CONFORMANCE.md
+++ b/xslt3/CONFORMANCE.md
@@ -40,6 +40,20 @@ The authoritative per-case reasons are the harness `w3cImplicitSkips` map
 `summary-xslt30.md`'s "Skipped by reason" table is regenerated from them. Every
 skip below reconciles to those sources.
 
+This taxonomy is also enforced as a machine-readable, CI-gated contract. The
+`helium-w3c-tests` module carries a generated per-case skip ledger
+(`expectations/xslt30-skip-ledger.json`, one row per default-run skip: test id,
+pinned upstream-suite commit, skip-class — the five labels below — reason, spec
+dependency, paired passing 3.0 case) and a count contract
+(`expectations/xslt30-skip-counts.json`). Both are regenerated from the real
+skip sources with `go test ./xslt3 -run TestXSLT30SkipLedger -update-ledger` and
+must never be hand-edited. `TestXSLT30SkipLedger` (run without the flag) is a
+fast, fixture-free drift-check — wired into the `Conformance Ledger` CI workflow
+— that fails if the failure count is nonzero, a skip is unrecorded or
+reclassified, a mandatory-facility skip appears (any skip that classifies as
+neither one of the four labels nor the enumerated narrow-quirk allowlist), or
+the default/slow skip counts drift.
+
 ## Conformance-level table
 
 The eight W3C conformance levels (Basic + seven optional), plus two

--- a/xslt3/CONFORMANCE.md
+++ b/xslt3/CONFORMANCE.md
@@ -54,6 +54,15 @@ reclassified, a mandatory-facility skip appears (any skip that classifies as
 neither one of the four labels nor the enumerated narrow-quirk allowlist), or
 the default/slow skip counts drift.
 
+Known limitation: by project policy CI lives in helium, so the `Conformance
+Ledger` workflow runs on helium PRs against `helium-w3c-tests@main`;
+`helium-w3c-tests` has no CI of its own. A `helium-w3c-tests` PR that edits a
+skip source without regenerating the ledger is therefore not gated on that PR —
+the drift is caught on the next helium PR instead. Contributors editing skip
+sources in `helium-w3c-tests` must regenerate the ledger with
+`go test ./xslt3 -run TestXSLT30SkipLedger -update-ledger` (or `go generate ./xslt3`)
+and commit it alongside the change.
+
 ## Conformance-level table
 
 The eight W3C conformance levels (Basic + seven optional), plus two


### PR DESCRIPTION
Adds .github/workflows/conformance-ledger.yml — a fast static PR check (no fixture fetch, no transforms) that checks out helium + helium-w3c-tests as siblings and runs TestXSLT30SkipLedger, failing on any conformance skip-ledger drift (new fail, new unclassified skip, reason/class change, count drift). Paired ledger: lestrrat-go/helium-w3c-tests#feat-conformance-skip-ledger.