### PR TITLE
type parse-json numbers as xs:double

### DIFF
--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -141,6 +141,12 @@ Misc: `adjust-dateTime-to-timezone`, `adjust-date-to-timezone`, `adjust-time-to-
 ### `functions_json.go`
 `parse-json`, `json-doc`
 
+Per F&O 3.1 §17.5 JSON has a single number type: every JSON number in a
+`fn:parse-json` / `fn:json-doc` XDM result is an `xs:double` (`jsonToXDM`),
+including integral values like `0`/`-0` — never `xs:integer`. `fn:json-to-xml`
+is unaffected: it keeps the number's lexical form as the `<number>` element's
+string value (`functions_json_xml.go`), a separate representation.
+
 ### `functions_json_xml.go`
 `json-to-xml`, `xml-to-json`
 

--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -141,11 +141,18 @@ Misc: `adjust-dateTime-to-timezone`, `adjust-date-to-timezone`, `adjust-time-to-
 ### `functions_json.go`
 `parse-json`, `json-doc`
 
-Per F&O 3.1 §17.5 JSON has a single number type: every JSON number in a
-`fn:parse-json` / `fn:json-doc` XDM result is an `xs:double` (`jsonToXDM`),
-including integral values like `0`/`-0` — never `xs:integer`. `fn:json-to-xml`
-is unaffected: it keeps the number's lexical form as the `<number>` element's
-string value (`functions_json_xml.go`), a separate representation.
+The streaming JSON parser (`parseJSONValue`/`parseJSONToken`) is shared by
+`fn:parse-json`/`fn:json-doc` and `fn:json-to-xml`, but the two consumers type
+JSON numbers differently, gated by `jsonOptions.retainNumberLexical`:
+
+- `fn:parse-json` / `fn:json-doc` (flag false): per F&O 3.1 §17.5 JSON has a
+  single number type, so every JSON number becomes an `xs:double` (`jsonToXDM`),
+  including integral values like `0`/`-0` — never `xs:integer`.
+- `fn:json-to-xml` (flag true, set in `parseJSONToXMLOptions`): the `<number>`
+  element retains the number's EXACT lexical form (`23E0`, `0.23e+02`, `-0`,
+  `1000000000000` — never scientific notation), per F&O 3.1 / W3C bug 28179. The
+  parser yields a private `jsonLexicalNumber{lexical}` item that
+  `buildJSONToXMLTree` writes verbatim, bypassing the `xs:double` canonicalizer.
 
 ### `functions_json_xml.go`
 `json-to-xml`, `xml-to-json`

--- a/xpath3/functions_json.go
+++ b/xpath3/functions_json.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/big"
 	"strings"
 	"unicode/utf8"
 
