### PR TITLE
fix fn:serialize text-node SENR0001 and edge cases

### DIFF
--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -294,12 +294,16 @@ applied as above; `text` (`serializeTextSequence`) concatenates the string value
 of the items with the `item-separator` and no markup (character maps applied);
 `xhtml` is serialized as `xml` — a defensible approximation, as helium implements
 no XHTML-specific serialization rules. Sequence normalization (Serialization 3.1
-§2) rejects an attribute node, a namespace node, OR a function item with
-`SENR0001` under EVERY markup method — `xml`/`xhtml`/`html`/`text` and the
-unspecified default — via the shared `serializeItemKindError` guard (which
-delegates node kinds to `serializeNodeKindError`); a function item does NOT fall
-through to adaptive serialization under the html method. The `adaptive` and `json`
-methods are exempt (they keep their own function-item handling, `FOER0000`).
+§2) rejects an attribute node, a namespace node, OR a function item — which in XDM
+includes maps and arrays — with `SENR0001` under EVERY markup method —
+`xml`/`xhtml`/`html`/`text` and the unspecified default — via the shared
+`serializeItemKindError` guard (which delegates node kinds to
+`serializeNodeKindError`); a map/array/function does NOT fall through to adaptive
+serialization under the html method, nor is it accepted by the unspecified default
+(which dispatches through `serializeAdaptiveItem`, guarded when the method is not
+adaptive). The `adaptive` and `json` methods are exempt: `json` serializes maps
+and arrays as JSON, `adaptive` serializes maps/arrays its own way, and both keep
+`FOER0000` for a bare function item.
 
 **Normalization + character maps (all methods incl. JSON).** `normalization-form`
 is APPLIED for the methods that support it — xml/xhtml/html/text, the unspecified

--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -225,10 +225,16 @@ non-`fn:serialize` caller — keeps the document's version, byte-identical).
 `undeclare-prefixes` is honored only when that effective version is 1.1;
 requesting it at an effective 1.0 (the default when `version` is unspecified) is
 the `SEPM0010` static error. `method="html"` (`serializeHTMLSequence` /
-`serializeHTMLNode`) emits its DOCTYPE and injects a `<meta http-equiv=
-"Content-Type">` into `<head>` — but ONLY when the document element's local name
-is `html` (case-insensitive); any other root (or a fragment node) is serialized
-under the html method with no DOCTYPE/meta. The html parameters are APPLIED:
+`serializeHTMLNode`) emits its DOCTYPE (`writeHTMLWithDoctype`, immediately before
+the first element) and injects a `<meta http-equiv="Content-Type">` into `<head>`.
+A DOCTYPE is emitted in two cases (Serialization 3.1 §7.4.6): (a) an explicit
+`doctype-system`/`doctype-public` — emitted regardless of the document element's
+name AND for a bare element input, since sequence normalization wraps the element
+in a document; or (b) the DEFAULT `<!DOCTYPE html>` (HTML5) / HTML 4.01 declaration,
+which is emitted ONLY when the document element's local name is `html`
+(case-insensitive). The `<meta>` injection likewise applies only to an
+html-rooted document (a fragment / non-html root has no `<head>`). The html
+parameters are APPLIED:
 `include-content-type` (default yes) gates the meta injection; `escape-uri-attributes`
 (default yes) selects `helium/html` `Writer.EscapeURIAttributes`; and the DOCTYPE
 is chosen by `htmlDoctype` — an explicit `doctype-public`/`doctype-system` yields
@@ -281,8 +287,11 @@ supported XML output version (`1.0`/`1.1`); any other value is `SESU0013`
 
 **Output methods.** `xml` (default) and `adaptive`/`json` are full; `html` is
 applied as above; `text` (`serializeTextSequence`) concatenates the string values
-of the items with the `item-separator` and no markup (character maps applied,
-no SENR0001 node-kind restriction); `xhtml` is serialized as `xml` — a defensible
+of the items with the `item-separator` and no markup (character maps applied);
+sequence normalization (Serialization 3.1 §2) applies to `text` too, so an
+attribute node, a namespace node, or a function item input is `SENR0001` — the
+same node-kind guard (`serializeNodeKindError`) the xml/xhtml/html methods use;
+`xhtml` is serialized as `xml` — a defensible
 approximation, as helium implements no XHTML-specific serialization rules.
 
 **Normalization + character maps (all methods incl. JSON).** `normalization-form`

--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -225,14 +225,18 @@ non-`fn:serialize` caller — keeps the document's version, byte-identical).
 `undeclare-prefixes` is honored only when that effective version is 1.1;
 requesting it at an effective 1.0 (the default when `version` is unspecified) is
 the `SEPM0010` static error. `method="html"` (`serializeHTMLSequence` /
-`serializeHTMLNode`) emits its DOCTYPE (`writeHTMLWithDoctype`, immediately before
-the first element) and injects a `<meta http-equiv="Content-Type">` into `<head>`.
+`serializeHTMLNode` / `writeHTMLNodeTree`) emits its DOCTYPE immediately before the
+first element and injects a `<meta http-equiv="Content-Type">` into `<head>`.
 A DOCTYPE is emitted in two cases (Serialization 3.1 §7.4.6): (a) an explicit
 `doctype-system`/`doctype-public` — emitted regardless of the document element's
 name AND for a bare element input, since sequence normalization wraps the element
 in a document; or (b) the DEFAULT `<!DOCTYPE html>` (HTML5) / HTML 4.01 declaration,
 which is emitted ONLY when the document element's local name is `html`
-(case-insensitive). The `<meta>` injection likewise applies only to an
+(case-insensitive). Because sequence normalization (§2) wraps the WHOLE sequence in
+a single document node, the DOCTYPE is emitted AT MOST ONCE for the entire
+sequence — before the first element — not once per item; the `doctypeEmitted` flag
+threaded through the item loop (and `serializeHTMLNode`'s `allowDoctype` parameter)
+enforces this. The `<meta>` injection likewise applies only to an
 html-rooted document (a fragment / non-html root has no `<head>`). The html
 parameters are APPLIED:
 `include-content-type` (default yes) gates the meta injection; `escape-uri-attributes`

--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -292,11 +292,14 @@ supported XML output version (`1.0`/`1.1`); any other value is `SESU0013`
 **Output methods.** `xml` (default) and `adaptive`/`json` are full; `html` is
 applied as above; `text` (`serializeTextSequence`) concatenates the string values
 of the items with the `item-separator` and no markup (character maps applied);
-sequence normalization (Serialization 3.1 §2) applies to `text` too, so an
-attribute node, a namespace node, or a function item input is `SENR0001` — the
-same node-kind guard (`serializeNodeKindError`) the xml/xhtml/html methods use;
-`xhtml` is serialized as `xml` — a defensible
-approximation, as helium implements no XHTML-specific serialization rules.
+`xhtml` is serialized as `xml` — a defensible approximation, as helium implements
+no XHTML-specific serialization rules. Sequence normalization (Serialization 3.1
+§2) rejects an attribute node, a namespace node, OR a function item with
+`SENR0001` under EVERY markup method — `xml`/`xhtml`/`html`/`text` and the
+unspecified default — via the shared `serializeItemKindError` guard (which
+delegates node kinds to `serializeNodeKindError`); a function item does NOT fall
+through to adaptive serialization under the html method. The `adaptive` and `json`
+methods are exempt (they keep their own function-item handling, `FOER0000`).
 
 **Normalization + character maps (all methods incl. JSON).** `normalization-form`
 is APPLIED for the methods that support it — xml/xhtml/html/text, the unspecified

--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -294,16 +294,22 @@ applied as above; `text` (`serializeTextSequence`) concatenates the string value
 of the items with the `item-separator` and no markup (character maps applied);
 `xhtml` is serialized as `xml` — a defensible approximation, as helium implements
 no XHTML-specific serialization rules. Sequence normalization (Serialization 3.1
-§2) rejects an attribute node, a namespace node, OR a function item — which in XDM
-includes maps and arrays — with `SENR0001` under EVERY markup method —
-`xml`/`xhtml`/`html`/`text` and the unspecified default — via the shared
-`serializeItemKindError` guard (which delegates node kinds to
-`serializeNodeKindError`); a map/array/function does NOT fall through to adaptive
-serialization under the html method, nor is it accepted by the unspecified default
-(which dispatches through `serializeAdaptiveItem`, guarded when the method is not
-adaptive). The `adaptive` and `json` methods are exempt: `json` serializes maps
-and arrays as JSON, `adaptive` serializes maps/arrays its own way, and both keep
-`FOER0000` for a bare function item.
+§2) governs maps/arrays/functions under EVERY markup method —
+`xml`/`xhtml`/`html`/`text` and the unspecified default — in two steps.
+(1) **Array flattening** (`flattenSerializeArrays`, reusing `ArrayItem.Flatten`):
+an array is NOT a rejected kind; it is replaced by its member items RECURSIVELY
+(nested arrays flatten too), which then serialize as if supplied directly — atomic
+members space-separated by the `item-separator`, node members as nodes. (2) The
+shared `serializeItemKindError` guard then rejects with `SENR0001` a bare attribute
+node, a namespace node, OR a function item — INCLUDING a map (a map is a function
+item; an array is not) — delegating node kinds to `serializeNodeKindError`. So a
+map, or a map member surfaced by array flattening, does NOT fall through to
+adaptive serialization under the html method, nor is it accepted by the unspecified
+default (which dispatches through `serializeAdaptiveItem`, guarded when the method
+is not adaptive; the default flattens arrays before that dispatch). The `adaptive`
+and `json` methods are exempt from BOTH steps: they serialize maps/arrays natively
+(`json` → JSON, `adaptive` → the `map{…}`/`[…]` form) and keep `FOER0000` for a
+bare function item.
 
 **Normalization + character maps (all methods incl. JSON).** `normalization-form`
 is APPLIED for the methods that support it — xml/xhtml/html/text, the unspecified

