### PR TITLE
fix xsd10 anyuri lexical

### DIFF
--- a/internal/xsd/value/validate.go
+++ b/internal/xsd/value/validate.go
@@ -98,7 +98,7 @@ func ValidateBuiltin(value, builtinLocal string, version Version) error {
 	case "NMTOKENS":
 		return validateSpaceSeparatedList(value, validateNMTOKEN)
 	case "anyURI":
-		return nil
+		return validateAnyURI(value, version)
 	default:
 		return nil
 	}
@@ -742,6 +742,38 @@ func validateToken(value string) error {
 		return fmt.Errorf("invalid token")
 	}
 	return nil
+}
+
+func validateAnyURI(value string, version Version) error {
+	if version == Version11 {
+		return nil
+	}
+	if value == "" {
+		return nil
+	}
+	if strings.HasPrefix(value, ":") || strings.HasSuffix(value, ":") {
+		return fmt.Errorf("invalid anyURI")
+	}
+	for i := 0; i < len(value); i++ {
+		ch := value[i]
+		if ch >= utf8.RuneSelf {
+			continue
+		}
+		if ch < ' ' || ch == 0x7f || strings.ContainsRune("\\^`", rune(ch)) {
+			return fmt.Errorf("invalid anyURI")
+		}
+		if ch == '%' {
+			if i+2 >= len(value) || !isHexDigit(value[i+1]) || !isHexDigit(value[i+2]) {
+				return fmt.Errorf("invalid anyURI")
+			}
+			i += 2
+		}
+	}
+	return nil
+}
+
+func isHexDigit(ch byte) bool {
+	return ('0' <= ch && ch <= '9') || ('A' <= ch && ch <= 'F') || ('a' <= ch && ch <= 'f')
 }
 
 func validateQName(value string) error {

--- a/internal/xsd/value/validate_test.go
+++ b/internal/xsd/value/validate_test.go
@@ -254,6 +254,19 @@ func TestBuiltinTypeValidation(t *testing.T) {
 	}
 }
 
+func TestAnyURIValidationVersionSpecific(t *testing.T) {
+	valid10 := []string{"", "a", "urn:isbn:123", "http://example.com/a%20b", "../relative/path", "#frag", "日本語", "foo>bar", `foo"bar`, "has space"}
+	for _, v := range valid10 {
+		require.NoError(t, value.ValidateBuiltin(v, "anyURI", value.Version10), "XSD 1.0 anyURI %q", v)
+	}
+
+	invalid10 := []string{":a", "b:", "has\tcontrol", "bad%escape", "%", `\`, "^"}
+	for _, v := range invalid10 {
+		require.Error(t, value.ValidateBuiltin(v, "anyURI", value.Version10), "XSD 1.0 anyURI %q", v)
+		require.NoError(t, value.ValidateBuiltin(v, "anyURI", value.Version11), "XSD 1.1 anyURI %q", v)
+	}
+}
+
 func TestCalendarYearExpandedLexicalRejectsLeadingZeroes(t *testing.T) {
 	t.Parallel()
 

--- a/xsd/check_annotations.go
+++ b/xsd/check_annotations.go
@@ -17,10 +17,12 @@ import (
 //     foreign element) and any non-whitespace character content is an error;
 //   - the only unqualified attribute allowed on xs:annotation is id (foreign
 //     namespaced attributes are allowed);
-//   - xs:appinfo allows only the unqualified attribute source;
+//   - xs:appinfo allows only the unqualified attribute source, whose value is
+//     xs:anyURI;
 //   - xs:documentation allows only the unqualified attribute source and the
-//     xml:lang attribute, whose value (after xs:language whiteSpace=collapse)
-//     must be a valid xs:language — an empty or whitespace-only value is invalid;
+//     xml:lang attribute; source is xs:anyURI and xml:lang (after xs:language
+//     whiteSpace=collapse) must be a valid xs:language — an empty or
+//     whitespace-only value is invalid;
 //   - every XSD element whose content model is (annotation?, ...) admits at most
 //     one xs:annotation child. Only xs:schema admits repeated annotations, so the
 //     "at most one" rule applies to every XSD-namespace element except xs:schema
@@ -166,6 +168,7 @@ func (c *compiler) checkAppinfo(ctx context.Context, elem *helium.Element, src s
 			continue
 		}
 		if attr.LocalName() == attrSource {
+			c.checkAnnotationSource(ctx, src, line, elemAppinfo, string(attr.Content()))
 			continue
 		}
 		c.schemaError(ctx, schemaParserError(src, line, elemAppinfo, elemAppinfo,
@@ -192,6 +195,7 @@ func (c *compiler) checkDocumentation(ctx context.Context, elem *helium.Element,
 			continue // other namespaced attributes are allowed
 		}
 		if name == attrSource {
+			c.checkAnnotationSource(ctx, src, line, elemDocumentation, string(attr.Content()))
 			continue
 		}
 		c.schemaError(ctx, schemaParserError(src, line, elemDocumentation, elemDocumentation,
@@ -205,5 +209,13 @@ func (c *compiler) checkDocumentation(ctx context.Context, elem *helium.Element,
 				helium.ClarkName(lexicon.NamespaceXML, lexicon.AttrLang),
 				"'"+langValue+"' is not a valid value of the atomic type 'xs:language'."))
 		}
+	}
+}
+
+func (c *compiler) checkAnnotationSource(ctx context.Context, src string, line int, elemName, raw string) {
+	collapsed := normalizeWhiteSpace(raw, "collapse")
+	if err := validateBuiltinValue(collapsed, lexicon.TypeAnyURI, c.version); err != nil {
+		c.schemaError(ctx, schemaParserErrorAttr(src, line, elemName, elemName, attrSource,
+			"'"+collapsed+"' is not a valid value of the atomic type 'xs:anyURI'."))
 	}
 }

--- a/xsd/check_annotations_test.go
+++ b/xsd/check_annotations_test.go
@@ -149,3 +149,42 @@ func TestAnnotationSchemaRepresentation(t *testing.T) {
 		})
 	}
 }
+
+func TestAnnotationSourceAnyURIVersionSpecific(t *testing.T) {
+	t.Parallel()
+
+	compile := func(t *testing.T, version xsd.Version, schemaXML string) bool {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, gotErr := xsd.NewCompiler().Version(version).Label("test.xsd").ErrorHandler(collector).Compile(t.Context(), doc)
+		return gotErr != nil
+	}
+
+	for _, tc := range []struct {
+		name   string
+		schema string
+	}{
+		{
+			name: "appinfo",
+			schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:annotation><xs:appinfo source="anyURI:"/></xs:annotation>
+  <xs:element name="foo" type="xs:string"/>
+</xs:schema>`,
+		},
+		{
+			name: "documentation",
+			schema: `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:annotation><xs:documentation source="bad%escape"/></xs:annotation>
+  <xs:element name="foo" type="xs:string"/>
+</xs:schema>`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.True(t, compile(t, xsd.Version10, tc.schema), "XSD 1.0 must reject invalid anyURI annotation source")
+			require.False(t, compile(t, xsd.Version11, tc.schema), "XSD 1.1 keeps the permissive anyURI lexical behavior")
+		})
+	}
+}


### PR DESCRIPTION
- enforce XSD 1.0 anyURI lexical checks
- validate annotation source attributes through the same version-aware xs:anyURI path
- keep XSD 1.1 anyURI permissive
- add version-specific anyURI validation coverage
