### PR TITLE
reset version for html serialization-params method

### DIFF
--- a/xslt3/functions_transform.go
+++ b/xslt3/functions_transform.go
@@ -1212,10 +1212,14 @@ func applySerializationParams(base *OutputDef, seq xpath3.Sequence) *OutputDef {
 	if out == nil {
 		out = defaultOutputDef()
 	}
+	versionExplicit := false
 	for _, key := range sm.Keys() {
 		name := serializationParamName(key)
 		if name == "" {
 			continue
+		}
+		if name == "version" {
+			versionExplicit = true
 		}
 		val, ok := sm.Get(key)
 		if !ok {
@@ -1230,6 +1234,15 @@ func applySerializationParams(base *OutputDef, seq xpath3.Sequence) *OutputDef {
 			continue
 		}
 		applySerializationParam(out, name, val)
+	}
+	// The version parameter's default is method-dependent, so an inherited xml
+	// version="1.0" must not carry into an html/xhtml method selected via
+	// serialization-params. When these params switch the method to html/xhtml
+	// without also supplying an explicit version, unset Version so the
+	// method-appropriate serialization default applies instead of the inherited
+	// "1.0" (which the html method rejects with SESU0007).
+	if !versionExplicit && out.MethodExplicit && (out.Method == methodHTML || out.Method == methodXHTML) {
+		out.Version = ""
 	}
 	return out
 }

--- a/xslt3/functions_transform.go
+++ b/xslt3/functions_transform.go
@@ -1238,10 +1238,13 @@ func applySerializationParams(base *OutputDef, seq xpath3.Sequence) *OutputDef {
 	// The version parameter's default is method-dependent, so an inherited xml
 	// version="1.0" must not carry into an html/xhtml method selected via
 	// serialization-params. When these params switch the method to html/xhtml
-	// without also supplying an explicit version, unset Version so the
+	// without supplying an explicit version — and the base stylesheet did not
+	// declare one either (VersionRaw empty) — unset Version so the
 	// method-appropriate serialization default applies instead of the inherited
-	// "1.0" (which the html method rejects with SESU0007).
-	if !versionExplicit && out.MethodExplicit && (out.Method == methodHTML || out.Method == methodXHTML) {
+	// "1.0" (which the html method rejects with SESU0007). An explicit base
+	// version (e.g. <xsl:output method="html" version="1.0"/>) is preserved so
+	// it still raises SESU0007.
+	if !versionExplicit && out.VersionRaw == "" && out.MethodExplicit && (out.Method == methodHTML || out.Method == methodXHTML) {
 		out.Version = ""
 	}
 	return out

--- a/xslt3/transform_options_test.go
+++ b/xslt3/transform_options_test.go
@@ -249,6 +249,16 @@ const htmlOutputStylesheet = `<?xml version="1.0"?>
   <xsl:template match="/"><html><body><br/></body></html></xsl:template>
 </xsl:stylesheet>`
 
+// htmlExplicitBadVersionStylesheet declares xsl:output method="html"
+// version="1.0" explicitly (an unsupported html version). serialization-params
+// that omit version must NOT clear this explicit base version, so SESU0007 must
+// still fire.
+const htmlExplicitBadVersionStylesheet = `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="html" version="1.0"/>
+  <xsl:template match="/"><html><body><br/></body></html></xsl:template>
+</xsl:stylesheet>`
+
 // TestTransformSerializationParams proves sub-fix 4: the serialization-params
 // option is applied to the serialized delivery output (QT3 fn-transform-30/31).
 func TestTransformSerializationParams(t *testing.T) {
@@ -346,6 +356,21 @@ func TestTransformSerializationParams(t *testing.T) {
 			`transform(map{'stylesheet-text': $ss, 'source-node': ., 'delivery-format': 'serialized', 'serialization-params': map{'method': 'html', 'version': '1.0'}})?output`,
 			sourceDoc,
 			map[string]xpath3.Sequence{"ss": xpath3.SingleString(htmlOutputStylesheet)},
+			transformFns(),
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "SESU0007")
+	})
+
+	// An EXPLICIT base stylesheet version (<xsl:output method="html"
+	// version="1.0"/>) must survive serialization-params that omit version: the
+	// html-method version reset applies only to an inherited (non-explicit)
+	// version, so SESU0007 must still fire here.
+	t.Run("ExplicitBaseVersionSurvivesUnrelatedParams", func(t *testing.T) {
+		_, err := evalTransform(t,
+			`transform(map{'stylesheet-text': $ss, 'source-node': ., 'delivery-format': 'serialized', 'serialization-params': map{'indent': true()}})?output`,
+			sourceDoc,
+			map[string]xpath3.Sequence{"ss": xpath3.SingleString(htmlExplicitBadVersionStylesheet)},
 			transformFns(),
 		)
 		require.Error(t, err)

--- a/xslt3/transform_options_test.go
+++ b/xslt3/transform_options_test.go
@@ -240,6 +240,15 @@ const methodTextOutputStylesheet = `<?xml version="1.0"?>
   <xsl:template match="/"><out><a><b>x</b></a></out></xsl:template>
 </xsl:stylesheet>`
 
+// htmlOutputStylesheet has an <html> root that emits an empty <br/> element and
+// declares NO xsl:output. It lets serialization-params map{'method':'html'}
+// switch the output method to html (QT3 fn-transform-31): the html serializer
+// emits the void <br> element without a self-closing slash.
+const htmlOutputStylesheet = `<?xml version="1.0"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/"><html><body><br/></body></html></xsl:template>
+</xsl:stylesheet>`
+
 // TestTransformSerializationParams proves sub-fix 4: the serialization-params
 // option is applied to the serialized delivery output (QT3 fn-transform-30/31).
 func TestTransformSerializationParams(t *testing.T) {
@@ -307,5 +316,39 @@ func TestTransformSerializationParams(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, reset, "<out")
 		require.Contains(t, reset, "<b>x</b>")
+	})
+
+	// QT3 fn-transform-31: serialization-params map{'method':'html'} over a
+	// stylesheet with no xsl:output must switch to html serialization (void
+	// <br> element, no self-closing slash) without raising SESU0007. The base
+	// output def carries the inherited xml version "1.0"; because the method is
+	// switched to html via serialization-params without an explicit version,
+	// the version must not carry over and trigger the SESU0007 html-version
+	// check.
+	t.Run("MethodHTMLResetsInheritedVersion", func(t *testing.T) {
+		out, err := evalTransform(t,
+			`transform(map{'stylesheet-text': $ss, 'source-node': ., 'delivery-format': 'serialized', 'serialization-params': map{'method': 'html'}})?output`,
+			sourceDoc,
+			map[string]xpath3.Sequence{"ss": xpath3.SingleString(htmlOutputStylesheet)},
+			transformFns(),
+		)
+		require.NoError(t, err)
+		require.Contains(t, out, "<br>")
+		require.NotContains(t, out, "<br/>")
+		require.NotContains(t, out, "<br />")
+	})
+
+	// An EXPLICIT version="1.0" alongside method="html" must still raise
+	// SESU0007: html only supports versions 4.0/4.01/5.0. The version reset
+	// applies only when the serialization-params map omits version.
+	t.Run("MethodHTMLExplicitBadVersionErrors", func(t *testing.T) {
+		_, err := evalTransform(t,
+			`transform(map{'stylesheet-text': $ss, 'source-node': ., 'delivery-format': 'serialized', 'serialization-params': map{'method': 'html', 'version': '1.0'}})?output`,
+			sourceDoc,
+			map[string]xpath3.Sequence{"ss": xpath3.SingleString(htmlOutputStylesheet)},
+			transformFns(),
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "SESU0007")
 	})
 }


### PR DESCRIPTION
- fn:transform serialization-params with method=html/xhtml but no explicit version no longer inherits the xml default version "1.0" into the html output method (which tripped SESU0007)
- when method is set to html/xhtml via serialization-params without a version, Version is unset so the method default applies, matching a bare `<xsl:output method="html"/>` stylesheet
- fixes a regression in fn:transform serialized delivery (QT3 fn-transform-31); explicit `version=1.0` for html still raises SESU0007