### PR TITLE
fix xsd10 attribute wildcards

### DIFF
--- a/testdata/libxml2-compat/schemas/result/anyAttr-processContents-err1_0_0.err
+++ b/testdata/libxml2-compat/schemas/result/anyAttr-processContents-err1_0_0.err
@@ -1,3 +1,2 @@
 ./test/schemas/anyAttr-processContents-err1_0.xml:8: Schemas validity error : Element '{http://FOO}elem.lax', attribute '{http://FOO}bar': 'o o' is not a valid value of the atomic type 'xs:language'.
-./test/schemas/anyAttr-processContents-err1_0.xml:9: Schemas validity error : Element '{http://FOO}elem.strict', attribute '{http://FOO}barB': No matching global attribute declaration available, but demanded by the strict wildcard.
 ./test/schemas/anyAttr-processContents-err1_0.xml fails to validate

--- a/xsd/attr_group_wildcard10_test.go
+++ b/xsd/attr_group_wildcard10_test.go
@@ -1,0 +1,179 @@
+package xsd_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersion10AttributeGroupWildcardCompletesTypeWildcard(t *testing.T) {
+	t.Parallel()
+
+	const schema = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="urn:t" xmlns:t="urn:t">
+  <xs:attributeGroup name="targetOnly">
+    <xs:anyAttribute namespace="##targetNamespace" processContents="skip"/>
+  </xs:attributeGroup>
+  <xs:complexType name="doc">
+    <xs:sequence/>
+    <xs:attributeGroup ref="t:targetOnly"/>
+    <xs:anyAttribute namespace="##any" processContents="skip"/>
+  </xs:complexType>
+  <xs:element name="doc" type="t:doc"/>
+</xs:schema>`
+
+	t.Run("admits attribute in the group wildcard namespace", func(t *testing.T) {
+		t.Parallel()
+		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schema,
+			`<t:doc xmlns:t="urn:t" t:a="1"/>`)
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects attribute outside the complete wildcard intersection", func(t *testing.T) {
+		t.Parallel()
+		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schema,
+			`<t:doc xmlns:t="urn:t" xmlns:x="urn:x" x:a="1"/>`)
+		require.ErrorIs(t, err, xsd.ErrValidationFailed)
+	})
+}
+
+func TestVersion10AttributeGroupWildcardExtensionUnion(t *testing.T) {
+	t.Parallel()
+
+	const schema = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="urn:t" xmlns:t="urn:t">
+  <xs:attributeGroup name="other">
+    <xs:anyAttribute namespace="##other" processContents="skip"/>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="withLocal">
+    <xs:anyAttribute namespace="##targetNamespace ##local urn:b" processContents="skip"/>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="withoutLocal">
+    <xs:anyAttribute namespace="##targetNamespace urn:b" processContents="skip"/>
+  </xs:attributeGroup>
+
+  <xs:complexType name="base">
+    <xs:sequence/>
+    <xs:attributeGroup ref="t:other"/>
+  </xs:complexType>
+  <xs:complexType name="anyDerived">
+    <xs:complexContent>
+      <xs:extension base="t:base">
+        <xs:sequence/>
+        <xs:attributeGroup ref="t:withLocal"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="notAbsentDerived">
+    <xs:complexContent>
+      <xs:extension base="t:base">
+        <xs:sequence/>
+        <xs:attributeGroup ref="t:withoutLocal"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="any" type="t:anyDerived"/>
+  <xs:element name="notAbsent" type="t:notAbsentDerived"/>
+</xs:schema>`
+
+	t.Run("union admits any namespace when the set contributes target and local", func(t *testing.T) {
+		t.Parallel()
+		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schema,
+			`<t:any xmlns:t="urn:t" xmlns:b="urn:b" xmlns:x="urn:x" t:a="1" local="1" b:a="1" x:a="1"/>`)
+		require.NoError(t, err)
+	})
+
+	t.Run("union without local rejects absent-namespace attributes", func(t *testing.T) {
+		t.Parallel()
+		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schema,
+			`<t:notAbsent xmlns:t="urn:t" local="1"/>`)
+		require.ErrorIs(t, err, xsd.ErrValidationFailed)
+	})
+
+	t.Run("union without local admits namespaced attributes", func(t *testing.T) {
+		t.Parallel()
+		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schema,
+			`<t:notAbsent xmlns:t="urn:t" xmlns:x="urn:x" x:a="1"/>`)
+		require.NoError(t, err)
+	})
+}
+
+func TestVersion10AttributeGroupWildcardExtensionUnionNotExpressible(t *testing.T) {
+	t.Parallel()
+
+	const schema = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="urn:t" xmlns:t="urn:t">
+  <xs:attributeGroup name="other">
+    <xs:anyAttribute namespace="##other" processContents="skip"/>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="localAndB">
+    <xs:anyAttribute namespace="##local urn:b" processContents="skip"/>
+  </xs:attributeGroup>
+  <xs:complexType name="base">
+    <xs:sequence/>
+    <xs:attributeGroup ref="t:other"/>
+  </xs:complexType>
+  <xs:complexType name="badDerived">
+    <xs:complexContent>
+      <xs:extension base="t:base">
+        <xs:sequence/>
+        <xs:attributeGroup ref="t:localAndB"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="bad" type="t:badDerived"/>
+</xs:schema>`
+
+	require.Contains(t, compileFatalErrors(t, schema), "not expressible")
+}
+
+func TestVersion10StrictWildcardLoadsInstanceSchemaLocation(t *testing.T) {
+	t.Parallel()
+
+	const (
+		mainXSD = "main.xsd"
+		hintXSD = "hint.xsd"
+	)
+	fsys := fstest.MapFS{
+		mainXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="urn:t" xmlns:t="urn:t" elementFormDefault="qualified">
+  <xs:element name="doc">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" type="t:itemType"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="itemType">
+    <xs:attributeGroup ref="t:strictOther"/>
+  </xs:complexType>
+  <xs:attributeGroup name="strictOther">
+    <xs:anyAttribute namespace="##other" processContents="strict"/>
+  </xs:attributeGroup>
+</xs:schema>`)},
+		hintXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="urn:hint" attributeFormDefault="qualified">
+  <xs:attribute name="att" type="xs:string"/>
+</xs:schema>`)},
+	}
+
+	schemaSrc, err := fsys.ReadFile(mainXSD)
+	require.NoError(t, err)
+	schemaDoc, err := helium.NewParser().BaseURI(mainXSD).Parse(t.Context(), schemaSrc)
+	require.NoError(t, err)
+	schema, err := xsd.NewCompiler().FS(fsys).BaseDir(".").Compile(t.Context(), schemaDoc)
+	require.NoError(t, err)
+
+	inst, err := helium.NewParser().BaseURI("doc.xml").Parse(t.Context(), []byte(`<t:doc
+  xmlns:t="urn:t"
+  xmlns:h="urn:hint"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="urn:hint hint.xsd">
+  <t:item h:att="ok"/>
+</t:doc>`))
+	require.NoError(t, err)
+	require.NoError(t, xsd.NewValidator(schema).Validate(t.Context(), inst))
+}

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -100,11 +100,10 @@ type compiler struct {
 	// through a referenced group — not just direct xs:attribute children — is
 	// reported (ag-props-correct.2).
 	attrGroupRefChildren map[QName][]QName
-	// XSD 1.1: the xs:anyAttribute wildcard declared directly inside a GLOBAL
-	// attribute group, keyed by the group's QName. A type referencing the group
-	// intersects this wildcard (and those of nested group refs) into its
-	// effective attribute wildcard. Populated only in Version11 so 1.0 behavior
-	// (group wildcards dropped) is unchanged.
+	// The xs:anyAttribute wildcard declared directly inside a GLOBAL attribute
+	// group, keyed by the group's QName. A type referencing the group intersects
+	// this wildcard (and those of nested group refs) into its effective attribute
+	// wildcard.
 	attrGroupWildcards map[QName]*Wildcard
 	// per-edge source info for the nested xs:attributeGroup ref children recorded in
 	// attrGroupRefChildren, keyed by the containing group's QName and index-aligned
@@ -611,12 +610,15 @@ func compileSchema(ctx context.Context, doc *helium.Document, baseDir string, cf
 	}
 	c := &compiler{
 		schema: &Schema{
-			elements:    make(map[QName]*ElementDecl),
-			types:       make(map[QName]*TypeDef),
-			groups:      make(map[QName]*ModelGroup),
-			attrGroups:  make(map[QName][]*AttrUse),
-			globalAttrs: make(map[QName]*AttrUse),
-			substGroups: make(map[QName][]*ElementDecl),
+			elements:      make(map[QName]*ElementDecl),
+			types:         make(map[QName]*TypeDef),
+			groups:        make(map[QName]*ModelGroup),
+			attrGroups:    make(map[QName][]*AttrUse),
+			globalAttrs:   make(map[QName]*AttrUse),
+			substGroups:   make(map[QName][]*ElementDecl),
+			loaderFS:      fsys,
+			loaderBaseDir: baseDir,
+			loaderParser:  parser,
 		},
 		baseDir:                   baseDir,
 		fsys:                      fsys,

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -1659,6 +1659,8 @@ func (c *compiler) processRedefineOverrides(ctx context.Context, redefineElem *h
 				continue
 			}
 			origAttrs := c.schema.attrGroups[qn]
+			origEffectiveAttrs := c.expandAttrGroupUses(qn, map[QName]struct{}{})
+			origEffectiveWildcard := c.attrGroupCompleteWildcard(qn, map[QName]struct{}{})
 			// The override REPLACES the Phase-A attribute group, so the nested
 			// attribute-group ref set must be rebuilt from the redefining group's
 			// children. Snapshot the Phase-A refs first (for self-reference
@@ -1676,6 +1678,7 @@ func (c *compiler) processRedefineOverrides(ctx context.Context, redefineElem *h
 			origWildcard := c.attrGroupWildcards[qn]
 			delete(c.attrGroupWildcards, qn)
 			var ownWildcard, selfRefWildcard *Wildcard
+			var selfRefSeen bool
 			var anyAttributeSeen bool
 			reportAfterWildcard := func(gce *helium.Element) {
 				c.schemaError(ctx, schemaParserError(c.diagSource(), gce.Line(), gce.LocalName(), "attributeGroup",
@@ -1712,14 +1715,28 @@ func (c *compiler) processRedefineOverrides(ctx context.Context, redefineElem *h
 					}
 					au := c.parseAttributeUse(ctx, gce)
 					attrs = append(attrs, au)
-				case c.version == Version11 && isXSDElement(gce, elemAnyAttribute):
+				case isXSDElement(gce, elemAnyAttribute):
 					if anyAttributeSeen {
-						c.schemaError(ctx, schemaParserError(c.diagSource(), gce.Line(), gce.LocalName(), "attributeGroup",
-							fmt.Sprintf("An attribute group definition must not have more than one attribute wildcard (found a second '%s').", gce.LocalName())))
+						if c.version == Version11 {
+							c.schemaError(ctx, schemaParserError(c.diagSource(), gce.Line(), gce.LocalName(), "attributeGroup",
+								fmt.Sprintf("An attribute group definition must not have more than one attribute wildcard (found a second '%s').", gce.LocalName())))
+						}
 						continue
 					}
 					anyAttributeSeen = true
-					ownWildcard = c.parseAnyAttribute(ctx, gce)
+					if c.version == Version11 {
+						ownWildcard = c.parseAnyAttribute(ctx, gce)
+					} else {
+						ns := WildcardNSAny
+						if hasAttr(gce, attrNamespace) {
+							ns = getAttr(gce, attrNamespace)
+						}
+						ownWildcard = &Wildcard{
+							Namespace:       ns,
+							ProcessContents: quietProcessContents(gce),
+							TargetNS:        c.schema.targetNamespace,
+						}
+					}
 				case isXSDElement(gce, elemAttributeGroup):
 					if c.version == Version11 && anyAttributeSeen {
 						reportAfterWildcard(gce)
@@ -1738,6 +1755,7 @@ func (c *compiler) processRedefineOverrides(ctx context.Context, redefineElem *h
 							if origAttrs != nil {
 								attrs = append(attrs, origAttrs...)
 							}
+							selfRefSeen = true
 							selfRefWildcard = origWildcard
 							if len(origRefChildren) > 0 {
 								c.attrGroupRefChildren[qn] = append(c.attrGroupRefChildren[qn], origRefChildren...)
@@ -1753,14 +1771,17 @@ func (c *compiler) processRedefineOverrides(ctx context.Context, redefineElem *h
 				}
 			}
 			c.schema.attrGroups[qn] = attrs
-			// Store the override's effective group wildcard (Version11): the group's
-			// own xs:anyAttribute INTERSECTED with the original wildcard a
-			// self-reference re-contributes. The type's "complete wildcard" further
-			// intersects the non-self refs recorded above at link time.
-			if c.version == Version11 {
-				if w := combineGroupWildcards(ownWildcard, selfRefWildcard); w != nil {
-					c.attrGroupWildcards[qn] = w
-				}
+			// Store the override's effective group wildcard: the group's own
+			// xs:anyAttribute INTERSECTED with the original wildcard a self-reference
+			// re-contributes. The type's "complete wildcard" further intersects the
+			// non-self refs recorded above at link time.
+			if w := combineGroupWildcards(c.version, ownWildcard, selfRefWildcard); w != nil {
+				c.attrGroupWildcards[qn] = w
+			}
+			if !selfRefSeen {
+				derivedAttrs := c.expandAttrGroupUses(qn, map[QName]struct{}{})
+				derivedWildcard := c.attrGroupCompleteWildcard(qn, map[QName]struct{}{})
+				c.checkRedefineAttrGroupRestriction(ctx, elem, qn, derivedAttrs, derivedWildcard, origEffectiveAttrs, origEffectiveWildcard)
 			}
 			// The override REPLACES the Phase-A attribute group, so re-record its
 			// source to the redefining file/line (c.includeFile is the redefining
@@ -2164,8 +2185,8 @@ func (c *compiler) loadImport(ctx context.Context, location, ns string, importEl
 			c.attrGroupRefChildren[qn] = refs
 		}
 	}
-	// Merge the XSD 1.1 attribute-group wildcards so a type in the importing
-	// schema that references an imported group sees the group's xs:anyAttribute.
+	// Merge attribute-group wildcards so a type in the importing schema that
+	// references an imported group sees the group's xs:anyAttribute.
 	for qn, wc := range impC.attrGroupWildcards {
 		if _, exists := c.attrGroupWildcards[qn]; !exists {
 			c.attrGroupWildcards[qn] = wc

--- a/xsd/instance_schema_location.go
+++ b/xsd/instance_schema_location.go
@@ -1,0 +1,173 @@
+package xsd
+
+import (
+	"context"
+	"io/fs"
+	"maps"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/internal/iofs"
+	"github.com/lestrrat-go/helium/internal/lexicon"
+	"github.com/lestrrat-go/helium/internal/xsd/value"
+)
+
+type instanceSchemaHint struct {
+	ns       string
+	location string
+}
+
+func schemaWithInstanceHints(ctx context.Context, base *Schema, doc *helium.Document) *Schema {
+	if base == nil || doc == nil || base.loaderFS == nil {
+		return base
+	}
+	if _, denyAll := base.loaderFS.(iofs.DenyAll); denyAll {
+		return base
+	}
+
+	hints := collectInstanceSchemaHints(doc)
+	if len(hints) == 0 {
+		return base
+	}
+
+	instanceBase := schemaBaseDir(doc.URL())
+	if doc.URL() == "" {
+		instanceBase = base.loaderBaseDir
+	}
+
+	var out *Schema
+	loaded := map[string]struct{}{}
+	for _, hint := range hints {
+		path, err := validateSchemaPath(instanceBase, hint.location)
+		if err != nil {
+			continue
+		}
+		if _, seen := loaded[path]; seen {
+			continue
+		}
+		loaded[path] = struct{}{}
+
+		hinted := compileInstanceHintSchema(ctx, base, path)
+		if hinted == nil || hinted.targetNamespace != hint.ns {
+			continue
+		}
+		if out == nil {
+			out = cloneSchemaSymbolTables(base)
+		}
+		mergeHintSchema(out, hinted)
+	}
+
+	if out == nil {
+		return base
+	}
+	return out
+}
+
+func collectInstanceSchemaHints(doc *helium.Document) []instanceSchemaHint {
+	var hints []instanceSchemaHint
+	_ = helium.Walk(doc, helium.NodeWalkerFunc(func(n helium.Node) error {
+		elem, ok := n.(*helium.Element)
+		if !ok {
+			return nil
+		}
+		for _, a := range elem.Attributes() {
+			if a.URI() != lexicon.NamespaceXSI {
+				continue
+			}
+			switch a.LocalName() {
+			case attrSchemaLocation:
+				fields := value.XSDFields(a.Value())
+				if len(fields)%2 != 0 {
+					continue
+				}
+				for i := 0; i < len(fields); i += 2 {
+					hints = append(hints, instanceSchemaHint{ns: fields[i], location: fields[i+1]})
+				}
+			case attrNoNSSchemaLocation:
+				loc := value.XSDFields(a.Value())
+				if len(loc) == 1 {
+					hints = append(hints, instanceSchemaHint{location: loc[0]})
+				}
+			}
+		}
+		return nil
+	}))
+	return hints
+}
+
+func compileInstanceHintSchema(ctx context.Context, base *Schema, path string) *Schema {
+	data, err := readInstanceHintSchema(base.loaderFS, path)
+	if err != nil {
+		return nil
+	}
+
+	parser := defaultSchemaParser()
+	if base.loaderParser != nil {
+		parser = *base.loaderParser
+	}
+	doc, err := parser.Parse(ctx, data)
+	if err != nil {
+		return nil
+	}
+
+	cfg := &compileConfig{
+		fsys:       base.loaderFS,
+		parser:     base.loaderParser,
+		version:    base.version,
+		versionSet: true,
+	}
+	schema, err := compileSchema(ctx, doc, schemaBaseDir(path), cfg)
+	if err != nil {
+		return nil
+	}
+	return schema
+}
+
+func readInstanceHintSchema(fsys fs.FS, path string) ([]byte, error) {
+	c := &compiler{fsys: fsys}
+	return c.readNestedSchema(path)
+}
+
+func cloneSchemaSymbolTables(s *Schema) *Schema {
+	cp := *s
+	cp.elements = maps.Clone(s.elements)
+	cp.types = maps.Clone(s.types)
+	cp.groups = maps.Clone(s.groups)
+	cp.attrGroups = maps.Clone(s.attrGroups)
+	cp.globalAttrs = maps.Clone(s.globalAttrs)
+	cp.substGroups = maps.Clone(s.substGroups)
+	return &cp
+}
+
+func mergeHintSchema(dst, src *Schema) {
+	for qn, decl := range src.elements {
+		if _, exists := dst.elements[qn]; !exists {
+			dst.elements[qn] = decl
+		}
+	}
+	for qn, td := range src.types {
+		if _, exists := dst.types[qn]; !exists {
+			dst.types[qn] = td
+		}
+	}
+	for qn, mg := range src.groups {
+		if _, exists := dst.groups[qn]; !exists {
+			dst.groups[qn] = mg
+		}
+	}
+	for qn, attrs := range src.attrGroups {
+		if _, exists := dst.attrGroups[qn]; !exists {
+			dst.attrGroups[qn] = attrs
+		}
+	}
+	for qn, au := range src.globalAttrs {
+		if _, exists := dst.globalAttrs[qn]; !exists {
+			dst.globalAttrs[qn] = au
+		}
+	}
+	for qn, members := range src.substGroups {
+		if len(members) == 0 {
+			continue
+		}
+		dst.substGroups[qn] = append(dst.substGroups[qn], members...)
+	}
+}

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -387,27 +387,38 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 	// behavior of appending raw group attributes.
 	for td, qns := range c.attrGroupRefs {
 		srcs := c.attrGroupRefUseSources[td]
+		localWildcard := td.AnyAttribute
+		groupWildcard := (*Wildcard)(nil)
 		for i, qn := range qns {
-			if _, ok := c.schema.attrGroups[qn]; !ok {
+			refQN, ok := c.resolveAttrGroupRefQName(qn)
+			if !ok {
 				continue
 			}
-			uses := c.expandAttrGroupUses(qn, map[QName]struct{}{})
+			uses := c.expandAttrGroupUses(refQN, map[QName]struct{}{})
 			if i < len(srcs) && srcs[i].attr == attrDefaultAttributes {
 				c.markDefaultAttrUses(td, uses)
 			}
 			td.Attributes = append(td.Attributes, uses...)
-			// XSD 1.1: a referenced attribute group's xs:anyAttribute wildcard is
-			// INTERSECTED into the type's effective attribute wildcard (XSD 3.4.2,
-			// "complete wildcard"). Gated on Version11 so 1.0 (which drops group
-			// wildcards) is unchanged.
-			if c.version != Version11 {
-				continue
-			}
-			if gw := c.attrGroupCompleteWildcard(qn, map[QName]struct{}{}); gw != nil {
-				if td.AnyAttribute == nil {
-					td.AnyAttribute = gw
+			// A referenced attribute group's xs:anyAttribute wildcard is INTERSECTED
+			// into the type's effective attribute wildcard (the complete wildcard).
+			if gw := c.attrGroupCompleteWildcard(refQN, map[QName]struct{}{}); gw != nil {
+				if c.version == Version10 {
+					if localWildcard != nil {
+						localWildcard = intersectWildcardsWithProcessContents(localWildcard, gw, localWildcard.ProcessContents)
+						td.AnyAttribute = localWildcard
+					} else if groupWildcard == nil {
+						groupWildcard = gw
+						td.AnyAttribute = groupWildcard
+					} else {
+						groupWildcard = intersectWildcardsWithProcessContents(groupWildcard, gw, groupWildcard.ProcessContents)
+						td.AnyAttribute = groupWildcard
+					}
 				} else {
-					td.AnyAttribute = intersectWildcards(td.AnyAttribute, gw)
+					if td.AnyAttribute == nil {
+						td.AnyAttribute = gw
+					} else {
+						td.AnyAttribute = intersectWildcards(td.AnyAttribute, gw)
+					}
 				}
 			}
 		}
@@ -634,7 +645,7 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 				if td.AnyAttribute == nil && td.BaseType.AnyAttribute != nil {
 					td.AnyAttribute = td.BaseType.AnyAttribute
 				} else if td.AnyAttribute != nil && td.BaseType.AnyAttribute != nil {
-					td.AnyAttribute = wildcardUnion(td.BaseType.AnyAttribute, td.AnyAttribute, c.version)
+					td.AnyAttribute = c.extensionWildcardUnion(ctx, td, td.BaseType.AnyAttribute, td.AnyAttribute)
 				}
 			}
 			continue
@@ -765,7 +776,7 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 			if td.AnyAttribute == nil && td.BaseType.AnyAttribute != nil {
 				td.AnyAttribute = td.BaseType.AnyAttribute
 			} else if td.AnyAttribute != nil && td.BaseType.AnyAttribute != nil {
-				td.AnyAttribute = wildcardUnion(td.BaseType.AnyAttribute, td.AnyAttribute, c.version)
+				td.AnyAttribute = c.extensionWildcardUnion(ctx, td, td.BaseType.AnyAttribute, td.AnyAttribute)
 			}
 		}
 	}
@@ -1014,6 +1025,19 @@ func (c *compiler) expandAttrGroupUses(qn QName, visited map[QName]struct{}) []*
 	return uses
 }
 
+func (c *compiler) resolveAttrGroupRefQName(qn QName) (QName, bool) {
+	if _, ok := c.schema.attrGroups[qn]; ok {
+		return qn, true
+	}
+	if qn.NS != "" {
+		fallback := QName{Local: qn.Local}
+		if _, ok := c.schema.attrGroups[fallback]; ok {
+			return fallback, true
+		}
+	}
+	return QName{}, false
+}
+
 func (c *compiler) markDefaultAttrUses(td *TypeDef, uses []*AttrUse) {
 	if td == nil || len(uses) == 0 {
 		return
@@ -1055,11 +1079,10 @@ func (c *compiler) markDefaultAttrUse(td *TypeDef, au *AttrUse) {
 	attrs[au.Name] = au
 }
 
-// attrGroupCompleteWildcard returns the XSD 1.1 "complete wildcard" of an
-// attribute group: its OWN xs:anyAttribute (if any) INTERSECTED with the
-// complete wildcards of every nested xs:attributeGroup ref child. visited guards
-// against reference cycles. Returns nil if neither the group nor any referenced
-// group declares a wildcard.
+// attrGroupCompleteWildcard returns an attribute group's complete wildcard: its
+// OWN xs:anyAttribute (if any) INTERSECTED with the complete wildcards of every
+// nested xs:attributeGroup ref child. visited guards against reference cycles.
+// Returns nil if neither the group nor any referenced group declares a wildcard.
 func (c *compiler) attrGroupCompleteWildcard(qn QName, visited map[QName]struct{}) *Wildcard {
 	if _, seen := visited[qn]; seen {
 		return nil
@@ -1076,19 +1099,26 @@ func (c *compiler) attrGroupCompleteWildcard(qn QName, visited map[QName]struct{
 			result = nested
 			continue
 		}
-		result = intersectWildcards(result, nested)
+		if c.version == Version10 {
+			result = intersectWildcardsWithProcessContents(result, nested, result.ProcessContents)
+		} else {
+			result = intersectWildcards(result, nested)
+		}
 	}
 	return result
 }
 
 // combineGroupWildcards intersects two possibly-nil attribute-group wildcards,
 // returning nil when both are nil and the non-nil one when only one is present.
-func combineGroupWildcards(a, b *Wildcard) *Wildcard {
+func combineGroupWildcards(version Version, a, b *Wildcard) *Wildcard {
 	if a == nil {
 		return b
 	}
 	if b == nil {
 		return a
+	}
+	if version == Version10 {
+		return intersectWildcardsWithProcessContents(a, b, a.ProcessContents)
 	}
 	return intersectWildcards(a, b)
 }
@@ -2638,21 +2668,10 @@ func isUrSimpleType(td *TypeDef) bool {
 }
 
 // effectiveAttrWildcard returns the {attribute wildcard} of a complex type for
-// the restriction-derivation check. In XSD 1.1 the group-ref wildcards are
-// already merged into td.AnyAttribute at link time, so this returns it unchanged.
-// In XSD 1.0 group wildcards are NOT merged into a type's {attribute wildcard} at
-// validation (byte-identical); this re-derives one on demand ONLY to recognize a
-// base whose attribute wildcard comes SOLELY through a referenced attribute group
-// (td.AnyAttribute nil): it fills in the first group-ref complete wildcard so
-// derivation-ok-restriction 4.1 sees a wildcard and 4.2/4.3 have one to compare.
-//
-// A DIRECT td.AnyAttribute is returned as-is and is NEVER narrowed by intersecting
-// group-ref wildcards: 1.0 instance validation uses only the direct wildcard, so
-// narrowing it here would newly reject a restriction whose derived wildcard is a
-// subset of the direct base wildcard but not of the (narrower) intersection —
-// breaking 1.0 byte-identical behavior. The first group-ref wildcard suffices to
-// discharge 4.1 for the transitive-only case; the full multi-group intersection is
-// not modeled here.
+// the restriction-derivation check. Attribute-group wildcards are merged into
+// td.AnyAttribute before restriction checks, but the fallback keeps older
+// partially-linked paths conservative when a type has only transitive group
+// wildcards.
 func (c *compiler) effectiveAttrWildcard(td *TypeDef) *Wildcard {
 	if td == nil {
 		return nil
@@ -2662,10 +2681,11 @@ func (c *compiler) effectiveAttrWildcard(td *TypeDef) *Wildcard {
 		return w
 	}
 	for _, qn := range c.attrGroupRefs[td] {
-		if _, ok := c.schema.attrGroups[qn]; !ok {
+		refQN, ok := c.resolveAttrGroupRefQName(qn)
+		if !ok {
 			continue
 		}
-		if gw := c.attrGroupCompleteWildcard(qn, map[QName]struct{}{}); gw != nil {
+		if gw := c.attrGroupCompleteWildcard(refQN, map[QName]struct{}{}); gw != nil {
 			return gw
 		}
 	}
@@ -2913,8 +2933,26 @@ func (c *compiler) finalizeEffectiveAttrs(ctx context.Context, td *TypeDef, merg
 	case td.AnyAttribute == nil:
 		td.AnyAttribute = base.AnyAttribute
 	case td.Derivation == DerivationExtension && base.AnyAttribute != nil:
-		td.AnyAttribute = wildcardUnion(base.AnyAttribute, td.AnyAttribute, c.version)
+		td.AnyAttribute = c.extensionWildcardUnion(ctx, td, base.AnyAttribute, td.AnyAttribute)
 	}
+}
+
+func (c *compiler) extensionWildcardUnion(ctx context.Context, td *TypeDef, base, derived *Wildcard) *Wildcard {
+	wc, ok := wildcardUnionWithStatus(base, derived, c.version)
+	if ok || c.version != Version10 || c.filename == "" {
+		return wc
+	}
+	src, hasSrc := c.typeDefSources[td]
+	if !hasSrc {
+		return wc
+	}
+	component := componentLocalComplexType
+	if !src.isLocal {
+		component = "complex type '" + td.Name.Local + "'"
+	}
+	c.schemaError(ctx, schemaComponentError(c.diagSourceOrRecorded(src.source), src.line, "complexType", component,
+		"The union of the base and derived attribute wildcards is not expressible."))
+	return wc
 }
 
 // wildcardNSSet expands a wildcard's namespace constraint into a set of URIs.
@@ -2955,6 +2993,11 @@ func wildcardNSSet(wc *Wildcard) map[string]bool {
 //   - "not(absent)" → matches everything except absent (empty namespace)
 //   - "set"       → finite set of namespace URIs (empty string = absent)
 func wildcardUnion(w1, w2 *Wildcard, version Version) *Wildcard {
+	wc, _ := wildcardUnionWithStatus(w1, w2, version)
+	return wc
+}
+
+func wildcardUnionWithStatus(w1, w2 *Wildcard, version Version) (*Wildcard, bool) {
 	// Route to the general constraint algebra for EVERY XSD 1.1 union, not just
 	// those whose operands carry a notNamespace/notQName field. The 1.0 case
 	// analysis below keys processContents on w1 and APPROXIMATES some namespace
@@ -2965,7 +3008,7 @@ func wildcardUnion(w1, w2 *Wildcard, version Version) *Wildcard {
 	// STRICTLY for Version10 so existing goldens stay byte-identical; the
 	// 1.1-field guard remains as a defensive fallback.
 	if version == Version11 || wildcardHas11Fields(w1) || wildcardHas11Fields(w2) {
-		return unionWildcards11(w1, w2)
+		return unionWildcards11(w1, w2), true
 	}
 
 	pc := w1.ProcessContents
@@ -2973,7 +3016,7 @@ func wildcardUnion(w1, w2 *Wildcard, version Version) *Wildcard {
 
 	// Case 2: If either is ##any, result is ##any.
 	if w1.Namespace == WildcardNSAny || w2.Namespace == WildcardNSAny {
-		return &Wildcard{Namespace: WildcardNSAny, ProcessContents: pc, TargetNS: tns}
+		return &Wildcard{Namespace: WildcardNSAny, ProcessContents: pc, TargetNS: tns}, true
 	}
 
 	w1IsNeg := w1.Namespace == WildcardNSOther || w1.Namespace == WildcardNSNotAbsent
@@ -2981,7 +3024,7 @@ func wildcardUnion(w1, w2 *Wildcard, version Version) *Wildcard {
 
 	// Case 1: Both are the same value.
 	if w1.Namespace == w2.Namespace && w1.TargetNS == w2.TargetNS {
-		return &Wildcard{Namespace: w1.Namespace, ProcessContents: pc, TargetNS: tns}
+		return &Wildcard{Namespace: w1.Namespace, ProcessContents: pc, TargetNS: tns}, true
 	}
 
 	// Case 3: Both are sets (neither is a negation or ##any).
@@ -2990,7 +3033,7 @@ func wildcardUnion(w1, w2 *Wildcard, version Version) *Wildcard {
 		for ns := range wildcardNSSet(w2) {
 			set[ns] = true
 		}
-		return wildcardFromSet(set, pc, tns)
+		return wildcardFromSet(set, pc, tns), true
 	}
 
 	// Case 4: Both are negations.
@@ -2999,10 +3042,10 @@ func wildcardUnion(w1, w2 *Wildcard, version Version) *Wildcard {
 		w2NegNS := wildcardNegatedNS(w2)
 		if w1NegNS == w2NegNS {
 			// Same negated value → same result.
-			return &Wildcard{Namespace: w1.Namespace, ProcessContents: pc, TargetNS: tns}
+			return &Wildcard{Namespace: w1.Namespace, ProcessContents: pc, TargetNS: tns}, true
 		}
 		// Different negated values → not(absent).
-		return &Wildcard{Namespace: WildcardNSNotAbsent, ProcessContents: pc, TargetNS: tns}
+		return &Wildcard{Namespace: WildcardNSNotAbsent, ProcessContents: pc, TargetNS: tns}, true
 	}
 
 	// Cases 5 & 6: One is a negation, the other is a set.
@@ -3022,28 +3065,27 @@ func wildcardUnion(w1, w2 *Wildcard, version Version) *Wildcard {
 		// Case 6: neg is not(absent).
 		if hasAbsent {
 			// 6.1: Set includes absent → any.
-			return &Wildcard{Namespace: WildcardNSAny, ProcessContents: pc, TargetNS: tns}
+			return &Wildcard{Namespace: WildcardNSAny, ProcessContents: pc, TargetNS: tns}, true
 		}
 		// 6.2: Set doesn't include absent → not(absent).
-		return &Wildcard{Namespace: WildcardNSNotAbsent, ProcessContents: pc, TargetNS: tns}
+		return &Wildcard{Namespace: WildcardNSNotAbsent, ProcessContents: pc, TargetNS: tns}, true
 	}
 
 	// Case 5: neg is not(ns).
 	if hasNegated && hasAbsent {
 		// 5.1: Set includes both negated ns and absent → any.
-		return &Wildcard{Namespace: WildcardNSAny, ProcessContents: pc, TargetNS: tns}
+		return &Wildcard{Namespace: WildcardNSAny, ProcessContents: pc, TargetNS: tns}, true
 	}
 	if hasNegated && !hasAbsent {
 		// 5.2: Set includes negated ns but not absent → not(absent).
-		return &Wildcard{Namespace: WildcardNSNotAbsent, ProcessContents: pc, TargetNS: tns}
+		return &Wildcard{Namespace: WildcardNSNotAbsent, ProcessContents: pc, TargetNS: tns}, true
 	}
 	if !hasNegated && !hasAbsent {
 		// 5.4: Set includes neither → the negation.
-		return &Wildcard{Namespace: neg.Namespace, ProcessContents: pc, TargetNS: neg.TargetNS}
+		return &Wildcard{Namespace: neg.Namespace, ProcessContents: pc, TargetNS: neg.TargetNS}, true
 	}
-	// 5.3: Set includes absent but not negated ns → not expressible.
-	// Fall back to ##any (permissive).
-	return &Wildcard{Namespace: WildcardNSAny, ProcessContents: pc, TargetNS: tns}
+	// 5.3: Set includes absent but not negated ns → not expressible in XSD 1.0.
+	return &Wildcard{Namespace: WildcardNSAny, ProcessContents: pc, TargetNS: tns}, false
 }
 
 // wildcardNegatedNS returns the namespace being negated.

--- a/xsd/read_particles.go
+++ b/xsd/read_particles.go
@@ -151,8 +151,8 @@ func (c *compiler) parseNamedAttributeGroup(ctx context.Context, elem *helium.El
 	// XSD 1.1: an xs:anyAttribute, if present, must be the OPTIONAL FINAL child of
 	// the group (XSD 3.6.2), and there may be at most one. anyAttributeSeen tracks
 	// it so a later attribute/attributeGroup child, or a second wildcard, is
-	// rejected. Gated on Version11 (1.0 ignores group wildcards entirely, so its
-	// grammar handling stays byte-identical).
+	// rejected. Gated on Version11 so 1.0 keeps its legacy lenient grammar
+	// diagnostics while still recording the wildcard below.
 	var anyAttributeSeen bool
 	// sawContent tracks whether any content particle (attribute, attributeGroup
 	// ref, or anyAttribute wildcard) has been seen, so a later <xs:annotation> can
@@ -233,15 +233,11 @@ func (c *compiler) parseNamedAttributeGroup(ctx context.Context, elem *helium.El
 			continue
 		}
 		// XSD 1.0: record the group's attribute wildcard (namespace + processContents
-		// only, no diagnostics) so checkRestrictionAttrs can compute a base type's
-		// effective/complete {attribute wildcard} when it is contributed transitively
-		// through this attribute group. XSD 1.0 never merges group wildcards into a
-		// type's {attribute wildcard} at validation (byte-identical); this record is
-		// consulted ONLY by the compile-time restriction-derivation check. The full
-		// readWildcard path is deliberately NOT used here — it would emit new 1.0
-		// diagnostics (checkWildcardAttrs / validateWildcardNamespace / a bad
-		// processContents value) for a malformed anyAttribute that XSD 1.0 currently
-		// silently accepts inside an attribute group.
+		// only, no diagnostics) so the referencing type's complete wildcard can be
+		// computed without adding new 1.0 grammar diagnostics. The full readWildcard
+		// path is deliberately NOT used here — it would report checkWildcardAttrs /
+		// validateWildcardNamespace / bad processContents errors for malformed
+		// anyAttribute declarations that XSD 1.0 currently accepts leniently.
 		if isXSDElement(ce, elemAnyAttribute) {
 			if _, exists := c.attrGroupWildcards[qn]; !exists {
 				ns := WildcardNSAny

--- a/xsd/redefine_attr_group_refset_test.go
+++ b/xsd/redefine_attr_group_refset_test.go
@@ -106,4 +106,62 @@ func TestRedefineAttrGroupRefSet(t *testing.T) {
 		require.Contains(t, errStr, "Duplicate attribute use",
 			"override's new nested ref must be flattened so its duplicate is detected; got: %q", errStr)
 	})
+
+	t.Run("no-self-ref override cannot add attributes outside original", func(t *testing.T) {
+		t.Parallel()
+		const (
+			mainXSD = "outside_main.xsd"
+			baseXSD = "outside_base.xsd"
+		)
+		fsys := fstest.MapFS{
+			mainXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="outside_base.xsd">
+    <xs:attributeGroup name="g">
+      <xs:attributeGroup ref="added"/>
+    </xs:attributeGroup>
+  </xs:redefine>
+  <xs:attributeGroup name="added">
+    <xs:attribute name="z" type="xs:string"/>
+  </xs:attributeGroup>
+  <xs:complexType name="t"><xs:attributeGroup ref="g"/></xs:complexType>
+  <xs:element name="root" type="t"/>
+</xs:schema>`)},
+			baseXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attributeGroup name="g">
+    <xs:attribute name="a" type="xs:string"/>
+  </xs:attributeGroup>
+</xs:schema>`)},
+		}
+		errStr := compile(t, fsys, mainXSD)
+		require.Contains(t, errStr, "src-redefine.7.2",
+			"a no-self-ref attributeGroup redefine must restrict the original group; got: %q", errStr)
+	})
+
+	t.Run("no-self-ref override cannot drop required original attribute", func(t *testing.T) {
+		t.Parallel()
+		const (
+			mainXSD = "required_main.xsd"
+			baseXSD = "required_base.xsd"
+		)
+		fsys := fstest.MapFS{
+			mainXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="required_base.xsd">
+    <xs:attributeGroup name="g">
+      <xs:attribute name="b" type="xs:string"/>
+    </xs:attributeGroup>
+  </xs:redefine>
+  <xs:complexType name="t"><xs:attributeGroup ref="g"/></xs:complexType>
+  <xs:element name="root" type="t"/>
+</xs:schema>`)},
+			baseXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:attributeGroup name="g">
+    <xs:attribute name="a" type="xs:string" use="required"/>
+    <xs:attribute name="b" type="xs:string"/>
+  </xs:attributeGroup>
+</xs:schema>`)},
+		}
+		errStr := compile(t, fsys, mainXSD)
+		require.Contains(t, errStr, "src-redefine.7.2",
+			"a no-self-ref attributeGroup redefine must keep required original attributes; got: %q", errStr)
+	})
 }

--- a/xsd/redefine_attr_group_restriction.go
+++ b/xsd/redefine_attr_group_restriction.go
@@ -1,0 +1,86 @@
+package xsd
+
+import (
+	"context"
+	"fmt"
+
+	helium "github.com/lestrrat-go/helium"
+)
+
+func (c *compiler) checkRedefineAttrGroupRestriction(ctx context.Context, elem *helium.Element, qn QName, derivedAttrs []*AttrUse, derivedWildcard *Wildcard, baseAttrs []*AttrUse, baseWildcard *Wildcard) {
+	if attrGroupValidRestriction(ctx, c, derivedAttrs, derivedWildcard, baseAttrs, baseWildcard) {
+		return
+	}
+	msg := fmt.Sprintf("src-redefine.7.2: The redefinition of attributeGroup '%s' is not a valid restriction of the original attribute group.", qn.Local)
+	c.schemaError(ctx, schemaParserError(c.diagSource(), elem.Line(), elem.LocalName(), elemAttributeGroup, msg))
+}
+
+func attrGroupValidRestriction(ctx context.Context, c *compiler, derivedAttrs []*AttrUse, derivedWildcard *Wildcard, baseAttrs []*AttrUse, baseWildcard *Wildcard) bool {
+	baseByName := make(map[QName]*AttrUse, len(baseAttrs))
+	for _, au := range baseAttrs {
+		if au == nil || au.Prohibited {
+			continue
+		}
+		baseByName[au.Name] = au
+	}
+
+	derivedByName := make(map[QName]*AttrUse, len(derivedAttrs))
+	for _, au := range derivedAttrs {
+		if au == nil || au.Prohibited {
+			continue
+		}
+		derivedByName[au.Name] = au
+		baseAU := baseByName[au.Name]
+		if baseAU == nil {
+			if baseWildcard == nil || !wildcardAllowsExpandedName(baseWildcard, au.Name.Local, au.Name.NS, c.schema, true) {
+				return false
+			}
+			continue
+		}
+		if !attrUseValidRestriction(ctx, c, au, baseAU) {
+			return false
+		}
+	}
+
+	for _, baseAU := range baseByName {
+		if !baseAU.Required {
+			continue
+		}
+		derivedAU := derivedByName[baseAU.Name]
+		if derivedAU == nil || !derivedAU.Required {
+			return false
+		}
+	}
+
+	if derivedWildcard == nil {
+		return true
+	}
+	if baseWildcard == nil {
+		return false
+	}
+	if !wildcardConstraintSubset(derivedWildcard, baseWildcard, c.schema, true) {
+		return false
+	}
+	return processContentsStrength(derivedWildcard.ProcessContents) >= processContentsStrength(baseWildcard.ProcessContents)
+}
+
+func attrUseValidRestriction(ctx context.Context, c *compiler, derived, base *AttrUse) bool {
+	if base.Required && !derived.Required {
+		return false
+	}
+	if c.version == Version11 && derived.Inheritable != base.Inheritable {
+		return false
+	}
+
+	derivedTD := attrUseEffectiveTypeDef(derived, c.schema)
+	baseTD := attrUseEffectiveTypeDef(base, c.schema)
+	if derivedTD != nil && baseTD != nil && !simpleTypeValidlyRestricts(derivedTD, baseTD) {
+		return false
+	}
+
+	if base.Fixed != nil {
+		return derived.Fixed != nil &&
+			fixedConstraintRestricts(ctx, *derived.Fixed, *base.Fixed, derivedTD, baseTD, derived.FixedNS, base.FixedNS, c.schema, c.version)
+	}
+	return true
+}

--- a/xsd/redefine_repeated_test.go
+++ b/xsd/redefine_repeated_test.go
@@ -44,11 +44,13 @@ func TestRedefine_RepeatedDocument(t *testing.T) {
 			mainXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:redefine schemaLocation="disjoint_base.xsd">
     <xs:attributeGroup name="g1">
+      <xs:attributeGroup ref="g1"/>
       <xs:attribute name="a1" type="xs:string"/>
     </xs:attributeGroup>
   </xs:redefine>
   <xs:redefine schemaLocation="disjoint_base.xsd">
     <xs:attributeGroup name="g2">
+      <xs:attributeGroup ref="g2"/>
       <xs:attribute name="b1" type="xs:string"/>
     </xs:attributeGroup>
   </xs:redefine>

--- a/xsd/restriction_attr_ns_test.go
+++ b/xsd/restriction_attr_ns_test.go
@@ -129,15 +129,12 @@ func TestRestrictionAttrNamespace(t *testing.T) {
 		require.Empty(t, compileFatalErrors(t, schema))
 	})
 
-	t.Run("does not narrow a direct base wildcard by a group-ref wildcard", func(t *testing.T) {
+	t.Run("narrows a direct base wildcard by a group-ref wildcard", func(t *testing.T) {
 		t.Parallel()
 		// The base has a DIRECT <xs:anyAttribute namespace="##any"/> AND a
 		// referenced attribute group contributing a NARROWER ##other wildcard.
-		// XSD 1.0 instance validation uses only the direct ##any wildcard, so the
-		// restriction check must too: a derived ##any wildcard is a valid subset of
-		// the direct base ##any and must compile. Intersecting the direct wildcard
-		// with the group's ##other would narrow the base and newly reject this in
-		// 1.0 — a byte-identical break.
+		// The effective complete wildcard is their intersection, so a derived
+		// ##any wildcard widens the base and is not a valid restriction.
 		schema := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:t" xmlns:t="urn:t">
   <xs:attributeGroup name="g">
     <xs:attribute name="a" type="xs:string"/>
@@ -158,7 +155,7 @@ func TestRestrictionAttrNamespace(t *testing.T) {
   </xs:complexType>
   <xs:element name="root" type="t:Derived"/>
 </xs:schema>`
