### PR TITLE
fix xsd10 idc xpath cache

### DIFF
--- a/internal/xpath/docorder_context.go
+++ b/internal/xpath/docorder_context.go
@@ -1,0 +1,21 @@
+package xpath
+
+import "context"
+
+type docOrderCacheContextKey struct{}
+
+// WithDocOrderCache returns a context that makes cache available to XPath
+// evaluators in this module. It is for internal callers that can guarantee the
+// described documents are not mutated while the cache is reused.
+func WithDocOrderCache(ctx context.Context, cache *DocOrderCache) context.Context {
+	if cache == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, docOrderCacheContextKey{}, cache)
+}
+
+// DocOrderCacheFromContext returns the document-order cache carried by ctx.
+func DocOrderCacheFromContext(ctx context.Context) *DocOrderCache {
+	cache, _ := ctx.Value(docOrderCacheContextKey{}).(*DocOrderCache)
+	return cache
+}

--- a/xpath1/docorder_cache_test.go
+++ b/xpath1/docorder_cache_test.go
@@ -1,0 +1,22 @@
+package xpath1
+
+import (
+	"testing"
+
+	ixpath "github.com/lestrrat-go/helium/internal/xpath"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvalContextUsesInternalDocOrderCacheFromContext(t *testing.T) {
+	defaultCtx := newEvalContextWithConfig(t.Context(), nil, nil)
+	require.NotNil(t, defaultCtx.docOrder)
+
+	cache := &ixpath.DocOrderCache{}
+	ctx := ixpath.WithDocOrderCache(t.Context(), cache)
+	cachedCtx := newEvalContextWithConfig(ctx, nil, nil)
+	require.Same(t, cache, cachedCtx.docOrder)
+	require.NotSame(t, defaultCtx.docOrder, cachedCtx.docOrder)
+
+	clone := cachedCtx.withNode(nil, 1, 1)
+	require.Same(t, cache, clone.docOrder)
+}

--- a/xpath1/eval.go
+++ b/xpath1/eval.go
@@ -34,14 +34,18 @@ type evalContext struct {
 	docOrder      *ixpath.DocOrderCache
 }
 
-func newEvalContextWithConfig(node helium.Node, cfg *evalConfig) *evalContext {
+func newEvalContextWithConfig(ctx context.Context, node helium.Node, cfg *evalConfig) *evalContext {
 	opCount := 0
+	docOrder := ixpath.DocOrderCacheFromContext(ctx)
+	if docOrder == nil {
+		docOrder = &ixpath.DocOrderCache{}
+	}
 	ectx := &evalContext{
 		node:     node,
 		position: 1,
 		size:     1,
 		opCount:  &opCount,
-		docOrder: &ixpath.DocOrderCache{},
+		docOrder: docOrder,
 	}
 	if cfg != nil {
 		ectx.namespaces = cfg.namespaces

--- a/xpath1/xpath.go
+++ b/xpath1/xpath.go
@@ -277,7 +277,7 @@ func (e Evaluator) Evaluate(ctx context.Context, expr *Expression, node helium.N
 	if expr == nil || expr.ast == nil {
 		return nil, ErrNilExpression
 	}
-	ectx := newEvalContextWithConfig(node, e.cfg)
+	ectx := newEvalContextWithConfig(ctx, node, e.cfg)
 	return eval(ctx, ectx, expr.ast)
 }
 
@@ -346,7 +346,7 @@ func (e *Expression) Evaluate(ctx context.Context, node helium.Node) (*Result, e
 	if e == nil || e.ast == nil {
 		return nil, ErrNilExpression
 	}
-	ectx := newEvalContextWithConfig(node, nil)
+	ectx := newEvalContextWithConfig(ctx, node, nil)
 	return eval(ctx, ectx, e.ast)
 }
 

--- a/xsd/idc_xpath_cache_test.go
+++ b/xsd/idc_xpath_cache_test.go
@@ -1,0 +1,53 @@
+package xsd_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdentityConstraintXPathCacheLargeDocument(t *testing.T) {
+	const rows = 5000
+	schema := `<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:t="urn:t" targetNamespace="urn:t" elementFormDefault="qualified">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="row" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="a" type="xs:NCName" use="required"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:key name="k">
+      <xs:selector xpath="t:row|t:row"/>
+      <xs:field xpath="@a|@a"/>
+    </xs:key>
+  </xs:element>
+</xs:schema>`
+
+	var inst strings.Builder
+	inst.WriteString(`<root xmlns="urn:t">`)
+	for i := range rows {
+		fmt.Fprintf(&inst, `<row a="v%d"/>`, i)
+	}
+	inst.WriteString(`</root>`)
+
+	sdoc, err := helium.NewParser().Parse(t.Context(), []byte(schema))
+	require.NoError(t, err)
+	compiled, err := xsd.NewCompiler().Compile(t.Context(), sdoc)
+	require.NoError(t, err)
+	idoc, err := helium.NewParser().Parse(t.Context(), []byte(inst.String()))
+	require.NoError(t, err)
+
+	validateCtx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, xsd.NewValidator(compiled).Validate(validateCtx, idoc))
+}

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -9,6 +9,7 @@ import (
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/xmlchar"
+	ixpath "github.com/lestrrat-go/helium/internal/xpath"
 	"github.com/lestrrat-go/helium/internal/xsd/value"
 )
 
@@ -471,6 +472,7 @@ type validationContext struct {
 	filename      string
 	errorHandler  helium.ErrorHandler
 	suppressDepth int
+	idcDocOrder   *ixpath.DocOrderCache
 	// edcType is the complex type whose content model is currently being matched.
 	// It is set (and restored) by validateContentByType, so the wildcard
 	// Element-Declarations-Consistent check (validateWildcardElementConsistent) can
@@ -612,6 +614,7 @@ func newValidationContext(schema *Schema, cfg *validateConfig, filename string, 
 		cfg:              cfg,
 		filename:         filename,
 		errorHandler:     handler,
+		idcDocOrder:      &ixpath.DocOrderCache{},
 		actualElemType:   make(map[*helium.Element]*TypeDef),
 		actualElemDecl:   make(map[*helium.Element]*ElementDecl),
 		attrInheritable:  make(map[*helium.Attribute]struct{}),

--- a/xsd/validate_idc.go
+++ b/xsd/validate_idc.go
@@ -9,6 +9,7 @@ import (
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/lexicon"
+	ixpath "github.com/lestrrat-go/helium/internal/xpath"
 	"github.com/lestrrat-go/helium/internal/xsd/value"
 	"github.com/lestrrat-go/helium/xpath1"
 )
@@ -37,6 +38,7 @@ func (vc *validationContext) validateIDConstraints(ctx context.Context, elem *he
 	if len(edecl.IDCs) == 0 {
 		return nil
 	}
+	ctx = ixpath.WithDocOrderCache(ctx, vc.idcDocOrder)
 
 	// Evaluate all constraints declared on this element and collect their
 	// key-sequence tables. The tables are scoped to THIS element OCCURRENCE: an


### PR DESCRIPTION
- reuse document-order cache for XSD identity constraints
- keep XPath 1.0 default cache behavior per evaluation
- add IDC cache regression coverage