### PR TITLE
stop entity-ref DTD spill in docorder and dsig

### DIFF
--- a/internal/xpath/docorder.go
+++ b/internal/xpath/docorder.go
@@ -1,6 +1,7 @@
 package xpath
 
 import (
+	"slices"
 	"sort"
 	"sync"
 
@@ -167,6 +168,9 @@ func (c *DocOrderCache) indexWalk(cur helium.Node, positions map[helium.Node]int
 
 	stack := make([]helium.Node, 0, 256)
 	stack = append(stack, cur)
+	// childBuf is reused across stack iterations to collect a node's owned
+	// children before pushing them in reverse.
+	var childBuf []helium.Node
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -183,9 +187,21 @@ func (c *DocOrderCache) indexWalk(cur helium.Node, positions map[helium.Node]int
 			})
 		}
 
-		// Push children in reverse (right-to-left) so left-most is processed first.
-		// Use LastChild + PrevSibling to avoid allocating a temporary slice.
-		for child := n.LastChild(); child != nil; child = child.PrevSibling() {
+		// Enumerate n's OWNED children via helium.Children, which stops at a
+		// foreign-owned child (an entity reference's shared Entity node is owned
+		// by the DTD, and its sibling pointers thread into the DTD's declaration
+		// list) and is cycle-safe. A raw LastChild/PrevSibling walk would escape
+		// into the DTD's declarations and assign them spurious document-order
+		// positions. This mirrors axisChild, which also enumerates via
+		// helium.Children, so entity-declaration and DTD nodes stay out of the
+		// order index. helium.Children iterates forward, so buffer the children
+		// and push them right-to-left so the left-most is processed first;
+		// entity-free documents get byte-identical positions.
+		childBuf = childBuf[:0]
+		for child := range helium.Children(n) {
+			childBuf = append(childBuf, child)
+		}
+		for _, child := range slices.Backward(childBuf) {
 			stack = append(stack, child)
 		}
 	}

--- a/internal/xpath/docorder_test.go
+++ b/internal/xpath/docorder_test.go
@@ -302,3 +302,121 @@ func TestDocOrderCache_BuildFromMultipleDocuments(t *testing.T) {
 	require.NotEqual(t, -1, cache.Position(child2))
 	require.Less(t, cache.Compare(root2, child2), 0)
 }
