### PR TITLE
fix xsd missing component deferral

### DIFF
--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -281,6 +281,10 @@ type compiler struct {
 	// is a fatal conflict (distinct constituents with colliding components), not a
 	// silent no-op.
 	overridePaths map[string]struct{}
+	// droppedOverrideTypes records type override children that matched no target
+	// component and were therefore ignored. A reference to one must remain a
+	// schema error rather than being deferred as an unused missing component.
+	droppedOverrideTypes map[QName]struct{}
 	// notations records the QNames of every <xs:notation> declared in the schema
 	// (and its included/imported documents). Used to verify that an xs:NOTATION
 	// restriction's enumeration values name declared notations.

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -155,9 +155,6 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 				}
 				td = missingTypePlaceholder(qn)
 				c.schema.types[qn] = td
-			} else if _, missing := missingTypeRef(td); missing {
-				// A prior unresolved reference may have installed the placeholder.
-				// Element declarations can carry it until they are selected.
 			}
 			edecl.Type = td
 		}

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -11,6 +11,29 @@ import (
 	"github.com/lestrrat-go/helium/internal/xmlchar"
 )
 
+func missingTypePlaceholder(qn QName) *TypeDef {
+	return &TypeDef{
+		Name:           qn,
+		ContentType:    ContentTypeSimple,
+		missingTypeRef: qn,
+	}
+}
+
+func missingTypeRef(td *TypeDef) (QName, bool) {
+	if td == nil || td.missingTypeRef == (QName{}) {
+		return QName{}, false
+	}
+	return td.missingTypeRef, true
+}
+
+func (c *compiler) deferMissingTypeRef(qn QName) bool {
+	if qn.NS != "" || isInvalidQName(qn) || c.deprecatedDatatypeQName(qn) {
+		return false
+	}
+	_, droppedOverrideType := c.droppedOverrideTypes[qn]
+	return !droppedOverrideType
+}
+
 func (c *compiler) resolveRefs(ctx context.Context) {
 	// Resolve element type references.
 	// Two passes: the first pass resolves type-name refs and may leave
@@ -119,16 +142,22 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 				}
 			}
 			if !ok {
-				// Report the unresolved element type — whether an XSD built-in
-				// that should exist or a missing user-defined type — before
-				// installing a recovery placeholder, so an invalid schema cannot
-				// silently compile and validate as if the type existed.
-				if src, hasSrc := c.elemRefSources[edecl]; hasSrc && c.filename != "" && !c.deprecatedDatatypeQName(qn) && !isInvalidQName(qn) {
-					msg := fmt.Sprintf("The QName value '{%s}%s' does not resolve to a(n) type definition.", qn.NS, qn.Local)
-					c.schemaError(ctx, schemaElemDeclErrorAttr(c.diagSourceOrRecorded(src.source), src.line, src.elemName, msg))
+				// XSD lets a no-namespace schema carry a declaration whose local
+				// type definition is missing until validation actually selects that
+				// declaration. Qualified misses remain fatal: a prefixed, target-
+				// namespace, or failed-import component dependency cannot be
+				// treated as an unused local declaration.
+				if !c.deferMissingTypeRef(qn) {
+					if src, hasSrc := c.elemRefSources[edecl]; hasSrc && c.filename != "" && !c.deprecatedDatatypeQName(qn) && !isInvalidQName(qn) {
+						msg := fmt.Sprintf("The QName value '{%s}%s' does not resolve to a(n) type definition.", qn.NS, qn.Local)
+						c.schemaError(ctx, schemaElemDeclErrorAttr(c.diagSourceOrRecorded(src.source), src.line, src.elemName, msg))
+					}
 				}
-				td = &TypeDef{Name: qn, ContentType: ContentTypeSimple}
+				td = missingTypePlaceholder(qn)
 				c.schema.types[qn] = td
+			} else if _, missing := missingTypeRef(td); missing {
+				// A prior unresolved reference may have installed the placeholder.
+				// Element declarations can carry it until they are selected.
 			}
 			edecl.Type = td
 		}
@@ -155,8 +184,14 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 			// Report the unresolved base type before installing a recovery
 			// placeholder, so an invalid schema cannot silently compile.
 			c.reportUnresolvedTypeRef(ctx, td, qn)
