### PR TITLE
no length facet on xs:QName/xs:NOTATION (errata 4009)

### DIFF
--- a/internal/xsd/value/facets.go
+++ b/internal/xsd/value/facets.go
@@ -68,15 +68,19 @@ var lengthApplicableTypes = map[string]struct{}{
 }
 
 // LengthApplicable reports whether the length facets (length, minLength,
-// maxLength) are applicable to builtinLocal's atomic value space. Callers gating
+// maxLength) may be DECLARED on builtinLocal's atomic value space. Callers gating
 // on this keep the length facets off the numeric/decimal family, boolean, float,
 // double and the date/time/duration family, where XSD declares them inapplicable.
 //
-// On the applicable types — including xs:QName and xs:NOTATION — the length
-// facets are CONSTRAINING (XSD 1.0 / libxml2 parity): a value whose length (rune
-// count for the string family / QName / NOTATION / anyURI, octet count for the
-// binary types) violates the bound is rejected, the same way the xsd package
-// enforces it (see xsd's facetLength). This keeps relaxng and xsd consistent.
+// Applicability (may the facet be declared) is a SEPARATE question from whether it
+// CONSTRAINS a value. xs:QName and xs:NOTATION are in the applicable set — a schema
+// may declare xs:length on them — but per XSD Part 2 (W3C errata bug 4009) their
+// length is undefined, so the facet is vacuously satisfied and the xsd package does
+// NOT reject an out-of-length QName/NOTATION value (see xsd's checkFacets). relaxng,
+// whose datatype library predates the errata, still enforces the bound on
+// QName/NOTATION (see relaxng's facetLength), so the two paths intentionally diverge
+// there. On the string family / anyURI (rune count) and the binary types (octet
+// count) both paths enforce the bound.
 func LengthApplicable(builtinLocal string) bool {
 	_, ok := lengthApplicableTypes[builtinLocal]
 	return ok

--- a/relaxng/data_facet_pattern_length_test.go
+++ b/relaxng/data_facet_pattern_length_test.go
@@ -95,13 +95,13 @@ func TestDataLengthFacetApplicability(t *testing.T) {
 	})
 }
 