+
+// childByType returns the first direct child of n whose node type and (when
+// non-empty) name match.
+func childByType(n helium.Node, typ helium.ElementType, name string) helium.Node {
+	for c := range helium.Children(n) {
+		if c.Type() != typ {
+			continue
+		}
+		if name == "" || c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}
+
+// TestDocOrderCache_EntityRefNoSiblingSpill guards the owned-boundary child
+// enumeration in indexWalk. An EntityRefNode's child is the shared Entity node
+// owned by the DTD, whose sibling pointers thread into the DTD's declaration
+// list. Enumerating an entity reference's children via a raw LastChild /
+// PrevSibling walk escapes into those sibling declarations and assigns them
+// spurious document-order positions AFTER the entity reference, interleaved
+// with the element content. indexWalk enumerates via helium.Children, which
+// stops at the foreign boundary, so a sibling declaration is never dragged into
+// the content region — it keeps only whatever position the DTD-child descent
+// already gave it (before the root element), and the real element nodes keep
+// correct document order.
+//
+// The reference is to the SECOND-declared entity (bar) so that a PrevSibling
+// walk from its shared node would reach the FIRST declaration (foo); foo is the
+// spill victim under the buggy enumeration.
+func TestDocOrderCache_EntityRefNoSiblingSpill(t *testing.T) {
+	const src = "<?xml version=\"1.0\"?>\n" +
+		"<!DOCTYPE root [\n" +
+		"<!ENTITY foo \"FOO\">\n" +
+		"<!ENTITY bar \"BAR\">\n" +
+		"]>\n" +
+		"<root><a>before</a>&bar;<b>after</b></root>"
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+	root := doc.DocumentElement()
+	require.NotNil(t, root)
+
+	elemA := childByType(root, helium.ElementNode, "a")
+	require.NotNil(t, elemA, "element a")
+	elemB := childByType(root, helium.ElementNode, "b")
+	require.NotNil(t, elemB, "element b")
+	entityRef := childByType(root, helium.EntityRefNode, "bar")
+	require.NotNil(t, entityRef, "entity reference bar")
+
+	// The un-referenced sibling declaration foo, found in the DTD.
+	dtd := childByType(doc, helium.DTDNode, "")
+	if dtd == nil {
+		dtd = childByType(doc, helium.DocumentTypeNode, "")
+	}
+	require.NotNil(t, dtd, "DTD node")
+	fooDecl := childByType(dtd, helium.EntityNode, "foo")
+	require.NotNil(t, fooDecl, "foo entity declaration")
+
+	cache := &ixpath.DocOrderCache{}
+	cache.BuildFrom(doc)
+
+	// Real element nodes keep correct document order regardless of the entity
+	// reference between them.
+	require.Less(t, cache.Compare(elemA, entityRef), 0, "a before entity ref")
+	require.Less(t, cache.Compare(entityRef, elemB), 0, "entity ref before b")
+	require.Less(t, cache.Compare(elemA, elemB), 0, "a before b")
+
+	// The spill is gone: the un-referenced declaration foo is NOT positioned
+	// after the entity reference. It stays in the DTD region, before the root
+	// element. Under the buggy sibling walk, foo landed after the reference,
+	// interleaved with the element content (Position(foo) > Position(ref)).
+	require.Less(t, cache.Position(fooDecl), cache.Position(root),
+		"sibling declaration foo must stay in the DTD region, before the root element")
+	require.Less(t, cache.Position(fooDecl), cache.Position(entityRef),
+		"sibling declaration foo must not be spilled after the entity reference")
+}
+
+// TestDocOrderCache_EntityFreeDocUnaffected locks the byte-identical invariant:
+// a document without entity references (and one with a DTD but no references)
+// gets exactly the document-order positions the pre-fix indexWalk produced.
+func TestDocOrderCache_EntityFreeDocUnaffected(t *testing.T) {
+	t.Run("no DTD", func(t *testing.T) {
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root><a>x</a><b>y</b></root>`))
+		require.NoError(t, err)
+		root := doc.DocumentElement()
+		a := childByType(root, helium.ElementNode, "a")
+		b := childByType(root, helium.ElementNode, "b")
+
+		cache := &ixpath.DocOrderCache{}
+		cache.BuildFrom(doc)
+
+		require.Equal(t, 0, cache.Position(doc))
+		require.Equal(t, 2, cache.Position(root))
+		require.Equal(t, 4, cache.Position(a))
+		require.Equal(t, 8, cache.Position(b))
+	})
+
+	t.Run("DTD with declarations but no reference", func(t *testing.T) {
+		const src = "<?xml version=\"1.0\"?>\n" +
+			"<!DOCTYPE root [\n<!ENTITY foo \"FOO\">\n<!ENTITY bar \"BAR\">\n]>\n" +
+			"<root><a>x</a><b>y</b></root>"
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+		require.NoError(t, err)
+		root := doc.DocumentElement()
+		a := childByType(root, helium.ElementNode, "a")
+		b := childByType(root, helium.ElementNode, "b")
+
+		cache := &ixpath.DocOrderCache{}
+		cache.BuildFrom(doc)
+
+		// Declarations index in the DTD region (pre-existing DTD-child descent),
+		// before the root element, in both the old and new enumeration.
+		require.Equal(t, 8, cache.Position(root))
+		require.Equal(t, 10, cache.Position(a))
+		require.Equal(t, 14, cache.Position(b))
+	})
+}

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -339,7 +339,15 @@ func collectSubtreeNodes(n helium.Node) []helium.Node {
 				nodes = append(nodes, attr)
 			}
 		}
-		for child := cur.FirstChild(); child != nil; child = child.NextSibling() {
+		// Enumerate owned children via helium.Children, which stops at a
+		// foreign-owned child (an entity reference's shared Entity node is owned
+		// by the DTD, whose sibling pointers thread into the DTD declaration
+		// list) and is cycle-safe. A raw FirstChild/NextSibling walk would spill
+		// DTD declaration nodes into the c14n node set. This matches the c14n
+		// canonicalizer itself, which enumerates element children and expands an
+		// entity reference through helium.Children, so the node set holds only
+		// the owned subtree.
+		for child := range helium.Children(cur) {
 			walk(child)
 		}
 	}

--- a/xmldsig1/transforms_internal_test.go
+++ b/xmldsig1/transforms_internal_test.go
@@ -206,6 +206,75 @@ func TestCanonicalizeSubtreeKeepsNamespaceDecls(t *testing.T) {
 	})
 }
 
+// dtdEntityDecl returns the DTD entity-declaration node named name, or nil.
+func dtdEntityDecl(doc *helium.Document, name string) helium.Node {
+	for c := range helium.Children(doc) {
+		if c.Type() != helium.DTDNode && c.Type() != helium.DocumentTypeNode {
+			continue
+		}
+		for d := range helium.Children(c) {
+			if d.Type() == helium.EntityNode && d.Name() == name {
+				return d
+			}
+		}
+	}
+	return nil
+}
+
+// TestCollectSubtreeNodesNoDTDSpill guards the owned-boundary child enumeration
+// in collectSubtreeNodes. An EntityRefNode's child is the shared Entity node
+// owned by the DTD, whose sibling pointers thread into the DTD's declaration
+// list. A raw FirstChild / NextSibling recursion escapes into those sibling
+// declarations and pulls foreign DTD-declaration nodes into the c14n node set.
+// collectSubtreeNodes enumerates via helium.Children — the same primitive the
+// c14n canonicalizer uses to walk element children and expand an entity
+// reference — so the node set holds only the owned subtree.
+//
+// The signed subtree references &foo; (the FIRST declaration); under the buggy
+// recursion the following sibling declaration &bar; leaked into the node set.
+func TestCollectSubtreeNodesNoDTDSpill(t *testing.T) {
+	const xml = "<?xml version=\"1.0\"?>\n" +
+		"<!DOCTYPE doc [\n" +
+		"<!ENTITY foo \"FOO\">\n" +
+		"<!ENTITY bar \"BAR\">\n" +
+		"]>\n" +
+		"<doc><target Id=\"x\"><child>pre &foo; post</child></target></doc>"
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(xml))
+	require.NoError(t, err)
+	target, err := resolveReference(doc, "#x")
+	require.NoError(t, err)
+
+	set := make(map[helium.Node]bool)
+	for _, n := range collectSubtreeNodes(target) {
+		set[n] = true
+	}
+
+	// Sanity: the owned subtree element is collected.
+	require.True(t, set[helium.Node(target)], "the target subtree element must be collected")
+
+	// The un-referenced sibling declaration bar must NOT leak into the node set.
+	barDecl := dtdEntityDecl(doc, "bar")
+	require.NotNil(t, barDecl, "bar entity declaration should exist in the DTD")
+	require.False(t, set[barDecl],
+		"un-referenced sibling entity declaration bar must not spill into the c14n node set")
+}
+
+// TestCanonicalizeSubtreeEntityFreeUnchanged locks the byte-identical invariant:
+// an entity-free signed subtree canonicalizes to the same W3C bytes as before
+// the owned-boundary enumeration change.
+func TestCanonicalizeSubtreeEntityFreeUnchanged(t *testing.T) {
+	const xml = `<doc><target Id="x"><child>v</child></target></doc>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(xml))
+	require.NoError(t, err)
+	target, err := resolveReference(doc, "#x")
+	require.NoError(t, err)
+
+	out, err := canonicalizeSubtree(C14N10, target, nil)
+	require.NoError(t, err)
+	require.Equal(t, `<target Id="x"><child>v</child></target>`, string(out))
+}
+
 // TestCanonicalizeEnvelopedMatchesDetach is the byte-equivalence contract for
 // the clone-based enveloped transform: the canonical bytes produced by cloning
 // the document and omitting the Signature from the copy MUST equal the bytes


### PR DESCRIPTION
- `internal/xpath/docorder.go` `indexWalk` and `xmldsig1/transforms.go` `collectSubtreeNodes` now enumerate children via `helium.Children` (owned-boundary, cycle-safe), so an entity reference no longer spills DTD declaration nodes into the document-order cache / c14n node-set
- robustness + consistency (aligns with the XPath axes and c14n, which already use `helium.Children`); eliminates unbounded spurious DTD traversal on entity-bearing input. No observable output change in current code — foreign DTD nodes were never queried (docorder) or rendered (c14n skips them); entity-free documents are byte-identical
- follow-up to #1043; addresses the two real-spill sites from the #1044 triage