### PR TITLE
propagate FOTY0013 from castable-as of non-atomizable operand

### DIFF
--- a/xpath3/cast_test.go
+++ b/xpath3/cast_test.go
@@ -708,3 +708,20 @@ func TestCastableExprForms(t *testing.T) {
 		require.Equal(t, tc.expect, b, tc.expr)
 	}
 }
+
+func TestCastableExprAtomizationError(t *testing.T) {
+	// Atomizing a non-atomizable operand (map/array/function) is a type error
+	// (FOTY0013) that must PROPAGATE from `castable as`, not be swallowed into a
+	// false result — W3C QT3 CastableAs666/668.
+	for _, expr := range []string{
+		`map{} castable as xs:integer`,
+		// A nested array that flattens to reach a map still atomizes to FOTY0013.
+		`[[], (), [[3, map{}]]] castable as xs:integer`,
+	} {
+		_, err := evaluate(t.Context(), nil, expr)
+		require.Error(t, err, expr)
+		var xerr *xpath3.XPathError
+		require.True(t, errors.As(err, &xerr), "%s: error must be *xpath3.XPathError, got %T: %v", expr, err, err)
+		require.Equal(t, "FOTY0013", xerr.Code, expr)
+	}
+}

--- a/xpath3/eval_types.go
+++ b/xpath3/eval_types.go
@@ -246,7 +246,15 @@ func evalCastableExpr(evalFn exprEvaluator, ctx context.Context, ec *evalContext
 	// castable to a single atomic type.
 	atoms, err := atomizeSingletonOperand(seq)
 	if err != nil {
-		return SingleBoolean(false), nil //nolint:nilerr // castable returns false on atomization failure
+		// Atomizing a function/map/array is a type error (FOTY0013) that
+		// PROPAGATES from `castable as` rather than making it false — the operand
+		// isn't a bad lexical, it's not atomizable at all (F&O 3.1 §19.1; QT3
+		// CastableAs666/668). Other atomization failures mean "not castable".
+		var xpErr *XPathError
+		if errors.As(err, &xpErr) && xpErr.Code == errCodeFOTY0013 {
+			return nil, err
+		}
+		return SingleBoolean(false), nil
 	}
 	if len(atoms) == 0 {
 		return SingleBoolean(e.AllowEmpty), nil


### PR DESCRIPTION
- `castable as` swallowed the atomization error of a non-atomizable operand (map/array/function) and returned false; now propagates FOTY0013, matching `fn:number`'s handling
- Unblocks W3C QT3 CastableAs666/668, which assert FOTY0013 (their expected code changed from XPTY0004 upstream in 2020)
