### PR TITLE
xsd: honor wildcard negation in xsd 1.0

### DIFF
--- a/xsd/check_upa.go
+++ b/xsd/check_upa.go
@@ -492,7 +492,7 @@ func (a *positionAutomaton) stateUnambiguous(reachable []int) bool {
 			if a.schema != nil {
 				version = a.schema.version
 			}
-			if entriesOverlap(a.positions[pi].entry, a.positions[pj].entry, version) {
+			if entriesOverlap(a.positions[pi].entry, a.positions[pj].entry, version, a.schema) {
 				return false
 			}
 		}
@@ -534,7 +534,7 @@ type firstSetEntry struct {
 // regardless of declaration order. The remaining gap is the SEQUENCE case (a
 // minOccurs=0 wildcard preceding an element in a sequence), which the
 // position-based sequence matcher does not yet override.
-func entriesOverlap(a, b firstSetEntry, version Version) bool {
+func entriesOverlap(a, b firstSetEntry, version Version, schema *Schema) bool {
 	// Two element positions overlap (are ambiguous) when they can match the same
 	// element name AND belong to DIFFERENT particles. Two positions with the same
 	// origin are occurrence-copies of ONE element declaration (the same particle),
@@ -558,18 +558,18 @@ func entriesOverlap(a, b firstSetEntry, version Version) bool {
 		return a.origin != b.origin
 	}
 	// Element vs wildcard: in 1.1 the element wins (no conflict); in 1.0 they
-	// overlap when the wildcard's namespace admits the element's namespace.
+	// overlap when the wildcard admits the element's full expanded name.
 	if !a.isWildcard && b.isWildcard {
 		if version == Version11 {
 			return false
 		}
-		return entryWildcardMatchesNS(b, a.qname.NS)
+		return entryWildcardAllowsName(b, a.qname, schema)
 	}
 	if a.isWildcard && !b.isWildcard {
 		if version == Version11 {
 			return false
 		}
-		return entryWildcardMatchesNS(a, b.qname.NS)
+		return entryWildcardAllowsName(a, b.qname, schema)
 	}
 	// Two wildcards. Occurrence-copies of ONE wildcard particle share an ORIGIN
 	// (applyOccurs re-walks the same textual leaf, see nextOrigin) — the same
@@ -675,6 +675,16 @@ func entryWildcardMatchesNS(e firstSetEntry, ns string) bool {
 		return wildcardMatches(e.wc, ns)
 	}
 	return wildcardMatchesNS(e.wildcard, e.targetNS, ns)
+}
+
+// entryWildcardAllowsName reports whether a wildcard first-set entry admits an
+// element expanded name, honoring notQName/##defined constraints when the full
+// *Wildcard is available.
+func entryWildcardAllowsName(e firstSetEntry, qn QName, schema *Schema) bool {
+	if e.wc != nil {
+		return wildcardAllowsExpandedName(e.wc, qn.Local, qn.NS, schema, false)
+	}
+	return wildcardMatchesNS(e.wildcard, e.targetNS, qn.NS)
 }
 
 // wildcardMatchesNS checks if a wildcard namespace constraint matches a given namespace.

--- a/xsd/check_upa.go
+++ b/xsd/check_upa.go
@@ -666,17 +666,6 @@ func upaWildcardNSSet(wcNS, targetNS string) map[string]bool {
 	}
 }
 
-// entryWildcardMatchesNS reports whether a wildcard first-set entry admits a
-// namespace, honoring an XSD 1.1 notNamespace constraint when the full *Wildcard
-// is available (it always is for entries built by this package) and falling back
-// to the string form otherwise.
-func entryWildcardMatchesNS(e firstSetEntry, ns string) bool {
-	if e.wc != nil {
-		return wildcardMatches(e.wc, ns)
-	}
-	return wildcardMatchesNS(e.wildcard, e.targetNS, ns)
-}
-
 // entryWildcardAllowsName reports whether a wildcard first-set entry admits an
 // element expanded name, honoring notQName/##defined constraints when the full
 // *Wildcard is available.

--- a/xsd/link_refs.go
+++ b/xsd/link_refs.go
@@ -817,13 +817,11 @@ func (c *compiler) resolveRefs(ctx context.Context) {
 		}
 	}
 
-	// XSD 1.1: resolve ##definedSibling on element wildcards now that content
-	// models (including expanded group refs) are fully built — BEFORE the
-	// restriction-derivation checks below, which compare base/derived wildcards'
-	// resolved SiblingNames.
-	if c.version == Version11 {
-		c.resolveDefinedSiblings()
-	}
+	// Resolve ##definedSibling on element wildcards now that content models
+	// (including expanded group refs) are fully built — BEFORE the restriction-
+	// derivation checks below, which compare base/derived wildcards' resolved
+	// SiblingNames.
+	c.resolveDefinedSiblings()
 
 	// Check restriction attribute compatibility.
 	// Collect and sort by source line for deterministic error ordering.

--- a/xsd/opencontent.go
+++ b/xsd/opencontent.go
@@ -1346,7 +1346,7 @@ func emptyChoiceBranchParticle() *Particle {
 }
 
 // resolveDefinedSiblings populates SiblingNames on every xs:any wildcard that
-// carries @notQName="##definedSibling" (XSD 1.1). The sibling set is the names
+// carries @notQName="##definedSibling". The sibling set is the names
 // of the element declarations that appear in the SAME content model as the
 // wildcard, so the wildcard never claims a child a sibling element declaration
 // would match. Runs after group refs are expanded so nested/group-contributed

--- a/xsd/read_elements.go
+++ b/xsd/read_elements.go
@@ -313,13 +313,6 @@ func (c *compiler) readWildcard(ctx context.Context, elem *helium.Element) *Wild
 		TargetNS:        c.schema.targetNamespace,
 	}
 
