### PR TITLE
accept undeclare-prefixes serialize element param

### DIFF
--- a/xpath3/functions_serialize.go
+++ b/xpath3/functions_serialize.go
@@ -246,6 +246,14 @@ func parseSerializeOptionsNode(opts serializeOptions, n helium.Node) (serializeO
 				return opts, err
 			}
 			opts.allowDuplicateNames = value
+		case "undeclare-prefixes":
+			// undeclare-prefixes is a yes/no boolean serialization parameter
+			// (Serialization 3.1 §2). helium does not emit XML 1.1 namespace
+			// undeclarations, so the value is validated and ignored — matching
+			// the map form, which accepts it without honoring the behavior.
+			if _, err := readSerializeParamYesNo(param); err != nil {
+				return opts, err
+			}
 		case "encoding":
 			value, err := readSerializeParamValue(param)
 			if err != nil {

--- a/xpath3/functions_serialize_test.go
+++ b/xpath3/functions_serialize_test.go
@@ -34,6 +34,43 @@ func TestSerialize_OptionsNode(t *testing.T) {
 	require.Contains(t, res.StringValue(), "hello")
 }
 
+// undeclare-prefixes is a valid yes/no boolean serialization parameter
+// (Serialization 3.1 §2); the element-options form must accept it (validated,
+// not necessarily honored) rather than raising XPTY0004 (W3C serialize-xml-035b,
+// serialize-xml-036b). An invalid value stays XPTY0004.
+func TestSerialize_OptionsNodeUndeclarePrefixes(t *testing.T) {
+	build := func(value string) xpath3.Sequence {
+		t.Helper()
+		xml := `<output:serialization-parameters xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">` +
+			`<output:method value="xml"/>` +
+			`<output:undeclare-prefixes value="` + value + `"/>` +
+			`</output:serialization-parameters>`
+		doc := mustParseXML(t, xml)
+		nodes, err := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).
+			Evaluate(t.Context(), mustCompile(t, `.`), doc.DocumentElement())
+		require.NoError(t, err)
+		return nodes.Sequence()
+	}
+
+	run := func(value string) error {
+		t.Helper()
+		doc := mustParseXML(t, `<root/>`)
+		eval := xpath3.NewEvaluator(xpath3.DefaultEvaluatorOptions).Variables(map[string]xpath3.Sequence{
+			"params": build(value),
+		})
+		_, err := eval.Evaluate(t.Context(), mustCompile(t, `serialize(., $params)`), doc)
+		return err
+	}
+
+	require.NoError(t, run("yes"))
+
+	err := run("maybe")
+	require.Error(t, err)
+	var xpErr *xpath3.XPathError
+	require.ErrorAs(t, err, &xpErr)
+	require.Equal(t, "XPTY0004", xpErr.Code)
+}
+
 func mustCompile(t *testing.T, expr string) *xpath3.Expression {
 	t.Helper()
 	c, err := xpath3.NewCompiler().Compile(expr)


### PR DESCRIPTION
- fn:serialize with an element-form serialization-parameters node now accepts the `undeclare-prefixes` parameter (validated yes/no) instead of rejecting it with XPTY0004; matches the map-form's acceptance (helium doesn't emit XML 1.1 undeclarations, so accept-and-validate)
- unblocks QT3 serialize-xml-035b/036b (un-skipped in a follow-up sibling PR)
