### PR TITLE
block simple xsi:type on anyType-typed element

### DIFF
--- a/xsd/builtin_hierarchy.go
+++ b/xsd/builtin_hierarchy.go
@@ -95,6 +95,13 @@ func builtinSimpleDerivedFrom(sub, super string) bool {
 	return false
 }
 
+// isAnyType reports whether td is the ur-type xs:anyType (the complex root of the
+// whole type hierarchy). Its BaseType chain is not pointer-linked from the simple
+// types, so callers that need to recognize it compare by expanded name.
+func isAnyType(td *TypeDef) bool {
+	return td != nil && td.Name.NS == lexicon.NamespaceXSD && td.Name.Local == typeAnyType
+}
+
 // isBuiltinSimpleType reports whether td is a built-in (XSD-namespace) SIMPLE type
 // definition. The built-in simple types are registered WITHOUT BaseType pointer
 // links, so their derivation must be resolved through the builtinSimpleBase table

--- a/xsd/validate_anytype_block_test.go
+++ b/xsd/validate_anytype_block_test.go
@@ -27,6 +27,9 @@ func TestXsiTypeAnyTypeBlockRestriction(t *testing.T) {
   <xs:simpleType name="l">
     <xs:list itemType="xs:integer"/>
   </xs:simpleType>
+  <xs:complexType name="CT">
+    <xs:sequence><xs:element name="a" type="xs:string"/></xs:sequence>
+  </xs:complexType>
 </xs:schema>`
 		doc, err := helium.NewParser().Parse(t.Context(), []byte(schema))
 		require.NoError(t, err)
@@ -39,6 +42,10 @@ func TestXsiTypeAnyTypeBlockRestriction(t *testing.T) {
 
 	unionInst := `<e ` + xsiNS + ` xsi:type="u">5</e>`
 	listInst := `<e ` + xsiNS + ` xsi:type="l">1 2 3</e>`
+	// CT is a named complex type with a DIRECT model group and no explicit
+	// <xs:complexContent> derivation, so it has an implicit {base type
+	// definition} = xs:anyType by RESTRICTION (§3.4.2).
+	ctInst := `<e ` + xsiNS + ` xsi:type="CT"><a>x</a></e>`
 
 	t.Run("block=restriction rejects a union xsi:type", func(t *testing.T) {
 		t.Parallel()
@@ -60,6 +67,18 @@ func TestXsiTypeAnyTypeBlockRestriction(t *testing.T) {
 		require.ErrorIs(t, compileValidate(t, `block="#all"`, listInst), xsd.ErrValidationFailed)
 	})
 
+	t.Run("block=restriction rejects an implicit-base complex xsi:type", func(t *testing.T) {
+		t.Parallel()
+		// CT reaches xs:anyType via its implicit restriction step (§3.4.2), so
+		// block="restriction" must reject it even though CT is a complex type.
+		require.ErrorIs(t, compileValidate(t, `block="restriction"`, ctInst), xsd.ErrValidationFailed)
+	})
+
+	t.Run("block=#all rejects an implicit-base complex xsi:type", func(t *testing.T) {
+		t.Parallel()
+		require.ErrorIs(t, compileValidate(t, `block="#all"`, ctInst), xsd.ErrValidationFailed)
+	})
+
 	t.Run("no block accepts a simple xsi:type", func(t *testing.T) {
 		t.Parallel()
 		require.NoError(t, compileValidate(t, ``, unionInst))
@@ -70,5 +89,12 @@ func TestXsiTypeAnyTypeBlockRestriction(t *testing.T) {
 		// A simple type reaches xs:anyType only by restriction, so an extension-only
 		// block does not apply.
 		require.NoError(t, compileValidate(t, `block="extension"`, listInst))
+	})
+
+	t.Run("block=extension accepts an implicit-base complex xsi:type", func(t *testing.T) {
+		t.Parallel()
+		// CT's only derivation step to xs:anyType is the implicit RESTRICTION, which
+		// an extension-only block does not forbid, so it must remain accepted.
+		require.NoError(t, compileValidate(t, `block="extension"`, ctInst))
 	})
 }

--- a/xsd/validate_anytype_block_test.go
+++ b/xsd/validate_anytype_block_test.go
@@ -1,0 +1,74 @@
+package xsd_test
+
+import (
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestXsiTypeAnyTypeBlockRestriction covers cvc-elt.4.3 / Type Derivation OK for a
+// typeless (xs:anyType-typed) element whose block forbids restriction. EVERY simple
+// type derives from xs:anyType through xs:anySimpleType by RESTRICTION, so a
+// block="restriction"/"#all" must reject a simple xsi:type (union or list) on such
+// an element. Mirrors W3C msMeta/Element_w3c elemT026-029 (restriction) and
+// elemT054-057 (#all).
+func TestXsiTypeAnyTypeBlockRestriction(t *testing.T) {
+	const xsiNS = `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema"`
+
+	compileValidate := func(t *testing.T, block, instance string) error {
+		t.Helper()
+		schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="e" ` + block + `/>
+  <xs:simpleType name="u">
+    <xs:union memberTypes="xs:integer xs:string"/>
+  </xs:simpleType>
+  <xs:simpleType name="l">
+    <xs:list itemType="xs:integer"/>
+  </xs:simpleType>
+</xs:schema>`
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schema))
+		require.NoError(t, err)
+		sc, err := xsd.NewCompiler().Compile(t.Context(), doc)
+		require.NoError(t, err)
+		idoc, err := helium.NewParser().Parse(t.Context(), []byte(instance))
+		require.NoError(t, err)
+		return xsd.NewValidator(sc).Validate(t.Context(), idoc)
+	}
+
+	unionInst := `<e ` + xsiNS + ` xsi:type="u">5</e>`
+	listInst := `<e ` + xsiNS + ` xsi:type="l">1 2 3</e>`
+
+	t.Run("block=restriction rejects a union xsi:type", func(t *testing.T) {
+		t.Parallel()
+		require.ErrorIs(t, compileValidate(t, `block="restriction"`, unionInst), xsd.ErrValidationFailed)
+	})
+
+	t.Run("block=restriction rejects a list xsi:type", func(t *testing.T) {
+		t.Parallel()
+		require.ErrorIs(t, compileValidate(t, `block="restriction"`, listInst), xsd.ErrValidationFailed)
+	})
+
+	t.Run("block=#all rejects a union xsi:type", func(t *testing.T) {
+		t.Parallel()
+		require.ErrorIs(t, compileValidate(t, `block="#all"`, unionInst), xsd.ErrValidationFailed)
+	})
+
+	t.Run("block=#all rejects a list xsi:type", func(t *testing.T) {
+		t.Parallel()
+		require.ErrorIs(t, compileValidate(t, `block="#all"`, listInst), xsd.ErrValidationFailed)
+	})
+
+	t.Run("no block accepts a simple xsi:type", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, compileValidate(t, ``, unionInst))
+	})
+
+	t.Run("block=extension accepts a simple xsi:type", func(t *testing.T) {
+		t.Parallel()
+		// A simple type reaches xs:anyType only by restriction, so an extension-only
+		// block does not apply.
+		require.NoError(t, compileValidate(t, `block="extension"`, listInst))
+	})
+}

--- a/xsd/validate_elem.go
+++ b/xsd/validate_elem.go
@@ -1526,12 +1526,22 @@ func isDerivationBlocked(derived, base *TypeDef, blocked BlockFlags) bool {
 			return true
 		}
 	}
-	// EVERY simple type restricts xs:anySimpleType, which in turn restricts the
-	// complex ur-type xs:anyType, so a block="restriction"/"#all" on an
-	// xs:anyType-typed element must reject a simple xsi:type. The BaseType pointer
-	// chain bottoms out (td == nil) before reaching the complex ur-type, so neither
-	// the union nor the built-in-simple-base hatch above catches it.
-	if td != base && blocked&BlockRestriction != 0 && isAnyType(base) && !derived.IsComplex {
+	// Reaching xs:anyType is ALWAYS a restriction step (§3.4.2): a simple type
+	// restricts xs:anySimpleType which restricts xs:anyType, and a complex type
+	// with no explicit <xs:complexContent>/<xs:simpleContent> derivation has an
+	// IMPLICIT {base type definition} = xs:anyType with {derivation method} =
+	// restriction. So on an xs:anyType-typed element a block="restriction"/"#all"
+	// must reject such an xsi:type (cvc-elt.4.3). The loop exits with td != base
+	// (i.e. td == nil) precisely when the BaseType pointer chain bottoms out WITHOUT
+	// reaching base by pointer — that is the implicit-restriction-to-anyType case,
+	// covering a simple xsi:type, a complex type with a direct model group, AND an
+	// explicit extension chain that bottoms out at such an implicit-base complex
+	// type (its suffix down to anyType still contains the implicit restriction step).
+	// An explicit <xs:extension base="xs:anyType"> instead reaches base BY POINTER
+	// (td == base), so it is correctly NOT blocked here — its only derivation step
+	// is the extension. Gated on blocked&BlockRestriction, so a block="extension"-
+	// only element still accepts these (the restriction step is not in its block).
+	if td != base && blocked&BlockRestriction != 0 && isAnyType(base) {
 		return true
 	}
 	return false

--- a/xsd/validate_elem.go
+++ b/xsd/validate_elem.go
@@ -1526,6 +1526,14 @@ func isDerivationBlocked(derived, base *TypeDef, blocked BlockFlags) bool {
 			return true
 		}
 	}
+	// EVERY simple type restricts xs:anySimpleType, which in turn restricts the
+	// complex ur-type xs:anyType, so a block="restriction"/"#all" on an
+	// xs:anyType-typed element must reject a simple xsi:type. The BaseType pointer
+	// chain bottoms out (td == nil) before reaching the complex ur-type, so neither
+	// the union nor the built-in-simple-base hatch above catches it.
+	if td != base && blocked&BlockRestriction != 0 && isAnyType(base) && !derived.IsComplex {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
- `isDerivationBlocked` now blocks a simple-type `xsi:type` on an xs:anyType-typed element under `block="restriction"`/`"#all"` (cvc-elt.4.3): every simple type reaches xs:anyType via xs:anySimpleType by restriction, but the BaseType chain bottoms out before the complex ur-type.
- add `isAnyType` helper in builtin_hierarchy.go; version-independent, extension-only block still accepts.
- fixes W3C Element_w3c elemT026-029, elemT054-057.