-		require.Empty(t, compileFatalErrors(t, schema))
+		require.Contains(t, compileFatalErrors(t, schema), "not a valid subset")
 	})
 
 	t.Run("rejects restriction widening a transitive base attribute-group wildcard", func(t *testing.T) {

--- a/xsd/schema.go
+++ b/xsd/schema.go
@@ -1,8 +1,10 @@
 package xsd
 
 import (
+	"io/fs"
 	"slices"
 
+	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/xsdregex"
 	"github.com/lestrrat-go/helium/xpath1"
 	"github.com/lestrrat-go/helium/xpath3"
@@ -56,6 +58,9 @@ type Schema struct {
 	attrGroups        map[QName][]*AttrUse
 	globalAttrs       map[QName]*AttrUse
 	substGroups       map[QName][]*ElementDecl // head QName → member element declarations
+	loaderFS          fs.FS
+	loaderBaseDir     string
+	loaderParser      *helium.Parser
 }
 
 // LookupElement returns the global element declaration for the given name.

--- a/xsd/version_wildcard_notqname_test.go
+++ b/xsd/version_wildcard_notqname_test.go
@@ -270,14 +270,13 @@ func TestVersion11AttrGroupWildcardIntersection(t *testing.T) {
 		require.ErrorIs(t, err, xsd.ErrValidationFailed)
 	})
 
-	t.Run("1.0 ignores attribute-group wildcards (lenient, attribute rejected)", func(t *testing.T) {
+	t.Run("1.0 applies attribute-group wildcards while ignoring notNamespace", func(t *testing.T) {
 		t.Parallel()
-		// In 1.0 the group wildcards are dropped (pre-existing behavior), and
-		// notNamespace is unrecognized, so the type has no effective wildcard and
-		// the unknown attribute is not allowed.
+		// In 1.0 notNamespace is unrecognized, so both group wildcards behave as
+		// the default ##any and their complete wildcard admits the attribute.
 		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schema,
 			`<e m:adam="m" xmlns:m="http://adam.com/"/>`)
-		require.ErrorIs(t, err, xsd.ErrValidationFailed)
+		require.NoError(t, err)
 	})
 }
 

--- a/xsd/wildcard_algebra.go
+++ b/xsd/wildcard_algebra.go
@@ -226,8 +226,17 @@ func notQNameUnion(a, b []QName) []QName {
 // (strict > lax > skip) so the intersection is order-independent — a strict
 // operand must not be weakened to skip just because it was listed second.
 func intersectWildcards(a, b *Wildcard) *Wildcard {
+	return intersectWildcardsWithProcessContents(a, b, strongerProcessContents(a.ProcessContents, b.ProcessContents))
+}
+
+// intersectWildcardsWithProcessContents computes the same namespace/disallowed-name
+// intersection as intersectWildcards, while taking the result processContents
+// from the caller. XSD 1.0 complete-wildcard construction fixes processContents
+// from the local wildcard or first contributing group wildcard; it does not use
+// the stronger-of-both rule that applies to the general intersection helper.
+func intersectWildcardsWithProcessContents(a, b *Wildcard, pc ProcessContentsKind) *Wildcard {
 	con := constraintIntersect(wildcardConstraint(a), wildcardConstraint(b))
-	return constraintToWildcard(con, strongerProcessContents(a.ProcessContents, b.ProcessContents), a.TargetNS,
+	return constraintToWildcard(con, pc, a.TargetNS,
 		notQNameUnion(a.NotQName, b.NotQName),
 		a.NotQNameDefined || b.NotQNameDefined,
 		a.NotQNameDefinedSibling || b.NotQNameDefinedSibling,

--- a/xsd/xsd.go
+++ b/xsd/xsd.go
@@ -435,7 +435,8 @@ func (v Validator) Validate(ctx context.Context, doc *helium.Document) error { /
 		return ErrNilDocument
 	}
 
-	valid := validateDocument(ctx, doc, v.schema, cfg, handler)
+	schema := schemaWithInstanceHints(ctx, v.schema, doc)
+	valid := validateDocument(ctx, doc, schema, cfg, handler)
 
 	if valid {
 		return nil


### PR DESCRIPTION
- apply XSD 1.0 attribute-group complete wildcard construction
- load instance schemaLocation hints for strict wildcard declarations
- reject invalid no-self-reference attributeGroup redefines