### PR TITLE
fix private-use regex ranges

### DIFF
--- a/internal/xsdregex/regex.go
+++ b/internal/xsdregex/regex.go
@@ -515,11 +515,7 @@ func translateUnicodePropertyInCharClass(name string, neg, xsd11 bool) (string, 
 		if !neg {
 			return rng, nil
 		}
-		low, high, err := parseUnicodeBlockRange(rng)
-		if err != nil {
-			return "", err
-		}
-		return complementUnicodeRange(low, high), nil
+		return complementClassRanges(rng)
 	}
 
 	return translateUnicodeProperty(name, neg, xsd11)
@@ -535,41 +531,6 @@ func lookupUnicodeBlockRange(blockName string) (string, bool) {
 		}
 	}
 	return "", false
-}
-
-func parseUnicodeBlockRange(rng string) (int64, int64, error) {
-	parts := strings.SplitN(rng, "-", 2)
-	if len(parts) != 2 {
-		return 0, 0, fmt.Errorf("invalid unicode block range: %s", rng)
-	}
-	low, err := parseUnicodeEscape(parts[0])
-	if err != nil {
-		return 0, 0, err
-	}
-	high, err := parseUnicodeEscape(parts[1])
-	if err != nil {
-		return 0, 0, err
-	}
-	return low, high, nil
-}
-
-func parseUnicodeEscape(s string) (int64, error) {
-	if !strings.HasPrefix(s, `\x{`) || !strings.HasSuffix(s, "}") {
-		return 0, fmt.Errorf("invalid unicode escape: %s", s)
-	}
-	return strconv.ParseInt(s[3:len(s)-1], 16, 64)
-}
-
-func complementUnicodeRange(low, high int64) string {
-	const maxCodepoint = 0x10FFFF
-	var parts []string
-	if low > 0 {
-		parts = append(parts, formatRuneRange(0, low-1))
-	}
-	if high < maxCodepoint {
-		parts = append(parts, formatRuneRange(high+1, maxCodepoint))
-	}
-	return strings.Join(parts, "")
 }
 
 func complementClassRanges(spec string) (string, error) {
@@ -904,10 +865,9 @@ var unicodeBlocks = map[string]string{
 	"SupplementaryPrivateUseArea-A":        `\x{F0000}-\x{FFFFD}`,
 	"SupplementaryPrivateUseArea-B":        `\x{100000}-\x{10FFFD}`,
 	"Tags":                                 `\x{E0000}-\x{E007F}`,
-	// The "Private Use" block is the BMP Private Use Area U+E000-U+F8FF. The
-	// supplementary planes are the separate SupplementaryPrivateUseArea-A/-B
-	// blocks, so \p{IsPrivateUse} must NOT match them.
-	"PrivateUse": `\x{E000}-\x{F8FF}`,
+	// The "Private Use" block spans all Unicode private-use ranges. Keep the
+	// individual block names above available for callers that need one range.
+	"PrivateUse": `\x{E000}-\x{F8FF}\x{F0000}-\x{FFFFD}\x{100000}-\x{10FFFD}`,
 }
 
 // validateXPathRegex checks for patterns that Go's regexp accepts but

--- a/internal/xsdregex/regex_test.go
+++ b/internal/xsdregex/regex_test.go
@@ -262,14 +262,16 @@ func TestXSD10CharClassRangeAfterRange(t *testing.T) {
 	})
 }
 
