### PR TITLE
document xslt3 resource-bound contract

### DIFF
--- a/examples/xslt3_untrusted_service_example_test.go
+++ b/examples/xslt3_untrusted_service_example_test.go
@@ -1,0 +1,129 @@
+package examples_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xslt3"
+)
+
+// Example_untrustedService is the pattern to copy into an exposed endpoint that
+// transforms an UNTRUSTED stylesheet against an UNTRUSTED source document. It
+// layers every bound the caller is responsible for on top of what xslt3 already
+// enforces itself. See the "Resource bounds" section of xslt3/README.md for the
+// contract split — what xslt3 bounds (per-resource byte cap, recursion depth,
+// regex timeout, default-deny I/O, context cancellation) versus what remains the
+// caller's job (raw input size, total output size, peak memory, CPU time). A
+// context deadline bounds wall-clock time, NOT peak memory, so the raw-input and
+// output caps below are not optional.
+func Example_untrustedService() {
+	// Untrusted request payloads. In a real endpoint these arrive as request
+	// bodies / io.Readers of unknown length.
+	const untrustedStylesheet = `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="text"/>
+  <xsl:template match="/">Hello, <xsl:value-of select="name/@who"/>!</xsl:template>
+</xsl:stylesheet>`
+	const untrustedSource = `<name who="World"/>`
+
+	// 1. Cap raw input size BEFORE parsing. Reject anything larger than a fixed
+	//    limit up front, so a huge body never reaches the parser.
+	const maxInputBytes = 64 * 1024 // 64 KiB per document
+	stylesheetBytes, err := readCapped(bytes.NewReader([]byte(untrustedStylesheet)), maxInputBytes)
+	if err != nil {
+		fmt.Printf("stylesheet rejected: %s\n", err)
+		return
+	}
+	sourceBytes, err := readCapped(bytes.NewReader([]byte(untrustedSource)), maxInputBytes)
+	if err != nil {
+		fmt.Printf("source rejected: %s\n", err)
+		return
+	}
+
+	// 3. Deadline-bearing context. A cancelled/expired ctx aborts compilation and
+	//    the transform promptly. Never pass context.Background() for untrusted work.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// 2. Hardened parse. helium's default parser is already XXE-blocked,
+	//    deny-all-filesystem, and no-network; we do NOT weaken it.
+	p := helium.NewParser()
+
+	stylesheetDoc, err := p.Parse(ctx, stylesheetBytes)
+	if err != nil {
+		fmt.Printf("parse stylesheet error: %s\n", err)
+		return
+	}
+	sourceDoc, err := p.Parse(ctx, sourceBytes)
+	if err != nil {
+		fmt.Printf("parse source error: %s\n", err)
+		return
+	}
+
+	// 4. Default-deny external access. We install NO URIResolver / HTTPClient, so
+	//    xsl:import, doc(), unparsed-text(), and network reads all stay refused. A
+	//    real service grants only a confined resolver rooted at a trusted dir.
+	stylesheet, err := xslt3.NewCompiler().Compile(ctx, stylesheetDoc)
+	if err != nil {
+		fmt.Printf("compile error: %s\n", err)
+		return
+	}
+
+	// 5 + 6. Cap output through a size-limited writer, and set a small
+	//    MaxResourceBytes as defense-in-depth for any resolver-fetched resource
+	//    or xsl:analyze-string match enumeration. MaxResourceBytes is PER-RESOURCE,
+	//    not a total-output budget — the writer cap is what bounds total output.
+	const maxOutputBytes = 1 * 1024 * 1024 // 1 MiB serialized result
+	out := &limitedWriter{w: new(bytes.Buffer), remaining: maxOutputBytes}
+
+	err = stylesheet.Transform(sourceDoc).
+		MaxResourceBytes(256*1024). // 256 KiB per resolver-fetched resource
+		WriteTo(ctx, out)
+	if err != nil {
+		fmt.Printf("transform error: %s\n", err)
+		return
+	}
+
+	fmt.Println(out.w.(*bytes.Buffer).String())
+	// Output:
+	// Hello, World!
+}
+
+// readCapped reads at most limit bytes from r and rejects anything larger, so an
+// untrusted body of unknown length can never exhaust memory during parsing.
+func readCapped(r io.Reader, limit int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, errInputTooLarge
+	}
+	return data, nil
+}
+
+// limitedWriter caps the total number of bytes written to the wrapped writer,
+// returning errOutputTooLarge once the cap would be exceeded. This bounds the
+// serialized result size of an output-fanout stylesheet.
+type limitedWriter struct {
+	w         io.Writer
+	remaining int64
+}
+
+func (lw *limitedWriter) Write(p []byte) (int, error) {
+	if int64(len(p)) > lw.remaining {
+		return 0, errOutputTooLarge
+	}
+	lw.remaining -= int64(len(p))
+	return lw.w.Write(p)
+}
+
+var (
+	errInputTooLarge  = errors.New("input exceeds maximum allowed size")
+	errOutputTooLarge = errors.New("output exceeds maximum allowed size")
+)

