### PR TITLE
fix xsi type root validation

### DIFF
--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -875,18 +875,16 @@ func (vc *validationContext) validateRootElement(ctx context.Context, elem *heli
 	// no-namespace schema declaring {}foo).
 	edecl, ok := vc.schema.LookupElement(local, ns)
 	if !ok {
-		// XSD 1.1 lax assessment (cvc-assess-elt.1.2): with no governing element
-		// declaration, an xsi:type attribute resolving to a known type definition
-		// governs the element. Assess it laxly against that type so its content is
-		// validated and PSVI type annotations are produced (matching the per-child
-		// wildcard/xs:anyType lax sites). Scoped to a lax fragment-validating caller
-		// (cfg.skipDatatypeIntegrity — the xslt3 source-validation path): a full
-		// standalone document validation keeps the strict "no matching global
-		// declaration" root policy (libxml2 parity). XSD 1.0 is byte-identical.
-		if vc.version == Version11 && vc.cfg != nil && vc.cfg.skipDatatypeIntegrity {
-			if _, hasType := vc.resolveXsiTypeQuiet(elem); hasType {
-				return vc.assessLaxElement(ctx, elem)
-			}
+		// With no governing element declaration, a present xsi:type can still supply
+		// the governing type definition. This is required for schemas that expose
+		// only global types and rely on the instance root's xsi:type. If no resolvable
+		// xsi:type is present, retain the strict no-root-declaration error.
+		td, err := vc.resolveXsiType(ctx, elem, nil, false)
+		if err != nil {
+			return err
+		}
+		if td != nil {
+			return vc.validateUndeclaredElementWithType(ctx, elem, td)
 		}
 		msg := "No matching global declaration available for the validation root."
 		vc.reportValidityError(ctx, vc.filename, elem.Line(), local, msg)
@@ -951,6 +949,21 @@ func (vc *validationContext) validateRootElement(ctx context.Context, elem *heli
 	}
 
 	return vc.validateElementContent(ctx, elem, edecl, td)
+}
+
+func (vc *validationContext) validateUndeclaredElementWithType(ctx context.Context, elem *helium.Element, td *TypeDef) error {
+	if td != nil && td.Abstract {
+		vc.reportValidityError(ctx, vc.filename, elem.Line(), elemDisplayName(elem), msgAbstractType)
+		return fmt.Errorf("abstract type")
+	}
+	vc.annotateElement(ctx, elem, td, true)
+	if td == nil {
+		return nil
+	}
+	if _, nilErr := vc.checkXsiNil(ctx, elem, nil); nilErr != nil {
+		return nilErr
+	}
+	return vc.validateElementContent(ctx, elem, nil, td)
 }
 
 func (vc *validationContext) validateElementContent(ctx context.Context, elem *helium.Element, edecl *ElementDecl, td *TypeDef) error {
@@ -1185,18 +1198,7 @@ func (vc *validationContext) assessLaxElement(ctx context.Context, ce *helium.El
 	if !hasType {
 		return vc.annotateAnyTypeChildren(ctx, ce)
 	}
-	if actual != nil && actual.Abstract {
-		vc.reportValidityError(ctx, vc.filename, ce.Line(), elemDisplayName(ce), msgAbstractType)
-		return fmt.Errorf("abstract type")
-	}
-	vc.annotateElement(ctx, ce, actual, true)
-	if actual == nil {
-		return nil
-	}
-	if _, nilErr := vc.checkXsiNil(ctx, ce, nil); nilErr != nil {
-		return nilErr
-	}
-	return vc.validateElementContent(ctx, ce, nil, actual)
+	return vc.validateUndeclaredElementWithType(ctx, ce, actual)
 }
 
 // annotateAnyTypeChildren lax-validates the child elements of an xs:anyType (or
@@ -2877,10 +2879,6 @@ func (vc *validationContext) resolveXsiType(ctx context.Context, elem *helium.El
 
 	td, ok := vc.schema.LookupType(local, ns)
 	if !ok {
-		// Try with schema's target namespace.
-		td, ok = vc.schema.LookupType(local, vc.schema.TargetNamespace())
-	}
-	if !ok {
 		msg := fmt.Sprintf("The value '%s' of the xsi:type attribute does not resolve to a type definition.", xsiTypeVal)
 		vc.reportValidityError(ctx, vc.filename, elem.Line(), elemDisplayName(elem), msg)
 		return nil, fmt.Errorf("xsi:type not found")
@@ -2938,9 +2936,6 @@ func (vc *validationContext) resolveXsiTypeQuiet(elem *helium.Element) (*TypeDef
 	}
 
 	td, ok := vc.schema.LookupType(local, ns)
-	if !ok {
-		td, ok = vc.schema.LookupType(local, vc.schema.TargetNamespace())
-	}
 	if !ok {
 		return nil, false
 	}

--- a/xsd/validate.go
+++ b/xsd/validate.go
@@ -2872,6 +2872,11 @@ func (vc *validationContext) resolveXsiType(ctx context.Context, elem *helium.El
 	if prefix, rest, ok := strings.Cut(xsiTypeVal, ":"); ok {
 		local = rest
 		ns = lookupNS(elem, prefix)
+		if ns == "" {
+			msg := fmt.Sprintf("The value '%s' of the xsi:type attribute does not resolve to a type definition.", xsiTypeVal)
+			vc.reportValidityError(ctx, vc.filename, elem.Line(), elemDisplayName(elem), msg)
+			return nil, fmt.Errorf("xsi:type prefix not bound")
+		}
 	} else {
 		// No prefix — use the default namespace (empty prefix) or schema target namespace.
 		ns = lookupNS(elem, "")
@@ -2931,6 +2936,9 @@ func (vc *validationContext) resolveXsiTypeQuiet(elem *helium.Element) (*TypeDef
 	if prefix, rest, ok := strings.Cut(xsiTypeVal, ":"); ok {
 		local = rest
 		ns = lookupNS(elem, prefix)
+		if ns == "" {
+			return nil, false
+		}
 	} else {
 		ns = lookupNS(elem, "")
 	}

--- a/xsd/validate_id_test.go
+++ b/xsd/validate_id_test.go
@@ -788,6 +788,9 @@ func TestIDLaxWildcardXsiTypeAssessed(t *testing.T) {
 	compileValidate := func(t *testing.T, processContents, instanceXML string) error {
 		t.Helper()
 		schemaXML := `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:simpleType name="LocalID">
+    <xs:restriction base="xs:ID"/>
+  </xs:simpleType>
   <xs:element name="doc">
     <xs:complexType>
       <xs:sequence>
@@ -822,6 +825,15 @@ func TestIDLaxWildcardXsiTypeAssessed(t *testing.T) {
 		t.Parallel()
 		require.NoError(t, compileValidate(t, "skip", dupDifferentOwners),
 			"skip content is never assessed, so its xsi:type=xs:ID must not be checked")
+	})
+
+	t.Run("lax wildcard unbound xsi:type prefix is not assessed as no-namespace type", func(t *testing.T) {
+		t.Parallel()
+		inst := `<doc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">` +
+			`<w1><id xsi:type="missing:LocalID">dup</id></w1>` +
+			`<w2><id xsi:type="missing:LocalID">dup</id></w2></doc>`
+		require.NoError(t, compileValidate(t, "lax", inst),
+			"an unbound xsi:type prefix must not fall through to a no-namespace type lookup")
 	})
 
 	t.Run("lax wildcard xsi:type=xs:ID under one owner is valid", func(t *testing.T) {

--- a/xsd/xsi_type_root_test.go
+++ b/xsd/xsi_type_root_test.go
@@ -1,0 +1,53 @@
+package xsd_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xsd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestXsiTypeCanGovernUndeclaredRoot(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="RootType">
+    <xs:sequence>
+      <xs:element name="n" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>`
+
+	const xsiNS = `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"`
+
+	require.NoError(t, compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schemaXML,
+		`<root `+xsiNS+` xsi:type="RootType"><n>7</n></root>`))
+	require.ErrorIs(t, compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schemaXML,
+		`<root `+xsiNS+` xsi:type="RootType"><n>not-int</n></root>`), xsd.ErrValidationFailed)
+	require.ErrorIs(t, compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schemaXML,
+		`<root><n>7</n></root>`), xsd.ErrValidationFailed)
+}
+
+func TestXsiTypeDoesNotFallbackToSchemaTargetNamespace(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="urn:t" xmlns:t="urn:t">
+  <xs:complexType name="base">
+  </xs:complexType>
+  <xs:complexType name="ext">
+    <xs:complexContent>
+      <xs:extension base="t:base"/>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="root" type="t:base"/>
+</xs:schema>`
+
+	const xsiNS = `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"`
+
+	require.NoError(t, compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schemaXML,
+		`<t:root xmlns:t="urn:t" xmlns="urn:wrong" `+xsiNS+` xsi:type="t:ext"/>`))
+	require.ErrorIs(t, compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schemaXML,
+		`<t:root xmlns:t="urn:t" xmlns="urn:wrong" `+xsiNS+` xsi:type="ext"/>`),
+		xsd.ErrValidationFailed)
+}

--- a/xsd/xsi_type_root_test.go
+++ b/xsd/xsi_type_root_test.go
@@ -28,6 +28,23 @@ func TestXsiTypeCanGovernUndeclaredRoot(t *testing.T) {
 		`<root><n>7</n></root>`), xsd.ErrValidationFailed)
 }
 
+func TestXsiTypeUnboundPrefixDoesNotResolveToNoNamespaceType(t *testing.T) {
+	t.Parallel()
+
+	const schemaXML = `<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:complexType name="RootType">
+    <xs:sequence>
+      <xs:element name="n" type="xs:int"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>`
+
+	const instanceXML = `<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="missing:RootType"><n>7</n></root>`
+
+	err := compileAndValidateV(t, xsd.NewCompiler().Version(xsd.Version10), schemaXML, instanceXML)
+	require.ErrorIs(t, err, xsd.ErrValidationFailed)
+}
+
 func TestXsiTypeDoesNotFallbackToSchemaTargetNamespace(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- allow an undeclared validation root to be governed by xsi:type
- resolve xsi:type strictly against the QName namespace without target namespace fallback
- add XSD 1.0 regression coverage for root xsi:type and namespace fallback