--- a/xpath3/functions_serialize.go
+++ b/xpath3/functions_serialize.go
@@ -1762,15 +1762,19 @@ func newSerializeXMLWriter(opts serializeOptions) helium.Writer {
 }
 
 // serializeHTMLSequence serializes a sequence under the html output method.
-// An html-rooted document is serialized with a DOCTYPE (the default <!DOCTYPE html>
-// or an explicit doctype-public/doctype-system) and a <meta http-equiv=
-// "Content-Type"> injected into <head>. A non-html-rooted document or a bare
-// element still gets a DOCTYPE when doctype-public/doctype-system is specified
-// (Serialization 3.1 §7.4.6); otherwise it is serialized as an HTML fragment
-// (no DOCTYPE, no meta). Character maps (use-character-maps) are applied to text
-// and attribute content.
+// Sequence normalization (Serialization 3.1 §2) wraps the WHOLE sequence in a
+// single document node, so the html method emits at most ONE DOCTYPE for the
+// entire sequence — immediately before the first element (§7.4.6). An html-rooted
+// document contributes the default <!DOCTYPE html> (or an explicit doctype) plus a
+// <meta http-equiv="Content-Type"> injected into <head>; a non-html-rooted
+// document or a bare element contributes a DOCTYPE only when doctype-public/
+// doctype-system is specified; any node with no element (or once a prior item has
+// emitted the DOCTYPE) is a plain HTML fragment. The doctypeEmitted flag threads
+// that "at most once" rule across the item loop. Character maps (use-character-
+// maps) are applied to text and attribute content.
 func serializeHTMLSequence(seq Sequence, opts serializeOptions) (string, error) {
 	parts := make([]string, 0, seqLen(seq))
+	doctypeEmitted := false
 	for item := range seqItems(seq) {
 		node, ok := item.(NodeItem)
 		if !ok {
@@ -1784,95 +1788,100 @@ func serializeHTMLSequence(seq Sequence, opts serializeOptions) (string, error) 
 		if err := serializeNodeKindError(node); err != nil {
 			return "", err
 		}
-		text, err := serializeHTMLNode(node.Node, opts)
+		text, emitted, err := serializeHTMLNode(node.Node, opts, !doctypeEmitted)
 		if err != nil {
 			return "", err
+		}
+		if emitted {
+			doctypeEmitted = true
 		}
 		parts = append(parts, text)
 	}
 	return strings.Join(parts, opts.itemSeparator), nil
 }
 
-func serializeHTMLNode(node helium.Node, opts serializeOptions) (string, error) {
+// serializeHTMLNode serializes a single node under the html output method,
+// reporting whether it emitted the DOCTYPE. allowDoctype is false once a prior
+// item in the sequence already emitted one, so the DOCTYPE appears at most once
+// for the whole sequence (Serialization 3.1 §2/§7.4.6). This node emits a DOCTYPE
+// only when allowDoctype is true AND either the document element is <html> (the
+// default <!DOCTYPE html> / HTML 4.01 declaration, html-version-gated) or
+// doctype-public/doctype-system was explicitly specified (any root, or a bare
+// element — §7.4.6). The include-content-type <meta> injection applies only to an
+// html-rooted document (a fragment / non-html root has no <head>).
+func serializeHTMLNode(node helium.Node, opts serializeOptions, allowDoctype bool) (string, bool, error) {
 	hw := htmlpkg.NewWriter().DefaultDTD(false).Format(false).PreserveCase(true).
 		EscapeURIAttributes(opts.escapeURIAttributes).CharacterMap(opts.charMap).
 		Normalization(opts.normalizationForm)
 
 	doc, isDoc := node.(*helium.Document)
 	htmlRooted := isDoc && htmlDocumentElementIsHTML(doc)
-	// An explicitly specified doctype-system or doctype-public makes the html
-	// output method emit a document type declaration (named "html", not the
-	// document element's name) immediately before the first element — per
-	// Serialization 3.1 §7.4.6, regardless of the document element's name or
-	// whether the input is a bare element. The DEFAULT DOCTYPE (<!DOCTYPE html> at
-	// html-version 5.0 with no explicit doctype) is emitted ONLY when the document
-	// element's local name is "html", so a non-html-rooted node with no explicit
-	// doctype is serialized as a plain HTML fragment.
 	explicitDoctype := opts.doctypePublic != "" || opts.doctypeSystem != ""
+	emitDoctype := allowDoctype && (htmlRooted || explicitDoctype)
 
-	if !htmlRooted && !explicitDoctype {
-		// A fragment / non-html-rooted node with no explicit doctype: no DOCTYPE and
-		// no meta injection. The input tree is not mutated; escape-uri-attributes
-		// still applies.
-		var buf strings.Builder
-		if err := hw.WriteTo(&buf, node); err != nil {
-			return "", err
-		}
-		return strings.TrimSuffix(buf.String(), "\n"), nil
+	if !htmlRooted {
+		// A non-html-rooted document, a bare element, or a fragment node. The input
+		// tree is not mutated (no meta injection — there is no <head>).
+		// escape-uri-attributes still applies.
+		return writeHTMLNodeTree(hw, node, opts, emitDoctype)
 	}
 
-	// The remaining cases emit a DOCTYPE. Only an html-rooted document receives the
-	// include-content-type <meta> injection (a fragment / non-html root has no
-	// <head>). The meta injection works on a copy so the caller's tree is never
-	// mutated.
-	if htmlRooted {
-		clone, err := helium.CopyDoc(doc)
-		if err != nil {
-			return "", err
-		}
-		if opts.includeContentType {
-			insertHTMLContentTypeMeta(clone, opts.encoding, opts.mediaType)
-		}
-		return writeHTMLWithDoctype(hw, clone, opts)
+	// An html-rooted document: inject the Content-Type meta on a COPY (never
+	// mutating the caller's tree), then serialize, emitting the DOCTYPE unless the
+	// sequence already emitted one.
+	clone, err := helium.CopyDoc(doc)
+	if err != nil {
+		return "", false, err
 	}
-	return writeHTMLWithDoctype(hw, node, opts)
+	if opts.includeContentType {
+		insertHTMLContentTypeMeta(clone, opts.encoding, opts.mediaType)
+	}
+	return writeHTMLNodeTree(hw, clone, opts, emitDoctype)
 }
 
-// writeHTMLWithDoctype serializes node under the html writer, emitting the
-// computed DOCTYPE (htmlDoctype) immediately before the first element
-// (Serialization 3.1 §7.4.6). A document node's children are written in order (its
-// DTD node skipped, the DOCTYPE inserted before the first element child); a bare
-// element is written after the DOCTYPE; any other single node (text/comment/PI,
-// which has no first element) is written unchanged with no DOCTYPE.
-func writeHTMLWithDoctype(hw htmlpkg.Writer, node helium.Node, opts serializeOptions) (string, error) {
-	doctype := htmlDoctype(opts)
+// writeHTMLNodeTree serializes node under the html writer, reporting whether it
+// emitted a DOCTYPE. When emitDoctype is true it writes the computed DOCTYPE
+// (htmlDoctype) immediately before the first element (Serialization 3.1 §7.4.6);
+// otherwise no DOCTYPE is written. A document node's children are written in order
+// (its DTD node skipped, the DOCTYPE inserted before the first element child); a
+// bare element is written after the DOCTYPE; any other single node (text/comment/
+// PI) has no first element, so no DOCTYPE is written even when emitDoctype is true
+// (and it reports false so a later item in the sequence can still emit one).
+func writeHTMLNodeTree(hw htmlpkg.Writer, node helium.Node, opts serializeOptions, emitDoctype bool) (string, bool, error) {
+	var doctype string
+	if emitDoctype {
+		doctype = htmlDoctype(opts)
+	}
 	var buf strings.Builder
+	emitted := false
 	switch n := node.(type) {
 	case *helium.Document:
-		doctypeEmitted := false
 		for child := range helium.Children(n) {
 			if child.Type() == helium.DTDNode {
 				continue
 			}
-			if child.Type() == helium.ElementNode && !doctypeEmitted {
+			if emitDoctype && !emitted && child.Type() == helium.ElementNode {
 				buf.WriteString(doctype)
-				doctypeEmitted = true
+				emitted = true
 			}
 			if err := hw.WriteTo(&buf, child); err != nil {
-				return "", err
+				return "", false, err
 			}
 		}
 	case *helium.Element:
-		buf.WriteString(doctype)
+		if emitDoctype {
+			buf.WriteString(doctype)
+			emitted = true
+		}
 		if err := hw.WriteTo(&buf, n); err != nil {
-			return "", err
+			return "", false, err
 		}
 	default:
 		if err := hw.WriteTo(&buf, node); err != nil {
-			return "", err
+			return "", false, err
 		}
 	}
-	return strings.TrimSuffix(buf.String(), "\n"), nil
+	return strings.TrimSuffix(buf.String(), "\n"), emitted, nil
 }
 
 // htmlDoctype computes the DOCTYPE declaration (with trailing newline) for the

--- a/xpath3/functions_serialize.go
+++ b/xpath3/functions_serialize.go
@@ -314,9 +314,9 @@ type serializeOptions struct {
 	mediaType string
 	// normalizationForm is the requested Unicode normalization form ("" / "none"
 	// = no normalization). NFC/NFD/NFKC/NFKD are applied to the serialized output
-	// for the methods that support normalization; "fully-normalized" is the
-	// SESU0011 unsupported-normalization serialization error; the parameter is not
-	// applicable to (ignored by) the json/adaptive methods.
+	// for the methods that support normalization — xml/xhtml/html/text and json
+	// (§9.1.9); "fully-normalized" is the SESU0011 unsupported-normalization
+	// serialization error; only the adaptive method ignores the parameter.
 	normalizationForm string
 	// jsonNodeOutputMethod is the requested json-node-output-method value ("" =
 	// the default xml). helium serializes a node embedded in JSON only with the
@@ -1277,14 +1277,16 @@ func resolveSerializeStandaloneMap(ctx context.Context, v Sequence) (string, err
 
 // serializeNodeKindError reports err:SENR0001 when a bare attribute or namespace
 // node is serialized under a markup output method (xml/xhtml/html/text or the
-// unspecified default). Under the adaptive and json methods these node kinds are
-// serialized specially, so callers must not apply this guard for those methods.
+// unspecified default). Sequence normalization (Serialization 3.1 §2) rejects
+// these node kinds before any of those output methods run. Under the adaptive and
+// json methods these node kinds are serialized specially, so callers must not
+// apply this guard for those methods.
 func serializeNodeKindError(item NodeItem) error {
 	if _, ok := item.Node.(*helium.Attribute); ok {
-		return &XPathError{Code: errCodeSENR0001, Message: "cannot serialize an attribute node using the xml output method"}
+		return &XPathError{Code: errCodeSENR0001, Message: "cannot serialize an attribute node under this output method"}
 	}
 	if item.Node != nil && item.Node.Type() == helium.NamespaceNode {
-		return &XPathError{Code: errCodeSENR0001, Message: "cannot serialize a namespace node using the xml output method"}
+		return &XPathError{Code: errCodeSENR0001, Message: "cannot serialize a namespace node under this output method"}
 	}
 	return nil
 }
@@ -1616,9 +1618,10 @@ func serializeJSONAtomic(v AtomicValue, opts serializeOptions) (string, error) {
 // serializeTextSequence implements the text output method (Serialization 3.1
 // §8): the concatenation of the string values of the items, with the
 // item-separator between adjacent items and no markup. A node contributes its
-// string value (an attribute or namespace node its value — the text method has
-// no SENR0001 node-kind restriction); an atomic its lexical form. Character maps
-// apply to the resulting text.
+// string value; an atomic its lexical form. Sequence normalization (Serialization
+// 3.1 §2) applies to the text method too, so an attribute node, a namespace node,
+// or a function item is a serialization error [err:SENR0001]. Character maps apply
+// to the resulting text.
 func serializeTextSequence(seq Sequence, opts serializeOptions) (string, error) {
 	parts := make([]string, 0, seqLen(seq))
 	for item := range seqItems(seq) {
@@ -1636,9 +1639,16 @@ func serializeTextItem(item Item) (string, error) {
 	case AtomicValue:
 		return atomicToString(v)
 	case NodeItem:
+		// Sequence normalization (Serialization 3.1 §2) rejects a bare attribute or
+		// namespace node with SENR0001 before the text output method runs.
+		if err := serializeNodeKindError(v); err != nil {
+			return "", err
+		}
 		return ixpath.StringValue(v.Node), nil
 	case FunctionItem:
-		return "", &XPathError{Code: errCodeFOER0000, Message: "cannot serialize function item"}
+		// Sequence normalization (Serialization 3.1 §2) rejects a function item with
+		// SENR0001.
+		return "", &XPathError{Code: errCodeSENR0001, Message: "cannot serialize a function item under the text output method"}
 	default:
 		// A map or array has no string value; it can only be serialized with the
 		// json or adaptive method.
@@ -1752,10 +1762,13 @@ func newSerializeXMLWriter(opts serializeOptions) helium.Writer {
 }
 
 // serializeHTMLSequence serializes a sequence under the html output method.
-// A document node is serialized with an HTML5 <!DOCTYPE html> and a
-// <meta http-equiv="Content-Type"> injected into <head>; any other node is
-// serialized as an HTML fragment (no DOCTYPE). Character maps (use-character-maps)
-// are applied to text and attribute content.
+// An html-rooted document is serialized with a DOCTYPE (the default <!DOCTYPE html>
+// or an explicit doctype-public/doctype-system) and a <meta http-equiv=
+// "Content-Type"> injected into <head>. A non-html-rooted document or a bare
+// element still gets a DOCTYPE when doctype-public/doctype-system is specified
+// (Serialization 3.1 §7.4.6); otherwise it is serialized as an HTML fragment
+// (no DOCTYPE, no meta). Character maps (use-character-maps) are applied to text
+// and attribute content.
 func serializeHTMLSequence(seq Sequence, opts serializeOptions) (string, error) {
 	parts := make([]string, 0, seqLen(seq))
 	for item := range seqItems(seq) {
@@ -1785,13 +1798,22 @@ func serializeHTMLNode(node helium.Node, opts serializeOptions) (string, error) 
 		EscapeURIAttributes(opts.escapeURIAttributes).CharacterMap(opts.charMap).
 		Normalization(opts.normalizationForm)
 
-	doc, ok := node.(*helium.Document)
-	if !ok || !htmlDocumentElementIsHTML(doc) {
-		// A non-document node, or a document whose document element is not <html>,
-		// is serialized under the html output method WITHOUT the DOCTYPE and
-		// WITHOUT meta injection (Serialization 3.1: those apply to an html-rooted
-		// result). The input tree is not mutated. escape-uri-attributes still
-		// applies.
+	doc, isDoc := node.(*helium.Document)
+	htmlRooted := isDoc && htmlDocumentElementIsHTML(doc)
+	// An explicitly specified doctype-system or doctype-public makes the html
+	// output method emit a document type declaration (named "html", not the
+	// document element's name) immediately before the first element — per
+	// Serialization 3.1 §7.4.6, regardless of the document element's name or
+	// whether the input is a bare element. The DEFAULT DOCTYPE (<!DOCTYPE html> at
+	// html-version 5.0 with no explicit doctype) is emitted ONLY when the document
+	// element's local name is "html", so a non-html-rooted node with no explicit
+	// doctype is serialized as a plain HTML fragment.
+	explicitDoctype := opts.doctypePublic != "" || opts.doctypeSystem != ""
+
+	if !htmlRooted && !explicitDoctype {
+		// A fragment / non-html-rooted node with no explicit doctype: no DOCTYPE and
+		// no meta injection. The input tree is not mutated; escape-uri-attributes
+		// still applies.
 		var buf strings.Builder
 		if err := hw.WriteTo(&buf, node); err != nil {
 			return "", err
@@ -1799,28 +1821,54 @@ func serializeHTMLNode(node helium.Node, opts serializeOptions) (string, error) 
 		return strings.TrimSuffix(buf.String(), "\n"), nil
 	}
 
-	// Work on a copy so the <meta> injection never mutates the caller's tree.
-	clone, err := helium.CopyDoc(doc)
-	if err != nil {
-		return "", err
+	// The remaining cases emit a DOCTYPE. Only an html-rooted document receives the
+	// include-content-type <meta> injection (a fragment / non-html root has no
+	// <head>). The meta injection works on a copy so the caller's tree is never
+	// mutated.
+	if htmlRooted {
+		clone, err := helium.CopyDoc(doc)
+		if err != nil {
+			return "", err
+		}
+		if opts.includeContentType {
+			insertHTMLContentTypeMeta(clone, opts.encoding, opts.mediaType)
+		}
+		return writeHTMLWithDoctype(hw, clone, opts)
 	}
-	// include-content-type (default yes) controls the Content-Type meta injection.
-	if opts.includeContentType {
-		insertHTMLContentTypeMeta(clone, opts.encoding, opts.mediaType)
-	}
+	return writeHTMLWithDoctype(hw, node, opts)
+}
 
+// writeHTMLWithDoctype serializes node under the html writer, emitting the
+// computed DOCTYPE (htmlDoctype) immediately before the first element
+// (Serialization 3.1 §7.4.6). A document node's children are written in order (its
+// DTD node skipped, the DOCTYPE inserted before the first element child); a bare
+// element is written after the DOCTYPE; any other single node (text/comment/PI,
+// which has no first element) is written unchanged with no DOCTYPE.
+func writeHTMLWithDoctype(hw htmlpkg.Writer, node helium.Node, opts serializeOptions) (string, error) {
 	doctype := htmlDoctype(opts)
 	var buf strings.Builder
-	doctypeEmitted := false
-	for child := range helium.Children(clone) {
-		if child.Type() == helium.DTDNode {
-			continue
+	switch n := node.(type) {
+	case *helium.Document:
+		doctypeEmitted := false
+		for child := range helium.Children(n) {
+			if child.Type() == helium.DTDNode {
+				continue
+			}
+			if child.Type() == helium.ElementNode && !doctypeEmitted {
+				buf.WriteString(doctype)
+				doctypeEmitted = true
+			}
+			if err := hw.WriteTo(&buf, child); err != nil {
+				return "", err
+			}
 		}
-		if child.Type() == helium.ElementNode && !doctypeEmitted {
-			buf.WriteString(doctype)
-			doctypeEmitted = true
+	case *helium.Element:
+		buf.WriteString(doctype)
+		if err := hw.WriteTo(&buf, n); err != nil {
+			return "", err
 		}
-		if err := hw.WriteTo(&buf, child); err != nil {
+	default:
+		if err := hw.WriteTo(&buf, node); err != nil {
 			return "", err
 		}
 	}

--- a/xpath3/functions_serialize.go
+++ b/xpath3/functions_serialize.go
@@ -159,7 +159,14 @@ func fnSerialize(ctx context.Context, args []Sequence) (Sequence, error) {
 
 	var result string
 	switch dispatchOpts.method {
-	case "", serializeMethodAdaptive:
+	case "":
+		// The unspecified default is the xml family: sequence normalization
+		// (Serialization 3.1 §2) flattens array inputs into their members. It
+		// otherwise reuses the adaptive machinery, whose node-kind guard treats the
+		// default method as a markup method (SENR0001 for attribute/namespace/map/
+		// function items).
+		result, err = serializeAdaptiveSequence(flattenSerializeArrays(args[0]), dispatchOpts)
+	case serializeMethodAdaptive:
 		result, err = serializeAdaptiveSequence(args[0], dispatchOpts)
 	case serializeMethodJSON:
 		result, err = serializeJSONSequence(args[0], dispatchOpts)
@@ -1294,23 +1301,52 @@ func serializeNodeKindError(item NodeItem) error {
 // serializeItemKindError reports err:SENR0001 for every item kind that sequence
 // normalization (Serialization 3.1 §2) rejects under the markup output methods
 // (xml/xhtml/html/text and the unspecified default): a bare attribute node, a
-// namespace node, OR a function item. Maps and arrays ARE function items in XDM,
-// so they are rejected too. It returns nil for any other item. The adaptive and
-// json methods serialize these kinds specially (json serializes maps/arrays; both
-// handle function items their own way), so callers must not apply this guard for
-// those methods.
+// namespace node, OR a function item — INCLUDING a map (a map is a function item),
+// but NOT an array. Arrays are flattened into their members by
+// flattenSerializeArrays before this guard runs, so an array is never a rejected
+// kind. It returns nil for any other item. The adaptive and json methods serialize
+// these kinds specially (json serializes maps/arrays; both handle function items
+// their own way), so callers must not apply this guard for those methods.
 func serializeItemKindError(item Item) error {
 	switch v := item.(type) {
 	case NodeItem:
 		return serializeNodeKindError(v)
 	case MapItem:
 		return &XPathError{Code: errCodeSENR0001, Message: "cannot serialize a map under this output method"}
-	case ArrayItem:
-		return &XPathError{Code: errCodeSENR0001, Message: "cannot serialize an array under this output method"}
 	case FunctionItem:
 		return &XPathError{Code: errCodeSENR0001, Message: "cannot serialize a function item under this output method"}
 	}
 	return nil
+}
+
+// flattenSerializeArrays implements the array-flattening step of sequence
+// normalization (Serialization 3.1 §2): an array supplied to a markup output
+// method (xml/xhtml/html/text and the unspecified default) is replaced by its
+// member items, RECURSIVELY (nested arrays flatten too), and those members are
+// serialized as if they had been supplied directly. A map is NOT flattened (it is
+// a function item, rejected by serializeItemKindError). The json and adaptive
+// methods keep their native array handling and must NOT call this. When the
+// sequence contains no array the input is returned unchanged.
+func flattenSerializeArrays(seq Sequence) Sequence {
+	hasArray := false
+	for item := range seqItems(seq) {
+		if _, ok := item.(ArrayItem); ok {
+			hasArray = true
+			break
+		}
+	}
+	if !hasArray {
+		return seq
+	}
+	out := make(ItemSlice, 0, seqLen(seq))
+	for item := range seqItems(seq) {
+		if arr, ok := item.(ArrayItem); ok {
+			out = append(out, arr.Flatten().Materialize()...)
+			continue
+		}
+		out = append(out, item)
+	}
+	return out
 }
 
 // resolveSerializeCharacterMapsElement validates the element form of
@@ -1650,6 +1686,9 @@ func serializeJSONAtomic(v AtomicValue, opts serializeOptions) (string, error) {
 // or a function item is a serialization error [err:SENR0001]. Character maps apply
 // to the resulting text.
 func serializeTextSequence(seq Sequence, opts serializeOptions) (string, error) {
+	// Sequence normalization (Serialization 3.1 §2) flattens array inputs into
+	// their members before serialization.
+	seq = flattenSerializeArrays(seq)
 	parts := make([]string, 0, seqLen(seq))
 	for item := range seqItems(seq) {
 		s, err := serializeTextItem(item)
@@ -1698,6 +1737,9 @@ func applyCharMapToString(s string, charMap map[rune]string) string {
 }
 
 func serializeXMLSequence(seq Sequence, opts serializeOptions) (string, error) {
+	// Sequence normalization (Serialization 3.1 §2) flattens array inputs into
+	// their members before serialization.
+	seq = flattenSerializeArrays(seq)
 	parts := make([]string, 0, seqLen(seq))
 	for item := range seqItems(seq) {
 		// Sequence normalization (Serialization 3.1 §2) rejects a bare attribute
@@ -1796,6 +1838,9 @@ func newSerializeXMLWriter(opts serializeOptions) helium.Writer {
 // that "at most once" rule across the item loop. Character maps (use-character-
 // maps) are applied to text and attribute content.
 func serializeHTMLSequence(seq Sequence, opts serializeOptions) (string, error) {
+	// Sequence normalization (Serialization 3.1 §2) flattens array inputs into
+	// their members before serialization.
+	seq = flattenSerializeArrays(seq)
 	parts := make([]string, 0, seqLen(seq))
 	doctypeEmitted := false
 	for item := range seqItems(seq) {

--- a/xpath3/functions_serialize.go
+++ b/xpath3/functions_serialize.go
@@ -1291,6 +1291,22 @@ func serializeNodeKindError(item NodeItem) error {
 	return nil
 }
 
+// serializeItemKindError reports err:SENR0001 for every item kind that sequence
+// normalization (Serialization 3.1 §2) rejects under the markup output methods
+// (xml/xhtml/html/text and the unspecified default): a bare attribute node, a
+// namespace node, OR a function item. It returns nil for any other item. The
+// adaptive and json methods serialize these kinds specially, so callers must not
+// apply this guard for those methods.
+func serializeItemKindError(item Item) error {
+	switch v := item.(type) {
+	case NodeItem:
+		return serializeNodeKindError(v)
+	case FunctionItem:
+		return &XPathError{Code: errCodeSENR0001, Message: "cannot serialize a function item under this output method"}
+	}
+	return nil
+}
+
 // resolveSerializeCharacterMapsElement validates the element form of
 // use-character-maps and builds the rune→replacement map from its
 // output:character-map children.
@@ -1465,6 +1481,13 @@ func serializeAdaptiveItem(item Item, opts serializeOptions) (string, error) {
 	case ArrayItem:
 		return serializeAdaptiveArray(v, opts)
 	case FunctionItem:
+		// The unspecified default method is the xml family, under which sequence
+		// normalization (Serialization 3.1 §2) rejects a function item [err:SENR0001].
+		// An explicit method="adaptive" handles a function item its own way (helium
+		// emits no adaptive function representation, so FOER0000).
+		if opts.method != serializeMethodAdaptive {
+			return "", &XPathError{Code: errCodeSENR0001, Message: "cannot serialize a function item under this output method"}
+		}
 		return "", &XPathError{Code: errCodeFOER0000, Message: "cannot serialize function item"}
 	default:
 		return "", &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("cannot serialize %T", item)}
@@ -1635,20 +1658,17 @@ func serializeTextSequence(seq Sequence, opts serializeOptions) (string, error) 
 }
 
 func serializeTextItem(item Item) (string, error) {
+	// Sequence normalization (Serialization 3.1 §2) rejects a bare attribute node,
+	// a namespace node, or a function item with SENR0001 before the text output
+	// method runs.
+	if err := serializeItemKindError(item); err != nil {
+		return "", err
+	}
 	switch v := item.(type) {
 	case AtomicValue:
 		return atomicToString(v)
 	case NodeItem:
-		// Sequence normalization (Serialization 3.1 §2) rejects a bare attribute or
-		// namespace node with SENR0001 before the text output method runs.
-		if err := serializeNodeKindError(v); err != nil {
-			return "", err
-		}
 		return ixpath.StringValue(v.Node), nil
-	case FunctionItem:
-		// Sequence normalization (Serialization 3.1 §2) rejects a function item with
-		// SENR0001.
-		return "", &XPathError{Code: errCodeSENR0001, Message: "cannot serialize a function item under the text output method"}
 	default:
 		// A map or array has no string value; it can only be serialized with the
 		// json or adaptive method.
@@ -1676,15 +1696,14 @@ func applyCharMapToString(s string, charMap map[rune]string) string {
 func serializeXMLSequence(seq Sequence, opts serializeOptions) (string, error) {
 	parts := make([]string, 0, seqLen(seq))
 	for item := range seqItems(seq) {
+		// Sequence normalization (Serialization 3.1 §2) rejects a bare attribute
+		// node, a namespace node, or a function item under the xml/xhtml methods
+		// [err:SENR0001] before serialization.
+		if err := serializeItemKindError(item); err != nil {
+			return "", err
+		}
 		switch v := item.(type) {
-		case FunctionItem:
-			return "", &XPathError{Code: errCodeFOER0000, Message: "cannot serialize function item"}
 		case NodeItem:
-			// xml/xhtml/html/text output methods cannot serialize a bare
-			// attribute or namespace node [err:SENR0001].
-			if err := serializeNodeKindError(v); err != nil {
-				return "", err
-			}
 			text, err := serializeNodeItem(v, opts)
 			if err != nil {
 				return "", err
@@ -1776,6 +1795,13 @@ func serializeHTMLSequence(seq Sequence, opts serializeOptions) (string, error) 
 	parts := make([]string, 0, seqLen(seq))
 	doctypeEmitted := false
 	for item := range seqItems(seq) {
+		// Sequence normalization (Serialization 3.1 §2) rejects a bare attribute
+		// node, a namespace node, or a function item under the html method
+		// [err:SENR0001] — a function item must NOT fall through to adaptive
+		// serialization.
+		if err := serializeItemKindError(item); err != nil {
+			return "", err
+		}
 		node, ok := item.(NodeItem)
 		if !ok {
 			s, err := serializeAdaptiveItem(item, opts)
@@ -1784,9 +1810,6 @@ func serializeHTMLSequence(seq Sequence, opts serializeOptions) (string, error) 
 			}
 			parts = append(parts, s)
 			continue
-		}
-		if err := serializeNodeKindError(node); err != nil {
-			return "", err
 		}
 		text, emitted, err := serializeHTMLNode(node.Node, opts, !doctypeEmitted)
 		if err != nil {

--- a/xpath3/functions_serialize.go
+++ b/xpath3/functions_serialize.go
@@ -1294,13 +1294,19 @@ func serializeNodeKindError(item NodeItem) error {
 // serializeItemKindError reports err:SENR0001 for every item kind that sequence
 // normalization (Serialization 3.1 §2) rejects under the markup output methods
 // (xml/xhtml/html/text and the unspecified default): a bare attribute node, a
-// namespace node, OR a function item. It returns nil for any other item. The
-// adaptive and json methods serialize these kinds specially, so callers must not
-// apply this guard for those methods.
+// namespace node, OR a function item. Maps and arrays ARE function items in XDM,
+// so they are rejected too. It returns nil for any other item. The adaptive and
+// json methods serialize these kinds specially (json serializes maps/arrays; both
+// handle function items their own way), so callers must not apply this guard for
+// those methods.
 func serializeItemKindError(item Item) error {
 	switch v := item.(type) {
 	case NodeItem:
 		return serializeNodeKindError(v)
+	case MapItem:
+		return &XPathError{Code: errCodeSENR0001, Message: "cannot serialize a map under this output method"}
+	case ArrayItem:
+		return &XPathError{Code: errCodeSENR0001, Message: "cannot serialize an array under this output method"}
 	case FunctionItem:
 		return &XPathError{Code: errCodeSENR0001, Message: "cannot serialize a function item under this output method"}
 	}
@@ -1445,6 +1451,18 @@ func serializeAdaptiveSequence(seq Sequence, opts serializeOptions) (string, err
 }
 
 func serializeAdaptiveItem(item Item, opts serializeOptions) (string, error) {
+	// serializeAdaptiveItem serves BOTH the explicit adaptive method and the
+	// unspecified default method (the xml family). Under the default method
+	// sequence normalization (Serialization 3.1 §2) rejects a bare attribute node,
+	// a namespace node, or a function item — which in XDM includes maps and arrays
+	// — with SENR0001. The explicit adaptive method (and the nested map/array
+	// serialization, which passes method="adaptive") serializes all of these its
+	// own way, so this guard applies only when the method is not adaptive.
+	if opts.method != serializeMethodAdaptive {
+		if err := serializeItemKindError(item); err != nil {
+			return "", err
+		}
+	}
 	switch v := item.(type) {
 	case AtomicValue:
 		if v.TypeName == TypeBoolean {
@@ -1466,28 +1484,14 @@ func serializeAdaptiveItem(item Item, opts serializeOptions) (string, error) {
 		}
 		return s, nil
 	case NodeItem:
-		// The default (empty) method is the xml family, under which an
-		// attribute or namespace node is a serialization error. An explicit
-		// method="adaptive" serializes them specially, so only guard when the
-		// method is not adaptive.
-		if opts.method != serializeMethodAdaptive {
-			if err := serializeNodeKindError(v); err != nil {
-				return "", err
-			}
-		}
 		return serializeNodeItem(v, opts)
 	case MapItem:
 		return serializeAdaptiveMap(v, opts)
 	case ArrayItem:
 		return serializeAdaptiveArray(v, opts)
 	case FunctionItem:
-		// The unspecified default method is the xml family, under which sequence
-		// normalization (Serialization 3.1 §2) rejects a function item [err:SENR0001].
-		// An explicit method="adaptive" handles a function item its own way (helium
-		// emits no adaptive function representation, so FOER0000).
-		if opts.method != serializeMethodAdaptive {
-			return "", &XPathError{Code: errCodeSENR0001, Message: "cannot serialize a function item under this output method"}
-		}
+		// Only reachable under the explicit adaptive method (the default method is
+		// rejected above). helium emits no adaptive function representation.
 		return "", &XPathError{Code: errCodeFOER0000, Message: "cannot serialize function item"}
 	default:
 		return "", &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("cannot serialize %T", item)}

--- a/xpath3/functions_serialize_params_test.go
+++ b/xpath3/functions_serialize_params_test.go
@@ -1572,6 +1572,64 @@ func TestSerialize_FunctionItemSENR0001(t *testing.T) {
 	}
 }
 
+// TestSerialize_MapArraySENR0001 verifies that a map or array input is a
+// serialization error [err:SENR0001] under every markup output method
+// (xml/xhtml/html/text and the unspecified default): maps and arrays ARE function
+// items in XDM, so sequence normalization (Serialization 3.1 §2) rejects them.
+// The json output method legitimately serializes maps/arrays, and the adaptive
+// method serializes them its own way — both must keep working.
+func TestSerialize_MapArraySENR0001(t *testing.T) {
+	requireSENR0001 := func(t *testing.T, expr string) {
+		t.Helper()
+		doc := mustParseXML(t, `<root>text</root>`)
+		_, err := evaluate(t.Context(), doc, expr)
+		require.Error(t, err)
+		var xerr *xpath3.XPathError
+		require.ErrorAs(t, err, &xerr)
+		require.Equal(t, "SENR0001", xerr.Code)
+	}
+
+	for _, input := range []struct{ name, expr string }{
+		{"map", `map{"a":1}`},
+		{"array", `[1]`},
+	} {
+		for _, method := range []string{"xml", "xhtml", "html", "text"} {
+			t.Run(input.name+" method="+method, func(t *testing.T) {
+				requireSENR0001(t, `serialize(`+input.expr+`, map{"method":"`+method+`"})`)
+			})
+		}
+		t.Run(input.name+" default method", func(t *testing.T) {
+			requireSENR0001(t, `serialize(`+input.expr+`)`)
+		})
+	}
+
+	// json and adaptive must still serialize maps and arrays (NOT SENR0001).
+	t.Run("json still serializes a map", func(t *testing.T) {
+		doc := mustParseXML(t, `<root/>`)
+		res, err := evaluate(t.Context(), doc, `serialize(map{"a":1}, map{"method":"json"})`)
+		require.NoError(t, err)
+		require.Equal(t, `{"a":1}`, res.StringValue())
+	})
+	t.Run("json still serializes an array", func(t *testing.T) {
+		doc := mustParseXML(t, `<root/>`)
+		res, err := evaluate(t.Context(), doc, `serialize([1,2], map{"method":"json"})`)
+		require.NoError(t, err)
+		require.Equal(t, `[1,2]`, res.StringValue())
+	})
+	t.Run("adaptive still serializes a map", func(t *testing.T) {
+		doc := mustParseXML(t, `<root/>`)
+		res, err := evaluate(t.Context(), doc, `serialize(map{"a":1}, map{"method":"adaptive"})`)
+		require.NoError(t, err)
+		require.Equal(t, `map{"a":1}`, res.StringValue())
+	})
+	t.Run("adaptive still serializes an array", func(t *testing.T) {
+		doc := mustParseXML(t, `<root/>`)
+		res, err := evaluate(t.Context(), doc, `serialize([1], map{"method":"adaptive"})`)
+		require.NoError(t, err)
+		require.Equal(t, `[1]`, res.StringValue())
+	})
+}
+
 // TestSerialize_HTMLDoctypeNonHTMLRoot verifies Serialization 3.1 §7.4.6: an
 // explicitly specified doctype-system/doctype-public makes the html output method
 // emit a document type declaration (named "html", not the document element's name)

--- a/xpath3/functions_serialize_params_test.go
+++ b/xpath3/functions_serialize_params_test.go
@@ -1503,3 +1503,69 @@ func TestSerialize_JSONCharacterMapsAndNormalization(t *testing.T) {
 		require.Equal(t, "\"e\u0301\u00e9\"", res.StringValue())
 	})
 }
+
+// TestSerialize_TextMethodSENR0001 verifies that sequence normalization
+// (Serialization 3.1 §2 — "It is a serialization error [err:SENR0001] if an item
+// … is an attribute node, a namespace node or a function item") applies to the
+// text output method too: such items are rejected with SENR0001 rather than
+// silently contributing their string value. This routes through the same
+// serializeNodeKindError checkpoint the xml/xhtml/html methods use.
+func TestSerialize_TextMethodSENR0001(t *testing.T) {
+	requireSENR0001 := func(t *testing.T, src, expr string) {
+		t.Helper()
+		doc := mustParseXML(t, src)
+		_, err := evaluate(t.Context(), doc, expr)
+		require.Error(t, err)
+		var xerr *xpath3.XPathError
+		require.ErrorAs(t, err, &xerr)
+		require.Equal(t, "SENR0001", xerr.Code)
+	}
+
+	t.Run("attribute node", func(t *testing.T) {
+		requireSENR0001(t, `<root id="x">text</root>`, `serialize(/root/@id, map{"method":"text"})`)
+	})
+	t.Run("namespace node", func(t *testing.T) {
+		requireSENR0001(t, `<root xmlns:p="urn:p">text</root>`, `serialize(/root/namespace::*[local-name()='p'], map{"method":"text"})`)
+	})
+	t.Run("function item", func(t *testing.T) {
+		requireSENR0001(t, `<root>text</root>`, `serialize(true#0, map{"method":"text"})`)
+	})
+}
+
+// TestSerialize_HTMLDoctypeNonHTMLRoot verifies Serialization 3.1 §7.4.6: an
+// explicitly specified doctype-system/doctype-public makes the html output method
+// emit a document type declaration (named "html", not the document element's name)
+// immediately before the first element, regardless of the document element's name
+// or whether the input is a bare element. With no explicit doctype a
+// non-html-rooted node stays a fragment — the default <!DOCTYPE html> is emitted
+// only for an <html>-rooted document.
+func TestSerialize_HTMLDoctypeNonHTMLRoot(t *testing.T) {
+	t.Run("non-html document + doctype-system emits DOCTYPE html", func(t *testing.T) {
+		doc := mustParseXML(t, `<page><body><p>Hi</p></body></page>`)
+		res, err := evaluate(t.Context(), doc,
+			`serialize(., map{"method":"html","doctype-system":"about:legacy-compat"})`)
+		require.NoError(t, err)
+		out := res.StringValue()
+		require.Contains(t, out, `<!DOCTYPE html SYSTEM "about:legacy-compat">`, "output:\n%s", out)
+		// The DOCTYPE name is the fixed token "html", never the root element name.
+		require.NotContains(t, out, "<!DOCTYPE page", "output:\n%s", out)
+	})
+
+	t.Run("bare non-html element + doctype-public/system emits DOCTYPE html", func(t *testing.T) {
+		doc := mustParseXML(t, `<page><body><p>Hi</p></body></page>`)
+		root := doc.DocumentElement() // a bare element, not a document node
+		res, err := evaluate(t.Context(), root,
+			`serialize(., map{"method":"html","doctype-public":"-//X//DTD//EN","doctype-system":"x.dtd"})`)
+		require.NoError(t, err)
+		out := res.StringValue()
+		require.Contains(t, out, `<!DOCTYPE html PUBLIC "-//X//DTD//EN" "x.dtd">`, "output:\n%s", out)
+		require.Contains(t, out, "<body>", "output:\n%s", out)
+	})
+
+	t.Run("non-html root without explicit doctype stays a fragment", func(t *testing.T) {
+		doc := mustParseXML(t, `<page><body><p>Hi</p></body></page>`)
+		res, err := evaluate(t.Context(), doc, `serialize(., map{"method":"html"})`)
+		require.NoError(t, err)
+		require.NotContains(t, res.StringValue(), "<!DOCTYPE", "output:\n%s", res.StringValue())
+	})
+}

--- a/xpath3/functions_serialize_params_test.go
+++ b/xpath3/functions_serialize_params_test.go
@@ -1568,4 +1568,19 @@ func TestSerialize_HTMLDoctypeNonHTMLRoot(t *testing.T) {
 		require.NoError(t, err)
 		require.NotContains(t, res.StringValue(), "<!DOCTYPE", "output:\n%s", res.StringValue())
 	})
+
+	// Sequence normalization (Serialization 3.1 §2) wraps the whole sequence in a
+	// SINGLE document node, so a multi-element sequence gets exactly ONE DOCTYPE,
+	// immediately before the first element — never one per item.
+	t.Run("multi-element sequence + doctype-system emits a single DOCTYPE", func(t *testing.T) {
+		doc := mustParseXML(t, `<root><a>A</a><b>B</b></root>`)
+		res, err := evaluate(t.Context(), doc,
+			`serialize((/root/a, /root/b), map{"method":"html","doctype-system":"x.dtd"})`)
+		require.NoError(t, err)
+		out := res.StringValue()
+		require.Equal(t, 1, strings.Count(out, "<!DOCTYPE"), "expected exactly one DOCTYPE, output:\n%s", out)
+		require.Contains(t, out, `<!DOCTYPE html SYSTEM "x.dtd">`, "output:\n%s", out)
+		// The single DOCTYPE precedes both elements.
+		require.Regexp(t, `(?s)<!DOCTYPE html SYSTEM "x\.dtd">.*<a>A</a>.*<b>B</b>`, out)
+	})
 }

--- a/xpath3/functions_serialize_params_test.go
+++ b/xpath3/functions_serialize_params_test.go
@@ -1572,13 +1572,17 @@ func TestSerialize_FunctionItemSENR0001(t *testing.T) {
 	}
 }
 
-// TestSerialize_MapArraySENR0001 verifies that a map or array input is a
-// serialization error [err:SENR0001] under every markup output method
-// (xml/xhtml/html/text and the unspecified default): maps and arrays ARE function
-// items in XDM, so sequence normalization (Serialization 3.1 §2) rejects them.
-// The json output method legitimately serializes maps/arrays, and the adaptive
-// method serializes them its own way — both must keep working.
-func TestSerialize_MapArraySENR0001(t *testing.T) {
+// TestSerialize_MapSENR0001AndArrayFlattening verifies sequence normalization
+// (Serialization 3.1 §2) for maps and arrays under the markup output methods
+// (xml/xhtml/html/text and the unspecified default). A MAP is a function item, so
+// it is a serialization error [err:SENR0001]; an ARRAY is NOT — it is flattened
+// (recursively) into its members, which serialize as if supplied directly. The
+// json output method serializes maps/arrays natively, and the adaptive method
+// serializes them its own way — both must keep working (no flattening, no
+// SENR0001).
+func TestSerialize_MapSENR0001AndArrayFlattening(t *testing.T) {
+	markupMethods := []string{"xml", "xhtml", "html", "text"}
+
 	requireSENR0001 := func(t *testing.T, expr string) {
 		t.Helper()
 		doc := mustParseXML(t, `<root>text</root>`)
@@ -1588,45 +1592,62 @@ func TestSerialize_MapArraySENR0001(t *testing.T) {
 		require.ErrorAs(t, err, &xerr)
 		require.Equal(t, "SENR0001", xerr.Code)
 	}
-
-	for _, input := range []struct{ name, expr string }{
-		{"map", `map{"a":1}`},
-		{"array", `[1]`},
-	} {
-		for _, method := range []string{"xml", "xhtml", "html", "text"} {
-			t.Run(input.name+" method="+method, func(t *testing.T) {
-				requireSENR0001(t, `serialize(`+input.expr+`, map{"method":"`+method+`"})`)
-			})
-		}
-		t.Run(input.name+" default method", func(t *testing.T) {
-			requireSENR0001(t, `serialize(`+input.expr+`)`)
-		})
+	requireEquals := func(t *testing.T, expr, want string) {
+		t.Helper()
+		doc := mustParseXML(t, `<r><a/><b/></r>`)
+		res, err := evaluate(t.Context(), doc, expr)
+		require.NoError(t, err)
+		require.Equal(t, want, res.StringValue())
 	}
 
-	// json and adaptive must still serialize maps and arrays (NOT SENR0001).
-	t.Run("json still serializes a map", func(t *testing.T) {
-		doc := mustParseXML(t, `<root/>`)
-		res, err := evaluate(t.Context(), doc, `serialize(map{"a":1}, map{"method":"json"})`)
-		require.NoError(t, err)
-		require.Equal(t, `{"a":1}`, res.StringValue())
+	// A map is still SENR0001 under every markup method + the unspecified default.
+	for _, method := range markupMethods {
+		t.Run("map method="+method+" is SENR0001", func(t *testing.T) {
+			requireSENR0001(t, `serialize(map{"a":1}, map{"method":"`+method+`"})`)
+		})
+	}
+	t.Run("map default method is SENR0001", func(t *testing.T) {
+		requireSENR0001(t, `serialize(map{"a":1})`)
 	})
-	t.Run("json still serializes an array", func(t *testing.T) {
-		doc := mustParseXML(t, `<root/>`)
-		res, err := evaluate(t.Context(), doc, `serialize([1,2], map{"method":"json"})`)
-		require.NoError(t, err)
-		require.Equal(t, `[1,2]`, res.StringValue())
+
+	// An array is flattened into its members (NOT SENR0001) under every markup
+	// method + the unspecified default. Atomic members serialize space-separated.
+	for _, method := range markupMethods {
+		t.Run("array of atomics method="+method+" flattens", func(t *testing.T) {
+			requireEquals(t, `serialize([1,2,3], map{"method":"`+method+`"})`, "1 2 3")
+		})
+	}
+	t.Run("array of atomics default method flattens", func(t *testing.T) {
+		requireEquals(t, `serialize([1,2,3])`, "1 2 3")
 	})
-	t.Run("adaptive still serializes a map", func(t *testing.T) {
-		doc := mustParseXML(t, `<root/>`)
-		res, err := evaluate(t.Context(), doc, `serialize(map{"a":1}, map{"method":"adaptive"})`)
-		require.NoError(t, err)
-		require.Equal(t, `map{"a":1}`, res.StringValue())
+	t.Run("nested array flattens recursively", func(t *testing.T) {
+		requireEquals(t, `serialize([1,[2,3],4], map{"method":"xml"})`, "1 2 3 4")
 	})
-	t.Run("adaptive still serializes an array", func(t *testing.T) {
-		doc := mustParseXML(t, `<root/>`)
-		res, err := evaluate(t.Context(), doc, `serialize([1], map{"method":"adaptive"})`)
+	t.Run("array of element nodes serializes the elements", func(t *testing.T) {
+		doc := mustParseXML(t, `<r><a/><b/></r>`)
+		res, err := evaluate(t.Context(), doc, `serialize([/r/a, /r/b], map{"method":"xml"})`)
 		require.NoError(t, err)
-		require.Equal(t, `[1]`, res.StringValue())
+		out := res.StringValue()
+		require.Contains(t, out, "<a/>", "output:\n%s", out)
+		require.Contains(t, out, "<b/>", "output:\n%s", out)
+	})
+	// A map member inside an array is still SENR0001 after the array is flattened.
+	t.Run("array containing a map member is SENR0001", func(t *testing.T) {
+		requireSENR0001(t, `serialize([1, map{"a":1}], map{"method":"xml"})`)
+	})
+
+	// json and adaptive keep native map/array handling (no flattening, no SENR0001).
+	t.Run("json serializes a map", func(t *testing.T) {
+		requireEquals(t, `serialize(map{"a":1}, map{"method":"json"})`, `{"a":1}`)
+	})
+	t.Run("json serializes an array", func(t *testing.T) {
+		requireEquals(t, `serialize([1,2], map{"method":"json"})`, `[1,2]`)
+	})
+	t.Run("adaptive serializes a map", func(t *testing.T) {
+		requireEquals(t, `serialize(map{"a":1}, map{"method":"adaptive"})`, `map{"a":1}`)
+	})
+	t.Run("adaptive serializes an array", func(t *testing.T) {
+		requireEquals(t, `serialize([1], map{"method":"adaptive"})`, `[1]`)
 	})
 }
 

--- a/xpath3/functions_serialize_params_test.go
+++ b/xpath3/functions_serialize_params_test.go
@@ -1509,7 +1509,7 @@ func TestSerialize_JSONCharacterMapsAndNormalization(t *testing.T) {
 // … is an attribute node, a namespace node or a function item") applies to the
 // text output method too: such items are rejected with SENR0001 rather than
 // silently contributing their string value. This routes through the same
-// serializeNodeKindError checkpoint the xml/xhtml/html methods use.
+// serializeItemKindError checkpoint the xml/xhtml/html methods use.
 func TestSerialize_TextMethodSENR0001(t *testing.T) {
 	requireSENR0001 := func(t *testing.T, src, expr string) {
 		t.Helper()
@@ -1530,6 +1530,46 @@ func TestSerialize_TextMethodSENR0001(t *testing.T) {
 	t.Run("function item", func(t *testing.T) {
 		requireSENR0001(t, `<root>text</root>`, `serialize(true#0, map{"method":"text"})`)
 	})
+}
+
+// TestSerialize_FunctionItemSENR0001 verifies that a function-item input is a
+// serialization error [err:SENR0001] under EVERY markup output method
+// (xml/xhtml/html and the unspecified default) — sequence normalization
+// (Serialization 3.1 §2) rejects function items for all of them, not just text.
+// The adaptive and json methods are exempt (they keep their own function-item
+// handling), so they stay FOER0000.
+func TestSerialize_FunctionItemSENR0001(t *testing.T) {
+	requireCode := func(t *testing.T, method, wantCode string) {
+		t.Helper()
+		doc := mustParseXML(t, `<root>text</root>`)
+		expr := `serialize(true#0, map{"method":"` + method + `"})`
+		_, err := evaluate(t.Context(), doc, expr)
+		require.Error(t, err)
+		var xerr *xpath3.XPathError
+		require.ErrorAs(t, err, &xerr)
+		require.Equal(t, wantCode, xerr.Code, "method=%s", method)
+	}
+
+	for _, method := range []string{"xml", "xhtml", "html", "text"} {
+		t.Run(method+" raises SENR0001", func(t *testing.T) {
+			requireCode(t, method, "SENR0001")
+		})
+	}
+	// The unspecified default (xml family) also raises SENR0001.
+	t.Run("default method raises SENR0001", func(t *testing.T) {
+		doc := mustParseXML(t, `<root>text</root>`)
+		_, err := evaluate(t.Context(), doc, `serialize(true#0)`)
+		require.Error(t, err)
+		var xerr *xpath3.XPathError
+		require.ErrorAs(t, err, &xerr)
+		require.Equal(t, "SENR0001", xerr.Code)
+	})
+	// adaptive and json are exempt from the SENR0001 sequence-normalization guard.
+	for _, method := range []string{"adaptive", "json"} {
+		t.Run(method+" is exempt (FOER0000)", func(t *testing.T) {
+			requireCode(t, method, "FOER0000")
+		})
+	}
 }
 
 // TestSerialize_HTMLDoctypeNonHTMLRoot verifies Serialization 3.1 §7.4.6: an


### PR DESCRIPTION
- text output method now raises SENR0001 for attribute/namespace/function-item input (sequence normalization §2), routed through the shared node-kind guard
- html output method emits a DOCTYPE (named html) for a non-html-rooted document or bare element when doctype-system/doctype-public is specified (§7.4.6); default DOCTYPE html still requires an html root
- correct stale code comments claiming the json method ignores normalization-form (it applies it; only adaptive ignores it) — no behavior change