### PR TITLE
fix: CopyDoc/CopyNode copy attribute values literally

### DIFF
--- a/copy_deep.go
+++ b/copy_deep.go
@@ -304,10 +304,15 @@ func (dc *deepCopier) bindNamespacesExact(src, elem *Element, inScope map[string
 	return childScope, nil
 }
 
-// copyAttributes copies src's attributes onto elem using the value-parsing
-// setters (SetAttribute/SetAttributeNS) so the copy is byte-for-byte identical,
-// including entity-reference handling. This loop is identical across all copy
-// sites.
+// copyAttributes copies src's attributes onto elem using the LITERAL setters
+// (SetLiteralAttribute/SetLiteralAttributeNS): a.Value() is the parser's
+// already-resolved value, so re-parsing it (SetAttribute/SetAttributeNS runs
+// CreateAttribute, which interprets entity references) would choke on a bare
+// '&' or '<' that was originally an entity (e.g. an href value carrying
+// '&amp;'), and silently double-resolve a value like '&amp;amp;'. Storing the
+// resolved value literally serializes byte-for-byte identically (the serializer
+// re-escapes '&'/'<') while never re-interpreting it. This loop is identical
+// across all copy sites.
 func (dc *deepCopier) copyAttributes(src, elem *Element) error {
 	for _, a := range src.Attributes() {
 		if a.URI() != "" {
@@ -315,10 +320,10 @@ func (dc *deepCopier) copyAttributes(src, elem *Element) error {
 			if nsErr != nil {
 				return nsErr
 			}
-			if _, err := elem.SetAttributeNS(a.LocalName(), a.Value(), ns); err != nil {
+			if err := elem.SetLiteralAttributeNS(a.LocalName(), a.Value(), ns); err != nil {
 				return err
 			}
-		} else if _, err := elem.SetAttribute(a.Name(), a.Value()); err != nil {
+		} else if err := elem.SetLiteralAttribute(a.Name(), a.Value()); err != nil {
 			return err
 		}
 		// Preserve the source attribute's line. SetAttribute* returns the element,

--- a/copy_test.go
+++ b/copy_test.go
@@ -126,6 +126,58 @@ func TestCopyDocWithDTD(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestCopyDocEntityBearingAttributes exercises the deep-copy attribute path with
+// values that the parser has already entity-resolved. Copying such values with
+// the value-PARSING setters (SetAttribute/SetAttributeNS) would re-interpret a
+// bare '&'/'<' — raising "entity was unterminated" for a value that came from
+// '&amp;', and silently double-resolving '&amp;amp;'. The literal setters store
+// the resolved value as-is and let the serializer re-escape it, so a CopyDoc
+// round-trips byte-for-byte identically.
+func TestCopyDocEntityBearingAttributes(t *testing.T) {
+	t.Parallel()
+
+	src := `<?xml version="1.0" encoding="UTF-8"?>` + "\n" +
+		`<root amp="x&amp;y" lt="a&lt;b" gt="a&gt;b" q="say &quot;hi&quot;" num="&#65;BC" dbl="a&amp;amp;b" p:ns="u&amp;v" xmlns:p="urn:p"/>`
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	// Sanity: the parser resolved the entity references, so the in-memory value
+	// carries a bare '&'/'<'/'>' — exactly the shape that breaks a re-parsing copy.
+	root := doc.DocumentElement()
+	require.NotNil(t, root)
+	amp, ok := root.FindAttribute(helium.LocalNamePredicate("amp"))
+	require.True(t, ok)
+	require.Equal(t, "x&y", amp.Value(), "parser resolved &amp; to a bare &")
+
+	orig, err := helium.WriteString(doc)
+	require.NoError(t, err)
+
+	cp, err := helium.CopyDoc(doc)
+	require.NoError(t, err, "CopyDoc must not choke on entity-resolved attribute values")
+
+	copied, err := helium.WriteString(cp)
+	require.NoError(t, err)
+
+	// The copy serializes byte-for-byte identically to the original: the
+	// serializer re-escapes '&'/'<' on both, and the resolved values are stored
+	// literally rather than re-parsed.
+	require.Equal(t, orig, copied)
+
+	// And CopyNode of just the element (the other deepCopier entry point) too.
+	dst := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+	cpNode, err := helium.CopyNode(root, dst)
+	require.NoError(t, err)
+	cpElem, ok := helium.AsNode[*helium.Element](cpNode)
+	require.True(t, ok)
+	cpAmp, ok := cpElem.FindAttribute(helium.LocalNamePredicate("amp"))
+	require.True(t, ok)
+	require.Equal(t, "x&y", cpAmp.Value(), "copied value stays resolved, not re-parsed or double-escaped")
+	cpDbl, ok := cpElem.FindAttribute(helium.LocalNamePredicate("dbl"))
+	require.True(t, ok)
+	require.Equal(t, "a&amp;b", cpDbl.Value(), "double-escaped source '&amp;amp;' resolves once to '&amp;', copied literally")
+}
+
 // TestCopyNodeVariants covers CopyNode across several node types.
 func TestCopyNodeVariants(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Follow-up to #1031. deepCopier.copyAttributes (used by both CopyDoc and CopyNode) re-materialized attribute values via the entity-reparsing setters SetAttribute/SetAttributeNS, but a.Value() is already entity-resolved — so a value with a bare & (from source &amp;) raised 'entity was unterminated' during copy, and a double-escaped value was silently corrupted. Now uses SetLiteralAttribute/SetLiteralAttributeNS (store as-is, serializer re-escapes), the exact analogue of the #1031 copyAndStrip fix. Byte-identical for all previously-working cases (full go test ./... green, all xsd/c14n/relaxng/html/xslt3/xinclude goldens unchanged); fixes the &-bearing and double-escaped cases. Regression test added; the bug reproduces on origin/main.