@@ -591,23 +590,15 @@ func jsonToXDM(v any) (Item, error) {
 	case bool:
 		return AtomicValue{TypeName: TypeBoolean, Value: val}, nil
 	case json.Number:
+		// Per F&O 3.1 §17.5, JSON has a single number type and every JSON
+		// number maps to an xs:double in the XDM result — including integral
+		// values such as 0/-0, which therefore become xs:double, not xs:integer.
 		s := val.String()
-		if strings.ContainsAny(s, ".eE") {
-			f, err := val.Float64()
-			if err != nil {
-				return nil, &XPathError{Code: errCodeFOJS0001, Message: "invalid JSON number: " + s}
-			}
-			return AtomicValue{TypeName: TypeDouble, Value: NewDouble(f)}, nil
+		f, err := val.Float64()
+		if err != nil {
+			return nil, &XPathError{Code: errCodeFOJS0001, Message: "invalid JSON number: " + s}
 		}
-		n, ok := new(big.Int).SetString(s, 10)
-		if !ok {
-			f, err := val.Float64()
-			if err != nil {
-				return nil, &XPathError{Code: errCodeFOJS0001, Message: "invalid JSON number: " + s}
-			}
-			return AtomicValue{TypeName: TypeDouble, Value: NewDouble(f)}, nil
-		}
-		return AtomicValue{TypeName: TypeInteger, Value: n}, nil
+		return AtomicValue{TypeName: TypeDouble, Value: NewDouble(f)}, nil
 	case string:
 		return AtomicValue{TypeName: TypeString, Value: val}, nil
 	case []any:

--- a/xpath3/functions_json.go
+++ b/xpath3/functions_json.go
@@ -26,7 +26,21 @@ type jsonOptions struct {
 	validate   bool // validate=true(): type-annotate the json-to-xml result tree
 	fallback   *FunctionItem
 	invalidEsc map[rune]string
+	// retainNumberLexical selects fn:json-to-xml's number handling: it retains a
+	// JSON number's exact lexical form in the <number> element (F&O 3.1, W3C bug
+	// 28179), whereas fn:parse-json/fn:json-doc (false) map every JSON number to
+	// the canonical xs:double.
+	retainNumberLexical bool
 }
+
+// jsonLexicalNumber carries a JSON number's exact lexical form for
+// fn:json-to-xml, which retains the source representation in the <number>
+// element rather than the canonical xs:double produced by fn:parse-json.
+type jsonLexicalNumber struct {
+	lexical string
+}
+
+func (jsonLexicalNumber) itemTag() {}
 
 func fnParseJSON(ctx context.Context, args []Sequence) (Sequence, error) {
 	// Route empty detection through post-atomization: an empty array or a
@@ -329,6 +343,9 @@ func parseJSONToken(ctx context.Context, tok json.Token, dec *json.Decoder, opts
 				return nil, err
 			}
 			return AtomicValue{TypeName: TypeString, Value: s}, nil
+		}
+		if num, ok := v.(json.Number); ok && opts.retainNumberLexical {
+			return jsonLexicalNumber{lexical: num.String()}, nil
 		}
 		return jsonToXDM(v)
 	}

--- a/xpath3/functions_json_test.go
+++ b/xpath3/functions_json_test.go
@@ -131,6 +131,43 @@ func TestParseJSON_Bounded(t *testing.T) {
 	})
 }
 