-	// XSD 1.1 negated namespace / name constraints. Gated on Version11 so 1.0
-	// behavior is byte-identical (the attributes are not recognized in 1.0; if
-	// present they are simply ignored, as any foreign attribute would be).
-	if c.version != Version11 {
-		return wc
-	}
-
 	hasNotNS := hasAttr(elem, attrNotNamespace)
 	// @namespace and @notNamespace are mutually exclusive (XSD 3.10.2,
 	// no-xmlns / src-wildcard): a wildcard may carry at most one of them.
@@ -345,10 +338,9 @@ func (c *compiler) readWildcard(ctx context.Context, elem *helium.Element) *Wild
 // error. Foreign-namespaced attributes are allowed; an XSD-namespaced attribute
 // or an unexpected unqualified attribute is a schema error.
 //
-// This rule is version-INDEPENDENT for the base attribute set. The 1.1 negated
-// constraints @notNamespace/@notQName are permitted-and-ignored in both versions
-// (in 1.0 they are unrecognized but leniently ignored, keeping the 1.0 path
-// byte-identical to origin). The stricter no-occurs grammar of an xs:openContent
+// This rule is version-INDEPENDENT for the base attribute set. The negated
+// constraints @notNamespace/@notQName are permitted here and parsed by
+// readWildcard when present. The stricter no-occurs grammar of an xs:openContent
 // wildcard is enforced separately by parseOpenContentWildcard.
 func (c *compiler) checkWildcardAttrs(ctx context.Context, elem *helium.Element) {
 	src := c.diagSource()
@@ -369,9 +361,7 @@ func (c *compiler) checkWildcardAttrs(ctx context.Context, elem *helium.Element)
 						attr.LocalName(), "The attribute '"+attr.LocalName()+"' is not allowed on 'anyAttribute'."))
 				}
 			case attrNotNamespace, attrNotQName:
-				// XSD 1.1 negated constraints. In 1.0 they are unrecognized but
-				// leniently IGNORED (the 1.0 path is byte-identical to origin),
-				// so they are permitted-and-ignored in both versions here.
+				// Negated wildcard constraints, parsed by readWildcard.
 			default:
 				c.schemaError(ctx, schemaParserErrorAttr(src, line, local, local,
 					attr.LocalName(), "The attribute '"+attr.LocalName()+"' is not allowed."))

--- a/xsd/version_wildcard_notqname_test.go
+++ b/xsd/version_wildcard_notqname_test.go
@@ -26,6 +26,103 @@ func mustCompile11OK(t *testing.T, schemaXML string) {
 	require.NoError(t, err)
 }
 
