### PR TITLE
restructure xsd README schema-version section

### DIFF
--- a/xsd/README.md
+++ b/xsd/README.md
@@ -6,23 +6,37 @@ Import path: `github.com/lestrrat-go/helium/xsd`
 
 ## Schema version
 
-The compiler targets **XSD 1.0** by default. In 1.0 mode it passes
-14,082 / 14,399 (97.8%) of the W3C XML Schema Test Suite's schema-validity
-tests and 24,613 / 25,004 of its instance tests, across the full Microsoft,
-NIST, Sun, Boeing, IBM, Saxon, Oracle, and W3C-WG collections. **XSD 1.1** is
-opt-in via `Compiler.Version(xsd.Version11)` (or a `vc:minVersion="1.1"`
-attribute on the root `<xs:schema>` when the version is not set explicitly).
-XSD 1.1 support includes assertions, conditional type assignment, open content,
-wildcard `notNamespace`/`notQName`, `xs:all` relaxations, `xs:override`,
-document-wide xs:ID/xs:IDREF/xs:ENTITY value-space validation, and
-identity-constraint scoping. It passes the XSD-1.1-tagged test cases of the same
-suite — 1,049 test cases from the IBM, Saxon, Oracle, and W3C-WG collections, 0
-failures. The suite's XSD 1.0-era collections (Microsoft, NIST, Sun, Boeing)
-contribute no 1.1 tests and are not part of that run. Committed evidence sits
-beside this package — a stamped `summary-xsd10.md`/`summary-xsd11.md` and JUnit
-`results-xsd10.xml`/`results-xsd11.xml` — regenerated from the sibling
-`helium-w3c-tests` module (e.g. `go run ./cmd/w3ctest -no-system-out -summary
-../helium/xsd/summary-xsd10.md -out ../helium/xsd/results-xsd10.xml xsd10`).
+The compiler targets **XSD 1.0 by default**. **XSD 1.1 is opt-in** — enable it
+with `Compiler.Version(xsd.Version11)`, or add `vc:minVersion="1.1"` to the root
+`<xs:schema>` (used only when the version is not set explicitly).
+
+### XSD 1.1 features
+
+Assertions, conditional type assignment, open content, wildcard
+`notNamespace`/`notQName`, `xs:all` relaxations, `xs:override`, document-wide
+xs:ID/xs:IDREF/xs:ENTITY value-space validation, and identity-constraint scoping.
+
+### Conformance
+
+Measured against the W3C XML Schema Test Suite:
+
+| Mode | Result | Collections |
+|------|--------|-------------|
+| **XSD 1.0** (default) | 14,082 / 14,399 (97.8%) schema-validity tests; 24,613 / 25,004 instance tests | Microsoft, NIST, Sun, Boeing, IBM, Saxon, Oracle, W3C-WG |
+| **XSD 1.1** | 1,049 / 1,049 (100%) XSD-1.1-tagged cases, 0 failures | IBM, Saxon, Oracle, W3C-WG |
+
+The 1.0-era collections (Microsoft, NIST, Sun, Boeing) contain no 1.1-tagged
+cases, so they are not part of the 1.1 run.
+
+Committed evidence sits beside this package — `summary-xsd10.md` /
+`summary-xsd11.md` and JUnit `results-xsd10.xml` / `results-xsd11.xml` —
+regenerated from the sibling `helium-w3c-tests` module:
+
+```sh
+go run ./cmd/w3ctest -no-system-out \
+  -summary ../helium/xsd/summary-xsd10.md \
+  -out ../helium/xsd/results-xsd10.xml xsd10
+```
 
 <!-- INCLUDE(examples/xsd_validate_example_test.go) -->
 ```go


### PR DESCRIPTION
- split the schema-version wall-of-text into opt-in / features / conformance sections
- conformance numbers moved into a table; regeneration command shown as a code block
- prose only; the auto-included example and all figures are unchanged