### PR TITLE
raise SENR0001 and XPTY0004 from fn:serialize

### DIFF
--- a/xpath3/errors.go
+++ b/xpath3/errors.go
@@ -45,6 +45,7 @@ const errCodeFOJS0005 = "FOJS0005"
 const errCodeFOJS0006 = "FOJS0006"
 const errCodeFOJS0007 = "FOJS0007"
 const errCodeFORG0002 = "FORG0002"
+const errCodeSENR0001 = "SENR0001"
 
 // Error message constants reused across the package.
 const (

--- a/xpath3/functions_serialize.go
+++ b/xpath3/functions_serialize.go
@@ -324,6 +324,11 @@ func readSerializeParamStandalone(elem *helium.Element) (string, error) {
 // value and is a type error [err:XPTY0004].
 func validateSerializeStandaloneMap(v Sequence) error {
 	xerr := &XPathError{Code: lexicon.ErrXPTY0004, Message: `serialize option "standalone" must be xs:boolean or "omit"`}
+	// An empty-sequence value selects the parameter default (omit); it is not a
+	// bad value (F&O 3.1 §18.9.1; QT3 serialize-xml-131 supplies map{"standalone":()}).
+	if seqLen(v) == 0 {
+		return nil
+	}
 	if seqLen(v) != 1 {
 		return xerr
 	}

--- a/xpath3/functions_serialize.go
+++ b/xpath3/functions_serialize.go
@@ -347,6 +347,16 @@ func validateSerializeStandaloneMap(v Sequence) error {
 		if s == "omit" {
 			return nil
 		}
+		// An untypedAtomic may carry an xs:boolean lexical; accept the same
+		// value space the other boolean map options do (readBool): true/false/1/0.
+		// A TYPED xs:string is not an xs:boolean member of the union, and yes/no
+		// are not xs:boolean lexicals — both stay rejected.
+		if av.TypeName == TypeUntypedAtomic {
+			switch s {
+			case lexicon.ValueTrue, lexicon.ValueFalse, "1", "0":
+				return nil
+			}
+		}
 		return xerr
 	default:
 		return xerr

--- a/xpath3/functions_serialize.go
+++ b/xpath3/functions_serialize.go
@@ -45,8 +45,14 @@ type serializeOptions struct {
 }
 
 func parseSerializeOptions(args []Sequence) (serializeOptions, error) {
+	// The default output method is xml (Serialization 3.1 §2 / F&O 3.1
+	// §18.9.1); adaptive is opt-in and must be requested explicitly. An empty
+	// method means "unspecified default (xml family)", which the dispatch
+	// treats like adaptive for atomic/map/array output but which the node-kind
+	// guard distinguishes from an explicit "adaptive" so serializing an
+	// attribute or namespace node under the default method raises SENR0001.
 	opts := serializeOptions{
-		method:        "adaptive",
+		method:        "",
 		itemSeparator: " ",
 	}
 	if len(args) <= 1 || seqLen(args[1]) == 0 {
@@ -149,6 +155,11 @@ func parseSerializeOptionsMap(opts serializeOptions, m MapItem) (serializeOption
 		return opts, err
 	} else if found {
 		opts.encoding = encoding
+	}
+	if v, found := m.Get(AtomicValue{TypeName: TypeString, Value: "standalone"}); found {
+		if err := validateSerializeStandaloneMap(v); err != nil {
+			return opts, err
+		}
 	}
 	if v, found := m.Get(AtomicValue{TypeName: TypeString, Value: "use-character-maps"}); found {
 		if err := validateSerializeCharacterMaps(v); err != nil {
@@ -306,6 +317,51 @@ func readSerializeParamStandalone(elem *helium.Element) (string, error) {
 	}
 }
 
+// validateSerializeStandaloneMap validates the "standalone" option value in the
+// map form of fn:serialize. Its value space is union(xs:boolean, enum("omit"))
+// (F&O 3.1 §18.9.1). The map form does NOT whitespace-collapse the value, so a
+// string such as " omit " (with surrounding spaces) is not the "omit" enum
+// value and is a type error [err:XPTY0004].
+func validateSerializeStandaloneMap(v Sequence) error {
+	xerr := &XPathError{Code: lexicon.ErrXPTY0004, Message: `serialize option "standalone" must be xs:boolean or "omit"`}
+	if seqLen(v) != 1 {
+		return xerr
+	}
+	av, ok := v.Get(0).(AtomicValue)
+	if !ok {
+		return xerr
+	}
+	switch av.TypeName {
+	case TypeBoolean:
+		return nil
+	case TypeString, TypeUntypedAtomic:
+		s, err := atomicToString(av)
+		if err != nil {
+			return xerr
+		}
+		if s == "omit" {
+			return nil
+		}
+		return xerr
+	default:
+		return xerr
+	}
+}
+
+// serializeNodeKindError reports err:SENR0001 when a bare attribute or namespace
+// node is serialized under a markup output method (xml/xhtml/html/text or the
+// unspecified default). Under the adaptive and json methods these node kinds are
+// serialized specially, so callers must not apply this guard for those methods.
+func serializeNodeKindError(item NodeItem) error {
+	if _, ok := item.Node.(*helium.Attribute); ok {
+		return &XPathError{Code: errCodeSENR0001, Message: "cannot serialize an attribute node using the xml output method"}
+	}
+	if item.Node != nil && item.Node.Type() == helium.NamespaceNode {
+		return &XPathError{Code: errCodeSENR0001, Message: "cannot serialize a namespace node using the xml output method"}
+	}
+	return nil
+}
+
 func validateSerializeCharacterMapsElement(elem *helium.Element) error {
 	if len(elem.Attributes()) != 0 {
 		return &XPathError{Code: lexicon.ErrXPTY0004, Message: "serialize parameter use-character-maps must not have attributes"}
@@ -439,6 +495,15 @@ func serializeAdaptiveItem(item Item, opts serializeOptions) (string, error) {
 		}
 		return s, nil
 	case NodeItem:
+		// The default (empty) method is the xml family, under which an
+		// attribute or namespace node is a serialization error. An explicit
+		// method="adaptive" serializes them specially, so only guard when the
+		// method is not adaptive.
+		if opts.method != "adaptive" {
+			if err := serializeNodeKindError(v); err != nil {
+				return "", err
+			}
+		}
 		return serializeNodeItem(v, opts)
 	case MapItem:
 		return serializeAdaptiveMap(v, opts)
@@ -587,6 +652,11 @@ func serializeXMLSequence(seq Sequence, opts serializeOptions) (string, error) {
 		case FunctionItem:
 			return "", &XPathError{Code: errCodeFOER0000, Message: "cannot serialize function item"}
 		case NodeItem:
+			// xml/xhtml/html/text output methods cannot serialize a bare
+			// attribute or namespace node [err:SENR0001].
+			if err := serializeNodeKindError(v); err != nil {
+				return "", err
+			}
 			text, err := serializeNodeItem(v, opts)
 			if err != nil {
 				return "", err

--- a/xpath3/functions_serialize_test.go
+++ b/xpath3/functions_serialize_test.go
@@ -85,6 +85,17 @@ func TestSerialize_StandaloneMapBadValueXPTY0004(t *testing.T) {
 	var xpErr *xpath3.XPathError
 	require.ErrorAs(t, err, &xpErr)
 	require.Equal(t, "XPTY0004", xpErr.Code)
+
+	// A typed xs:string is not an xs:boolean member of union(xs:boolean,"omit"),
+	// and "yes"/"no" are not xs:boolean lexicals — both stay XPTY0004 (matching
+	// the readBool value space used by the other boolean serialize options).
+	for _, bad := range []string{"yes", "true"} {
+		_, err := evaluate(t.Context(), doc,
+			`serialize(., map{"standalone": "`+bad+`"})`)
+		require.Error(t, err, bad)
+		require.ErrorAs(t, err, &xpErr)
+		require.Equal(t, "XPTY0004", xpErr.Code, bad)
+	}
 }
 
 // A valid standalone map value ("omit") is accepted.

--- a/xpath3/functions_serialize_test.go
+++ b/xpath3/functions_serialize_test.go
@@ -41,6 +41,61 @@ func mustCompile(t *testing.T, expr string) *xpath3.Expression {
 	return c
 }
 
+// fn:serialize with no serialization parameters uses the xml output method
+// (adaptive is opt-in), under which serializing an attribute or namespace node
+// is err:SENR0001 (W3C serialize-xml-002/011/012).
+func TestSerialize_AttributeNodeSENR0001(t *testing.T) {
+	doc := mustParseXML(t, `<root attr="value"/>`)
+
+	_, err := evaluate(t.Context(), doc, `serialize((//@*)[1])`)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, "SENR0001", xpErr.Code)
+}
+
+func TestSerialize_NamespaceNodeSENR0001(t *testing.T) {
+	doc := mustParseXML(t, `<root xmlns:p="urn:example"/>`)
+
+	_, err := evaluate(t.Context(), doc, `serialize((//namespace::*)[1])`)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, "SENR0001", xpErr.Code)
+}
+
+// An explicit method="adaptive" still serializes an attribute as name="value".
+func TestSerialize_AttributeNodeAdaptiveOK(t *testing.T) {
+	doc := mustParseXML(t, `<root attr="value"/>`)
+
+	res, err := evaluate(t.Context(), doc, `serialize((//@*)[1], map{"method":"adaptive"})`)
+	require.NoError(t, err)
+	require.Contains(t, res.StringValue(), `attr="value"`)
+}
+
+// The standalone map option value space is union(xs:boolean, "omit"); a bad
+// string value (" omit " with surrounding spaces) is err:XPTY0004
+// (W3C serialize-xml-131a).
+func TestSerialize_StandaloneMapBadValueXPTY0004(t *testing.T) {
+	doc := mustParseXML(t, `<root/>`)
+
+	_, err := evaluate(t.Context(), doc,
+		`serialize(., map{"omit-xml-declaration": false(), "standalone": " omit "})`)
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, "XPTY0004", xpErr.Code)
+}
+
+// A valid standalone map value ("omit") is accepted.
+func TestSerialize_StandaloneMapValidOK(t *testing.T) {
+	doc := mustParseXML(t, `<root/>`)
+
+	_, err := evaluate(t.Context(), doc,
+		`serialize(., map{"omit-xml-declaration": true(), "standalone": "omit"})`)
+	require.NoError(t, err)
+}
+
 // xml-to-json with an options map exercises parseXMLToJSONOptions.
 func TestXMLToJSON_OptionsMap(t *testing.T) {
 	r, err := evaluate(t.Context(), nil,

--- a/xpath3/functions_serialize_test.go
+++ b/xpath3/functions_serialize_test.go
@@ -94,6 +94,12 @@ func TestSerialize_StandaloneMapValidOK(t *testing.T) {
 	_, err := evaluate(t.Context(), doc,
 		`serialize(., map{"omit-xml-declaration": true(), "standalone": "omit"})`)
 	require.NoError(t, err)
+
+	// An empty-sequence value selects the default and must NOT error (QT3
+	// serialize-xml-131).
+	_, err = evaluate(t.Context(), doc,
+		`serialize(., map{"omit-xml-declaration": true(), "standalone": ()})`)
+	require.NoError(t, err)
 }
 
 // xml-to-json with an options map exercises parseXMLToJSONOptions.


### PR DESCRIPTION
- `fn:serialize` defaulted the output method to adaptive; the default is xml, and the xml/html/xhtml/text methods must raise SENR0001 for a bare attribute or namespace node (QT3 serialize-xml-002/011/012)
- the `standalone` map option accepted any value; its value space is union(xs:boolean, "omit") and the map form doesn't whitespace-collapse, so a bad value now raises XPTY0004 (QT3 serialize-xml-131a)
- default and explicit "adaptive" share the same dispatch, so element/document/atomic serialization is unchanged