-// TestDataLengthFacetQNameEnforced covers RNG-104+105 r4: the length facets
-// (length, minLength, maxLength) on xs:QName and xs:NOTATION are CONSTRAINING
-// (XSD 1.0 / libxml2 parity, matching the shared xsd validator's facetLength), not
-// a no-op. A value whose rune count violates the bound is REJECTED exactly as the
-// xsd package rejects it, while an in-bounds value is accepted, the bound is still
-// compile-validated as an xs:nonNegativeInteger, and string-type enforcement is
-// unaffected.
+// TestDataLengthFacetQNameEnforced covers RNG-104+105 r4: RELAX NG's datatype
+// library treats the length facets (length, minLength, maxLength) on xs:QName and
+// xs:NOTATION as CONSTRAINING (predating W3C Schema errata 4009), not a no-op — a
+// value whose rune count violates the bound is REJECTED. This intentionally DIVERGES
+// from the xsd validator, which treats those facets as vacuous on QName/NOTATION per
+// errata 4009. An in-bounds value is accepted, the bound is still compile-validated
+// as an xs:nonNegativeInteger, and string-type enforcement is unaffected.
 func TestDataLengthFacetQNameEnforced(t *testing.T) {
 	t.Parallel()
 

--- a/relaxng/data_facet_pattern_length_test.go
+++ b/relaxng/data_facet_pattern_length_test.go
@@ -115,10 +115,12 @@ func TestDataLengthFacetQNameEnforced(t *testing.T) {
 
 	t.Run("maxLength constrains a QName", func(t *testing.T) {
 		t.Parallel()
-		// "abc" is a 3-rune lexically valid QName; maxLength="1" rejects it, the same
-		// way the xsd validator rejects an out-of-space QName length facet.
+		// "abc" is a 3-rune lexically valid QName; RELAX NG's datatype library
+		// (pre-errata-4009) treats maxLength="1" as constraining and rejects it. The
+		// xsd validator instead treats QName length facets as vacuous (errata 4009),
+		// so this is a deliberate RELAX-NG-vs-XSD divergence.
 		require.Error(t, validateWith(t, mk("QName", "maxLength", "1"), `<r>abc</r>`),
-			`maxLength on xs:QName must reject a longer value (XSD 1.0 parity)`)
+			`RELAX NG maxLength on xs:QName rejects a longer value (pre-errata-4009 enforcement)`)
 	})
 
 	t.Run("maxLength accepts an in-bounds QName", func(t *testing.T) {

--- a/relaxng/validate.go
+++ b/relaxng/validate.go
@@ -2152,10 +2152,11 @@ func validateXSDType(typeName, text string, params []*param) int {
 // stays reachable for the ordering-facet comparisons below.
 //
 // The length facets (length/minLength/maxLength) are measured via facetLength on
-// every applicable type — including xs:QName and xs:NOTATION, where they are
-// CONSTRAINING (XSD 1.0 / libxml2 parity, matching the xsd package's facetLength)
-// rather than a no-op, so RELAX NG rejects an out-of-length QName/NOTATION exactly
-// as the shared xsd validator does;
+// every applicable type — including xs:QName and xs:NOTATION, where RELAX NG's
+// datatype library (predating W3C Schema errata 4009) treats them as CONSTRAINING
+// and REJECTS an out-of-length QName/NOTATION. The xsd validator now treats those
+// facets as vacuous on QName/NOTATION (errata 4009), so the two paths intentionally
+// diverge there; on every other applicable type they agree;
 // the ordering facets (min/maxInclusive, min/maxExclusive) are evaluated through
 // the shared XSD value engine (value.Compare) so RELAX NG and XSD agree on the
 // value space (e.g. xs:integer "5" really is less than "10"); and the digit

--- a/xsd/check_facets.go
+++ b/xsd/check_facets.go
@@ -422,9 +422,10 @@ func (c *compiler) checkEnumValueAgainstBase(ctx context.Context, td *TypeDef, f
 		// checkEnumQNameAndNotation; suppress the report HERE for just that literal
 		// to avoid a duplicate / differently-phrased diagnostic. This is per-literal,
 		// not a blanket skip of the whole type: a QName/NOTATION base still has its
-		// other enumeration literals validated against the base value space, so e.g.
-		// a QName base restricted with xs:length value="2" rejects an out-of-space
-		// "abc" enumeration member rather than silently compiling it.
+		// other enumeration literals validated against the base value space (prefix
+		// binding, and any applicable facets). The length facets do NOT apply to
+		// QName/NOTATION (errata 4009; see checkFacets), so they never contribute a
+		// rejection here — only genuinely value-space-invalid members are caught.
 		if c.enumLiteralHasUnboundQName(ctx, ev, enumNS, td, variety) {
 			continue
 		}

--- a/xsd/check_facets.go
+++ b/xsd/check_facets.go
@@ -402,9 +402,11 @@ func (c *compiler) checkFacetValueAgainstBase(ctx context.Context, td *TypeDef, 
 // because checkEnumQNameAndNotation already reports that exact case with
 // libxml2-matching phrasing; validating it here too would produce a duplicate /
 // differently-phrased diagnostic. Every OTHER enumeration literal of a
-// QName/NOTATION-carrying type is still validated against the base value space,
-// so a QName base restricted with (e.g.) xs:length value="2" still rejects an
-// out-of-space "abc" enumeration member.
+// QName/NOTATION-carrying type is still validated against the base value space
+// (prefix binding, and any applicable facets). The length facets do NOT apply to
+// QName/NOTATION (errata 4009; see checkFacets), so a QName base carrying xs:length
+// does not reject an "out-of-length" enumeration member — only a genuinely
+// value-space-invalid literal is caught.
 func (c *compiler) checkEnumValueAgainstBase(ctx context.Context, td *TypeDef, fs *FacetSet, line int, component string) {
 	base := td.BaseType
 	if base == nil || len(fs.Enumeration) == 0 {

--- a/xsd/check_facets_qname_enum_test.go
+++ b/xsd/check_facets_qname_enum_test.go
@@ -25,11 +25,12 @@ func TestEnumValueAgainstBaseQNameValueSpace(t *testing.T) {
 		offending        string
 	}{
 		{
-			// "abc" is a perfectly bound (prefix-less) QName, so the prefix-binding
-			// check passes; but its collapsed length is 3, which violates the
-			// xs:length value="2" facet carried by the base. The value-space check
-			// must reject it.
-			name: "qname base length facet out-of-space enum rejected",
+			// Per XSD Part 2 (W3C Schema errata, bug 4009), length/minLength/maxLength
+			// do NOT apply to xs:QName — the facet is vacuously satisfied. So "abc",
+			// a perfectly bound (prefix-less) QName, is a valid enumeration value even
+			// though the base carries xs:length value="2": the length facet does not
+			// constrain a QName, so the schema must COMPILE.
+			name: "qname base length facet does not constrain enum",
 			schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:simpleType name="qname2">
     <xs:restriction base="xs:QName">
@@ -43,8 +44,7 @@ func TestEnumValueAgainstBaseQNameValueSpace(t *testing.T) {
   </xs:simpleType>
   <xs:element name="root" type="enumQname2"/>
 </xs:schema>`,
-			wantCompileError: true,
-			offending:        "abc",
+			wantCompileError: false,
 		},
 		{
 			// "ab" satisfies the length-2 facet and is a valid bound QName, so the

--- a/xsd/check_facets_qname_enum_test.go
+++ b/xsd/check_facets_qname_enum_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestEnumValueAgainstBaseQNameValueSpace verifies that the per-literal QName/
-// NOTATION suppression in checkEnumValueAgainstBase is narrow: a QName base that
-// is further restricted with a value-space facet (xs:length) still has its
-// enumeration values validated against the base value space, so an out-of-space
-// member is rejected at COMPILE time. Previously a blanket early-return for any
-// QName/NOTATION base over-suppressed and let such a schema compile.
+// TestEnumValueAgainstBaseQNameValueSpace verifies how a QName base carrying an
+// xs:length facet treats its enumeration members. Per XSD Part 2 (W3C errata bug
+// 4009) the length facets do not apply to xs:QName, so an enumeration value the
+// base's xs:length would nominally exclude (e.g. "abc" under xs:length value="2")
+// still COMPILES — the length facet is vacuous. A well-formed, bound QName member
+// is accepted regardless of its rune count.
 func TestEnumValueAgainstBaseQNameValueSpace(t *testing.T) {
 	t.Parallel()
 

--- a/xsd/simplevalue_facets.go
+++ b/xsd/simplevalue_facets.go
@@ -235,9 +235,18 @@ func checkFacets(ctx context.Context, val string, valueNS map[string]string, fs 
 	}
 
 	// Length facets — interpretation depends on the builtin base type.
+	//
+	// length/minLength/maxLength do NOT apply to xs:QName or xs:NOTATION: their
+	// length is undefined (a QName's value is an (namespace, local) pair, not a
+	// string), so per XSD Part 2 (W3C Schema errata, bug 4009) these facets are
+	// VACUOUSLY SATISFIED by every value. A schema may still declare them, but they
+	// never constrain a value — enforcing a lexical rune-count here wrongly rejects
+	// e.g. an `xs:QName` restricted to `length="7"` holding the value `a`.
+	// Version-independent.
+	lengthApplies := builtinLocal != lexicon.TypeQName && builtinLocal != lexicon.TypeNotation
 	valueLen := facetLength(val, builtinLocal)
 
-	if fs.Length != nil {
+	if fs.Length != nil && lengthApplies {
 		if valueLen != *fs.Length {
 			msg := fmt.Sprintf("[facet 'length'] The value has a length of '%d'; this differs from the allowed length of '%d'.", valueLen, *fs.Length)
 			vc.reportValidityError(ctx, filename, line, elemName, msg)
@@ -245,7 +254,7 @@ func checkFacets(ctx context.Context, val string, valueNS map[string]string, fs 
 		}
 	}
 
-	if fs.MinLength != nil {
+	if fs.MinLength != nil && lengthApplies {
 		if valueLen < *fs.MinLength {
 			msg := fmt.Sprintf("[facet 'minLength'] The value has a length of '%d'; this underruns the allowed minimum length of '%d'.", valueLen, *fs.MinLength)
 			vc.reportValidityError(ctx, filename, line, elemName, msg)
@@ -253,7 +262,7 @@ func checkFacets(ctx context.Context, val string, valueNS map[string]string, fs 
 		}
 	}
 
-	if fs.MaxLength != nil {
+	if fs.MaxLength != nil && lengthApplies {
 		if valueLen > *fs.MaxLength {
 			msg := fmt.Sprintf("[facet 'maxLength'] The value has a length of '%d'; this exceeds the allowed maximum length of '%d'.", valueLen, *fs.MaxLength)
 			vc.reportValidityError(ctx, filename, line, elemName, msg)

--- a/xsd/validate_simplevalue_facets_test.go
+++ b/xsd/validate_simplevalue_facets_test.go
@@ -1416,3 +1416,30 @@ func TestNestedUnionRangeFacetRejectedAtCompile(t *testing.T) {
 		require.Contains(t, compileSchemaErrors(t, schemaXML), "The facet 'minInclusive' is not allowed.")
 	})
 }
+
+// TestQNameLengthFacetVacuous verifies XSD Part 2 (W3C errata bug 4009): the
+// length/minLength/maxLength facets are vacuously satisfied on xs:QName (and
+// xs:NOTATION) — their length is undefined — so a value whose lexical rune count
+// differs from the declared bound is still VALID. A bare (unbound-prefix) QName
+// value is used so only the length facet is in question.
+func TestQNameLengthFacetVacuous(t *testing.T) {
+	t.Parallel()
+
+	// length is mutually exclusive with minLength/maxLength, so use minLength +
+	// maxLength together (a valid combination) to exercise both bounds at once.
+	const schema = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="qname45">
+    <xs:restriction base="xs:QName">
+      <xs:minLength value="4"/>
+      <xs:maxLength value="5"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="root" type="qname45"/>
+</xs:schema>`
+
+	// value "a" is length 1 — outside minLength=4 / maxLength=5, yet valid because
+	// the length facets do not constrain a QName.
+	errs, err := validateInstance(t, schema, `<root>a</root>`)
+	require.NoError(t, err, "QName length facets must be vacuous (errata 4009); errors: %s", errs)
+	require.Empty(t, errs)
+}


### PR DESCRIPTION
- XSD length/minLength/maxLength facets are vacuously satisfied on `xs:QName`/`xs:NOTATION` per XSD Part 2 (W3C Schema errata bug 4009) — their length is undefined — so `checkFacets` no longer rejects an out-of-length value; the facet may still be declared
- clears 53 W3C xsd10 instance false-rejects (45 NIST atomic-QName length family + 8 MS QName/NOTATION length)
- version-independent; relaxng keeps its own (pre-errata) QName length enforcement (separate path), a documented divergence