### PR TITLE
xsd: reject abstract validation root

### DIFF
--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -17,6 +17,10 @@ import (
 // effective type definition is abstract (cvc-elt / cvc-type).
 const msgAbstractType = "The type definition is abstract."
 
+// msgAbstractElement is the validity-error message reported when an instance
+// element directly matches an abstract element declaration.
+const msgAbstractElement = "The element declaration is abstract."
+
 // fixedValueMatches reports whether an instance value satisfies a fixed value
 // constraint whose declared simple type is td. The comparison is performed in
 // the type's value space (XSD 1.1 §3.16, cvc-au/cvc-elt fixed-value rules):
@@ -894,6 +898,11 @@ func (vc *validationContext) validateRootElement(ctx context.Context, elem *heli
 	// member, the effective TYPE is inherited from the head (effectiveDeclType
 	// walks the substitutionGroup chain), but the declaration — and thus the
 	// nillable flag — stays the member's. This mirrors the particle paths.
+	if edecl.Abstract {
+		msg := msgAbstractElement
+		vc.reportValidityError(ctx, vc.filename, elem.Line(), elemDisplayName(elem), msg)
+		return fmt.Errorf("abstract element")
+	}
 	declType := effectiveDeclType(edecl, vc.schema)
 	if declType == nil {
 		return nil

--- a/xsd/validate_abstract_test.go
+++ b/xsd/validate_abstract_test.go
@@ -15,7 +15,7 @@ func TestAbstractTypeValidation(t *testing.T) {
   <xs:element name="root" abstract="true"/>
 </xs:schema>`
 
-		instanceXML := `<root/>`
+		instanceXML := `<root></root>`
 
 		schemaDOC, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
 		require.NoError(t, err)

--- a/xsd/validate_abstract_test.go
+++ b/xsd/validate_abstract_test.go
@@ -9,6 +9,29 @@ import (
 )
 
 func TestAbstractTypeValidation(t *testing.T) {
+	t.Run("abstract root element declaration rejected", func(t *testing.T) {
+		t.Parallel()
+		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="root" abstract="true"/>
+</xs:schema>`
+
+		instanceXML := `<root/>`
+
+		schemaDOC, err := helium.NewParser().Parse(t.Context(), []byte(schemaXML))
+		require.NoError(t, err)
+
+		schema, err := xsd.NewCompiler().Compile(t.Context(), schemaDOC)
+		require.NoError(t, err)
+
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(instanceXML))
+		require.NoError(t, err)
+
+		var errs string
+		err = validateWithOutput(t, xsd.NewValidator(schema), doc, &errs)
+		require.Error(t, err)
+		require.Contains(t, errs, "The element declaration is abstract.")
+	})
+
 	t.Run("abstract complex type rejected", func(t *testing.T) {
 		t.Parallel()
 		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">


### PR DESCRIPTION
- reject document roots that directly match an abstract global element declaration
- keep abstract-type validation and substitution-member root handling unchanged
- add regression coverage for an abstract validation root and the Sun abstract00201m1 conformance case