+// Per F&O 3.1 §17.5 JSON has a single number type, so every JSON number in a
+// fn:parse-json / fn:json-doc result is an xs:double — including integral
+// values such as 0 and -0 (QT3 json-doc-032, json-doc-033). The value is
+// preserved (0 stays 0), only the type is xs:double, so deep-equal to the
+// xs:integer literal 0 still holds via numeric promotion.
+func TestParseJSON_NumbersAreDouble(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+	}{
+		{"zero", "0"},           // json-doc-032
+		{"negative zero", "-0"}, // json-doc-033
+		{"positive integer", "1"},
+		{"negative integer", "-5"},
+		{"non-integral", "2.5"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expr := `parse-json("` + escapeForXPathString(tc.json) + `") instance of xs:double`
+			r, err := evaluate(t.Context(), nil, expr)
+			require.NoError(t, err, expr)
+			require.Equal(t, wantTrue, r.StringValue(), "expected xs:double for %s", tc.json)
+		})
+	}
+
+	// Value is preserved for the integral cases: deep-equal to the xs:integer
+	// literal 0 still holds (numeric promotion), matching json-doc-032's
+	// assert-deep-eq 0.
+	r, err := evaluate(t.Context(), nil, `deep-equal(parse-json("0"), 0)`)
+	require.NoError(t, err)
+	require.Equal(t, wantTrue, r.StringValue())
+
+	r, err = evaluate(t.Context(), nil, `deep-equal(parse-json("-0"), 0)`)
+	require.NoError(t, err)
+	require.Equal(t, wantTrue, r.StringValue())
+}
+
 // fn:json-to-xml shares the same streaming parser and must be bounded too.
 func TestJSONToXML_DeepNestingBounded(t *testing.T) {
 	depth := xpath3.DefaultMaxRecursionDepth + 1

--- a/xpath3/functions_json_test.go
+++ b/xpath3/functions_json_test.go
@@ -168,6 +168,35 @@ func TestParseJSON_NumbersAreDouble(t *testing.T) {
 	require.Equal(t, wantTrue, r.StringValue())
 }
 
+// fn:json-to-xml retains a JSON number's EXACT lexical form in the <number>
+// element (F&O 3.1, W3C bug 28179 / QT3 json-to-xml-030/031/033) — the opposite
+// of fn:parse-json, which canonicalizes every number to xs:double. In
+// particular a large integer must NOT be rendered in scientific notation, and
+// -0 must be retained. This locks the split between the two consumers of the
+// shared JSON parser so the parse-json xs:double change cannot leak into
+// json-to-xml's number representation.
+func TestJSONToXML_NumbersRetainLexicalForm(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+		want string
+	}{
+		{"large integer no scientific notation", `{"a": 1000000000000}`, "1000000000000"},
+		{"negative zero retained", `-0`, "-0"},
+		{"upper-case exponent retained", `23E0`, "23E0"},
+		{"lower-case exponent with sign retained", `0.23e+02`, "0.23e+02"},
+		{"plain zero", `0`, "0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expr := `json-to-xml("` + escapeForXPathString(tc.json) + `")//*:number/string()`
+			r, err := evaluate(t.Context(), nil, expr)
+			require.NoError(t, err, expr)
+			require.Equal(t, tc.want, r.StringValue(), "json-to-xml must retain lexical form for %s", tc.json)
+		})
+	}
+}
+
 // fn:json-to-xml shares the same streaming parser and must be bounded too.
 func TestJSONToXML_DeepNestingBounded(t *testing.T) {
 	depth := xpath3.DefaultMaxRecursionDepth + 1

--- a/xpath3/functions_json_xml.go
+++ b/xpath3/functions_json_xml.go
@@ -136,6 +136,8 @@ func buildJSONToXMLTree(doc *helium.Document, item Item, opts jsonOptions, root 
 		_ = v
 	case ArrayItem:
 		name = jsonKindArray
+	case jsonLexicalNumber:
+		name = lexicon.TypeNumber
 	case AtomicValue:
 		switch v.TypeName {
 		case TypeString:
@@ -165,6 +167,13 @@ func buildJSONToXMLTree(doc *helium.Document, item Item, opts jsonOptions, root 
 	switch v := item.(type) {
 	case nil:
 		return elem, nil
+	case jsonLexicalNumber:
+		// Retain the JSON number's exact lexical form (e.g. 23E0, 0.23e+02, -0,
+		// 1000000000000) rather than the canonical xs:double, per F&O 3.1 (bug
+		// 28179).
+		if err := elem.AppendText([]byte(v.lexical)); err != nil {
+			return nil, &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("json-to-xml: failed to append numeric value: %v", err)}
+		}
 	case MapItem:
 		if err := v.forEach0(func(key AtomicValue, value Sequence) error {
 			child, err := buildJSONToXMLTree(doc, jsonSequenceToItem(value), opts, false, annotations)
@@ -235,7 +244,8 @@ func jsonSequenceToItem(seq Sequence) Item {
 
 func parseJSONToXMLOptions(ctx context.Context, args []Sequence) (jsonOptions, error) {
 	opts := jsonOptions{
-		duplicates: duplicatesUseFirst,
+		duplicates:          duplicatesUseFirst,
+		retainNumberLexical: true,
 	}
 	if len(args) <= 1 || seqLen(args[1]) == 0 {
 		return opts, nil

--- a/xpath3/option_value_flatten_test.go
+++ b/xpath3/option_value_flatten_test.go
@@ -36,7 +36,10 @@ func TestOptionValueFlattenBeforeCardinality(t *testing.T) {
 		require.Equal(t, 1, seq.Len())
 		av, ok := seq.Get(0).(xpath3.AtomicValue)
 		require.True(t, ok)
-		require.Equal(t, int64(2), av.IntegerVal())
+		// Per F&O 3.1 §17.5 a JSON number is an xs:double; use-last resolves the
+		// duplicate key to the second value, 2.
+		require.Equal(t, xpath3.TypeDouble, av.TypeName)
+		require.Equal(t, float64(2), av.DoubleVal())
 	})
 
 	// fn:serialize string parameter (item-separator). Atomizing ([], "-") yields


### PR DESCRIPTION
- fn:parse-json/fn:json-doc now type every JSON number as xs:double (F&O 3.1 §17.5: JSON's single number type maps to xs:double); integral numbers previously became xs:integer
- value preserved (0 stays 0, deep-equal to 0 holds via numeric promotion); fn:json-to-xml untouched (separate representation)
- closes QT3 json-doc-032/033