+// TestVersion10DefaultWildcardNegatedConstraints covers the default compiler
+// path used by the XSD 1.0 conformance suite: negated wildcard constraints must
+// be parsed and enforced when they appear in the schema.
+func TestVersion10DefaultWildcardNegatedConstraints(t *testing.T) {
+	compileDefault := func(t *testing.T, schemaXML string) error {
+		t.Helper()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+		require.NoError(t, err)
+		_, err = xsd.NewCompiler().Compile(t.Context(), doc)
+		return err
+	}
+
+	t.Run("namespace and notNamespace are mutually exclusive on element wildcard", func(t *testing.T) {
+		t.Parallel()
+		err := compileDefault(t, `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:any namespace="##any" notNamespace="urn:x" processContents="skip"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`)
+		require.ErrorIs(t, err, xsd.ErrCompilationFailed)
+	})
+
+	t.Run("namespace and notNamespace are mutually exclusive on attribute wildcard", func(t *testing.T) {
+		t.Parallel()
+		err := compileDefault(t, `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="e">
+    <xs:complexType>
+      <xs:sequence/>
+      <xs:anyAttribute namespace="##any" notNamespace="urn:x" processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`)
+		require.ErrorIs(t, err, xsd.ErrCompilationFailed)
+	})
+
+	t.Run("notQName name must be in an admitted namespace", func(t *testing.T) {
+		t.Parallel()
+		err := compileDefault(t, `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:b="urn:b">
+  <xs:complexType name="c">
+    <xs:sequence>
+      <xs:any notNamespace="urn:b" notQName="b:blocked" processContents="skip"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="root" type="c"/>
+</xs:schema>`)
+		require.ErrorIs(t, err, xsd.ErrCompilationFailed)
+	})
+
+	t.Run("anyAttribute notNamespace rejects excluded absent namespace", func(t *testing.T) {
+		t.Parallel()
+		const schema = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="e">
+    <xs:complexType>
+      <xs:sequence/>
+      <xs:anyAttribute notNamespace="##local" processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>`
+		err := compileAndValidateV(t, xsd.NewCompiler(), schema, `<e local="x"/>`)
+		require.ErrorIs(t, err, xsd.ErrValidationFailed)
+		require.NoError(t, compileAndValidateV(t, xsd.NewCompiler(), schema,
+			`<e n:a="x" xmlns:n="urn:n"/>`))
+	})
+
+	t.Run("definedSibling excludes repeated sibling and substitution member", func(t *testing.T) {
+		t.Parallel()
+		const schema = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:t="urn:t" targetNamespace="urn:t" elementFormDefault="qualified">
+  <xs:element name="root" type="t:ct"/>
+  <xs:element name="b" type="xs:string"/>
+  <xs:element name="c" type="xs:string"/>
+  <xs:element name="d" substitutionGroup="t:b" type="xs:string"/>
+  <xs:complexType name="ct">
+    <xs:sequence>
+      <xs:element ref="t:b"/>
+      <xs:any notQName="##definedSibling" processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="t:c"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>`
+		require.NoError(t, compileAndValidateV(t, xsd.NewCompiler(), schema,
+			`<t:root xmlns:t="urn:t"><t:b>one</t:b><t:c>two</t:c></t:root>`))
+
+		errRepeat := compileAndValidateV(t, xsd.NewCompiler(), schema,
+			`<t:root xmlns:t="urn:t"><t:b>one</t:b><t:b>two</t:b><t:c>three</t:c></t:root>`)
+		require.ErrorIs(t, errRepeat, xsd.ErrValidationFailed)
+
+		errSubst := compileAndValidateV(t, xsd.NewCompiler(), schema,
+			`<t:root xmlns:t="urn:t"><t:b>one</t:b><t:d>two</t:d><t:c>three</t:c></t:root>`)
+		require.ErrorIs(t, errSubst, xsd.ErrValidationFailed)
+	})
+}
+
 // TestVersion11WildcardNotNamespace covers the XSD 1.1 @notNamespace constraint
 // on xs:anyAttribute and xs:any: it admits any namespace EXCEPT the listed ones
 // (with ##local = absent, ##targetNamespace = the schema TNS).
@@ -104,10 +201,10 @@ func TestVersion11WildcardNotQName(t *testing.T) {
 		require.ErrorIs(t, err, xsd.ErrValidationFailed)
 	})
 
-	t.Run("1.0 still admits xml:space (XML-namespace attrs always allowed)", func(t *testing.T) {
+	t.Run("1.0 still admits xml:space through special-attribute handling", func(t *testing.T) {
 		t.Parallel()
-		// In 1.0 @notQName is not recognized and xml: attributes are leniently
-		// allowed, so the same instance validates.
+		// In 1.0 xml: attributes are leniently allowed before wildcard matching,
+		// so the same instance validates even though @notQName is parsed.
 		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), attrSchema,
 			`<e xml:space="preserve"/>`)
 		require.NoError(t, err)
@@ -270,10 +367,11 @@ func TestVersion11AttrGroupWildcardIntersection(t *testing.T) {
 		require.ErrorIs(t, err, xsd.ErrValidationFailed)
 	})
 
-	t.Run("1.0 applies attribute-group wildcards while ignoring notNamespace", func(t *testing.T) {
+	t.Run("1.0 applies attribute-group wildcards with complete-wildcard aggregation", func(t *testing.T) {
 		t.Parallel()
-		// In 1.0 notNamespace is unrecognized, so both group wildcards behave as
-		// the default ##any and their complete wildcard admits the attribute.
+		// XSD 1.0 complete-wildcard aggregation still admits this attribute. Direct
+		// wildcard notNamespace enforcement in the default compiler is covered by
+		// TestVersion10DefaultWildcardNegatedConstraints.
 		err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schema,
 			`<e m:adam="m" xmlns:m="http://adam.com/"/>`)
 		require.NoError(t, err)


### PR DESCRIPTION
- parse and enforce wildcard notNamespace/notQName constraints in the default XSD 1.0 compiler path
- resolve defined-sibling wildcard exclusions before UPA checks and use expanded-name admission for 1.0 element/wildcard UPA
- add default-version regressions for schema errors, anyAttribute rejection, and definedSibling/substitution-member exclusion