-func TestPrivateUseBlockBMPOnly(t *testing.T) {
-	// \p{IsPrivateUse} is the BMP Private Use Area U+E000-U+F8FF only. The two
-	// supplementary Private Use planes are the separate
-	// SupplementaryPrivateUseArea-A/-B blocks and must NOT be matched by
-	// \p{IsPrivateUse}. This block table is shared by XSD, Relax NG and XPath, so
-	// lock the boundary down (both bare and inside a character class).
+func TestPrivateUseBlockAllRanges(t *testing.T) {
+	// \p{IsPrivateUse} is the union of the BMP Private Use Area and both
+	// supplementary private-use planes. The individual block names still name
+	// their separate ranges.
+	const privateUsePattern = `\p{IsPrivateUse}`
+
 	bmpLo, bmpHi := string(rune(0xE000)), string(rune(0xF8FF))
 	suppA, suppB := string(rune(0xF0000)), string(rune(0x10FFFD))
+	tagsHi := string(rune(0xE007F))
+	cjkCompatLo := string(rune(0xF900))
 
 	for _, tc := range []struct {
 		name    string
@@ -277,18 +279,30 @@ func TestPrivateUseBlockBMPOnly(t *testing.T) {
 		input   string
 		want    bool
 	}{
-		{"bmp-low-matches", `\p{IsPrivateUse}`, bmpLo, true},
-		{"bmp-high-matches", `\p{IsPrivateUse}`, bmpHi, true},
-		{"supp-a-not-matched", `\p{IsPrivateUse}`, suppA, false},
-		{"supp-b-not-matched", `\p{IsPrivateUse}`, suppB, false},
+		{"bmp-low-matches", privateUsePattern, bmpLo, true},
+		{"bmp-high-matches", privateUsePattern, bmpHi, true},
+		{"supp-a-matches", privateUsePattern, suppA, true},
+		{"supp-b-matches", privateUsePattern, suppB, true},
+		{"tags-boundary-not-matched", privateUsePattern, tagsHi, false},
+		{"cjk-compat-boundary-not-matched", privateUsePattern, cjkCompatLo, false},
 		{"class-bmp-matches", `[\p{IsPrivateUse}]`, bmpLo, true},
-		{"class-supp-a-not-matched", `[\p{IsPrivateUse}]`, suppA, false},
+		{"class-supp-a-matches", `[\p{IsPrivateUse}]`, suppA, true},
+		{"class-supp-b-matches", `[\p{IsPrivateUse}]`, suppB, true},
+		{"class-tags-boundary-not-matched", `[\p{IsPrivateUse}]`, tagsHi, false},
 		{"supp-a-block-still-matches", `\p{IsSupplementaryPrivateUseArea-A}`, suppA, true},
 		{"supp-b-block-still-matches", `\p{IsSupplementaryPrivateUseArea-B}`, suppB, true},
 		{"neg-bmp-not-matched", `\P{IsPrivateUse}`, bmpLo, false},
-		{"neg-supp-a-matched", `\P{IsPrivateUse}`, suppA, true},
+		{"neg-supp-a-not-matched", `\P{IsPrivateUse}`, suppA, false},
+		{"neg-supp-b-not-matched", `\P{IsPrivateUse}`, suppB, false},
+		{"neg-cjk-compat-boundary-matched", `\P{IsPrivateUse}`, cjkCompatLo, true},
 		{"neg-class-bmp-not-matched", `[^\p{IsPrivateUse}]`, bmpHi, false},
-		{"neg-class-supp-b-matched", `[^\p{IsPrivateUse}]`, suppB, true},
+		{"neg-class-supp-a-not-matched", `[^\p{IsPrivateUse}]`, suppA, false},
+		{"neg-class-supp-b-not-matched", `[^\p{IsPrivateUse}]`, suppB, false},
+		{"neg-class-tags-boundary-matched", `[^\p{IsPrivateUse}]`, tagsHi, true},
+		{"prop-neg-class-bmp-not-matched", `[\P{IsPrivateUse}]`, bmpLo, false},
+		{"prop-neg-class-supp-a-not-matched", `[\P{IsPrivateUse}]`, suppA, false},
+		{"prop-neg-class-supp-b-not-matched", `[\P{IsPrivateUse}]`, suppB, false},
+		{"prop-neg-class-cjk-compat-boundary-matched", `[\P{IsPrivateUse}]`, cjkCompatLo, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			re, err := xsdregex.Compile(tc.pattern)

--- a/xpath3/functions_test.go
+++ b/xpath3/functions_test.go
@@ -81,6 +81,11 @@ func TestFnMatches(t *testing.T) {
 	require.Equal(t, 1, seq.Len())
 	av := seq.Get(0).(xpath3.AtomicValue)
 	require.True(t, av.BooleanVal())
+
+	seq = evalExpr(t, doc, `matches(codepoints-to-string(983040), "[\p{IsPrivateUse}]")`)
+	require.Equal(t, 1, seq.Len())
+	av = seq.Get(0).(xpath3.AtomicValue)
+	require.True(t, av.BooleanVal())
 }
 
 func TestFnReplace(t *testing.T) {


### PR DESCRIPTION
- expand IsPrivateUse to cover BMP and supplementary private-use ranges
- use multi-range complements for negated block properties in char classes
- add translator and XPath matches regressions
