### PR TITLE
fall back to no-namespace for unresolved element refs

### DIFF
--- a/xsd/elem_ref_chameleon_test.go
+++ b/xsd/elem_ref_chameleon_test.go
@@ -1,0 +1,99 @@
+package xsd_test
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestElementRefChameleonFallback verifies that the no-targetNamespace ({})
+// fallback for an element @ref fires ONLY for a chameleon-eligible ref — an
+// unprefixed ref with no in-scope default namespace, whose lexical name
+// resolves to the schema targetNamespace but whose global element lives in the
+// absent namespace of an imported no-targetNamespace schema. A prefixed ref, or
+// an unprefixed ref bound by an in-scope xmlns="..." default namespace, is NOT
+// eligible: the fallback must not mask a genuine src-resolve failure by
+// silently resolving to {}local.
+func TestElementRefChameleonFallback(t *testing.T) {
+	t.Parallel()
+
+	const (
+		nsResolveErr = "does not resolve to a(n)"
+		fileMain     = "erc_main.xsd"
+		fileNoNS     = "erc_nons.xsd"
+	)
+
+	// noNSDoc has NO targetNamespace and declares a global element "foo".
+	noNSDoc := &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="foo" type="xs:string"/>
+</xs:schema>`)}
+
+	compile := func(t *testing.T, mainDoc string) (string, error) {
+		t.Helper()
+		fsys := fstest.MapFS{
+			fileMain: &fstest.MapFile{Data: []byte(mainDoc)},
+			fileNoNS: noNSDoc,
+		}
+		data, err := fsys.ReadFile(fileMain)
+		require.NoError(t, err)
+		doc, err := helium.NewParser().Parse(t.Context(), data)
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, cerr := xsd.NewCompiler().Label(fileMain).ErrorHandler(collector).FS(fsys).Compile(t.Context(), doc)
+		require.NoError(t, collector.Close())
+		var sb strings.Builder
+		for _, e := range collector.Errors() {
+			sb.WriteString(e.Error())
+			sb.WriteString("\n")
+		}
+		return sb.String(), cerr
+	}
+
+	t.Run("unprefixed ref with no default ns resolves via empty-namespace fallback", func(t *testing.T) {
+		t.Parallel()
+		// The chameleon case: ref="foo" resolves lexically to {urn:main}foo, but
+		// the global lives in {} (the imported no-targetNamespace schema).
+		_, cerr := compile(t, `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:main">
+  <xs:import schemaLocation="erc_nons.xsd"/>
+  <xs:complexType name="ct"><xs:sequence>
+    <xs:element ref="foo"/>
+  </xs:sequence></xs:complexType>
+</xs:schema>`)
+		require.NoError(t, cerr, "a chameleon-eligible unprefixed ref must resolve to the {} global")
+	})
+
+	t.Run("prefixed ref does not fall back to empty namespace", func(t *testing.T) {
+		t.Parallel()
+		// ref="o:foo" resolves to {urn:main}foo (o bound to the target namespace);
+		// no such global exists — only {}foo. The prefixed ref is NOT eligible, so
+		// it must report unresolved instead of silently resolving to {}foo.
+		errs, cerr := compile(t, `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:main" xmlns:o="urn:main">
+  <xs:import schemaLocation="erc_nons.xsd"/>
+  <xs:complexType name="ct"><xs:sequence>
+    <xs:element ref="o:foo"/>
+  </xs:sequence></xs:complexType>
+</xs:schema>`)
+		require.Error(t, cerr, "a prefixed ref must not fall back to the {} global")
+		require.Contains(t, errs, "{urn:main}foo")
+		require.Contains(t, errs, nsResolveErr)
+	})
+
+	t.Run("unprefixed ref bound by default namespace does not fall back", func(t *testing.T) {
+		t.Parallel()
+		// xmlns="urn:main" qualifies the unprefixed ref to {urn:main}foo; no such
+		// global exists — only {}foo. A default-namespace-bound ref is NOT eligible.
+		errs, cerr := compile(t, `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:main" xmlns="urn:main">
+  <xs:import schemaLocation="erc_nons.xsd"/>
+  <xs:complexType name="ct"><xs:sequence>
+    <xs:element ref="foo"/>
+  </xs:sequence></xs:complexType>
+</xs:schema>`)
+		require.Error(t, cerr, "a default-ns-bound ref must not fall back to the {} global")
+		require.Contains(t, errs, "{urn:main}foo")
+		require.Contains(t, errs, nsResolveErr)
+	})
+}

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -36,8 +36,28 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 			// Skip self-referencing elements (where the element name matches
 			// the type name, e.g., <xs:element name="X" type="X"/>); these
 			// should resolve against the type map instead.
-			if ge, ok := c.schema.elements[qn]; ok && ge != edecl {
+			ge, ok := c.schema.elements[qn]
+			if !ok && edecl.IsRef && qn.NS != "" {
+				// An unprefixed ref resolves to the schema's targetNamespace,
+				// but the referenced global element may come from a no-namespace
+				// imported schema. Mirror the empty-namespace fallback used for
+				// group and attribute-group references so a valid reference into
+				// an imported no-targetNamespace schema resolves.
+				ge, ok = c.schema.elements[QName{Local: qn.Local}]
+			}
+			if ok && ge != edecl {
 				edecl.Type = ge.Type
+				if edecl.IsRef {
+					// Adopt the resolved global element's expanded name so the
+					// content model matches instance children by the referenced
+					// element's ACTUAL namespace. This corrects the empty-namespace
+					// fallback above, where the ref's name was resolved to the
+					// schema targetNamespace but the global lives in the absent
+					// namespace of an imported no-targetNamespace schema. For an
+					// ordinary ref the resolved name already equals edecl.Name, so
+					// this is a no-op.
+					edecl.Name = ge.Name
+				}
 				if edecl.Default == nil {
 					edecl.Default = ge.Default
 					edecl.DefaultNS = ge.DefaultNS

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -37,12 +37,15 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 			// the type name, e.g., <xs:element name="X" type="X"/>); these
 			// should resolve against the type map instead.
 			ge, ok := c.schema.elements[qn]
-			if !ok && edecl.IsRef && qn.NS != "" {
-				// An unprefixed ref resolves to the schema's targetNamespace,
-				// but the referenced global element may come from a no-namespace
+			if _, eligible := c.chameleonEligible[edecl]; !ok && edecl.IsRef && eligible {
+				// A chameleon-eligible ref (unprefixed, no in-scope default
+				// namespace) resolves to the schema's targetNamespace, but the
+				// referenced global element may come from a no-targetNamespace
 				// imported schema. Mirror the empty-namespace fallback used for
-				// group and attribute-group references so a valid reference into
-				// an imported no-targetNamespace schema resolves.
+				// type and attribute-group references so such a valid reference
+				// resolves. A prefixed ref or one bound by an in-scope default
+				// namespace is NOT eligible, so a genuine unresolved reference
+				// still reports rather than silently resolving to {}local.
 				ge, ok = c.schema.elements[QName{Local: qn.Local}]
 			}
 			if ok && ge != edecl {

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -801,6 +801,7 @@ func (c *compiler) parseLocalElement(ctx context.Context, elem *helium.Element) 
 			IsRef:     true,
 		}
 		c.elemRefs[edecl] = qn
+		c.markChameleonEligible(edecl, elem, ref)
 		c.elemRefSources[edecl] = elemRefSource{elemName: elem.LocalName(), line: elem.Line(), source: c.diagSource()}
 		return &Particle{
 			MinOccurs: minOcc,


### PR DESCRIPTION
Element `ref` resolution now mirrors the group/attribute-group empty-namespace fallback: an unprefixed ref that misses under the schema targetNamespace retries in the absent namespace and adopts the resolved global's expanded name, so a ref into an imported no-targetNamespace schema resolves and matches instance children correctly. xsd10 221->216, xsd11 0->0; fixes particlesQ016/Q022/R016/R022/Js001.