-			base = &TypeDef{Name: qn, ContentType: ContentTypeSimple}
+			base = missingTypePlaceholder(qn)
 			c.schema.types[qn] = base
+			if c.recoveryBaseTypes == nil {
+				c.recoveryBaseTypes = make(map[*TypeDef]bool)
+			}
+			c.recoveryBaseTypes[base] = true
+		} else if _, missing := missingTypeRef(base); missing {
+			c.reportUnresolvedTypeRef(ctx, td, qn)
 			if c.recoveryBaseTypes == nil {
 				c.recoveryBaseTypes = make(map[*TypeDef]bool)
 			}
@@ -176,8 +211,12 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 			}
 		}
 		if !ok {
-			c.reportUnresolvedTypeRef(ctx, td, qn)
-			itemTD = &TypeDef{Name: qn, ContentType: ContentTypeSimple}
+			// As with element declarations, only an absent-namespace user item
+			// type is deferred. Qualified misses remain compile-time errors.
+			if !c.deferMissingTypeRef(qn) {
+				c.reportUnresolvedTypeRef(ctx, td, qn)
+			}
+			itemTD = missingTypePlaceholder(qn)
 			c.schema.types[qn] = itemTD
 		}
 		td.ItemType = itemTD
@@ -193,8 +232,10 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 		}
 		if !ok {
 			c.reportUnresolvedTypeRef(ctx, ref.owner, ref.name)
-			memberTD = &TypeDef{Name: ref.name, ContentType: ContentTypeSimple}
+			memberTD = missingTypePlaceholder(ref.name)
 			c.schema.types[ref.name] = memberTD
+		} else if _, missing := missingTypeRef(memberTD); missing {
+			c.reportUnresolvedTypeRef(ctx, ref.owner, ref.name)
 		}
 		ref.owner.MemberTypes = append(ref.owner.MemberTypes, memberTD)
 	}

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -154,7 +154,6 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 					}
 				}
 				td = missingTypePlaceholder(qn)
-				c.schema.types[qn] = td
 			}
 			edecl.Type = td
 		}
@@ -214,7 +213,6 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 				c.reportUnresolvedTypeRef(ctx, td, qn)
 			}
 			itemTD = missingTypePlaceholder(qn)
-			c.schema.types[qn] = itemTD
 		}
 		td.ItemType = itemTD
 	}

