### PR TITLE
chore: gitignore local dev-time scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,10 @@ testdata/saxon/source/
 !THIRD_PARTY_NOTICES.md
 !AGENTS.md
 !CLAUDE.md
+
+# Local dev-time scratch (not committed)
 .review-gauntlet/
+.worktrees/
+.tmp/
+.cache/
+.envrc


### PR DESCRIPTION
Ignore local dev-time scratch that currently shows as untracked clutter: `.worktrees/`, `.tmp/`, `.cache/`, `.envrc`. Left `tools/examples_audit/`, `testdata/xslt30/`, and the fuzz corpus alone since those may be intentional content.