### PR TITLE
fix: schema-aware transforms no longer mutate the caller's source

### DIFF
--- a/xslt3/concurrency_test.go
+++ b/xslt3/concurrency_test.go
@@ -306,6 +306,134 @@ func TestStylesheetConcurrentSchemaAwareDistinctSources(t *testing.T) {
 	}
 }
 
+// TestSchemaAwareDoesNotMutateSource proves the read-only-source contract for a
+// schema-aware transform: source-schema validation inserts default/fixed
+// attributes into the tree it validates, but that tree is now a PRIVATE COPY, so
+// the caller's original source document is left untouched. The result still
+// reflects the schema default (the copy carries the inserted attribute), proving
+// the mutation moved off the caller's tree rather than being skipped.
+func TestSchemaAwareDoesNotMutateSource(t *testing.T) {
+	schema := compileSchemaString(t, `
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:attribute name="def" type="xs:string" default="DEF"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`)
+
+	// The stylesheet reads the schema-defaulted @def, so the default-attribute
+	// insertion is observable in the output.
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/root"><out def="{@def}"/></xsl:template>
+</xsl:stylesheet>`)
+
+	src, err := helium.NewParser().Parse(t.Context(), []byte(`<root/>`))
+	require.NoError(t, err)
+
+	// Before the transform the caller's root carries no 'def' attribute.
+	root := src.DocumentElement()
+	require.NotNil(t, root)
+	_, present := root.GetAttribute("def")
+	require.False(t, present, "precondition: source must not already carry the schema default")
+
+	out, err := ss.Transform(src).SourceSchemas(schema).Serialize(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, out, `def="DEF"`, "result must reflect the schema default")
+
+	// After the transform the caller's original source is unchanged: the
+	// default/fixed attribute was inserted into a private copy, not this tree.
+	root = src.DocumentElement()
+	require.NotNil(t, root)
+	_, present = root.GetAttribute("def")
+	require.False(t, present, "schema-aware transform must not mutate the caller's source document")
+}
+
+// TestStylesheetConcurrentSharedSourceSchemaAware proves the strengthened
+// shared-source guarantee: because a schema-aware transform validates a PRIVATE
+// COPY of the source (never the caller's tree), a SINGLE source document may be
+// shared across many concurrent schema-aware transforms of the same compiled
+// stylesheet. Before the source was treated read-only, this would race (each
+// transform inserted default attributes into the shared tree in place). Every
+// goroutine reads the same shared *helium.Document and must produce the same
+// deterministic, schema-defaulted output; under -race, any write to the shared
+// source (or the compiled stylesheet/schema) would be reported.
+func TestStylesheetConcurrentSharedSourceSchemaAware(t *testing.T) {
+	const (
+		goroutines = 50
+		iterations = 25
+	)
+
+	schema := compileSchemaString(t, `
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="tag" type="xs:string"/>
+            <xs:attribute name="def" type="xs:string" default="DEF"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`)
+
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/root">
+    <out><tag><xsl:value-of select="item/@tag"/></tag><def><xsl:value-of select="item/@def"/></def></out>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	// ONE shared source document, handed to every concurrent schema-aware
+	// transform. Its 'item' has an explicit @tag but no @def (the schema default).
+	sharedSrc, err := helium.NewParser().Parse(t.Context(), []byte(
+		`<root><item tag="T"/></root>`))
+	require.NoError(t, err)
+
+	const wantFrag = `<out><tag>T</tag><def>DEF</def></out>`
+
+	failures := make([]string, goroutines)
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for iter := range iterations {
+				out, err := ss.Transform(sharedSrc).SourceSchemas(schema).Serialize(t.Context())
+				if err != nil {
+					failures[i] = fmt.Sprintf("goroutine %d iter %d: transform error: %v", i, iter, err)
+					return
+				}
+				if !strings.Contains(out, wantFrag) {
+					failures[i] = fmt.Sprintf("goroutine %d iter %d: output missing %q\ngot: %s", i, iter, wantFrag, out)
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for i, f := range failures {
+		require.Empty(t, f, "goroutine %d reported a failure", i)
+	}
+
+	// The shared source is still pristine: no 'def' attribute leaked into it.
+	root := sharedSrc.DocumentElement()
+	require.NotNil(t, root)
+	for item := range helium.Children(root) {
+		el, ok := item.(*helium.Element)
+		if !ok {
+			continue
+		}
+		_, present := el.GetAttribute("def")
+		require.False(t, present, "shared source must not be mutated by concurrent schema-aware transforms")
+	}
+}
+
 func compileSchemaString(t *testing.T, src string) *xsd.Schema {
 	t.Helper()
 

--- a/xslt3/doc.go
+++ b/xslt3/doc.go
@@ -42,28 +42,22 @@
 // goroutines. A single compiled stylesheet may be transformed from many
 // goroutines at once (via [Transform], [TransformString], [TransformToWriter],
 // [Stylesheet.Transform], [Stylesheet.ApplyTemplates], [Stylesheet.CallTemplate],
-// or [Stylesheet.CallFunction]) without external synchronization, PROVIDED each
-// concurrent transform uses its own source document (see the source-document
-// caveat below). Every mutable per-transform state (global-variable values, key
-// tables, caches, accumulator state, the result tree, and serialization
-// overrides) lives in a per-call execution context that is never shared between
-// transforms, and a transform never mutates the compiled stylesheet.
+// or [Stylesheet.CallFunction]) without external synchronization. Every mutable
+// per-transform state (global-variable values, key tables, caches, accumulator
+// state, the result tree, and serialization overrides) lives in a per-call
+// execution context that is never shared between transforms, and a transform
+// never mutates the compiled stylesheet.
 //
-// Source-document handling depends on whether the transform is schema-aware:
-//
-//   - A NON-schema-aware transform treats the caller's source document as
-//     read-only (whitespace stripping, when it applies, runs against a private
-//     copy). A single source document may therefore be shared, read-only, across
-//     concurrent non-schema-aware transforms, as long as the caller does not
-//     mutate it concurrently.
-//   - A SCHEMA-AWARE / source-validating transform — one where the stylesheet has
-//     an xsl:import-schema, [Invocation.SourceSchemas] supplies schemas, or the
-//     source carries an xsi:schemaLocation — VALIDATES AND MUTATES the caller's
-//     source tree IN PLACE (source-schema validation inserts default/fixed
-//     attributes). Such a source document must NOT be shared across concurrent
-//     transforms, and more generally a schema-aware transform mutates its input
-//     document. Give each concurrent schema-aware transform its own source
-//     document (and do not reuse a validated source for a second transform).
+// The caller's source document is treated as READ-ONLY in ALL cases —
+// schema-aware and non-schema-aware alike. Whitespace stripping (xsl:strip-space
+// and the schema-aware whitespace rules) runs against a private copy, and
+// source-schema validation (which inserts default/fixed attributes into the tree
+// it validates) also runs against a private copy, so neither mutates the caller's
+// tree. A single source document may therefore be shared, read-only, across
+// concurrent transforms — schema-aware or not — as long as the caller does not
+// mutate it concurrently. A schema-aware transform is one where the stylesheet
+// has an xsl:import-schema, [Invocation.SourceSchemas] supplies schemas, or the
+// source carries an xsi:schemaLocation.
 //
 // Compilation itself is not concurrent with transformation of the same
 // stylesheet: finish compiling before sharing the result. [Invocation] and

--- a/xslt3/execute_builtin.go
+++ b/xslt3/execute_builtin.go
@@ -493,6 +493,15 @@ func (ec *execContext) stripWhitespaceFromDoc(doc *helium.Document) {
 }
 
 func (ec *execContext) stripWhitespaceFromNode(root helium.Node) {
+	ec.stripWhitespaceFromNodeInto(root, nil)
+}
+
+// stripWhitespaceFromNodeInto is stripWhitespaceFromNode with an optional out
+// parameter: when removed is non-nil, every unlinked whitespace-only node is
+// recorded in it. The in-place strip of a schema-validated source copy uses this
+// so a selected node the strip removes can be dropped from the initial match
+// selection.
+func (ec *execContext) stripWhitespaceFromNodeInto(root helium.Node, removed map[helium.Node]struct{}) {
 	// Use an explicit stack to avoid deep recursion on large documents.
 	stack := make([]helium.Node, 0, 32)
 	stack = append(stack, root)
@@ -503,6 +512,9 @@ func (ec *execContext) stripWhitespaceFromNode(root helium.Node) {
 		for child != nil {
 			next := child.NextSibling()
 			if ec.shouldStripWhitespace(child) {
+				if removed != nil {
+					removed[child] = struct{}{}
+				}
 				helium.UnlinkNode(child.(helium.MutableNode)) //nolint:forcetypeassert
 			} else if child.FirstChild() != nil {
 				stack = append(stack, child)

--- a/xslt3/execute_transform.go
+++ b/xslt3/execute_transform.go
@@ -89,6 +89,26 @@ func remapSelectionToCopy(sel xpath3.Sequence, src *helium.Document, nodeMap map
 	return items
 }
 
+// dropSelectionItems removes from an initial match selection any NodeItem whose
+// node is in the removed set. It is used after an IN-PLACE whitespace strip of
+// the (already-copied) source: a selected whitespace-only node the strip unlinked
+// must be dropped so it is absent from the selection and does not skew
+// position()/last() in the apply-templates loop. Non-node items and retained
+// nodes pass through unchanged.
+func dropSelectionItems(sel xpath3.Sequence, removed map[helium.Node]struct{}) xpath3.Sequence {
+	items := make(xpath3.ItemSlice, 0, sequence.Len(sel))
+	for i := range sequence.Len(sel) {
+		item := sel.Get(i)
+		if ni, ok := item.(xpath3.NodeItem); ok {
+			if _, gone := removed[ni.Node]; gone {
+				continue
+			}
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
 // mapElementAttributes records the correspondence between the attributes of an
 // original element and those of its copy, keyed by expanded (URI, local) name
 // (unique within a single element).
@@ -200,14 +220,16 @@ func executeTransform(ctx context.Context, source *helium.Document, ss *Styleshe
 		effectiveSource = nil
 	}
 
-	// xsl:strip-space (and the schema-aware whitespace rules) remove whitespace-only
-	// text nodes from the source tree. The source document is owned by the caller,
-	// so it must never be mutated in place: doing so destroys node identity, corrupts
-	// a tree the caller may reuse (e.g. for a later XPath query or a second
-	// transform), and is unsafe under concurrent reuse. Whitespace stripping below
-	// therefore runs against a private deep copy (copyAndStrip), which becomes the
-	// exec context's source so the initial context node and all node identity stay
-	// consistent. The copy is built only when there is stripping work to do.
+	// The caller's source document is owned by the caller and must never be
+	// mutated in place: doing so destroys node identity, corrupts a tree the
+	// caller may reuse (e.g. for a later XPath query or a second transform), and
+	// is unsafe under concurrent reuse. Two operations would otherwise mutate it:
+	// xsl:strip-space / schema-aware whitespace stripping (which removes
+	// whitespace-only text nodes), and source-schema validation (which inserts
+	// default/fixed attributes). Both therefore run against a private deep copy
+	// that becomes the exec context's source, so the initial context node and all
+	// node identity stay consistent. A copy is built only when validation or
+	// stripping actually has work to do.
 	var matchSelection xpath3.Sequence
 	if cfg != nil {
 		matchSelection = cfg.initialMatchSelection
@@ -219,16 +241,6 @@ func executeTransform(ctx context.Context, source *helium.Document, ss *Styleshe
 	// must run against the (empty) selection — producing no output — rather than
 	// falling through to the source document.
 	selectionSupplied := matchSelection != nil
-	// validationSource is the ORIGINAL, un-stripped source. Source-schema
-	// validation runs against it (before any strip copy) for two reasons: a
-	// schema that rejects whitespace-only content must not have its violation
-	// masked by xsl:strip-space, and — more importantly — the schema type
-	// annotations it produces DRIVE the strip decision (XSLT 3.0 §4.4.2: an
-	// element-only content type strips whitespace regardless of xsl:preserve-space,
-	// while simple/mixed content or an assertion-bearing ancestor preserves it
-	// regardless of xsl:strip-space). The strip copy therefore runs AFTER
-	// validation, below, consulting those annotations.
-	validationSource := effectiveSource
 
 	captureItems := cfg != nil && cfg.rawCapture
 	if defOut := ss.outputs[""]; defOut != nil && isItemSerializationMethod(defOut.Method) {
@@ -330,19 +342,47 @@ func executeTransform(ctx context.Context, source *helium.Document, ss *Styleshe
 		runtimeSchemas = mergeRuntimeSchemas(runtimeSchemas, cfg.sourceSchemas)
 	}
 	sourceValidated := false
+	// sourceCopied records whether effectiveSource has been replaced by a private
+	// deep copy (made for schema validation). When set, the strip block below
+	// strips that copy IN PLACE rather than making a second deep copy.
+	sourceCopied := false
 	if ss.schemaAware || len(runtimeSchemas) > 0 {
 		ec.schemaRegistry = &schemaRegistry{schemas: runtimeSchemas}
 		ec.typeAnnotations = make(map[helium.Node]string)
-		if len(runtimeSchemas) > 0 && validationSource != nil {
-			// Validate the ORIGINAL, un-stripped source so xsl:strip-space cannot
-			// drop whitespace-only nodes (and thus mask schema violations) before
-			// validation, and so the schema type annotations are available to drive
-			// the strip decision below. Annotations key on the original nodes; the
-			// strip block below (if any) remaps them onto the copy the transform runs on.
-			vr, valErr := ec.schemaRegistry.ValidateDoc(ctx, validationSource)
+		if len(runtimeSchemas) > 0 && effectiveSource != nil {
+			// Source-schema validation inserts default/fixed attributes into the
+			// tree it validates, so it must never touch the caller's source. Work
+			// on a private, byte-faithful deep copy: validate + annotate + navigate
+			// the copy, leaving the caller's source read-only. The copy reuses
+			// copyAndStrip with no strip rules and no schema classifier (a pure
+			// copy), so the original->copy node map needed to remap an initial-match
+			// selection comes for free; the strip block below strips this SAME copy
+			// in place (no second copy). The type annotations produced by validating
+			// the copy key on the copy's nodes, which is also what drives the
+			// XSLT 3.0 §4.4.2 whitespace-strip decision below.
+			needMap := selectionSupplied && sequence.Len(matchSelection) > 0
+			srcCopy, upfrontMap, copyErr := copyAndStrip(effectiveSource, nil, nil, needMap, nil)
+			if copyErr != nil {
+				return nil, copyErr
+			}
+			// The initial match selection (if any) was computed against the caller's
+			// original tree; remap each selected node onto the copy the transform
+			// navigates. The pure copy omits nothing, so every node has a mapping.
+			if needMap {
+				matchSelection = remapSelectionToCopy(matchSelection, effectiveSource, upfrontMap)
+			}
+			effectiveSource = srcCopy
+			ec.sourceDoc = srcCopy
+			ec.currentNode = srcCopy
+			ec.contextNode = srcCopy
+			sourceCopied = true
+
+			vr, valErr := ec.schemaRegistry.ValidateDoc(ctx, effectiveSource)
 			if valErr != nil && ss.defaultValidation == validationStrict {
 				return nil, valErr
 			}
+			// Annotations and nilled flags key on the copy's nodes (validation ran
+			// on the copy), so no remap is needed.
 			for node, typeName := range vr.Annotations {
 				ec.annotateNode(node, typeName)
 			}
@@ -355,17 +395,33 @@ func executeTransform(ctx context.Context, source *helium.Document, ss *Styleshe
 
 	// xsl:strip-space, plus the schema-aware whitespace rules (XSLT 3.0 §4.4.2),
 	// remove or preserve whitespace-only text nodes in the source tree. The source
-	// document is owned by the caller and must never be mutated in place, so this
-	// runs against a private deep copy (copyAndStrip) that omits the stripped nodes;
-	// the copy becomes the exec context's source. A copy is built only when there
-	// is actual work — explicit xsl:strip-space rules, or an element-only content
-	// type whose whitespace the schema strips — so the common no-strip case keeps
-	// the original source (and its node identity) untouched.
+	// document is owned by the caller and must never be mutated in place. A copy is
+	// built only when there is actual work — explicit xsl:strip-space rules, or an
+	// element-only content type whose whitespace the schema strips — so the common
+	// no-strip case keeps the caller's source (and its node identity) untouched.
 	if effectiveSource != nil {
 		schemaClass := newSchemaWSClassifier(ec.typeAnnotations, ec.schemaRegistry)
 		doStrip := len(ss.stripSpace) > 0 ||
 			(schemaClass != nil && sourceNeedsSchemaStrip(effectiveSource, schemaClass))
-		if doStrip {
+		switch {
+		case doStrip && sourceCopied:
+			// effectiveSource is already the private copy made for schema
+			// validation, so strip it IN PLACE to avoid a second deep copy. The
+			// type annotations already key on this tree (validation ran on it), so
+			// no remap is needed. Any initial-match-selection node the strip removes
+			// is dropped so it does not skew position()/last().
+			var removed map[helium.Node]struct{}
+			if selectionSupplied && sequence.Len(matchSelection) > 0 {
+				removed = make(map[helium.Node]struct{})
+			}
+			ec.stripWhitespaceFromNodeInto(effectiveSource, removed)
+			if len(removed) > 0 {
+				matchSelection = dropSelectionItems(matchSelection, removed)
+			}
+		case doStrip:
+			// Non-schema path: the caller's source has not been copied, so copy and
+			// strip it in a single pass (omitting whitespace-only nodes from the
+			// copy), and remap the selection onto the copy.
 			needSelectionMap := matchSelection != nil && sequence.Len(matchSelection) > 0
 			// Build the original->copy node map whenever the initial match selection
 			// or the gathered type annotations must be carried over to the copy.

--- a/xslt3/strip_space_copy.go
+++ b/xslt3/strip_space_copy.go
@@ -267,21 +267,26 @@ func (sc *stripCopier) copyElement(src *helium.Element, inScope map[string]*heli
 		elem.SetNs(active)
 	}
 
-	// Copy attributes, preserving namespace information. Use the same value-
-	// parsing setters as helium.CopyDoc (SetAttribute/SetAttributeNS) so the copy
-	// is byte-for-byte identical, including any entity-reference handling.
+	// Copy attributes, preserving namespace information. Use the LITERAL setters
+	// (SetLiteralAttribute/SetLiteralAttributeNS): a.Value() is the parser's
+	// already-resolved value, so re-parsing it (SetAttribute/SetAttributeNS runs
+	// CreateAttribute, which interprets entity references) would choke on a bare
+	// '&' or '<' that was originally an entity (e.g. an href value carrying
+	// '&amp;'), and silently double-resolve a value like '&amp;amp;'. Storing the
+	// resolved value literally serializes byte-for-byte identically (the serializer
+	// re-escapes '&'/'<') while never re-interpreting it.
 	for _, a := range src.Attributes() {
 		if a.URI() != "" {
 			ns, nsErr := sc.dst.CreateNamespace(a.Prefix(), a.URI())
 			if nsErr != nil {
 				return nil, nsErr
 			}
-			if _, err := elem.SetAttributeNS(a.LocalName(), a.Value(), ns); err != nil {
+			if err := elem.SetLiteralAttributeNS(a.LocalName(), a.Value(), ns); err != nil {
 				return nil, err
 			}
 			continue
 		}
-		if _, err := elem.SetAttribute(a.Name(), a.Value()); err != nil {
+		if err := elem.SetLiteralAttribute(a.Name(), a.Value()); err != nil {
 			return nil, err
 		}
 	}
@@ -341,6 +346,15 @@ func (sc *stripCopier) stripText(src helium.Node, parent *helium.Element) bool {
 	}
 	if isElementStrippedBy(parent, sc.strip, sc.preserve) {
 		return true
+	}
+	// A copyAndStrip call with no strip rules AND no schema classifier is a PURE
+	// copy (used to make the private validation copy). It must stay byte-faithful
+	// and NOT drop DTD element-only whitespace, so the fallback below is skipped.
+	// A genuine strip invocation always carries strip rules or a classifier (the
+	// non-schema strip path always has non-empty strip rules), so this guard never
+	// affects it.
+	if len(sc.strip) == 0 && sc.schemaWS == nil {
+		return false
 	}
 	return hasElementOnlyContent(parent)
 }

--- a/xslt3/stylesheet.go
+++ b/xslt3/stylesheet.go
@@ -90,13 +90,14 @@ type funcKey struct {
 //
 // A *Stylesheet is immutable after compilation and safe for concurrent use by
 // multiple goroutines: the same compiled stylesheet may be transformed from
-// many goroutines at once, each with its OWN source document, without external
-// synchronization. Every mutable per-transform state lives in a separate
-// execution context created per call, so transforms never share state and never
-// write back to the stylesheet. Note that a schema-aware / source-validating
-// transform mutates its source document in place, so such a source must not be
-// shared across concurrent transforms. See the package documentation's
-// Concurrency section for the full contract.
+// many goroutines at once without external synchronization. Every mutable
+// per-transform state lives in a separate execution context created per call, so
+// transforms never share state and never write back to the stylesheet. The
+// caller's source document is treated as read-only in all cases (whitespace
+// stripping and source-schema validation both run against a private copy), so a
+// single source may be shared, read-only, across concurrent transforms —
+// schema-aware or not. See the package documentation's Concurrency section for
+// the full contract.
 type Stylesheet struct {
 	version string
 	// compatExprs holds every compiled XPath expression that must evaluate in

--- a/xslt3/xslt3.go
+++ b/xslt3/xslt3.go
@@ -156,10 +156,10 @@ func parseStylesheetDocument(ctx context.Context, injected *helium.Parser, data 
 // This is a convenience wrapper over NewCompiler().Compile(ctx, doc).
 //
 // The returned [*Stylesheet] is immutable and safe for concurrent use by
-// multiple goroutines, each with its own source document; it may be reused
-// across many transformations. See the package documentation's Concurrency
-// section (in particular the source-document caveat for schema-aware
-// transforms).
+// multiple goroutines; it may be reused across many transformations. The
+// caller's source is treated as read-only (including by schema-aware transforms),
+// so a single source may be shared, read-only, across concurrent transforms. See
+// the package documentation's Concurrency section.
 func CompileStylesheet(ctx context.Context, doc *helium.Document) (*Stylesheet, error) {
 	return NewCompiler().Compile(ctx, doc)
 }
@@ -168,9 +168,10 @@ func CompileStylesheet(ctx context.Context, doc *helium.Document) (*Stylesheet, 
 // This is a convenience wrapper over ss.Transform(source).Do(ctx).
 //
 // ss is not mutated and may be transformed concurrently from multiple
-// goroutines, each with its own source document. A schema-aware transform
-// mutates source in place, so such a source must not be shared across
-// concurrent transforms (see the package documentation's Concurrency section).
+// goroutines. The caller's source is treated as read-only (including by a
+// schema-aware transform, which validates a private copy), so a single source
+// may be shared, read-only, across concurrent transforms (see the package
+// documentation's Concurrency section).
 func Transform(ctx context.Context, source *helium.Document, ss *Stylesheet) (*helium.Document, error) {
 	if ss == nil {
 		return nil, errNilStylesheet
@@ -182,9 +183,10 @@ func Transform(ctx context.Context, source *helium.Document, ss *Stylesheet) (*h
 // This is a convenience wrapper over ss.Transform(source).Serialize(ctx).
 //
 // ss is not mutated and may be transformed concurrently from multiple
-// goroutines, each with its own source document. A schema-aware transform
-// mutates source in place, so such a source must not be shared across
-// concurrent transforms (see the package documentation's Concurrency section).
+// goroutines. The caller's source is treated as read-only (including by a
+// schema-aware transform, which validates a private copy), so a single source
+// may be shared, read-only, across concurrent transforms (see the package
+// documentation's Concurrency section).
 func TransformString(ctx context.Context, source *helium.Document, ss *Stylesheet) (string, error) {
 	if ss == nil {
 		return "", errNilStylesheet


### PR DESCRIPTION
Option A (approved follow-up to the concurrency review). Schema-aware source validation previously ran against the caller's original tree and inserted default/fixed attributes in place, mutating the caller's input even single-threaded. Now the source is deep-copied up front when validation will run, and validation + annotation + the transform all operate on the private copy — the caller's tree is read-only in all cases. Schema+strip does exactly one copy; the non-schema path adds zero copies. Also fixes a latent copyAndStrip bug (attribute values re-parsed via SetAttribute, breaking validation-0501) by copying values literally. Full W3C xslt30 suite: 0 failures, byte-identical. Strengthens the concurrency contract: a source may now be shared read-only across concurrent transforms regardless of schema-awareness (new shared-source schema-aware -race test). Godoc updated.