--- a/xsd/override.go
+++ b/xsd/override.go
@@ -287,6 +287,12 @@ func (c *compiler) registerMatchedChildren(ctx context.Context, entries []overri
 	for _, e := range entries {
 		mctx, ok := matched[e.key]
 		if !ok {
+			if e.key.sym == overrideSymType {
+				if c.droppedOverrideTypes == nil {
+					c.droppedOverrideTypes = make(map[QName]struct{})
+				}
+				c.droppedOverrideTypes[e.key.qn] = struct{}{}
+			}
 			continue
 		}
 		// Register under the DECLARING document's per-document @defaultAttributes AND

--- a/xsd/schema.go
+++ b/xsd/schema.go
@@ -364,6 +364,11 @@ type TypeDef struct {
 	// the base content type. It is not a source-level simpleType restriction, so
 	// checkSimpleTypeResolution skips it — the complex base is intentional here.
 	syntheticComplexBase bool
+	// missingTypeRef marks a recovery placeholder for a QName that did not
+	// resolve to a type definition. Some declarations are allowed to carry such a
+	// placeholder until validation selects them; fatal contexts still reject it at
+	// compile time.
+	missingTypeRef QName
 
 	// pendingDefaultOpenContent is the schema-level <xs:defaultOpenContent> active
 	// in THIS type's own schema document at parse time, captured only when the type

--- a/xsd/schema_attr_ws_collapse_test.go
+++ b/xsd/schema_attr_ws_collapse_test.go
@@ -362,19 +362,22 @@ func TestSchemaAttrWhitespaceCollapse(t *testing.T) {
 		}
 	})
 
-	// A well-formed but genuinely UNDECLARED ref still gets the normal unresolved
-	// diagnostic — the sentinel skip is only for LEXICALLY malformed values, not for
-	// a lexically-valid name that happens to resolve to nothing.
-	t.Run("undeclared-ref-still-unresolved", func(t *testing.T) {
+	// A well-formed absent-namespace element type ref that resolves to nothing is
+	// a deferred missing component: not a lexical QName error at compile time, but
+	// invalid when validation selects the declaration.
+	t.Run("undeclared-ref-deferred-until-validation", func(t *testing.T) {
 		t.Parallel()
 		const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"><xs:element name="e" type="missing"/></xs:schema>`
 		for _, v := range []xsd.Version{xsd.Version10, xsd.Version11} {
-			_, errs, cerr := compileWith(t, v, schemaXML)
-			require.ErrorIs(t, cerr, xsd.ErrCompilationFailed, "version=%v", v)
+			schema, errs, cerr := compileWith(t, v, schemaXML)
+			require.NoError(t, cerr, "version=%v: absent-namespace missing element type is deferred: %s", v, errs)
 			require.NotContains(t, errs, "is not a valid QName",
 				"version=%v: a well-formed name is not a lexical error; got: %s", v, errs)
-			require.Contains(t, errs, "does not resolve",
-				"version=%v: an undeclared type must still report unresolved; got: %s", v, errs)
+			require.NotContains(t, errs, "does not resolve",
+				"version=%v: deferred missing type must not report unresolved at compile time; got: %s", v, errs)
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(`<e>value</e>`))
+			require.NoError(t, err)
+			require.ErrorIs(t, xsd.NewValidator(schema).Validate(t.Context(), doc), xsd.ErrValidationFailed)
 		}
 	})
 

--- a/xsd/simplevalue_core.go
+++ b/xsd/simplevalue_core.go
@@ -149,6 +149,13 @@ func collapseSpaces(s string) string {
 
 // validateValue validates a text value against a simple type definition.
 func validateValue(ctx context.Context, value string, valueNS map[string]string, td *TypeDef, elemName, filename string, line int, vc *validationContext) error {
+	if qn, ok := missingTypeRef(td); ok {
+		if vc != nil {
+			vc.reportValidityError(ctx, filename, line, elemName, missingTypeRefMessage(qn))
+		}
+		return fmt.Errorf("unresolved type definition")
+	}
+
 	// Apply whitespace normalization per the type's whiteSpace facet.
 	trimmed := normalizeWhiteSpace(value, resolveWhiteSpace(td))
 
@@ -423,6 +430,11 @@ func validateListValue(ctx context.Context, value string, valueNS map[string]str
 		items = valuepkg.XSDFields(value)
 	}
 	itemCount := len(items)
+	itemType := resolveItemType(td)
+	if qn, ok := missingTypeRef(itemType); ok {
+		vc.reportValidityError(ctx, filename, line, elemName, missingTypeRefMessage(qn))
+		return fmt.Errorf("unresolved type definition")
+	}
 
 	// Check length facets using item count.
 	var facetErr error
@@ -451,7 +463,6 @@ func validateListValue(ctx context.Context, value string, valueNS map[string]str
 	// length facets are interpreted as item counts above; checkFacets would
 	// instead measure character length, so enumeration and pattern are applied
 	// here on their own rather than via the generic checkFacets path.
-	itemType := resolveItemType(td)
 	for cur := range baseChain(td) {
 		if cur.Facets == nil {
 			continue

--- a/xsd/unresolved_type_ref_test.go
+++ b/xsd/unresolved_type_ref_test.go
@@ -130,6 +130,19 @@ func TestUnresolvedTypeRef(t *testing.T) {
 		require.NotContains(t, out, "xsi:type definition")
 	})
 
+	t.Run("missing anyType child element type rejects before xsi type", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" type="xs:anyType"/>
+  <xs:element name="bad" type="MissingType"/>
+</xs:schema>`
+		schema := compileOK(t, schemaXML)
+		out, err := validateXMLWithOutput(t, schema, `<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema"><bad xsi:type="xs:string">ok</bad></root>`)
+		require.ErrorIs(t, err, xsd.ErrValidationFailed)
+		require.Contains(t, out, wantMsg)
+		require.NotContains(t, out, "xsi:type definition")
+	})
+
 	// Inline (local) simpleTypes follow the same phase split as named types:
 	// unresolved bases and union members are compile-fatal, while an unresolved
 	// list item type is deferred until the inline list type validates a value.

--- a/xsd/unresolved_type_ref_test.go
+++ b/xsd/unresolved_type_ref_test.go
@@ -89,6 +89,21 @@ func TestUnresolvedTypeRef(t *testing.T) {
 		require.ErrorIs(t, validateXML(t, schema, `<bad>1</bad>`), xsd.ErrValidationFailed)
 	})
 
+	t.Run("deferred missing list item type is not globally visible", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="myList">
+    <xs:list itemType="MissingItem"/>
+  </xs:simpleType>
+  <xs:element name="root" type="xs:anyType"/>
+  <xs:element name="bad" type="myList"/>
+</xs:schema>`
+		schema := compileOK(t, schemaXML)
+		_, ok := schema.LookupType("MissingItem", "")
+		require.False(t, ok)
+		require.NoError(t, validateXML(t, schema, `<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><unknown xsi:type="MissingItem">ok</unknown></root>`))
+	})
+
 	t.Run("missing union member type", func(t *testing.T) {
 		t.Parallel()
 		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">

--- a/xsd/unresolved_type_ref_test.go
+++ b/xsd/unresolved_type_ref_test.go
@@ -8,11 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestUnresolvedTypeRef verifies that a reference to a missing user-defined
-// type (base type, list item type, union member type, or element type) is
-// reported as a fatal schema parser error instead of being silently inserted
-// as an empty placeholder, which would let an invalid schema compile and
-// validate documents as if the missing type existed.
+// TestUnresolvedTypeRef verifies that unresolved type references fail in the
+// right phase. Base and union-member references are fatal schema errors. Element
+// type and list item type references may sit on unused declarations, but fail
+// validation when the offending declaration/type is selected.
 func TestUnresolvedTypeRef(t *testing.T) {
 	t.Parallel()
 
@@ -28,6 +27,24 @@ func TestUnresolvedTypeRef(t *testing.T) {
 		_, errors := partitionCompileErrors(collector.Errors())
 		return errors
 	}
+	compileOK := func(t *testing.T, schemaXML string) *xsd.Schema {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		schema, err := xsd.NewCompiler().Label("test.xsd").ErrorHandler(collector).Compile(t.Context(), doc)
+		require.NoError(t, err)
+		require.NoError(t, collector.Close())
+		_, errors := partitionCompileErrors(collector.Errors())
+		require.Empty(t, errors)
+		return schema
+	}
+	validateXML := func(t *testing.T, schema *xsd.Schema, xml string) error {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(xml))
+		require.NoError(t, err)
+		return xsd.NewValidator(schema).Validate(t.Context(), doc)
+	}
 
 	t.Run("missing base type", func(t *testing.T) {
 		t.Parallel()
@@ -40,15 +57,18 @@ func TestUnresolvedTypeRef(t *testing.T) {
 		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
 	})
 
-	t.Run("missing list item type", func(t *testing.T) {
+	t.Run("missing list item type is deferred until validation", func(t *testing.T) {
 		t.Parallel()
 		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:simpleType name="myList">
     <xs:list itemType="MissingItem"/>
   </xs:simpleType>
-  <xs:element name="root" type="myList"/>
+  <xs:element name="good" type="xs:integer"/>
+  <xs:element name="bad" type="myList"/>
 </xs:schema>`
-		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
+		schema := compileOK(t, schemaXML)
+		require.NoError(t, validateXML(t, schema, `<good>1</good>`))
+		require.ErrorIs(t, validateXML(t, schema, `<bad>1</bad>`), xsd.ErrValidationFailed)
 	})
 
 	t.Run("missing union member type", func(t *testing.T) {
@@ -62,18 +82,31 @@ func TestUnresolvedTypeRef(t *testing.T) {
 		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
 	})
 
-	t.Run("missing element type", func(t *testing.T) {
+	t.Run("missing element type is deferred until validation", func(t *testing.T) {
 		t.Parallel()
 		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:element name="root" type="MissingType"/>
+  <xs:element name="good" type="xs:integer"/>
+  <xs:element name="bad" type="MissingType"/>
 </xs:schema>`
-		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
+		schema := compileOK(t, schemaXML)
+		require.NoError(t, validateXML(t, schema, `<good>1</good>`))
+		require.ErrorIs(t, validateXML(t, schema, `<bad>1</bad>`), xsd.ErrValidationFailed)
 	})
 
-	// Inline (local) simpleTypes must also report unresolved type refs, not
-	// just top-level named simpleTypes. Before recording source info for local
-	// simple types, reportUnresolvedTypeRef returned early and these compiled
-	// silently.
+	t.Run("missing element type and substitution head are deferred until validation", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="good" type="xs:integer"/>
+  <xs:element name="bad" type="MissingType" substitutionGroup="MissingHead"/>
+</xs:schema>`
+		schema := compileOK(t, schemaXML)
+		require.NoError(t, validateXML(t, schema, `<good>1</good>`))
+		require.ErrorIs(t, validateXML(t, schema, `<bad>1</bad>`), xsd.ErrValidationFailed)
+	})
+
+	// Inline (local) simpleTypes follow the same phase split as named types:
+	// unresolved bases and union members are compile-fatal, while an unresolved
+	// list item type is deferred until the inline list type validates a value.
 	t.Run("missing base type in inline simpleType", func(t *testing.T) {
 		t.Parallel()
 		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
@@ -86,7 +119,7 @@ func TestUnresolvedTypeRef(t *testing.T) {
 		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
 	})
 
-	t.Run("missing list item type in inline simpleType", func(t *testing.T) {
+	t.Run("missing list item type in inline simpleType is deferred until validation", func(t *testing.T) {
 		t.Parallel()
 		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="root">
@@ -95,7 +128,8 @@ func TestUnresolvedTypeRef(t *testing.T) {
     </xs:simpleType>
   </xs:element>
 </xs:schema>`
-		require.Contains(t, compileErrors(t, schemaXML), wantMsg)
+		schema := compileOK(t, schemaXML)
+		require.ErrorIs(t, validateXML(t, schema, `<root>1</root>`), xsd.ErrValidationFailed)
 	})
 
 	t.Run("missing union member type in inline simpleType", func(t *testing.T) {

--- a/xsd/unresolved_type_ref_test.go
+++ b/xsd/unresolved_type_ref_test.go
@@ -45,13 +45,13 @@ func TestUnresolvedTypeRef(t *testing.T) {
 		require.NoError(t, err)
 		return xsd.NewValidator(schema).Validate(t.Context(), doc)
 	}
-	validateXMLWithOutput := func(t *testing.T, schema *xsd.Schema, xml string) (error, string) {
+	validateXMLWithOutput := func(t *testing.T, schema *xsd.Schema, xml string) (string, error) {
 		t.Helper()
 		doc, err := helium.NewParser().Parse(t.Context(), []byte(xml))
 		require.NoError(t, err)
 		var out string
 		err = validateWithOutput(t, xsd.NewValidator(schema), doc, &out)
-		return err, out
+		return out, err
 	}
 
 	t.Run("missing base type", func(t *testing.T) {
@@ -124,7 +124,7 @@ func TestUnresolvedTypeRef(t *testing.T) {
   </xs:element>
 </xs:schema>`
 		schema := compileOK(t, schemaXML)
-		err, out := validateXMLWithOutput(t, schema, `<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema"><bad xsi:type="xs:string">ok</bad></root>`)
+		out, err := validateXMLWithOutput(t, schema, `<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema"><bad xsi:type="xs:string">ok</bad></root>`)
 		require.ErrorIs(t, err, xsd.ErrValidationFailed)
 		require.Contains(t, out, wantMsg)
 		require.NotContains(t, out, "xsi:type definition")

--- a/xsd/unresolved_type_ref_test.go
+++ b/xsd/unresolved_type_ref_test.go
@@ -45,6 +45,14 @@ func TestUnresolvedTypeRef(t *testing.T) {
 		require.NoError(t, err)
 		return xsd.NewValidator(schema).Validate(t.Context(), doc)
 	}
+	validateXMLWithOutput := func(t *testing.T, schema *xsd.Schema, xml string) (error, string) {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(xml))
+		require.NoError(t, err)
+		var out string
+		err = validateWithOutput(t, xsd.NewValidator(schema), doc, &out)
+		return err, out
+	}
 
 	t.Run("missing base type", func(t *testing.T) {
 		t.Parallel()
@@ -102,6 +110,24 @@ func TestUnresolvedTypeRef(t *testing.T) {
 		schema := compileOK(t, schemaXML)
 		require.NoError(t, validateXML(t, schema, `<good>1</good>`))
 		require.ErrorIs(t, validateXML(t, schema, `<bad>1</bad>`), xsd.ErrValidationFailed)
+	})
+
+	t.Run("missing nested element type rejects before xsi type", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="bad" type="MissingType"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		schema := compileOK(t, schemaXML)
+		err, out := validateXMLWithOutput(t, schema, `<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema"><bad xsi:type="xs:string">ok</bad></root>`)
+		require.ErrorIs(t, err, xsd.ErrValidationFailed)
+		require.Contains(t, out, wantMsg)
+		require.NotContains(t, out, "xsi:type definition")
 	})
 
 	// Inline (local) simpleTypes follow the same phase split as named types:

--- a/xsd/unresolved_type_ref_test.go
+++ b/xsd/unresolved_type_ref_test.go
@@ -39,6 +39,16 @@ func TestUnresolvedTypeRef(t *testing.T) {
 		require.Empty(t, errors)
 		return schema
 	}
+	compileErrorsVersion11 := func(t *testing.T, schemaXML string) string {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+		require.NoError(t, err)
+		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+		_, err = xsd.NewCompiler().Label("test.xsd").Version(xsd.Version11).ErrorHandler(collector).Compile(t.Context(), doc)
+		requireCompileResultErr(t, err)
+		_, errors := partitionCompileErrors(collector.Errors())
+		return errors
+	}
 	validateXML := func(t *testing.T, schema *xsd.Schema, xml string) error {
 		t.Helper()
 		doc, err := helium.NewParser().Parse(t.Context(), []byte(xml))
@@ -99,6 +109,29 @@ func TestUnresolvedTypeRef(t *testing.T) {
 		schema := compileOK(t, schemaXML)
 		require.NoError(t, validateXML(t, schema, `<good>1</good>`))
 		require.ErrorIs(t, validateXML(t, schema, `<bad>1</bad>`), xsd.ErrValidationFailed)
+	})
+
+	t.Run("deferred missing element type is not globally visible", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" type="xs:anyType"/>
+  <xs:element name="unused" type="MissingType"/>
+</xs:schema>`
+		schema := compileOK(t, schemaXML)
+		_, ok := schema.LookupType("MissingType", "")
+		require.False(t, ok)
+		require.NoError(t, validateXML(t, schema, `<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><unknown xsi:type="MissingType">ok</unknown></root>`))
+	})
+
+	t.Run("deferred missing element type does not satisfy alternative type", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" type="xs:anyType">
+    <xs:alternative test="true()" type="MissingType"/>
+  </xs:element>
+  <xs:element name="unused" type="MissingType"/>
+</xs:schema>`
+		require.Contains(t, compileErrorsVersion11(t, schemaXML), wantMsg)
 	})
 
 	t.Run("missing element type and substitution head are deferred until validation", func(t *testing.T) {

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -1221,7 +1221,12 @@ func (vc *validationContext) annotateAnyTypeChildren(ctx context.Context, elem *
 		// through xs:anyType too: select the alternative type BEFORE resolving
 		// xsi:type (xsi:type still wins), mirroring the established order at the
 		// explicit-particle/wildcard match sites.
-		declType := vc.applyTypeAlternatives(ctx, ce, edecl, effectiveDeclType(edecl, vc.schema))
+		declType := effectiveDeclType(edecl, vc.schema)
+		if err := vc.rejectMissingTypeRef(ctx, ce, declType); err != nil {
+			contentErr = err
+			continue
+		}
+		declType = vc.applyTypeAlternatives(ctx, ce, edecl, declType)
 		td, xsiErr := vc.resolveXsiType(ctx, ce, declType, vc.hasTypeTable(edecl))
 		if xsiErr != nil {
 			contentErr = xsiErr

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -898,6 +898,9 @@ func (vc *validationContext) validateRootElement(ctx context.Context, elem *heli
 	if declType == nil {
 		return nil
 	}
+	if err := vc.rejectMissingTypeRef(ctx, elem, declType); err != nil {
+		return err
+	}
 
 	// XSD 1.1 conditional type assignment: the alternatives may select a
 	// different governing type. xsi:type (resolved next) still takes precedence.
@@ -942,6 +945,10 @@ func (vc *validationContext) validateRootElement(ctx context.Context, elem *heli
 }
 
 func (vc *validationContext) validateElementContent(ctx context.Context, elem *helium.Element, edecl *ElementDecl, td *TypeDef) error {
+	if err := vc.rejectMissingTypeRef(ctx, elem, td); err != nil {
+		return err
+	}
+
 	// XSD 1.1: a governing type of xs:error (selected by conditional type
 	// assignment, or referenced directly) has an empty value space, so any element
 	// it governs is invalid. This is the single choke point for every type-selection
@@ -969,6 +976,25 @@ func (vc *validationContext) validateElementContent(ctx context.Context, elem *h
 		return vc.checkAssertions(ctx, elem, edecl, td)
 	}
 	return nil
+}
+
+func (vc *validationContext) rejectMissingTypeRef(ctx context.Context, elem *helium.Element, td *TypeDef) error {
+	qn, ok := missingTypeRef(td)
+	if !ok {
+		return nil
+	}
+	elemName := ""
+	line := 0
+	if elem != nil {
+		elemName = elemDisplayName(elem)
+		line = elem.Line()
+	}
+	vc.reportValidityError(ctx, vc.filename, line, elemName, missingTypeRefMessage(qn))
+	return fmt.Errorf("unresolved type definition")
+}
+
+func missingTypeRefMessage(qn QName) string {
+	return fmt.Sprintf("The QName value '{%s}%s' does not resolve to a(n) type definition.", qn.NS, qn.Local)
 }
 
 // rejectNonWhitespaceText reports a validity error and returns a non-nil error

--- a/xsd/validate_elem.go
+++ b/xsd/validate_elem.go
@@ -752,6 +752,10 @@ func (vc *validationContext) matchElementParticle(ctx context.Context, parent *h
 		// The host declaration was already recorded during the initial match scan
 		// above (before any early return). Nothing to record here.
 		declType := effectiveDeclType(actualDecl, vc.schema)
+		if err := vc.rejectMissingTypeRef(ctx, child.elem, declType); err != nil {
+			contentErr = err
+			continue
+		}
 		declType = vc.applyTypeAlternatives(ctx, child.elem, actualDecl, declType)
 		td, xsiErr := vc.resolveXsiType(ctx, child.elem, declType, vc.hasTypeTable(actualDecl))
 		if xsiErr != nil {

--- a/xsd/validate_elem.go
+++ b/xsd/validate_elem.go
@@ -475,6 +475,9 @@ func (vc *validationContext) matchAll11(ctx context.Context, parent *helium.Elem
 func (vc *validationContext) validateAllMatchedChild(ctx context.Context, child childElem, edecl *ElementDecl) error {
 	actualDecl := resolveSubstDecl(child, edecl, vc.schema)
 	declType := effectiveDeclType(actualDecl, vc.schema)
+	if err := vc.rejectMissingTypeRef(ctx, child.elem, declType); err != nil {
+		return err
+	}
 	declType = vc.applyTypeAlternatives(ctx, child.elem, actualDecl, declType)
 	td, xsiErr := vc.resolveXsiType(ctx, child.elem, declType, vc.hasTypeTable(actualDecl))
 	if xsiErr != nil {
@@ -1247,6 +1250,9 @@ func (vc *validationContext) validateWildcardChild(ctx context.Context, wc *Wild
 		return vc.assessLaxElement(ctx, child.elem)
 	}
 	declType := effectiveDeclType(edecl, vc.schema)
+	if err := vc.rejectMissingTypeRef(ctx, child.elem, declType); err != nil {
+		return err
+	}
 	declType = vc.applyTypeAlternatives(ctx, child.elem, edecl, declType)
 	td, xsiErr := vc.resolveXsiType(ctx, child.elem, declType, vc.hasTypeTable(edecl))
 	if xsiErr != nil {


### PR DESCRIPTION
- defer absent-namespace missing element/list type errors until validation
- keep qualified, base, union, and dropped xs:override refs compile-fatal
- cover Saxon Missing missing001/missing003/missing006