--- a/examples/xslt3_untrusted_service_example_test.go
+++ b/examples/xslt3_untrusted_service_example_test.go
@@ -45,12 +45,12 @@ func Example_untrustedService() {
 		return
 	}
 
-	// 3. Deadline-bearing context. A cancelled/expired ctx aborts compilation and
+	// 2. Deadline-bearing context. A cancelled/expired ctx aborts compilation and
 	//    the transform promptly. Never pass context.Background() for untrusted work.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	// 2. Hardened parse. helium's default parser is already XXE-blocked,
+	// 3. Hardened parse. helium's default parser is already XXE-blocked,
 	//    deny-all-filesystem, and no-network; we do NOT weaken it.
 	p := helium.NewParser()
 
@@ -77,8 +77,13 @@ func Example_untrustedService() {
 	// 5 + 6. Cap output through a size-limited writer, and set a small
 	//    MaxResourceBytes as defense-in-depth for any resolver-fetched resource
 	//    or xsl:analyze-string match enumeration. MaxResourceBytes is PER-RESOURCE,
-	//    not a total-output budget — the writer cap is what bounds total output.
-	const maxOutputBytes = 1 * 1024 * 1024 // 1 MiB serialized result
+	//    not a total-output budget — the writer cap is what bounds the PRIMARY
+	//    serialized result. It does NOT bound total output: xsl:result-document
+	//    trees are delivered separately through ResultDocumentHandler and bypass
+	//    this writer cap, so an untrusted-input service should either reject
+	//    stylesheets that use xsl:result-document or wrap that handler with its
+	//    own byte budget.
+	const maxOutputBytes = 1 * 1024 * 1024 // 1 MiB primary serialized result
 	out := &limitedWriter{w: new(bytes.Buffer), remaining: maxOutputBytes}
 
 	err = stylesheet.Transform(sourceDoc).
@@ -109,7 +114,8 @@ func readCapped(r io.Reader, limit int64) ([]byte, error) {
 
 // limitedWriter caps the total number of bytes written to the wrapped writer,
 // returning errOutputTooLarge once the cap would be exceeded. This bounds the
-// serialized result size of an output-fanout stylesheet.
+// PRIMARY serialized result only; xsl:result-document trees are delivered
+// through ResultDocumentHandler and never pass through this writer.
 type limitedWriter struct {
 	w         io.Writer
 	remaining int64

--- a/xslt3/README.md
+++ b/xslt3/README.md
@@ -165,20 +165,177 @@ at their iteration points (e.g. `execute_control.go`, `execute_apply.go`,
 promptly rather than running to completion. Always pass a `ctx` with a deadline
 when processing untrusted input.
 
-### Caller responsibilities
+### Resource bounds
 
-The engine bounds a few things itself: each external resource read is capped at
-`MaxResourceBytes` (10 MiB default; `Invocation.MaxResourceBytes` overrides it),
-which also bounds `xsl:analyze-string` match enumeration. But the engine cannot
-know your overall resource budget, so the caller must still:
+`xslt3` draws a **contractual** line between what it bounds itself and what stays
+the caller's responsibility. In particular, `MaxResourceBytes` is a **per-resource**
+cap, not a global execution budget — do not read it as one.
 
-- Enforce a maximum **raw input size** before parsing the stylesheet and source
-  document — the byte cap governs resolver-fetched resources, not the primary
-  source you hand in.
-- Bound **output size**: a stylesheet can fan out large numbers of
-  `xsl:result-document`s and materialize large result trees in memory. Cap the
-  work (or reject the stylesheet) when transforming untrusted input.
-- Pass a `context.Context` with a deadline (see Cancellation above).
+**Bounded by `xslt3`:**
+
+- each resolver / HTTP / package resource read, via `MaxResourceBytes` (10 MiB
+  default; `Invocation.MaxResourceBytes` overrides it; a negative value disables it);
+- `xsl:analyze-string` match enumeration, via the same `MaxResourceBytes`;
+- external I/O access — default-deny unless a resolver / `HTTPClient` is installed
+  (see the table above);
+- template / function call recursion depth — a fixed internal cap; overflow raises
+  `XTDE0820`;
+- `fn:matches` and other regex evaluation — a wall-clock match timeout guards
+  catastrophic backtracking (ReDoS);
+- cooperative cancellation via `context.Context` in compilation and the terminal
+  transform calls (`Compile`, `Serialize`, `Do`, `WriteTo`).
+
+**Not claimed as globally bounded by `xslt3`** — the caller must bound these when
+processing untrusted input:
+
+- primary stylesheet bytes supplied directly by the caller;
+- primary source XML bytes supplied directly by the caller;
+- total serialized primary result size;
+- total result-tree node count / peak memory;
+- aggregate bytes across all resources (the cap is per-resource, not cumulative);
+- number and aggregate size of `xsl:result-document` outputs;
+- CPU time, except via `context.Context` cancellation and host / process scheduling.
+
+A `context` deadline bounds *wall-clock time*, not *peak memory*: a single fast
+allocation (e.g. a large result tree) can exhaust memory before the next
+cancellation poll fires. For untrusted input, also enforce a maximum raw input
+size up front, cap the serialized output, and run under a memory-limited process.
+The example below shows the shape.
+
+<!-- INCLUDE(examples/xslt3_untrusted_service_example_test.go) -->
+```go
+package examples_test
+
+import (
+  "bytes"
+  "context"
+  "errors"
+  "fmt"
+  "io"
+  "time"
+
+  "github.com/lestrrat-go/helium"
+  "github.com/lestrrat-go/helium/xslt3"
+)
+
+// Example_untrustedService is the pattern to copy into an exposed endpoint that
+// transforms an UNTRUSTED stylesheet against an UNTRUSTED source document. It
+// layers every bound the caller is responsible for on top of what xslt3 already
+// enforces itself. See the "Resource bounds" section of xslt3/README.md for the
+// contract split — what xslt3 bounds (per-resource byte cap, recursion depth,
+// regex timeout, default-deny I/O, context cancellation) versus what remains the
+// caller's job (raw input size, total output size, peak memory, CPU time). A
+// context deadline bounds wall-clock time, NOT peak memory, so the raw-input and
+// output caps below are not optional.
+func Example_untrustedService() {
+  // Untrusted request payloads. In a real endpoint these arrive as request
+  // bodies / io.Readers of unknown length.
+  const untrustedStylesheet = `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="text"/>
+  <xsl:template match="/">Hello, <xsl:value-of select="name/@who"/>!</xsl:template>
+</xsl:stylesheet>`
+  const untrustedSource = `<name who="World"/>`
+
+  // 1. Cap raw input size BEFORE parsing. Reject anything larger than a fixed
+  //    limit up front, so a huge body never reaches the parser.
+  const maxInputBytes = 64 * 1024 // 64 KiB per document
+  stylesheetBytes, err := readCapped(bytes.NewReader([]byte(untrustedStylesheet)), maxInputBytes)
+  if err != nil {
+    fmt.Printf("stylesheet rejected: %s\n", err)
+    return
+  }
+  sourceBytes, err := readCapped(bytes.NewReader([]byte(untrustedSource)), maxInputBytes)
+  if err != nil {
+    fmt.Printf("source rejected: %s\n", err)
+    return
+  }
+
+  // 3. Deadline-bearing context. A cancelled/expired ctx aborts compilation and
+  //    the transform promptly. Never pass context.Background() for untrusted work.
+  ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+  defer cancel()
+
+  // 2. Hardened parse. helium's default parser is already XXE-blocked,
+  //    deny-all-filesystem, and no-network; we do NOT weaken it.
+  p := helium.NewParser()
+
+  stylesheetDoc, err := p.Parse(ctx, stylesheetBytes)
+  if err != nil {
+    fmt.Printf("parse stylesheet error: %s\n", err)
+    return
+  }
+  sourceDoc, err := p.Parse(ctx, sourceBytes)
+  if err != nil {
+    fmt.Printf("parse source error: %s\n", err)
+    return
+  }
+
+  // 4. Default-deny external access. We install NO URIResolver / HTTPClient, so
+  //    xsl:import, doc(), unparsed-text(), and network reads all stay refused. A
+  //    real service grants only a confined resolver rooted at a trusted dir.
+  stylesheet, err := xslt3.NewCompiler().Compile(ctx, stylesheetDoc)
+  if err != nil {
+    fmt.Printf("compile error: %s\n", err)
+    return
+  }
+
+  // 5 + 6. Cap output through a size-limited writer, and set a small
+  //    MaxResourceBytes as defense-in-depth for any resolver-fetched resource
+  //    or xsl:analyze-string match enumeration. MaxResourceBytes is PER-RESOURCE,
+  //    not a total-output budget — the writer cap is what bounds total output.
+  const maxOutputBytes = 1 * 1024 * 1024 // 1 MiB serialized result
+  out := &limitedWriter{w: new(bytes.Buffer), remaining: maxOutputBytes}
+
+  err = stylesheet.Transform(sourceDoc).
+    MaxResourceBytes(256*1024). // 256 KiB per resolver-fetched resource
+    WriteTo(ctx, out)
+  if err != nil {
+    fmt.Printf("transform error: %s\n", err)
+    return
+  }
+
+  fmt.Println(out.w.(*bytes.Buffer).String())
+  // Output:
+  // Hello, World!
+}
+
+// readCapped reads at most limit bytes from r and rejects anything larger, so an
+// untrusted body of unknown length can never exhaust memory during parsing.
+func readCapped(r io.Reader, limit int64) ([]byte, error) {
+  data, err := io.ReadAll(io.LimitReader(r, limit+1))
+  if err != nil {
+    return nil, err
+  }
+  if int64(len(data)) > limit {
+    return nil, errInputTooLarge
+  }
+  return data, nil
+}
+
+// limitedWriter caps the total number of bytes written to the wrapped writer,
+// returning errOutputTooLarge once the cap would be exceeded. This bounds the
+// serialized result size of an output-fanout stylesheet.
+type limitedWriter struct {
+  w         io.Writer
+  remaining int64
+}
+
+func (lw *limitedWriter) Write(p []byte) (int, error) {
+  if int64(len(p)) > lw.remaining {
+    return 0, errOutputTooLarge
+  }
+  lw.remaining -= int64(len(p))
+  return lw.w.Write(p)
+}
+
+var (
+  errInputTooLarge  = errors.New("input exceeds maximum allowed size")
+  errOutputTooLarge = errors.New("output exceeds maximum allowed size")
+)
+```
+source: [examples/xslt3_untrusted_service_example_test.go](https://github.com/lestrrat-go/helium/blob/main/examples/xslt3_untrusted_service_example_test.go)
+<!-- END INCLUDE -->
 
 ## Conformance
 

--- a/xslt3/README.md
+++ b/xslt3/README.md
@@ -251,12 +251,12 @@ func Example_untrustedService() {
     return
   }
 
-  // 3. Deadline-bearing context. A cancelled/expired ctx aborts compilation and
+  // 2. Deadline-bearing context. A cancelled/expired ctx aborts compilation and
   //    the transform promptly. Never pass context.Background() for untrusted work.
   ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
   defer cancel()
 
-  // 2. Hardened parse. helium's default parser is already XXE-blocked,
+  // 3. Hardened parse. helium's default parser is already XXE-blocked,
   //    deny-all-filesystem, and no-network; we do NOT weaken it.
   p := helium.NewParser()
 
@@ -283,8 +283,13 @@ func Example_untrustedService() {
   // 5 + 6. Cap output through a size-limited writer, and set a small
   //    MaxResourceBytes as defense-in-depth for any resolver-fetched resource
   //    or xsl:analyze-string match enumeration. MaxResourceBytes is PER-RESOURCE,
-  //    not a total-output budget — the writer cap is what bounds total output.
-  const maxOutputBytes = 1 * 1024 * 1024 // 1 MiB serialized result
+  //    not a total-output budget — the writer cap is what bounds the PRIMARY
+  //    serialized result. It does NOT bound total output: xsl:result-document
+  //    trees are delivered separately through ResultDocumentHandler and bypass
+  //    this writer cap, so an untrusted-input service should either reject
+  //    stylesheets that use xsl:result-document or wrap that handler with its
+  //    own byte budget.
+  const maxOutputBytes = 1 * 1024 * 1024 // 1 MiB primary serialized result
   out := &limitedWriter{w: new(bytes.Buffer), remaining: maxOutputBytes}
 
   err = stylesheet.Transform(sourceDoc).
@@ -315,7 +320,8 @@ func readCapped(r io.Reader, limit int64) ([]byte, error) {
 
 // limitedWriter caps the total number of bytes written to the wrapped writer,
 // returning errOutputTooLarge once the cap would be exceeded. This bounds the
-// serialized result size of an output-fanout stylesheet.
+// PRIMARY serialized result only; xsl:result-document trees are delivered
+// through ResultDocumentHandler and never pass through this writer.
 type limitedWriter struct {
   w         io.Writer
   remaining int64


### PR DESCRIPTION
- document xslt3 resource-bound contract (bounded-vs-caller split) in xslt3/README.md
- add safe untrusted-service example with raw-input cap, hardened parse, deadline ctx, default-deny I/O, output cap, MaxResourceBytes
