### PR TITLE
lex whitespace around the :: axis separator

### DIFF
--- a/internal/xpath1/lexer/lexer.go
+++ b/internal/xpath1/lexer/lexer.go
@@ -133,6 +133,20 @@ func (l *Lexer) tokenize() error {
 			} else {
 				l.emit(TokenSlash, "/")
 			}
+		case r == ':':
+			// A ':' reaches the main scanner only at a token boundary
+			// (start of input or after whitespace); a QName's ':' is consumed
+			// contiguously by scanNameOrKeyword. XPath permits insignificant
+			// whitespace around the '::' axis separator (ExprWhitespace), so a
+			// space-separated '::' — e.g. 'child :: para' — must still lex as an
+			// axis. A lone ':' at a token boundary is not valid XPath.
+			if l.pos+1 < len(l.input) && l.input[l.pos+1] == ':' {
+				l.emit(TokenColonColon, "::")
+				l.advance(1)
+				l.advance(1)
+			} else {
+				return fmt.Errorf("%w: %q at position %d", ErrUnexpectedChar, string(r), l.pos)
+			}
 		case r == '.':
 			l.advance(1)
 			switch {

--- a/internal/xpath1/lexer/lexer_test.go
+++ b/internal/xpath1/lexer/lexer_test.go
@@ -130,6 +130,26 @@ func TestLexerAxisNotation(t *testing.T) {
 	require.Equal(t, "para", tokens[2].Value)
 }
 
+func TestLexerAxisWhitespace(t *testing.T) {
+	// XPath permits insignificant whitespace around the '::' axis separator,
+	// so 'child :: para' must lex to the same tokens as 'child::para'.
+	for _, input := range []string{"child ::para", "child:: para", "child :: para"} {
+		l, err := lexer.New(input)
+		require.NoError(t, err, input)
+		tokens := l.Tokens()
+		require.Len(t, tokens, 3, input)
+		require.Equal(t, lexer.TokenName, tokens[0].Type, input)
+		require.Equal(t, "child", tokens[0].Value, input)
+		require.Equal(t, lexer.TokenColonColon, tokens[1].Type, input)
+		require.Equal(t, lexer.TokenName, tokens[2].Type, input)
+		require.Equal(t, "para", tokens[2].Value, input)
+	}
+
+	// A lone ':' at a token boundary is not valid XPath.
+	_, err := lexer.New("child : para")
+	require.Error(t, err)
+}
+
 func TestLexerDots(t *testing.T) {
 	l, err := lexer.New("../child")
 	require.NoError(t, err)

--- a/xsd/idc_xpath_axis_whitespace_test.go
+++ b/xsd/idc_xpath_axis_whitespace_test.go
@@ -1,0 +1,60 @@
+package xsd_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIDCXPathAxisWhitespace verifies that an identity-constraint selector/field
+// @xpath tolerates insignificant whitespace around the '::' axis separator, which
+// XPath permits (ExprWhitespace) — e.g. 'child ::item' / 'attribute ::id'. The
+// restricted IDC XPath subset (XSD Structures 3.11.6) constrains the grammar
+// (no node-type tests, limited '//', bound prefixes) but does NOT forbid
+// whitespace around '::'; libxml2/Xerces accept these. Mirrors the W3C xsd10
+// msMeta cases idI024 (selector 'child ::imp:iid') and idJ033 (field
+// 'attribute ::imp:sid').
+func TestIDCXPathAxisWhitespace(t *testing.T) {
+	t.Parallel()
+
+	const tmpl = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="id" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="u">
+      <xs:selector xpath="%s"/>
+      <xs:field xpath="%s"/>
+    </xs:unique>
+  </xs:element>
+</xs:schema>`
+
+	t.Run("whitespace around :: compiles clean", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range []struct{ selector, field string }{
+			{"child ::item", "@id"},
+			{"child:: item", "@id"},
+			{"child :: item", "@id"},
+			{"item", "attribute ::id"},
+			{"item", "attribute :: id"},
+		} {
+			errs := compileSchemaErrors(t, fmt.Sprintf(tmpl, tc.selector, tc.field))
+			require.Empty(t, errs, "selector=%q field=%q", tc.selector, tc.field)
+		}
+	})
+
+	// The whitespace relaxation must not loosen the genuine §3.11.6 subset
+	// restrictions: a node-type test is still rejected.
+	t.Run("node-type test still rejected", func(t *testing.T) {
+		t.Parallel()
+		errs := compileSchemaErrors(t, fmt.Sprintf(tmpl, "child ::node()", "@id"))
+		require.NotEmpty(t, errs)
+	})
+}


### PR DESCRIPTION
- The xpath1 lexer only recognized `::`/`:` when contiguous with a preceding name; a `:` reaching the main scanner after whitespace fell through to the unexpected-char error, so `child ::foo` failed to lex.
- XPath permits insignificant whitespace around the `::` axis separator (ExprWhitespace); the lexer now emits `TokenColonColon` for a `::` at any token boundary. A lone `:` at a boundary stays an error (QName colons remain contiguous).
- Fixes xsd10 over-rejection of IDC selector/field `@xpath` with whitespace before `::` — W3C msMeta idI024 (`child ::imp:iid`) and idJ033 (`attribute ::imp:sid`); libxml2/Xerces accept both.
- xsd10 conformance: idI024 + idJ033 fixed, zero regressions; xsd11 unchanged (0 failures). `go test ./xsd/ ./xpath1/ ./internal/xpath1/...` green.