### PR TITLE
fix xsd10 legacy gMonth instance values

### DIFF
--- a/xsd/assertion_facet.go
+++ b/xsd/assertion_facet.go
@@ -26,10 +26,14 @@ func buildValueSequence(ctx context.Context, value string, valueNS map[string]st
 	effTD := td
 	if td != nil && resolveVariety(td) == TypeVarietyUnion {
 		var schema *Schema
+		version := Version10
+		allowLegacyGMonth := false
 		if vc != nil {
 			schema = vc.schema
+			version = vc.version
+			allowLegacyGMonth = vc.allowXSD10LegacyGMonthInstance
 		}
-		if active := fixedUnionActiveMember(ctx, value, valueNS, resolveUnionMembers(td), schema, vc.version); active != nil {
+		if active := fixedUnionActiveMember(ctx, value, valueNS, resolveUnionMembers(td), schema, version, allowLegacyGMonth); active != nil {
 			effTD = active
 		}
 	}
@@ -56,10 +60,14 @@ func buildValueSequence(ctx context.Context, value string, valueNS map[string]st
 func typedAtomic(ctx context.Context, value string, valueNS map[string]string, td *TypeDef, vc *validationContext) xpath3.AtomicValue {
 	if td != nil && resolveVariety(td) == TypeVarietyUnion {
 		var schema *Schema
+		version := Version10
+		allowLegacyGMonth := false
 		if vc != nil {
 			schema = vc.schema
+			version = vc.version
+			allowLegacyGMonth = vc.allowXSD10LegacyGMonthInstance
 		}
-		td = fixedUnionActiveMember(ctx, value, valueNS, resolveUnionMembers(td), schema, vc.version)
+		td = fixedUnionActiveMember(ctx, value, valueNS, resolveUnionMembers(td), schema, version, allowLegacyGMonth)
 	}
 	return atomicForType(value, valueNS, td)
 }

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -2657,7 +2657,7 @@ func fixedConstraintRestricts(ctx context.Context, derivedFixed, baseFixed strin
 	if isUrSimpleType(derivedTD) || isUrSimpleType(baseTD) {
 		return derivedFixed == baseFixed
 	}
-	return crossMemberValueEqual(ctx, derivedFixed, baseFixed, derivedTD, baseTD, derivedNS, baseNS, schema, version)
+	return crossMemberValueEqual(ctx, derivedFixed, baseFixed, derivedTD, baseTD, derivedNS, baseNS, schema, version, false)
 }
 
 // isUrSimpleType reports whether td is xs:anySimpleType, the simple ur-type. It

--- a/xsd/simplevalue_core.go
+++ b/xsd/simplevalue_core.go
@@ -209,21 +209,26 @@ func validateValueByVariety(ctx context.Context, value, trimmed string, valueNS 
 }
 
 func acceptsXSD10LegacyGMonthInstance(value, builtinLocal string, td *TypeDef, vc *validationContext) bool {
-	if !vc.allowXSD10LegacyGMonthInstance || vc.version != Version10 || builtinLocal != lexicon.TypeGMonth {
-		return false
+	_, ok := xsd10LegacyGMonthCurrentLexicalForType(value, builtinLocal, td, vc.allowXSD10LegacyGMonthInstance, vc.version)
+	return ok
+}
+
+func xsd10LegacyGMonthCurrentLexicalForType(value, builtinLocal string, td *TypeDef, allow bool, version Version) (string, bool) {
+	if !allow || version != Version10 || builtinLocal != lexicon.TypeGMonth {
+		return "", false
 	}
 	// XSTS bug-6901-era XSD 1.0 cases accept legacy "--MM--" instance values, but
 	// the same spelling remains invalid for schema facet/default literals.
 	for cur := range baseChain(td) {
 		if !facetSetEmpty(cur.Facets) {
-			return false
+			return "", false
 		}
 	}
 	current, ok := xsd10LegacyGMonthCurrentLexical(value)
 	if !ok {
-		return false
+		return "", false
 	}
-	return validateBuiltinValue(current, builtinLocal, vc.version) == nil
+	return current, validateBuiltinValue(current, builtinLocal, version) == nil
 }
 
 func xsd10LegacyGMonthCurrentLexical(value string) (string, bool) {
@@ -300,7 +305,7 @@ func validateUnionValue(ctx context.Context, value string, valueNS map[string]st
 		// fallback on a string leaf.
 		memberLocal := ""
 		memberWS := resolveWhiteSpace(cur)
-		if active := fixedUnionActiveMember(ctx, value, valueNS, resolveUnionMembers(cur), nil, vc.version); active != nil {
+		if active := fixedUnionActiveMember(ctx, value, valueNS, resolveUnionMembers(cur), nil, vc.version, vc.allowXSD10LegacyGMonthInstance); active != nil {
 			memberLocal = builtinBaseLocal(active)
 			memberWS = resolveWhiteSpace(active)
 		}
@@ -357,7 +362,7 @@ func checkUnionEnumeration(ctx context.Context, value string, valueNS map[string
 		if i < len(td.Facets.EnumerationNS) {
 			enumNS = td.Facets.EnumerationNS[i]
 		}
-		if fixedUnionMatches(ctx, value, ev, td, valueNS, enumNS, vc.schema, vc.version) {
+		if fixedUnionMatches(ctx, value, ev, td, valueNS, enumNS, vc.schema, vc.version, vc.allowXSD10LegacyGMonthInstance) {
 			return nil
 		}
 	}
@@ -529,7 +534,7 @@ func checkListEnumeration(ctx context.Context, value string, valueNS map[string]
 		if i < len(fs.EnumerationNS) {
 			enumNS = fs.EnumerationNS[i]
 		}
-		if fixedListMatches(ctx, value, ev, &TypeDef{Variety: TypeVarietyList, ItemType: itemType}, valueNS, enumNS, vc.schema, vc.version) {
+		if fixedListMatches(ctx, value, ev, &TypeDef{Variety: TypeVarietyList, ItemType: itemType}, valueNS, enumNS, vc.schema, vc.version, vc.allowXSD10LegacyGMonthInstance) {
 			return nil
 		}
 	}

--- a/xsd/simplevalue_core.go
+++ b/xsd/simplevalue_core.go
@@ -183,6 +183,9 @@ func validateValueByVariety(ctx context.Context, value, trimmed string, valueNS 
 
 	// Validate against the builtin type's lexical space.
 	if err := validateBuiltinValue(trimmed, builtinLocal, vc.version); err != nil {
+		if acceptsXSD10LegacyGMonthRuntime(trimmed, builtinLocal, td, elemName, line, vc) {
+			return validateFacets(ctx, trimmed, valueNS, td, builtinLocal, elemName, filename, line, vc)
+		}
 		typeName := typeDisplayName(td)
 		msg := fmt.Sprintf("'%s' is not a valid value of the atomic type '%s'.", trimmed, typeName)
 		vc.reportValidityError(ctx, filename, line, elemName, msg)
@@ -203,6 +206,43 @@ func validateValueByVariety(ctx context.Context, value, trimmed string, valueNS 
 
 	// Validate facets along the type chain.
 	return validateFacets(ctx, trimmed, valueNS, td, builtinLocal, elemName, filename, line, vc)
+}
+
+func acceptsXSD10LegacyGMonthRuntime(value, builtinLocal string, td *TypeDef, elemName string, line int, vc *validationContext) bool {
+	if vc.version != Version10 || builtinLocal != lexicon.TypeGMonth {
+		return false
+	}
+	// XSTS bug-6901-era XSD 1.0 cases accept legacy "--MM--" instance values, but
+	// the same spelling remains invalid for schema facet literals. Runtime element
+	// and attribute validation passes an element name and source line; compile-time
+	// facet/default checks call validateValue with empty source metadata.
+	if elemName == "" || line == 0 {
+		return false
+	}
+	for cur := range baseChain(td) {
+		if !facetSetEmpty(cur.Facets) {
+			return false
+		}
+	}
+	current, ok := xsd10LegacyGMonthCurrentLexical(value)
+	if !ok {
+		return false
+	}
+	return validateBuiltinValue(current, builtinLocal, vc.version) == nil
+}
+
+func xsd10LegacyGMonthCurrentLexical(value string) (string, bool) {
+	if len(value) < 6 || !strings.HasPrefix(value, "--") || value[4:6] != "--" {
+		return "", false
+	}
+	if value[2] < '0' || value[2] > '9' || value[3] < '0' || value[3] > '9' {
+		return "", false
+	}
+	tz := value[6:]
+	if tz != "" && tz != "Z" && !strings.HasPrefix(tz, "+") && !strings.HasPrefix(tz, "-") {
+		return "", false
+	}
+	return "--" + value[2:4] + tz, true
 }
 
 // resolveUnionMembers walks up the base type chain to find the union's member

--- a/xsd/simplevalue_core.go
+++ b/xsd/simplevalue_core.go
@@ -219,16 +219,23 @@ func xsd10LegacyGMonthCurrentLexicalForType(value, builtinLocal string, td *Type
 	}
 	// XSTS bug-6901-era XSD 1.0 cases accept legacy "--MM--" instance values, but
 	// the same spelling remains invalid for schema facet/default literals.
-	for cur := range baseChain(td) {
-		if !facetSetEmpty(cur.Facets) {
-			return "", false
-		}
+	if !typeChainHasNoFacets(td) {
+		return "", false
 	}
 	current, ok := xsd10LegacyGMonthCurrentLexical(value)
 	if !ok {
 		return "", false
 	}
 	return current, validateBuiltinValue(current, builtinLocal, version) == nil
+}
+
+func typeChainHasNoFacets(td *TypeDef) bool {
+	for cur := range baseChain(td) {
+		if !facetSetEmpty(cur.Facets) {
+			return false
+		}
+	}
+	return true
 }
 
 func xsd10LegacyGMonthCurrentLexical(value string) (string, bool) {
@@ -260,6 +267,11 @@ func resolveUnionMembers(td *TypeDef) []*TypeDef {
 // If all member types fail, a union-level error is reported.
 func validateUnionValue(ctx context.Context, value string, valueNS map[string]string, td *TypeDef, elemName, filename string, line int, vc *validationContext) error {
 	members := resolveUnionMembers(td)
+	oldAllowLegacyGMonth := vc.allowXSD10LegacyGMonthInstance
+	vc.allowXSD10LegacyGMonthInstance = oldAllowLegacyGMonth && typeChainHasNoFacets(td)
+	defer func() {
+		vc.allowXSD10LegacyGMonthInstance = oldAllowLegacyGMonth
+	}()
 
 	// First, check restriction facets on the union type itself (e.g., enumeration).
 	// If the type has facets and the value doesn't match them, that's the error.
@@ -395,6 +407,12 @@ func resolveVariety(td *TypeDef) TypeVariety {
 
 // validateListValue validates a space-separated list value against a list type.
 func validateListValue(ctx context.Context, value string, valueNS map[string]string, td *TypeDef, elemName, filename string, line int, vc *validationContext) error {
+	oldAllowLegacyGMonth := vc.allowXSD10LegacyGMonthInstance
+	vc.allowXSD10LegacyGMonthInstance = oldAllowLegacyGMonth && typeChainHasNoFacets(td)
+	defer func() {
+		vc.allowXSD10LegacyGMonthInstance = oldAllowLegacyGMonth
+	}()
+
 	// Split value into items by XSD whitespace only (space, tab, CR, LF). Using
 	// strings.Fields would also split on NBSP and other Unicode whitespace,
 	// silently turning an invalid item like "1 2" into two valid tokens;

--- a/xsd/simplevalue_core.go
+++ b/xsd/simplevalue_core.go
@@ -183,7 +183,7 @@ func validateValueByVariety(ctx context.Context, value, trimmed string, valueNS 
 
 	// Validate against the builtin type's lexical space.
 	if err := validateBuiltinValue(trimmed, builtinLocal, vc.version); err != nil {
-		if acceptsXSD10LegacyGMonthRuntime(trimmed, builtinLocal, td, elemName, line, vc) {
+		if acceptsXSD10LegacyGMonthInstance(trimmed, builtinLocal, td, vc) {
 			return validateFacets(ctx, trimmed, valueNS, td, builtinLocal, elemName, filename, line, vc)
 		}
 		typeName := typeDisplayName(td)
@@ -208,17 +208,12 @@ func validateValueByVariety(ctx context.Context, value, trimmed string, valueNS 
 	return validateFacets(ctx, trimmed, valueNS, td, builtinLocal, elemName, filename, line, vc)
 }
 
-func acceptsXSD10LegacyGMonthRuntime(value, builtinLocal string, td *TypeDef, elemName string, line int, vc *validationContext) bool {
-	if vc.version != Version10 || builtinLocal != lexicon.TypeGMonth {
+func acceptsXSD10LegacyGMonthInstance(value, builtinLocal string, td *TypeDef, vc *validationContext) bool {
+	if !vc.allowXSD10LegacyGMonthInstance || vc.version != Version10 || builtinLocal != lexicon.TypeGMonth {
 		return false
 	}
 	// XSTS bug-6901-era XSD 1.0 cases accept legacy "--MM--" instance values, but
-	// the same spelling remains invalid for schema facet literals. Runtime element
-	// and attribute validation passes an element name and source line; compile-time
-	// facet/default checks call validateValue with empty source metadata.
-	if elemName == "" || line == 0 {
-		return false
-	}
+	// the same spelling remains invalid for schema facet/default literals.
 	for cur := range baseChain(td) {
 		if !facetSetEmpty(cur.Facets) {
 			return false

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -472,7 +472,12 @@ type validationContext struct {
 	filename      string
 	errorHandler  helium.ErrorHandler
 	suppressDepth int
-	idcDocOrder   *ixpath.DocOrderCache
+	// allowXSD10LegacyGMonthInstance is set only for real instance-validation
+	// contexts. Compile-time schema literals, default/fixed constraints, and
+	// standalone TypeDef.Validate stay strict even when they carry diagnostic
+	// source metadata.
+	allowXSD10LegacyGMonthInstance bool
+	idcDocOrder                    *ixpath.DocOrderCache
 	// edcType is the complex type whose content model is currently being matched.
 	// It is set (and restored) by validateContentByType, so the wildcard
 	// Element-Declarations-Consistent check (validateWildcardElementConsistent) can
@@ -609,18 +614,19 @@ func newValidationContext(schema *Schema, cfg *validateConfig, filename string, 
 		version = schema.version
 	}
 	vc := &validationContext{
-		schema:           schema,
-		version:          version,
-		cfg:              cfg,
-		filename:         filename,
-		errorHandler:     handler,
-		idcDocOrder:      &ixpath.DocOrderCache{},
-		actualElemType:   make(map[*helium.Element]*TypeDef),
-		actualElemDecl:   make(map[*helium.Element]*ElementDecl),
-		attrInheritable:  make(map[*helium.Attribute]struct{}),
-		assessedElemType: make(map[*helium.Element]*TypeDef),
-		actualAttrType:   make(map[*helium.Attribute]*TypeDef),
-		assessedAttrs:    make(map[*helium.Attribute]struct{}),
+		schema:                         schema,
+		version:                        version,
+		cfg:                            cfg,
+		filename:                       filename,
+		errorHandler:                   handler,
+		allowXSD10LegacyGMonthInstance: true,
+		idcDocOrder:                    &ixpath.DocOrderCache{},
+		actualElemType:                 make(map[*helium.Element]*TypeDef),
+		actualElemDecl:                 make(map[*helium.Element]*ElementDecl),
+		attrInheritable:                make(map[*helium.Attribute]struct{}),
+		assessedElemType:               make(map[*helium.Element]*TypeDef),
+		actualAttrType:                 make(map[*helium.Attribute]*TypeDef),
+		assessedAttrs:                  make(map[*helium.Attribute]struct{}),
 	}
 	if version == Version11 {
 		vc.assertAnnotations = make(TypeAnnotations)
@@ -1905,7 +1911,7 @@ func (vc *validationContext) validateAttributes(ctx context.Context, elem *heliu
 			// type is associated only for the fixed-value comparison just done), so
 			// skip the generic check to avoid validating the same value twice.
 			if tdOK && attrTD.ContentType == ContentTypeSimple && !declaredXsiValueChecked {
-				if err := validateValue(ctx, a.Value(), collectNSContext(elem), attrTD, elemDisplayName(elem), vc.filename, elem.Line(), &validationContext{schema: vc.schema, version: vc.version, errorHandler: helium.NilErrorHandler{}}); err != nil {
+				if err := validateValue(ctx, a.Value(), collectNSContext(elem), attrTD, elemDisplayName(elem), vc.filename, elem.Line(), &validationContext{schema: vc.schema, version: vc.version, errorHandler: helium.NilErrorHandler{}, allowXSD10LegacyGMonthInstance: vc.allowXSD10LegacyGMonthInstance}); err != nil {
 					ad := attrDisplayName(a)
 					msg := fmt.Sprintf("The value '%s' is not valid for the type of attribute '%s'.", a.Value(), ad)
 					vc.reportValidityErrorAttr(ctx, vc.filename, elem.Line(), elemDisplayName(elem), ad, msg)
@@ -2328,7 +2334,7 @@ func (vc *validationContext) validateWildcardAttr(ctx context.Context, a *helium
 
 	if ok && attrTD.ContentType == ContentTypeSimple {
 		value := a.Value()
-		if err := validateValue(ctx, value, collectNSContext(elem), attrTD, elemDisplayName(elem), vc.filename, elem.Line(), &validationContext{schema: vc.schema, version: vc.version, errorHandler: helium.NilErrorHandler{}}); err != nil {
+		if err := validateValue(ctx, value, collectNSContext(elem), attrTD, elemDisplayName(elem), vc.filename, elem.Line(), &validationContext{schema: vc.schema, version: vc.version, errorHandler: helium.NilErrorHandler{}, allowXSD10LegacyGMonthInstance: vc.allowXSD10LegacyGMonthInstance}); err != nil {
 			ad := attrDisplayName(a)
 			typeName := typeDisplayName(attrTD)
 			msg := fmt.Sprintf("'%s' is not a valid value of the atomic type '%s'.", strings.TrimSpace(value), typeName)

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -49,6 +49,14 @@ const msgAbstractType = "The type definition is abstract."
 // QName/NOTATION types. When td is nil the comparison falls back to raw string
 // equality.
 func fixedValueMatches(ctx context.Context, instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string, schema *Schema, version Version) bool {
+	return fixedValueMatchesInternal(ctx, instance, fixed, td, instanceNS, fixedNS, schema, version, false)
+}
+
+func fixedValueMatchesForInstance(ctx context.Context, instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string, schema *Schema, version Version, allowXSD10LegacyGMonthInstance bool) bool {
+	return fixedValueMatchesInternal(ctx, instance, fixed, td, instanceNS, fixedNS, schema, version, allowXSD10LegacyGMonthInstance)
+}
+
+func fixedValueMatchesInternal(ctx context.Context, instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string, schema *Schema, version Version, allowXSD10LegacyGMonthInstance bool) bool {
 	if td == nil {
 		return instance == fixed
 	}
@@ -74,7 +82,7 @@ func fixedValueMatches(ctx context.Context, instance, fixed string, td *TypeDef,
 	// each member normalize with its own facet. List and atomic types keep their
 	// type-level normalization.
 	if resolveVariety(td) == TypeVarietyUnion {
-		return fixedUnionMatches(ctx, instance, fixed, td, instanceNS, fixedNS, schema, version)
+		return fixedUnionMatches(ctx, instance, fixed, td, instanceNS, fixedNS, schema, version, allowXSD10LegacyGMonthInstance)
 	}
 
 	ws := resolveWhiteSpace(td)
@@ -82,9 +90,9 @@ func fixedValueMatches(ctx context.Context, instance, fixed string, td *TypeDef,
 	nf := normalizeWhiteSpace(fixed, ws)
 
 	if resolveVariety(td) == TypeVarietyList {
-		return fixedListMatches(ctx, ni, nf, td, instanceNS, fixedNS, schema, version)
+		return fixedListMatches(ctx, ni, nf, td, instanceNS, fixedNS, schema, version, allowXSD10LegacyGMonthInstance)
 	}
-	return fixedAtomicMatches(ni, nf, builtinBaseLocal(td), instanceNS, fixedNS)
+	return fixedAtomicMatches(ni, nf, td, instanceNS, fixedNS, version, allowXSD10LegacyGMonthInstance)
 }
 
 // fixedListMatches compares two whitespace-normalized list values item by item
@@ -92,7 +100,7 @@ func fixedValueMatches(ctx context.Context, instance, fixed string, td *TypeDef,
 // variety-aware comparator on the actual item type, so a list whose item type is
 // a union (or itself a list) is compared in the correct value space rather than
 // raw lexical text.
-func fixedListMatches(ctx context.Context, instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string, schema *Schema, version Version) bool {
+func fixedListMatches(ctx context.Context, instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string, schema *Schema, version Version, allowXSD10LegacyGMonthInstance bool) bool {
 	ii := value.XSDFields(instance)
 	fi := value.XSDFields(fixed)
 	if len(ii) != len(fi) {
@@ -100,7 +108,7 @@ func fixedListMatches(ctx context.Context, instance, fixed string, td *TypeDef, 
 	}
 	itemType := resolveItemType(td)
 	for i := range ii {
-		if !fixedValueMatches(ctx, ii[i], fi[i], itemType, instanceNS, fixedNS, schema, version) {
+		if !fixedValueMatchesInternal(ctx, ii[i], fi[i], itemType, instanceNS, fixedNS, schema, version, allowXSD10LegacyGMonthInstance) {
 			return false
 		}
 	}
@@ -142,14 +150,14 @@ func fixedListMatches(ctx context.Context, instance, fixed string, td *TypeDef, 
 // same per-member validateValue path the normal (non-fixed) validation uses, so
 // the fixed-comparison and ordinary-validation notions of "active member" stay
 // consistent.
-func fixedUnionMatches(ctx context.Context, instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string, schema *Schema, version Version) bool {
+func fixedUnionMatches(ctx context.Context, instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string, schema *Schema, version Version, allowXSD10LegacyGMonthInstance bool) bool {
 	members := resolveUnionMembers(td)
 
-	fixedMember := fixedUnionActiveMember(ctx, fixed, fixedNS, members, schema, version)
+	fixedMember := fixedUnionActiveMember(ctx, fixed, fixedNS, members, schema, version, false)
 	if fixedMember == nil {
 		return false
 	}
-	instanceMember := fixedUnionActiveMember(ctx, instance, instanceNS, members, schema, version)
+	instanceMember := fixedUnionActiveMember(ctx, instance, instanceNS, members, schema, version, allowXSD10LegacyGMonthInstance)
 	if instanceMember == nil {
 		return false
 	}
@@ -158,7 +166,7 @@ func fixedUnionMatches(ctx context.Context, instance, fixed string, td *TypeDef,
 		// Same active member: compare in that member's value space. A union has no
 		// whiteSpace facet of its own, so the raw values are forwarded and the
 		// member normalizes both with its own facet inside fixedValueMatches.
-		return fixedValueMatches(ctx, instance, fixed, fixedMember, instanceNS, fixedNS, schema, version)
+		return fixedValueMatchesInternal(ctx, instance, fixed, fixedMember, instanceNS, fixedNS, schema, version, allowXSD10LegacyGMonthInstance)
 	}
 
 	// Different active members. XSD 1.1 §2.3 — restrictions do not create new
@@ -169,7 +177,7 @@ func fixedUnionMatches(ctx context.Context, instance, fixed string, td *TypeDef,
 	// atomic members reduce to their primitive value-space family. Cross-variety
 	// pairs (a list member vs an atomic member) have no shared value space and
 	// remain unequal.
-	return crossMemberValueEqual(ctx, instance, fixed, instanceMember, fixedMember, instanceNS, fixedNS, schema, version)
+	return crossMemberValueEqual(ctx, instance, fixed, instanceMember, fixedMember, instanceNS, fixedNS, schema, version, allowXSD10LegacyGMonthInstance)
 }
 
 // crossMemberValueComparisonMaxDepth bounds the recursion of
@@ -207,11 +215,11 @@ const crossMemberValueComparisonMaxDepth = 64
 //     normalized-lexical for the string family).
 //   - Any other variety mismatch that cannot be reconciled (e.g. list vs atomic):
 //     no shared value space → unequal.
-func crossMemberValueEqual(ctx context.Context, instance, fixed string, instanceMember, fixedMember *TypeDef, instanceNS, fixedNS map[string]string, schema *Schema, version Version) bool {
-	return crossMemberValueEqualDepth(ctx, instance, fixed, instanceMember, fixedMember, instanceNS, fixedNS, 0, schema, version)
+func crossMemberValueEqual(ctx context.Context, instance, fixed string, instanceMember, fixedMember *TypeDef, instanceNS, fixedNS map[string]string, schema *Schema, version Version, allowXSD10LegacyGMonthInstance bool) bool {
+	return crossMemberValueEqualDepth(ctx, instance, fixed, instanceMember, fixedMember, instanceNS, fixedNS, 0, schema, version, allowXSD10LegacyGMonthInstance)
 }
 
-func crossMemberValueEqualDepth(ctx context.Context, instance, fixed string, instanceMember, fixedMember *TypeDef, instanceNS, fixedNS map[string]string, depth int, schema *Schema, version Version) bool {
+func crossMemberValueEqualDepth(ctx context.Context, instance, fixed string, instanceMember, fixedMember *TypeDef, instanceNS, fixedNS map[string]string, depth int, schema *Schema, version Version, allowXSD10LegacyGMonthInstance bool) bool {
 	if depth > crossMemberValueComparisonMaxDepth {
 		return false
 	}
@@ -227,18 +235,18 @@ func crossMemberValueEqualDepth(ctx context.Context, instance, fixed string, ins
 	// a union nested directly inside another union, and any deeper combination, so
 	// the recursion always descends to a non-union variety before comparing.
 	if instanceVariety == TypeVarietyUnion {
-		active := fixedUnionActiveMember(ctx, instance, instanceNS, resolveUnionMembers(instanceMember), schema, version)
+		active := fixedUnionActiveMember(ctx, instance, instanceNS, resolveUnionMembers(instanceMember), schema, version, allowXSD10LegacyGMonthInstance)
 		if active == nil {
 			return false
 		}
-		return crossMemberValueEqualDepth(ctx, instance, fixed, active, fixedMember, instanceNS, fixedNS, depth+1, schema, version)
+		return crossMemberValueEqualDepth(ctx, instance, fixed, active, fixedMember, instanceNS, fixedNS, depth+1, schema, version, allowXSD10LegacyGMonthInstance)
 	}
 	if fixedVariety == TypeVarietyUnion {
-		active := fixedUnionActiveMember(ctx, fixed, fixedNS, resolveUnionMembers(fixedMember), schema, version)
+		active := fixedUnionActiveMember(ctx, fixed, fixedNS, resolveUnionMembers(fixedMember), schema, version, false)
 		if active == nil {
 			return false
 		}
-		return crossMemberValueEqualDepth(ctx, instance, fixed, instanceMember, active, instanceNS, fixedNS, depth+1, schema, version)
+		return crossMemberValueEqualDepth(ctx, instance, fixed, instanceMember, active, instanceNS, fixedNS, depth+1, schema, version, allowXSD10LegacyGMonthInstance)
 	}
 
 	if instanceVariety == TypeVarietyList && fixedVariety == TypeVarietyList {
@@ -255,7 +263,7 @@ func crossMemberValueEqualDepth(ctx context.Context, instance, fixed string, ins
 			return false
 		}
 		for i := range ii {
-			if !crossMemberValueEqualDepth(ctx, ii[i], fi[i], instanceItem, fixedItem, instanceNS, fixedNS, depth+1, schema, version) {
+			if !crossMemberValueEqualDepth(ctx, ii[i], fi[i], instanceItem, fixedItem, instanceNS, fixedNS, depth+1, schema, version, allowXSD10LegacyGMonthInstance) {
 				return false
 			}
 		}
@@ -271,7 +279,7 @@ func crossMemberValueEqualDepth(ctx context.Context, instance, fixed string, ins
 	// QName/NOTATION item pair resolves namespaces rather than being dropped by the
 	// no-shared-family rule.
 	if instanceMember == fixedMember {
-		return fixedValueMatches(ctx, instance, fixed, fixedMember, instanceNS, fixedNS, schema, version)
+		return fixedValueMatchesInternal(ctx, instance, fixed, fixedMember, instanceNS, fixedNS, schema, version, allowXSD10LegacyGMonthInstance)
 	}
 
 	fixedLocal := builtinBaseLocal(fixedMember)
@@ -317,6 +325,9 @@ func crossMemberValueEqualDepth(ctx context.Context, instance, fixed string, ins
 	// form first.
 	ni := normalizeWhiteSpace(instance, resolveWhiteSpace(instanceMember))
 	nf := normalizeWhiteSpace(fixed, resolveWhiteSpace(fixedMember))
+	if current, ok := xsd10LegacyGMonthCurrentLexicalForType(ni, instanceLocal, instanceMember, allowXSD10LegacyGMonthInstance, version); ok {
+		ni = current
+	}
 	if !fComparable {
 		// String-family: the value space equals the whitespace-processed lexical
 		// space, so compare the normalized lexical forms directly.
@@ -405,13 +416,14 @@ func primitiveValueSpaceFamily(builtinLocal string) (string, bool, bool) {
 // (schema-awareness is immaterial for plain fixed/enumeration comparisons); the
 // assertion $value path passes the real schema so union member typing is
 // consistent with validation.
-func fixedUnionActiveMember(ctx context.Context, value string, valueNS map[string]string, members []*TypeDef, schema *Schema, version Version) *TypeDef {
+func fixedUnionActiveMember(ctx context.Context, value string, valueNS map[string]string, members []*TypeDef, schema *Schema, version Version, allowXSD10LegacyGMonthInstance bool) *TypeDef {
 	for _, member := range members {
 		vc := &validationContext{
-			schema:        schema,
-			errorHandler:  helium.NilErrorHandler{},
-			suppressDepth: 1,
-			version:       version,
+			schema:                         schema,
+			errorHandler:                   helium.NilErrorHandler{},
+			suppressDepth:                  1,
+			version:                        version,
+			allowXSD10LegacyGMonthInstance: allowXSD10LegacyGMonthInstance,
 		}
 		if validateValue(ctx, value, valueNS, member, "", "", 0, vc) != nil {
 			continue
@@ -420,7 +432,7 @@ func fixedUnionActiveMember(ctx context.Context, value string, valueNS map[strin
 		// the active basic member within it; the validateValue success above
 		// guarantees at least one nested member accepts the value.
 		if resolveVariety(member) == TypeVarietyUnion {
-			if basic := fixedUnionActiveMember(ctx, value, valueNS, resolveUnionMembers(member), schema, version); basic != nil {
+			if basic := fixedUnionActiveMember(ctx, value, valueNS, resolveUnionMembers(member), schema, version, allowXSD10LegacyGMonthInstance); basic != nil {
 				return basic
 			}
 		}
@@ -435,7 +447,8 @@ func fixedUnionActiveMember(ctx context.Context, value string, valueNS map[strin
 // Other value-comparable builtins use value.Compare (covering numeric, boolean,
 // date/time, and binary value spaces); everything else falls back to exact
 // equality of the normalized lexical forms.
-func fixedAtomicMatches(instance, fixed, builtinLocal string, instanceNS, fixedNS map[string]string) bool {
+func fixedAtomicMatches(instance, fixed string, td *TypeDef, instanceNS, fixedNS map[string]string, version Version, allowXSD10LegacyGMonthInstance bool) bool {
+	builtinLocal := builtinBaseLocal(td)
 	if builtinLocal == lexicon.TypeQName || builtinLocal == lexicon.TypeNotation {
 		// resolveNotationOrQNameValue applies the unprefixed-NOTATION default-namespace
 		// resolution (instance value → instanceNS[""], fixed/enum literal → fixedNS[""])
@@ -452,6 +465,9 @@ func fixedAtomicMatches(instance, fixed, builtinLocal string, instanceNS, fixedN
 			return false
 		}
 		return iqn == fqn
+	}
+	if current, ok := xsd10LegacyGMonthCurrentLexicalForType(instance, builtinLocal, td, allowXSD10LegacyGMonthInstance, version); ok {
+		instance = current
 	}
 	if _, ok := enumValueSpaceTypes[builtinLocal]; ok {
 		if (builtinLocal == lexicon.TypeFloat || builtinLocal == lexicon.TypeDouble) &&
@@ -1322,7 +1338,7 @@ func (vc *validationContext) validateSimpleContent(ctx context.Context, elem *he
 		}
 		// In XSD 1.1 fixedValueMatches itself narrows a simpleContent type to its
 		// effective content simple type, so the raw declared type is passed here.
-		if !fixedValueMatches(ctx, value, *edecl.Fixed, fixedType, collectNSContext(elem), edecl.FixedNS, vc.schema, vc.version) {
+		if !fixedValueMatchesForInstance(ctx, value, *edecl.Fixed, fixedType, collectNSContext(elem), edecl.FixedNS, vc.schema, vc.version, vc.allowXSD10LegacyGMonthInstance) {
 			msg := fmt.Sprintf("The element content '%s' does not match the fixed value constraint '%s'.", value, *edecl.Fixed)
 			vc.reportValidityError(ctx, vc.filename, elem.Line(), elemDisplayName(elem), msg)
 			return fmt.Errorf("fixed value constraint")
@@ -1896,7 +1912,7 @@ func (vc *validationContext) validateAttributes(ctx context.Context, elem *heliu
 				case isDeclaredXsiSchemaLocationUse(au, vc.version):
 					fixedMatches = xsiSchemaLocationValueEqual(a.Value(), *au.Fixed)
 				default:
-					fixedMatches = fixedValueMatches(ctx, a.Value(), *au.Fixed, attrTD, collectNSContext(elem), au.FixedNS, vc.schema, vc.version)
+					fixedMatches = fixedValueMatchesForInstance(ctx, a.Value(), *au.Fixed, attrTD, collectNSContext(elem), au.FixedNS, vc.schema, vc.version, vc.allowXSD10LegacyGMonthInstance)
 				}
 				if !fixedMatches {
 					ad := attrDisplayName(a)
@@ -2085,7 +2101,7 @@ func (vc *validationContext) materializeQNameValueVisit(ctx context.Context, ele
 	switch resolveVariety(td) {
 	case TypeVarietyUnion:
 		collapsed := normalizeWhiteSpace(raw, "collapse")
-		activeTD := fixedUnionActiveMember(ctx, collapsed, declNS, resolveUnionMembers(td), vc.schema, vc.version)
+		activeTD := fixedUnionActiveMember(ctx, collapsed, declNS, resolveUnionMembers(td), vc.schema, vc.version, false)
 		if activeTD == nil {
 			return raw, false
 		}
@@ -2151,7 +2167,7 @@ func (vc *validationContext) valueHasQNameNotationCarrierVisit(ctx context.Conte
 	switch resolveVariety(td) {
 	case TypeVarietyUnion:
 		collapsed := normalizeWhiteSpace(raw, "collapse")
-		activeTD := fixedUnionActiveMember(ctx, collapsed, declNS, resolveUnionMembers(td), vc.schema, vc.version)
+		activeTD := fixedUnionActiveMember(ctx, collapsed, declNS, resolveUnionMembers(td), vc.schema, vc.version, false)
 		return vc.valueHasQNameNotationCarrierVisit(ctx, activeTD, collapsed, declNS, seen)
 	case TypeVarietyList:
 		itemType := resolveItemType(td)
@@ -2325,7 +2341,7 @@ func (vc *validationContext) validateWildcardAttr(ctx context.Context, a *helium
 	// Enforce the global attribute's fixed-value constraint. A wildcard-matched
 	// global fixed attribute must still satisfy its fixed value, in the declared
 	// type's value space (mirroring the non-wildcard attribute path).
-	if globalAttr.Fixed != nil && !fixedValueMatches(ctx, a.Value(), *globalAttr.Fixed, attrTD, collectNSContext(elem), globalAttr.FixedNS, vc.schema, vc.version) {
+	if globalAttr.Fixed != nil && !fixedValueMatchesForInstance(ctx, a.Value(), *globalAttr.Fixed, attrTD, collectNSContext(elem), globalAttr.FixedNS, vc.schema, vc.version, vc.allowXSD10LegacyGMonthInstance) {
 		ad := attrDisplayName(a)
 		msg := fmt.Sprintf("The value '%s' does not match the fixed value constraint '%s'.", a.Value(), *globalAttr.Fixed)
 		vc.reportValidityErrorAttr(ctx, vc.filename, elem.Line(), elemDisplayName(elem), ad, msg)

--- a/xsd/validate_idc.go
+++ b/xsd/validate_idc.go
@@ -526,7 +526,7 @@ func (vc *validationContext) canonicalValueKey(ctx context.Context, raw string, 
 		if item := vc.builtinListItemType(td); item != nil {
 			return vc.canonicalListKey(ctx, raw, fieldNode, item)
 		}
-		return canonicalAtomicKey(raw, fieldNode, td)
+		return vc.canonicalAtomicKey(raw, fieldNode, td)
 	}
 }
 
@@ -591,7 +591,7 @@ const primitiveKeySeparator = "\x01"
 // types and the whitespace-processed lexical value for lexical-only ones (xs:string
 // family, anyURI, …). An unresolvable type or QName falls back to the raw value
 // (untagged — it can only collide with other equally-unresolvable raw values).
-func canonicalAtomicKey(raw string, fieldNode helium.Node, td *TypeDef) string {
+func (vc *validationContext) canonicalAtomicKey(raw string, fieldNode helium.Node, td *TypeDef) string {
 	builtinLocal := builtinBaseLocal(td)
 	if builtinLocal == "" {
 		return raw
@@ -620,6 +620,9 @@ func canonicalAtomicKey(raw string, fieldNode helium.Node, td *TypeDef) string {
 			return raw
 		}
 		return primitive + primitiveKeySeparator + helium.ClarkName(qn.NS, qn.Local)
+	}
+	if current, ok := xsd10LegacyGMonthCurrentLexicalForType(normalized, builtinLocal, td, vc.allowXSD10LegacyGMonthInstance, vc.version); ok {
+		normalized = current
 	}
 	key, _ := value.CanonicalKey(normalized, builtinLocal)
 	return primitive + primitiveKeySeparator + key

--- a/xsd/validate_idc.go
+++ b/xsd/validate_idc.go
@@ -672,10 +672,11 @@ func (vc *validationContext) typeAcceptsValue(ctx context.Context, td *TypeDef, 
 	// real schema. Mirrors the compile-time throwaway contexts that reach
 	// validateValue (built with schema: c.schema).
 	tvc := &validationContext{
-		errorHandler:  helium.NilErrorHandler{},
-		suppressDepth: 1,
-		version:       vc.version,
-		schema:        vc.schema,
+		errorHandler:                   helium.NilErrorHandler{},
+		suppressDepth:                  1,
+		version:                        vc.version,
+		schema:                         vc.schema,
+		allowXSD10LegacyGMonthInstance: vc.allowXSD10LegacyGMonthInstance,
 	}
 	return validateValue(ctx, raw, fieldNodeNSContext(fieldNode), td, "", "", 0, tvc) == nil
 }

--- a/xsd/version_test.go
+++ b/xsd/version_test.go
@@ -139,6 +139,52 @@ func TestVersion10LegacyGMonthElementValueConstraintRejected(t *testing.T) {
 	}
 }
 
+func TestVersion10LegacyGMonthFixedValueComparison(t *testing.T) {
+	t.Run("element fixed", func(t *testing.T) {
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="v" type="xs:gMonth" fixed="--03"/>
+</xs:schema>`
+
+		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schemaXML, `<v>--03--</v>`)
+		require.NoError(t, err)
+	})
+
+	t.Run("attribute fixed", func(t *testing.T) {
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="v">
+    <xs:complexType>
+      <xs:attribute name="m" type="xs:gMonth" fixed="--03"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+
+		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schemaXML, `<v m="--03--"/>`)
+		require.NoError(t, err)
+	})
+}
+
+func TestVersion10LegacyGMonthIDCCanonicalValue(t *testing.T) {
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="m" type="xs:gMonth" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:unique name="uniqueMonth">
+      <xs:selector xpath="m"/>
+      <xs:field xpath="."/>
+    </xs:unique>
+  </xs:element>
+</xs:schema>`
+
+	err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schemaXML, `<root><m>--03</m><m>--04--</m></root>`)
+	require.NoError(t, err)
+
+	err = compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schemaXML, `<root><m>--03</m><m>--03--</m></root>`)
+	require.ErrorIs(t, err, xsd.ErrValidationFailed)
+}
+
 // TestVersion11BuiltinTypes verifies the XSD 1.1-only built-in datatypes are
 // registered (and resolve) only in 1.1 mode, and validate per their lexical
 // space.

--- a/xsd/version_test.go
+++ b/xsd/version_test.go
@@ -72,6 +72,58 @@ func TestVersionToggle(t *testing.T) {
 	})
 }
 
+func TestVersion10LegacyGMonthInstanceLexical(t *testing.T) {
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="v" type="xs:gMonth"/>
+</xs:schema>`
+
+	for _, instance := range []string{`<v>--03--</v>`, `<v>--05---05:00</v>`} {
+		t.Run("xsd10 accepts "+instance, func(t *testing.T) {
+			t.Parallel()
+			err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schemaXML, instance)
+			require.NoError(t, err)
+		})
+
+		t.Run("xsd11 rejects "+instance, func(t *testing.T) {
+			t.Parallel()
+			err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version11), schemaXML, instance)
+			require.ErrorIs(t, err, xsd.ErrValidationFailed)
+		})
+	}
+}
+
+func TestVersion10LegacyGMonthPatternRestrictionDoesNotAcceptLegacyLexical(t *testing.T) {
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="v">
+    <xs:simpleType>
+      <xs:restriction base="xs:gMonth">
+        <xs:pattern value="--[0-9]{2}--"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>`
+
+	err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schemaXML, `<v>--03--</v>`)
+	require.ErrorIs(t, err, xsd.ErrValidationFailed)
+}
+
+func TestVersion10LegacyGMonthFacetLexicalRejected(t *testing.T) {
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="v">
+    <xs:simpleType>
+      <xs:restriction base="xs:gMonth">
+        <xs:enumeration value="--10--"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>`
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+	require.NoError(t, err)
+	_, err = xsd.NewCompiler().Version(xsd.Version10).Compile(t.Context(), doc)
+	require.ErrorIs(t, err, xsd.ErrCompilationFailed)
+}
+
 // TestVersion11BuiltinTypes verifies the XSD 1.1-only built-in datatypes are
 // registered (and resolve) only in 1.1 mode, and validate per their lexical
 // space.

--- a/xsd/version_test.go
+++ b/xsd/version_test.go
@@ -185,6 +185,46 @@ func TestVersion10LegacyGMonthIDCCanonicalValue(t *testing.T) {
 	require.ErrorIs(t, err, xsd.ErrValidationFailed)
 }
 
+func TestVersion10LegacyGMonthFacetedListUnionWrappersStrict(t *testing.T) {
+	t.Run("union enumeration", func(t *testing.T) {
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="monthUnion">
+    <xs:union memberTypes="xs:gMonth"/>
+  </xs:simpleType>
+  <xs:element name="v">
+    <xs:simpleType>
+      <xs:restriction base="monthUnion">
+        <xs:enumeration value="--03"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>`
+
+		require.NoError(t, compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schemaXML, `<v>--03</v>`))
+		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schemaXML, `<v>--03--</v>`)
+		require.ErrorIs(t, err, xsd.ErrValidationFailed)
+	})
+
+	t.Run("list enumeration", func(t *testing.T) {
+		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="monthList">
+    <xs:list itemType="xs:gMonth"/>
+  </xs:simpleType>
+  <xs:element name="v">
+    <xs:simpleType>
+      <xs:restriction base="monthList">
+        <xs:enumeration value="--03"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>`
+
+		require.NoError(t, compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schemaXML, `<v>--03</v>`))
+		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schemaXML, `<v>--03--</v>`)
+		require.ErrorIs(t, err, xsd.ErrValidationFailed)
+	})
+}
+
 // TestVersion11BuiltinTypes verifies the XSD 1.1-only built-in datatypes are
 // registered (and resolve) only in 1.1 mode, and validate per their lexical
 // space.

--- a/xsd/version_test.go
+++ b/xsd/version_test.go
@@ -124,6 +124,21 @@ func TestVersion10LegacyGMonthFacetLexicalRejected(t *testing.T) {
 	require.ErrorIs(t, err, xsd.ErrCompilationFailed)
 }
 
+func TestVersion10LegacyGMonthElementValueConstraintRejected(t *testing.T) {
+	for _, attr := range []string{`default="--03--"`, `fixed="--03--"`} {
+		t.Run(attr, func(t *testing.T) {
+			schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="v" type="xs:gMonth" ` + attr + `/>
+</xs:schema>`
+
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+			require.NoError(t, err)
+			_, err = xsd.NewCompiler().Version(xsd.Version10).Compile(t.Context(), doc)
+			require.ErrorIs(t, err, xsd.ErrCompilationFailed)
+		})
+	}
+}
+
 // TestVersion11BuiltinTypes verifies the XSD 1.1-only built-in datatypes are
 // registered (and resolve) only in 1.1 mode, and validate per their lexical
 // space.


### PR DESCRIPTION
## Summary
- accept the XSTS legacy XSD 1.0 gMonth instance spelling `--MM--` for unfaceted gMonth types
- keep schema facet literals and faceted derived gMonth types strict, including pattern restrictions
- add version-specific coverage for XSD 1.0 compatibility and XSD 1.1 rejection

## Tests
- `go test ./xsd -run 'TestVersion10LegacyGMonth' -count=1`
- `go test ./xsd -count=1`
- focused XSD 1.0 W3C gMonth conformance cases including `gMonth002_2061`, `gMonth004_2063`, and `gMonth_pattern001_1274`
- full `TestXSD10W3C` checkpoint remains nonzero from pre-existing failures; no gMonth failures remain on this branch

Gauntlet run: `g260706-1434-211ae96c`