### PR TITLE
xsd: validate redefine model groups

### DIFF
--- a/xsd/all_occurs_test.go
+++ b/xsd/all_occurs_test.go
@@ -495,7 +495,7 @@ func TestRedefineAllGroupNesting(t *testing.T) {
 
 	// base.xsd declares group "g" as an xs:all model group; main.xsd redefines it.
 	const baseSchema = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:group name="g"><xs:all><xs:element name="a" type="xs:string"/></xs:all></xs:group>
+  <xs:group name="g"><xs:all><xs:element name="a" type="xs:string"/><xs:element name="b" type="xs:string" minOccurs="0"/></xs:all></xs:group>
 </xs:schema>`
 
 	compileErrors := func(t *testing.T, mainSchema string) string {

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -298,8 +298,9 @@ type compiler struct {
 // component that an earlier xs:redefine already redefined as a duplicate, while
 // still accepting redefinitions of disjoint components.
 type redefinableSet struct {
-	keys     map[redefineKind]map[QName]struct{}
-	consumed map[redefineKind]map[QName]struct{}
+	keys      map[redefineKind]map[QName]struct{}
+	consumed  map[redefineKind]map[QName]struct{}
+	chameleon bool
 }
 
 // redefineKind identifies the component category a redefine override targets.

--- a/xsd/compile.go
+++ b/xsd/compile.go
@@ -292,14 +292,16 @@ type compiler struct {
 }
 
 // redefinableSet caches the redefinable component names a schema document
-// contributed (keys, split by kind) plus the names already consumed by
-// xs:redefine overrides across every xs:redefine of that document (consumed).
-// The consumed set lets a second xs:redefine of the same document reject a
-// component that an earlier xs:redefine already redefined as a duplicate, while
-// still accepting redefinitions of disjoint components.
+// contributed (keys, split by kind), the original Phase-A group bodies, and the
+// names already consumed by xs:redefine overrides across every xs:redefine of
+// that document (consumed). The consumed set lets a second xs:redefine of the
+// same document reject a component that an earlier xs:redefine already
+// redefined as a duplicate, while still accepting redefinitions of disjoint
+// components.
 type redefinableSet struct {
 	keys      map[redefineKind]map[QName]struct{}
 	consumed  map[redefineKind]map[QName]struct{}
+	groups    map[QName]*ModelGroup
 	chameleon bool
 }
 

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -884,6 +884,7 @@ func (c *compiler) loadInclude(ctx context.Context, location string, includeElem
 		c.loadedRedefinable[path] = &redefinableSet{
 			keys:      c.computeRedefinableKeys(beforeTypes, beforeGroups, beforeAttrGroups),
 			consumed:  make(map[redefineKind]map[QName]struct{}),
+			groups:    c.computeRedefinableGroups(beforeGroups),
 			chameleon: incTargetNS == "",
 		}
 	}
@@ -959,6 +960,17 @@ func (c *compiler) computeRedefinableKeys(beforeTypes, beforeGroups, beforeAttrG
 	}
 }
 
+func (c *compiler) computeRedefinableGroups(beforeGroups map[QName]struct{}) map[QName]*ModelGroup {
+	groups := make(map[QName]*ModelGroup)
+	for qn, group := range c.schema.groups {
+		if _, existed := beforeGroups[qn]; existed {
+			continue
+		}
+		groups[qn] = group
+	}
+	return groups
+}
+
 // loadRedefine loads a schema via xs:redefine and processes override children.
 // It works like xs:include (merging original declarations) but then applies
 // redefinitions for complexType, simpleType, group, and attributeGroup children.
@@ -989,9 +1001,11 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 	if _, seen := c.includeVisited[path]; seen {
 		rs := c.loadedRedefinable[path]
 		var phaseAKeys, consumed map[redefineKind]map[QName]struct{}
+		var phaseAGroups map[QName]*ModelGroup
 		if rs != nil {
 			phaseAKeys = rs.keys
 			consumed = rs.consumed
+			phaseAGroups = rs.groups
 		} else {
 			// The document was registered without a recorded redefinable set
 			// (e.g. the root schema seeded into includeVisited by CompileFile, or
@@ -1003,9 +1017,10 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 				redefineKindGroup:       {},
 				redefineKindAttrGroup:   {},
 			}
+			phaseAGroups = map[QName]*ModelGroup{}
 		}
 		chameleon := rs != nil && rs.chameleon
-		return c.processRedefineOverrides(ctx, redefineElem, phaseAKeys, consumed, chameleon)
+		return c.processRedefineOverrides(ctx, redefineElem, phaseAKeys, consumed, chameleon, phaseAGroups)
 	}
 	c.includeVisited[path] = struct{}{}
 
@@ -1062,10 +1077,11 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 		rs := &redefinableSet{
 			keys:      emptyKeys,
 			consumed:  make(map[redefineKind]map[QName]struct{}),
+			groups:    map[QName]*ModelGroup{},
 			chameleon: incTargetNS == "",
 		}
 		c.loadedRedefinable[path] = rs
-		return c.processRedefineOverrides(ctx, redefineElem, rs.keys, rs.consumed, rs.chameleon)
+		return c.processRedefineOverrides(ctx, redefineElem, rs.keys, rs.consumed, rs.chameleon, rs.groups)
 	}
 
 	// Check target namespace compatibility (same rules as include).
@@ -1195,9 +1211,11 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 	// validate its overrides against it (the delta cannot be recomputed once the
 	// components are merged), then process this redefine's overrides against it.
 	phaseAKeys := c.computeRedefinableKeys(beforeTypes, beforeGroups, beforeAttrGroups)
+	phaseAGroups := c.computeRedefinableGroups(beforeGroups)
 	rs := &redefinableSet{
 		keys:      phaseAKeys,
 		consumed:  make(map[redefineKind]map[QName]struct{}),
+		groups:    phaseAGroups,
 		chameleon: incTargetNS == "",
 	}
 	c.loadedRedefinable[path] = rs
@@ -1227,7 +1245,7 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 	// open content (restored here), not the redefined document's Phase A value.
 	c.defaultOpenContent = savedDefaultOpenContent
 
-	return c.processRedefineOverrides(ctx, redefineElem, phaseAKeys, rs.consumed, rs.chameleon)
+	return c.processRedefineOverrides(ctx, redefineElem, phaseAKeys, rs.consumed, rs.chameleon, phaseAGroups)
 }
 
 // checkRedefineSelfDerivation enforces src-redefine.5: a <simpleType> or
@@ -1483,14 +1501,15 @@ func (c *compiler) validateComponentChildName(ctx context.Context, elem *helium.
 	return name, false
 }
 
-func (c *compiler) processRedefineOverrides(ctx context.Context, redefineElem *helium.Element, phaseAKeys, consumed map[redefineKind]map[QName]struct{}, chameleon bool) error {
+func (c *compiler) processRedefineOverrides(ctx context.Context, redefineElem *helium.Element, phaseAKeys, consumed map[redefineKind]map[QName]struct{}, chameleon bool, phaseAGroups map[QName]*ModelGroup) error {
 	savedElemForm := c.schema.elemFormQualified
 	savedAttrForm := c.schema.attrFormQualified
 	savedBlockDefault := c.schema.blockDefault
 	savedFinalDefault := c.schema.finalDefault
 	savedIncludeFile := c.includeFile
-	phaseAGroups := make(map[QName]*ModelGroup, len(c.schema.groups))
-	maps.Copy(phaseAGroups, c.schema.groups)
+	if phaseAGroups == nil {
+		phaseAGroups = map[QName]*ModelGroup{}
+	}
 	c.redefine = &redefineState{
 		phaseAKeys: phaseAKeys,
 		seen:       make(map[redefineKind]map[QName]struct{}),

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -1256,18 +1256,94 @@ func (c *compiler) checkRedefineSelfDerivation(ctx context.Context, elem *helium
 // checkRedefineGroupRestriction enforces src-redefine.6.2 (§4.2.3): a
 // redefining <group> with no self-reference must be a valid restriction of the
 // original group. Redefine override processing runs before the normal group-ref
-// resolver, so callers invoke this only after confirming the override introduced
-// no unresolved group references.
+// resolver, so the original group is cloned with group-reference placeholders
+// expanded just for this check. The real schema tree is left for the normal
+// resolver so diagnostics and all-group reference checks stay centralized.
 func (c *compiler) checkRedefineGroupRestriction(ctx context.Context, elem *helium.Element, qn QName, origGroup *ModelGroup) {
 	redef := c.schema.groups[qn]
 	if redef == nil || origGroup == nil {
 		return
 	}
-	if redefineGroupValidRestriction(ctx, redef, origGroup, c.schema, c.version) {
+	expandedOrig, ok := c.expandGroupRefsForRedefineRestriction(origGroup)
+	if !ok {
+		return
+	}
+	if redefineGroupValidRestriction(ctx, redef, expandedOrig, c.schema, c.version) {
 		return
 	}
 	c.schemaError(ctx, schemaParserError(c.diagSource(), elem.Line(), elem.LocalName(), "group",
 		fmt.Sprintf("src-redefine.6.2: The redefinition of group '%s' is not a valid restriction of the original group.", qn.Local)))
+}
+
+func (c *compiler) expandGroupRefsForRedefineRestriction(mg *ModelGroup) (*ModelGroup, bool) {
+	return c.expandGroupRefsForRedefineRestrictionVisit(mg, make(map[*ModelGroup]*ModelGroup), make(map[QName]struct{}))
+}
+
+func (c *compiler) expandGroupRefsForRedefineRestrictionVisit(mg *ModelGroup, cloned map[*ModelGroup]*ModelGroup, resolving map[QName]struct{}) (*ModelGroup, bool) {
+	if mg == nil {
+		return nil, true
+	}
+	if qn, isRef := c.groupRefs[mg]; isRef {
+		target, ok := c.lookupGroupForRef(qn)
+		if !ok {
+			return nil, false
+		}
+		if _, recursive := resolving[qn]; recursive {
+			return nil, false
+		}
+		resolving[qn] = struct{}{}
+		expanded, ok := c.expandGroupRefsForRedefineRestrictionVisit(target, cloned, resolving)
+		delete(resolving, qn)
+		if !ok || expanded == nil {
+			return nil, false
+		}
+		return &ModelGroup{
+			Compositor: expanded.Compositor,
+			Particles:  expanded.Particles,
+			MinOccurs:  mg.MinOccurs,
+			MaxOccurs:  mg.MaxOccurs,
+		}, true
+	}
+	if existing := cloned[mg]; existing != nil {
+		return existing, true
+	}
+	out := &ModelGroup{
+		Compositor: mg.Compositor,
+		MinOccurs:  mg.MinOccurs,
+		MaxOccurs:  mg.MaxOccurs,
+	}
+	cloned[mg] = out
+	if len(mg.Particles) == 0 {
+		return out, true
+	}
+	out.Particles = make([]*Particle, 0, len(mg.Particles))
+	for _, p := range mg.Particles {
+		if p == nil {
+			continue
+		}
+		cp := *p
+		if sub, ok := p.Term.(*ModelGroup); ok {
+			expanded, ok := c.expandGroupRefsForRedefineRestrictionVisit(sub, cloned, resolving)
+			if !ok {
+				return nil, false
+			}
+			cp.Term = expanded
+		}
+		out.Particles = append(out.Particles, &cp)
+	}
+	return out, true
+}
+
+func (c *compiler) lookupGroupForRef(qn QName) (*ModelGroup, bool) {
+	grp, ok := c.schema.groups[qn]
+	if ok {
+		return grp, true
+	}
+	if qn.NS != "" {
+		grp, ok = c.schema.groups[QName{Local: qn.Local}]
+		return grp, ok
+	}
+	return nil, false
 }
 
 func redefineGroupValidRestriction(ctx context.Context, redef, origGroup *ModelGroup, schema *Schema, version Version) bool {

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -1259,12 +1259,12 @@ func (c *compiler) checkRedefineSelfDerivation(ctx context.Context, elem *helium
 // resolver, so the original group is cloned with group-reference placeholders
 // expanded just for this check. The real schema tree is left for the normal
 // resolver so diagnostics and all-group reference checks stay centralized.
-func (c *compiler) checkRedefineGroupRestriction(ctx context.Context, elem *helium.Element, qn QName, origGroup *ModelGroup) {
+func (c *compiler) checkRedefineGroupRestriction(ctx context.Context, elem *helium.Element, qn QName, origGroup *ModelGroup, phaseAGroups map[QName]*ModelGroup) {
 	redef := c.schema.groups[qn]
 	if redef == nil || origGroup == nil {
 		return
 	}
-	expandedOrig, ok := c.expandGroupRefsForRedefineRestriction(origGroup)
+	expandedOrig, ok := c.expandGroupRefsForRedefineRestriction(origGroup, phaseAGroups)
 	if !ok {
 		return
 	}
@@ -1275,16 +1275,16 @@ func (c *compiler) checkRedefineGroupRestriction(ctx context.Context, elem *heli
 		fmt.Sprintf("src-redefine.6.2: The redefinition of group '%s' is not a valid restriction of the original group.", qn.Local)))
 }
 
-func (c *compiler) expandGroupRefsForRedefineRestriction(mg *ModelGroup) (*ModelGroup, bool) {
-	return c.expandGroupRefsForRedefineRestrictionVisit(mg, make(map[*ModelGroup]*ModelGroup), make(map[QName]struct{}))
+func (c *compiler) expandGroupRefsForRedefineRestriction(mg *ModelGroup, phaseAGroups map[QName]*ModelGroup) (*ModelGroup, bool) {
+	return c.expandGroupRefsForRedefineRestrictionVisit(mg, phaseAGroups, make(map[*ModelGroup]*ModelGroup), make(map[QName]struct{}))
 }
 
-func (c *compiler) expandGroupRefsForRedefineRestrictionVisit(mg *ModelGroup, cloned map[*ModelGroup]*ModelGroup, resolving map[QName]struct{}) (*ModelGroup, bool) {
+func (c *compiler) expandGroupRefsForRedefineRestrictionVisit(mg *ModelGroup, phaseAGroups map[QName]*ModelGroup, cloned map[*ModelGroup]*ModelGroup, resolving map[QName]struct{}) (*ModelGroup, bool) {
 	if mg == nil {
 		return nil, true
 	}
 	if qn, isRef := c.groupRefs[mg]; isRef {
-		target, ok := c.lookupGroupForRef(qn)
+		target, ok := c.lookupGroupForRef(qn, phaseAGroups)
 		if !ok {
 			return nil, false
 		}
@@ -1292,7 +1292,7 @@ func (c *compiler) expandGroupRefsForRedefineRestrictionVisit(mg *ModelGroup, cl
 			return nil, false
 		}
 		resolving[qn] = struct{}{}
-		expanded, ok := c.expandGroupRefsForRedefineRestrictionVisit(target, cloned, resolving)
+		expanded, ok := c.expandGroupRefsForRedefineRestrictionVisit(target, phaseAGroups, cloned, resolving)
 		delete(resolving, qn)
 		if !ok || expanded == nil {
 			return nil, false
@@ -1323,7 +1323,7 @@ func (c *compiler) expandGroupRefsForRedefineRestrictionVisit(mg *ModelGroup, cl
 		}
 		cp := *p
 		if sub, ok := p.Term.(*ModelGroup); ok {
-			expanded, ok := c.expandGroupRefsForRedefineRestrictionVisit(sub, cloned, resolving)
+			expanded, ok := c.expandGroupRefsForRedefineRestrictionVisit(sub, phaseAGroups, cloned, resolving)
 			if !ok {
 				return nil, false
 			}
@@ -1334,13 +1334,13 @@ func (c *compiler) expandGroupRefsForRedefineRestrictionVisit(mg *ModelGroup, cl
 	return out, true
 }
 
-func (c *compiler) lookupGroupForRef(qn QName) (*ModelGroup, bool) {
-	grp, ok := c.schema.groups[qn]
+func (c *compiler) lookupGroupForRef(qn QName, groups map[QName]*ModelGroup) (*ModelGroup, bool) {
+	grp, ok := groups[qn]
 	if ok {
 		return grp, true
 	}
 	if qn.NS != "" {
-		grp, ok = c.schema.groups[QName{Local: qn.Local}]
+		grp, ok = groups[QName{Local: qn.Local}]
 		return grp, ok
 	}
 	return nil, false
@@ -1489,6 +1489,8 @@ func (c *compiler) processRedefineOverrides(ctx context.Context, redefineElem *h
 	savedBlockDefault := c.schema.blockDefault
 	savedFinalDefault := c.schema.finalDefault
 	savedIncludeFile := c.includeFile
+	phaseAGroups := make(map[QName]*ModelGroup, len(c.schema.groups))
+	maps.Copy(phaseAGroups, c.schema.groups)
 	c.redefine = &redefineState{
 		phaseAKeys: phaseAKeys,
 		seen:       make(map[redefineKind]map[QName]struct{}),
@@ -1660,7 +1662,7 @@ func (c *compiler) processRedefineOverrides(ctx context.Context, redefineElem *h
 				// group (Particle Valid (Restriction) §3.9.6). Enforce the
 				// provably-sound core of that rule here.
 				if len(selfRefs) == 0 && !nonSelfRefSeen {
-					c.checkRedefineGroupRestriction(ctx, elem, qn, origGroup)
+					c.checkRedefineGroupRestriction(ctx, elem, qn, origGroup, phaseAGroups)
 				}
 			}
 		case isXSDElement(elem, elemAttributeGroup):

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -1359,6 +1359,20 @@ func (c *compiler) lookupGroupForRef(qn QName, groups map[QName]*ModelGroup) (*M
 	}
 	if qn.NS != "" {
 		grp, ok = groups[QName{Local: qn.Local}]
+		if ok {
+			return grp, true
+		}
+	}
+	return c.lookupGroupForRefFallback(qn)
+}
+
+func (c *compiler) lookupGroupForRefFallback(qn QName) (*ModelGroup, bool) {
+	grp, ok := c.schema.groups[qn]
+	if ok {
+		return grp, true
+	}
+	if qn.NS != "" {
+		grp, ok = c.schema.groups[QName{Local: qn.Local}]
 		return grp, ok
 	}
 	return nil, false

--- a/xsd/compile_imports.go
+++ b/xsd/compile_imports.go
@@ -882,8 +882,9 @@ func (c *compiler) loadInclude(ctx context.Context, location string, includeElem
 	// xs:redefine of the same already-loaded document can validate its overrides.
 	if err == nil {
 		c.loadedRedefinable[path] = &redefinableSet{
-			keys:     c.computeRedefinableKeys(beforeTypes, beforeGroups, beforeAttrGroups),
-			consumed: make(map[redefineKind]map[QName]struct{}),
+			keys:      c.computeRedefinableKeys(beforeTypes, beforeGroups, beforeAttrGroups),
+			consumed:  make(map[redefineKind]map[QName]struct{}),
+			chameleon: incTargetNS == "",
 		}
 	}
 
@@ -1003,12 +1004,14 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 				redefineKindAttrGroup:   {},
 			}
 		}
-		return c.processRedefineOverrides(ctx, redefineElem, phaseAKeys, consumed)
+		chameleon := rs != nil && rs.chameleon
+		return c.processRedefineOverrides(ctx, redefineElem, phaseAKeys, consumed, chameleon)
 	}
 	c.includeVisited[path] = struct{}{}
 
 	data, err := c.readNestedSchema(path)
 	if err != nil {
+		c.checkRedefineOverrideRepresentation(ctx, redefineElem)
 		// Roll back the loaded-set marker added above (see loadInclude): a
 		// missing redefine target demoted to a warning must not leave the path
 		// marked, or a later xs:redefine of the same location would hit the
@@ -1040,6 +1043,7 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 	}
 	rootExcluded := c.applyConditionalInclusion(ctx, incRoot)
 	c.includeFile = savedIncludeFileVC
+	incTargetNS := getAttr(incRoot, attrTargetNamespace)
 	if rootExcluded {
 		// The redefined document's root is vc-excluded, so it contributes NO
 		// Phase-A components. The <xs:redefine> override children (which live in the
@@ -1056,15 +1060,15 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 			redefineKindAttrGroup:   {},
 		}
 		rs := &redefinableSet{
-			keys:     emptyKeys,
-			consumed: make(map[redefineKind]map[QName]struct{}),
+			keys:      emptyKeys,
+			consumed:  make(map[redefineKind]map[QName]struct{}),
+			chameleon: incTargetNS == "",
 		}
 		c.loadedRedefinable[path] = rs
-		return c.processRedefineOverrides(ctx, redefineElem, rs.keys, rs.consumed)
+		return c.processRedefineOverrides(ctx, redefineElem, rs.keys, rs.consumed, rs.chameleon)
 	}
 
 	// Check target namespace compatibility (same rules as include).
-	incTargetNS := getAttr(incRoot, attrTargetNamespace)
 	if incTargetNS != "" && incTargetNS != c.schema.targetNamespace {
 		displayLoc := location
 		if c.filename != "" {
@@ -1192,8 +1196,9 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 	// components are merged), then process this redefine's overrides against it.
 	phaseAKeys := c.computeRedefinableKeys(beforeTypes, beforeGroups, beforeAttrGroups)
 	rs := &redefinableSet{
-		keys:     phaseAKeys,
-		consumed: make(map[redefineKind]map[QName]struct{}),
+		keys:      phaseAKeys,
+		consumed:  make(map[redefineKind]map[QName]struct{}),
+		chameleon: incTargetNS == "",
 	}
 	c.loadedRedefinable[path] = rs
 
@@ -1222,7 +1227,7 @@ func (c *compiler) loadRedefine(ctx context.Context, location string, redefineEl
 	// open content (restored here), not the redefined document's Phase A value.
 	c.defaultOpenContent = savedDefaultOpenContent
 
-	return c.processRedefineOverrides(ctx, redefineElem, phaseAKeys, rs.consumed)
+	return c.processRedefineOverrides(ctx, redefineElem, phaseAKeys, rs.consumed, rs.chameleon)
 }
 
 // checkRedefineSelfDerivation enforces src-redefine.5: a <simpleType> or
@@ -1248,194 +1253,109 @@ func (c *compiler) checkRedefineSelfDerivation(ctx context.Context, elem *helium
 	return false
 }
 
-// checkRedefineGroupRestriction enforces the provably-sound core of
-// src-redefine.6.2 (§4.2.3): a redefining <group> with no self-reference must be
-// a ·valid restriction· of the original group (Particle Valid (Restriction),
-// §3.9.6). A restriction can never REQUIRE an element that the base group
-// EXPLICITLY forbids: if the original model declares element E with an effective
-// maximum occurrence of ZERO (so E can never appear) while the redefined model
-// GUARANTEES at least one occurrence of E, the redefinition resurrects a
-// declared-but-forbidden element and is not a valid restriction.
-//
-// The check is deliberately conservative. It fires only when (1) BOTH the
-// redefined and the original content models are fully analyzable as name-only
-// model groups — no wildcards, no unresolved group references, and no element
-// references / substitution groups — and (2) the offending name is DECLARED by
-// the original group (present as a particle) yet capped at zero occurrences. A
-// name the original omits entirely is left alone. Anything else returns without a
-// verdict, so the check can only ever add a rejection for a clear violation and
-// never over-rejects a valid restriction. Version-independent.
+// checkRedefineGroupRestriction enforces src-redefine.6.2 (§4.2.3): a
+// redefining <group> with no self-reference must be a valid restriction of the
+// original group. Redefine override processing runs before the normal group-ref
+// resolver, so callers invoke this only after confirming the override introduced
+// no unresolved group references.
 func (c *compiler) checkRedefineGroupRestriction(ctx context.Context, elem *helium.Element, qn QName, origGroup *ModelGroup) {
 	redef := c.schema.groups[qn]
 	if redef == nil || origGroup == nil {
 		return
 	}
-	// Any group ref still pending resolution is a placeholder in c.groupRefs; a
-	// nested inline sequence/choice/all is not. Snapshot the ref placeholders so
-	// the walk can distinguish them and bail on an unresolved reference.
-	refSet := make(map[*ModelGroup]bool, len(c.groupRefs))
-	for mg := range c.groupRefs {
-		refSet[mg] = true
-	}
-	if !groupContentAnalyzable(redef, refSet) || !groupContentAnalyzable(origGroup, refSet) {
+	if redefineGroupValidRestriction(ctx, redef, origGroup, c.schema, c.version) {
 		return
 	}
-	// Names the ORIGINAL group declares but caps at zero occurrences.
-	origNames := map[QName]struct{}{}
-	collectGroupElementNames(origGroup, origNames)
-	// For each element name the redefined model guarantees (min >= 1), reject when
-	// the original DECLARES that name yet can never contain it (max == 0).
-	redefNames := map[QName]struct{}{}
-	collectGroupElementNames(redef, redefNames)
-	for name := range redefNames {
-		if _, declared := origNames[name]; !declared {
-			continue
-		}
-		if groupMinCount(redef, name) >= 1 && groupMaxCount(origGroup, name) == 0 {
-			c.schemaError(ctx, schemaParserError(c.diagSource(), elem.Line(), elem.LocalName(), "group",
-				fmt.Sprintf("src-redefine.6.2: The redefinition of group '%s' is not a valid restriction of the original: it requires element '%s', which the original group forbids (maxOccurs=0).", qn.Local, name.Local)))
-			return
-		}
-	}
+	c.schemaError(ctx, schemaParserError(c.diagSource(), elem.Line(), elem.LocalName(), "group",
+		fmt.Sprintf("src-redefine.6.2: The redefinition of group '%s' is not a valid restriction of the original group.", qn.Local)))
 }
 
-// groupContentAnalyzable reports whether a model group's content is composed
-// solely of local element declarations and nested inline model groups — i.e. no
-// wildcard, no element reference/substitution group, and no unresolved group
-// reference (a *ModelGroup present in refSet). It is the precondition for the
-// sound occurrence-counting used by checkRedefineGroupRestriction.
-func groupContentAnalyzable(mg *ModelGroup, refSet map[*ModelGroup]bool) bool {
-	for _, p := range mg.Particles {
-		switch t := p.Term.(type) {
-		case *ElementDecl:
-			if t.IsRef {
-				return false
-			}
-		case *ModelGroup:
-			if refSet[t] {
-				return false
-			}
-			if !groupContentAnalyzable(t, refSet) {
-				return false
-			}
-		default: // *Wildcard or anything unexpected
+func redefineGroupValidRestriction(ctx context.Context, redef, origGroup *ModelGroup, schema *Schema, version Version) bool {
+	derivedP := &Particle{MinOccurs: redef.MinOccurs, MaxOccurs: redef.MaxOccurs, Term: redef}
+	baseP := &Particle{MinOccurs: origGroup.MinOccurs, MaxOccurs: origGroup.MaxOccurs, Term: origGroup}
+
+	// XSD 1.0 applies the intensional Particle Valid (Restriction) rules. For
+	// all->all redefine groups that means member mapping is source-order
+	// preserving; the XSD 1.1 language-subset relaxation below is what makes the
+	// same all-member set in a different declaration order valid.
+	if version != Version11 && redef.Compositor == CompositorAll && origGroup.Compositor == CompositorAll {
+		if !occurrenceEmptiableRestriction(derivedP, baseP, version) {
 			return false
 		}
+		return recurseOrdered(ctx, redef.Particles, origGroup.Particles, schema, version)
 	}
-	return true
+
+	if particleValidRestriction(ctx, derivedP, baseP, schema, version) {
+		return true
+	}
+	if version == Version11 && particleLanguageSubset(ctx, derivedP, baseP, schema, version) {
+		return true
+	}
+	return false
 }
 
-// collectGroupElementNames gathers every element declaration name reachable in a
-// name-only model group (precondition: groupContentAnalyzable).
-func collectGroupElementNames(mg *ModelGroup, out map[QName]struct{}) {
-	for _, p := range mg.Particles {
-		switch t := p.Term.(type) {
-		case *ElementDecl:
-			out[t.Name] = struct{}{}
-		case *ModelGroup:
-			collectGroupElementNames(t, out)
-		}
-	}
-}
-
-// occursSat is a saturating count used to fold occurrence products without
-// overflow; any value at or above it is treated as "many".
-const occursSat = 1 << 20
-
-// groupMaxCount returns the maximum number of times an element named `name` can
-// occur in one instance of the given name-only model group's content (its own
-// occurrence range excluded — the caller applies particle occurrences).
-func groupMaxCount(mg *ModelGroup, name QName) int {
-	total := 0
-	for _, p := range mg.Particles {
-		var per int
-		switch t := p.Term.(type) {
-		case *ElementDecl:
-			if t.Name == name {
-				per = 1
-			}
-		case *ModelGroup:
-			per = groupMaxCount(t, name)
-		}
-		if per == 0 {
+func (c *compiler) checkRedefineOverrideRepresentation(ctx context.Context, redefineElem *helium.Element) {
+	for child := range helium.Children(redefineElem) {
+		if child.Type() != helium.ElementNode {
 			continue
 		}
-		per = satMul(per, occursMaxBound(p.MaxOccurs))
-		if mg.Compositor == CompositorChoice {
-			if per > total {
-				total = per
-			}
+		elem, ok := helium.AsNode[*helium.Element](child)
+		if !ok || !isXSDElement(elem, elemGroup) {
 			continue
 		}
-		total = satAdd(total, per)
+		c.checkRedefineGroupDefinitionRepresentation(ctx, elem)
 	}
-	return total
 }
 
-// groupMinCount returns the minimum number of times an element named `name` is
-// GUARANTEED to occur in every instance of the given name-only model group's
-// content (its own occurrence range excluded).
-func groupMinCount(mg *ModelGroup, name QName) int {
-	if mg.Compositor == CompositorChoice {
-		// A choice guarantees only what EVERY branch guarantees.
-		minVal := -1
-		for _, p := range mg.Particles {
-			per := particleMinCount(p, name)
-			if minVal < 0 || per < minVal {
-				minVal = per
+func (c *compiler) checkRedefineGroupDefinitionRepresentation(ctx context.Context, elem *helium.Element) {
+	if c.filename == "" {
+		return
+	}
+	if hasAttr(elem, attrRef) {
+		c.schemaError(ctx, schemaParserErrorAttr(c.diagSource(), elem.Line(), elem.LocalName(), "group", attrRef,
+			"The attribute 'ref' is not allowed on a model group definition."))
+	}
+	for child := range helium.Children(elem) {
+		if child.Type() != helium.ElementNode {
+			continue
+		}
+		ce, ok := helium.AsNode[*helium.Element](child)
+		if !ok || !isXSDElement(ce, elemAll) {
+			continue
+		}
+		c.validateAllOccurs(ctx, ce)
+		for grand := range helium.Children(ce) {
+			if grand.Type() != helium.ElementNode {
+				continue
+			}
+			ge, ok := helium.AsNode[*helium.Element](grand)
+			if ok && isXSDElement(ge, elemElement) {
+				c.checkAllElementParticleOccurs(ctx, ge)
 			}
 		}
-		if minVal < 0 {
-			return 0
+	}
+}
+
+func redefineGroupHasUnprefixedSelfRef(elem *helium.Element, local string) bool {
+	for child := range helium.Children(elem) {
+		if child.Type() != helium.ElementNode {
+			continue
 		}
-		return minVal
-	}
-	total := 0
-	for _, p := range mg.Particles {
-		total = satAdd(total, particleMinCount(p, name))
-	}
-	return total
-}
-
-func particleMinCount(p *Particle, name QName) int {
-	var per int
-	switch t := p.Term.(type) {
-	case *ElementDecl:
-		if t.Name == name {
-			per = 1
+		ce, ok := helium.AsNode[*helium.Element](child)
+		if !ok {
+			continue
 		}
-	case *ModelGroup:
-		per = groupMinCount(t, name)
+		if isXSDElement(ce, elemGroup) && hasAttr(ce, attrRef) {
+			ref := normalizeWhiteSpace(getAttr(ce, attrRef), "collapse")
+			if ref == local && refChameleonEligible(ce, ref) {
+				return true
+			}
+		}
+		if redefineGroupHasUnprefixedSelfRef(ce, local) {
+			return true
+		}
 	}
-	if per == 0 || p.MinOccurs == 0 {
-		return 0
-	}
-	return satMul(per, p.MinOccurs)
-}
-
-func occursMaxBound(m int) int {
-	if m < 0 { // unbounded
-		return occursSat
-	}
-	return m
-}
-
-func satMul(a, b int) int {
-	if a == 0 || b == 0 {
-		return 0
-	}
-	if a >= occursSat || b >= occursSat || a > occursSat/b {
-		return occursSat
-	}
-	return a * b
-}
-
-func satAdd(a, b int) int {
-	s := a + b
-	if s >= occursSat {
-		return occursSat
-	}
-	return s
+	return false
 }
 
 // processRedefineOverrides applies the override children of an xs:redefine
@@ -1487,7 +1407,7 @@ func (c *compiler) validateComponentChildName(ctx context.Context, elem *helium.
 	return name, false
 }
 
-func (c *compiler) processRedefineOverrides(ctx context.Context, redefineElem *helium.Element, phaseAKeys, consumed map[redefineKind]map[QName]struct{}) error {
+func (c *compiler) processRedefineOverrides(ctx context.Context, redefineElem *helium.Element, phaseAKeys, consumed map[redefineKind]map[QName]struct{}, chameleon bool) error {
 	savedElemForm := c.schema.elemFormQualified
 	savedAttrForm := c.schema.attrFormQualified
 	savedBlockDefault := c.schema.blockDefault
@@ -1573,6 +1493,11 @@ func (c *compiler) processRedefineOverrides(ctx context.Context, redefineElem *h
 				c.typeRefs[newType] = origKey
 			}
 		case isXSDElement(elem, elemGroup):
+			if hasAttr(elem, attrRef) {
+				c.schemaError(ctx, schemaParserErrorAttr(c.diagSource(), elem.Line(), elem.LocalName(), "group", attrRef,
+					"The attribute 'ref' is not allowed on a model group definition."))
+				continue
+			}
 			name, ok := c.validateComponentChildName(ctx, elem)
 			if !ok {
 				continue
@@ -1595,18 +1520,36 @@ func (c *compiler) processRedefineOverrides(ctx context.Context, redefineElem *h
 				c.includeFile = savedIncludeFile
 				return err
 			}
+			chameleonUnprefixedSelfRef := chameleon && qn.NS != "" && redefineGroupHasUnprefixedSelfRef(elem, qn.Local)
+			if chameleonUnprefixedSelfRef {
+				c.schemaError(ctx, schemaParserError(c.diagSource(), elem.Line(), elem.LocalName(), "group",
+					fmt.Sprintf("src-redefine.6.1.1: The self-reference to chameleon group '%s' inside <redefine> must use a qualified name in the redefining namespace.", qn.Local)))
+			}
 			// Patch self-reference: find newly-added groupRefs entries referencing qn.
 			if origGroup != nil {
-				// Collect the newly-parsed self-references (a group ref inside the
-				// redefine child whose ref names the redefined group itself).
+				// Collect the newly-parsed group references in the redefine child. A
+				// group reference inside a redefining group must name the group being
+				// redefined; non-self refs are invalid and cannot be left for the normal
+				// resolver because this path runs before reference resolution.
 				var selfRefs []*ModelGroup
+				var nonSelfRef QName
+				var nonSelfRefSeen bool
 				for mg, refQN := range c.groupRefs {
 					if existingRefs[mg] {
 						continue
 					}
 					if refQN == qn {
 						selfRefs = append(selfRefs, mg)
+						continue
 					}
+					if !nonSelfRefSeen {
+						nonSelfRef = refQN
+						nonSelfRefSeen = true
+					}
+				}
+				if nonSelfRefSeen {
+					c.schemaError(ctx, schemaParserError(c.diagSource(), elem.Line(), elem.LocalName(), "group",
+						fmt.Sprintf("src-redefine.6.1.1: The group '%s' redefined inside <redefine> must not reference a different group ('%s').", qn.Local, nonSelfRef.Local)))
 				}
 				// src-redefine.6.1.1/6.1.2 (§4.2.3): a <group> child of <redefine>
 				// that references itself must do so exactly ONCE and with
@@ -1640,7 +1583,7 @@ func (c *compiler) processRedefineOverrides(ctx context.Context, redefineElem *h
 				// self-reference must be a ·valid restriction· of the original
 				// group (Particle Valid (Restriction) §3.9.6). Enforce the
 				// provably-sound core of that rule here.
-				if len(selfRefs) == 0 {
+				if len(selfRefs) == 0 && !nonSelfRefSeen {
 					c.checkRedefineGroupRestriction(ctx, elem, qn, origGroup)
 				}
 			}

--- a/xsd/redefine_form_default_test.go
+++ b/xsd/redefine_form_default_test.go
@@ -44,7 +44,7 @@ func TestRedefine_OverrideUsesRedefiningSchemaFormDefault(t *testing.T) {
 		baseXSD: &fstest.MapFile{Data: []byte(`<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="` + ns + `">
   <xs:group name="g">
     <xs:sequence>
-      <xs:element name="placeholder" type="xs:string"/>
+      <xs:any namespace="##targetNamespace" processContents="skip"/>
     </xs:sequence>
   </xs:group>
 </xs:schema>`)},

--- a/xsd/redefine_group_restriction_test.go
+++ b/xsd/redefine_group_restriction_test.go
@@ -95,6 +95,21 @@ func TestRedefineGroupRestriction(t *testing.T) {
 		require.Contains(t, compileErrors(t, main, base), wantMsg)
 	})
 
+	t.Run("resolves referenced preexisting group while checking original", func(t *testing.T) {
+		t.Parallel()
+		base := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="g"><xs:sequence><xs:group ref="h"/></xs:sequence></xs:group>
+</xs:schema>`
+		main := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="h"><xs:sequence><xs:element name="a" type="xs:string"/><xs:element name="b" type="xs:string"/></xs:sequence></xs:group>
+  <xs:redefine schemaLocation="base.xsd">
+    <xs:group name="g"><xs:sequence><xs:element name="a" type="xs:string"/></xs:sequence></xs:group>
+  </xs:redefine>
+  <xs:element name="doc"><xs:complexType><xs:group ref="g"/></xs:complexType></xs:element>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, main, base), wantMsg)
+	})
+
 	t.Run("referenced original group uses phase a even after earlier redefine", func(t *testing.T) {
 		t.Parallel()
 		base := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">

--- a/xsd/redefine_group_restriction_test.go
+++ b/xsd/redefine_group_restriction_test.go
@@ -9,24 +9,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestRedefineGroupRestriction verifies the provably-sound core of
-// src-redefine.6.2 (§4.2.3): a redefining <group> with no self-reference must be
-// a valid restriction of the original group. A restriction can never REQUIRE an
-// element the original group EXPLICITLY forbids (declares with maxOccurs=0). This
-// mirrors W3C ModelGroups mgO013, which the corpus marks invalid. A redefinition
-// that merely picks a subset of the original (choice{e1} restricting all{e1,e2?})
-// stays valid. Version-independent.
+// TestRedefineGroupRestriction verifies src-redefine.6.2 (§4.2.3): a
+// redefining <group> with no self-reference must be a valid restriction of the
+// original group. The default XSD 1.0 path uses the intensional Particle Valid
+// (Restriction) rules; XSD 1.1 can accept language-subset cases such as a
+// reordered xs:all.
 func TestRedefineGroupRestriction(t *testing.T) {
 	t.Parallel()
 
-	compileErrors := func(t *testing.T, mainSchema, baseSchema string) string {
+	compileErrors := func(t *testing.T, mainSchema, baseSchema string, configure ...func(xsd.Compiler) xsd.Compiler) string {
 		t.Helper()
 		doc, err := helium.NewParser().Parse(t.Context(), []byte(mainSchema))
 		require.NoError(t, err)
 		fsys := fstest.MapFS{"base.xsd": &fstest.MapFile{Data: []byte(baseSchema)}}
 		collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
-		_, err = xsd.NewCompiler().Label("main.xsd").FS(fsys).ErrorHandler(collector).Compile(t.Context(), doc)
-		requireCompileResultErr(t, err)
+		compiler := xsd.NewCompiler().Label("main.xsd").FS(fsys).ErrorHandler(collector)
+		for _, fn := range configure {
+			compiler = fn(compiler)
+		}
+		_, err = compiler.Compile(t.Context(), doc)
+		if err != nil {
+			requireCompileResultErr(t, err)
+		}
 		_, errors := partitionCompileErrors(collector.Errors())
 		return errors
 	}
@@ -62,11 +66,22 @@ func TestRedefineGroupRestriction(t *testing.T) {
 		require.Empty(t, compileErrors(t, main, base))
 	})
 
-	t.Run("ignores an element the original omits", func(t *testing.T) {
+	t.Run("rejects dropping a required base member", func(t *testing.T) {
 		t.Parallel()
-		// The redefinition introduces a new required element the original never
-		// declares. The conservative rule stays silent (only explicitly-forbidden
-		// declared names are rejected), so this compiles.
+		base := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="g"><xs:all><xs:element name="a" type="xs:string"/><xs:element name="b" type="xs:string"/></xs:all></xs:group>
+</xs:schema>`
+		main := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base.xsd">
+    <xs:group name="g"><xs:all><xs:element name="a" type="xs:string"/></xs:all></xs:group>
+  </xs:redefine>
+  <xs:element name="doc"><xs:complexType><xs:group ref="g"/></xs:complexType></xs:element>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, main, base), wantMsg)
+	})
+
+	t.Run("rejects adding an element the original omits", func(t *testing.T) {
+		t.Parallel()
 		base := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:group name="g"><xs:all><xs:element name="a" type="xs:string"/></xs:all></xs:group>
 </xs:schema>`
@@ -76,6 +91,37 @@ func TestRedefineGroupRestriction(t *testing.T) {
   </xs:redefine>
   <xs:element name="doc"><xs:complexType><xs:group ref="g"/></xs:complexType></xs:element>
 </xs:schema>`
-		require.Empty(t, compileErrors(t, main, base))
+		require.Contains(t, compileErrors(t, main, base), wantMsg)
+	})
+
+	t.Run("rejects reordered sequence", func(t *testing.T) {
+		t.Parallel()
+		base := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="g"><xs:sequence><xs:element name="a" type="xs:string"/><xs:element name="b" type="xs:string"/></xs:sequence></xs:group>
+</xs:schema>`
+		main := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base.xsd">
+    <xs:group name="g"><xs:sequence><xs:element name="b" type="xs:string"/><xs:element name="a" type="xs:string"/></xs:sequence></xs:group>
+  </xs:redefine>
+  <xs:element name="doc"><xs:complexType><xs:group ref="g"/></xs:complexType></xs:element>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, main, base), wantMsg)
+	})
+
+	t.Run("reordered all is invalid in xsd 1.0 and valid in xsd 1.1", func(t *testing.T) {
+		t.Parallel()
+		base := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="g"><xs:all><xs:element name="a" type="xs:string"/><xs:element name="b" type="xs:string"/></xs:all></xs:group>
+</xs:schema>`
+		main := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base.xsd">
+    <xs:group name="g"><xs:all><xs:element name="b" type="xs:string"/><xs:element name="a" type="xs:string"/></xs:all></xs:group>
+  </xs:redefine>
+  <xs:element name="doc"><xs:complexType><xs:group ref="g"/></xs:complexType></xs:element>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, main, base), wantMsg)
+		require.Empty(t, compileErrors(t, main, base, func(c xsd.Compiler) xsd.Compiler {
+			return c.Version(xsd.Version11)
+		}))
 	})
 }

--- a/xsd/redefine_group_restriction_test.go
+++ b/xsd/redefine_group_restriction_test.go
@@ -80,6 +80,21 @@ func TestRedefineGroupRestriction(t *testing.T) {
 		require.Contains(t, compileErrors(t, main, base), wantMsg)
 	})
 
+	t.Run("rejects dropping required base member hidden behind group ref", func(t *testing.T) {
+		t.Parallel()
+		base := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="h"><xs:sequence><xs:element name="a" type="xs:string"/></xs:sequence></xs:group>
+  <xs:group name="g"><xs:sequence><xs:group ref="h"/></xs:sequence></xs:group>
+</xs:schema>`
+		main := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base.xsd">
+    <xs:group name="g"><xs:sequence/></xs:group>
+  </xs:redefine>
+  <xs:element name="doc"><xs:complexType><xs:group ref="g"/></xs:complexType></xs:element>
+</xs:schema>`
+		require.Contains(t, compileErrors(t, main, base), wantMsg)
+	})
+
 	t.Run("rejects adding an element the original omits", func(t *testing.T) {
 		t.Parallel()
 		base := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">

--- a/xsd/redefine_group_restriction_test.go
+++ b/xsd/redefine_group_restriction_test.go
@@ -111,6 +111,24 @@ func TestRedefineGroupRestriction(t *testing.T) {
 		require.Empty(t, compileErrors(t, main, base))
 	})
 
+	t.Run("repeated redefine uses cached phase a group for referenced original", func(t *testing.T) {
+		t.Parallel()
+		base := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="h"><xs:choice><xs:element name="a" type="xs:string"/><xs:element name="b" type="xs:string"/></xs:choice></xs:group>
+  <xs:group name="g"><xs:sequence><xs:group ref="h"/></xs:sequence></xs:group>
+</xs:schema>`
+		main := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base.xsd">
+    <xs:group name="h"><xs:choice><xs:element name="a" type="xs:string"/></xs:choice></xs:group>
+  </xs:redefine>
+  <xs:redefine schemaLocation="base.xsd">
+    <xs:group name="g"><xs:sequence><xs:element name="b" type="xs:string"/></xs:sequence></xs:group>
+  </xs:redefine>
+  <xs:element name="doc"><xs:complexType><xs:group ref="g"/></xs:complexType></xs:element>
+</xs:schema>`
+		require.Empty(t, compileErrors(t, main, base))
+	})
+
 	t.Run("rejects adding an element the original omits", func(t *testing.T) {
 		t.Parallel()
 		base := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">

--- a/xsd/redefine_group_restriction_test.go
+++ b/xsd/redefine_group_restriction_test.go
@@ -95,6 +95,22 @@ func TestRedefineGroupRestriction(t *testing.T) {
 		require.Contains(t, compileErrors(t, main, base), wantMsg)
 	})
 
+	t.Run("referenced original group uses phase a even after earlier redefine", func(t *testing.T) {
+		t.Parallel()
+		base := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="h"><xs:choice><xs:element name="a" type="xs:string"/><xs:element name="b" type="xs:string"/></xs:choice></xs:group>
+  <xs:group name="g"><xs:sequence><xs:group ref="h"/></xs:sequence></xs:group>
+</xs:schema>`
+		main := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:redefine schemaLocation="base.xsd">
+    <xs:group name="h"><xs:choice><xs:element name="a" type="xs:string"/></xs:choice></xs:group>
+    <xs:group name="g"><xs:sequence><xs:element name="b" type="xs:string"/></xs:sequence></xs:group>
+  </xs:redefine>
+  <xs:element name="doc"><xs:complexType><xs:group ref="g"/></xs:complexType></xs:element>
+</xs:schema>`
+		require.Empty(t, compileErrors(t, main, base))
+	})
+
 	t.Run("rejects adding an element the original omits", func(t *testing.T) {
 		t.Parallel()
 		base := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">

--- a/xsd/redefine_group_selfref_test.go
+++ b/xsd/redefine_group_selfref_test.go
@@ -77,13 +77,14 @@ func TestRedefine_GroupSelfReferenceCardinality(t *testing.T) {
 			wantErr: "src-redefine.6.1.1",
 		},
 		{
-			name: "no self-reference (references a different group) is not caught by 6.1",
+			name: "different group reference is invalid",
 			redef: `<xs:group name="g">
     <xs:choice>
       <xs:element name="c1" type="xs:int"/>
       <xs:group ref="other"/>
     </xs:choice>
   </xs:group>`,
+			wantErr: "src-redefine.6.1.1",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- enforce model-group redefine restriction using the existing particle restriction machinery
- reject invalid redefine group references and preserve chameleon self-reference rules
- keep redefine child representation diagnostics visible when the target schemaLocation only warns

## Tests
- go test ./xsd -run 'TestRedefineGroupRestriction|TestRedefine_GroupSelfReferenceCardinality|TestAllGroupOccurs|TestAllGroupRef' -count=1
- W3C XSD 1.0 focused redefine subset: schL1/schL5/schL6/schL8/schL10/schN6/schN7/schN12/schN13i/schO2/schR5/groupB007/mgO020/mgP041/mgP050
- go test ./xsd -count=1
- go test ./... -count=1
