### PR TITLE
scope fn:serialize normalization to text and attribute content

### DIFF
--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -211,7 +211,7 @@ but unapplied parameters (`byte-order-mark`, `escape-uri-attributes`,
 ignored rather than rejected as unsupported.
 The xml path builds a `helium.Writer` via `newSerializeXMLWriter` wiring
 `OutputVersion`/`Standalone`/`OmitStandalone`/`AllowPrefixUndeclarations`/
-`CDATASectionElements`/`SuppressIndentElements`/`CharacterMap` — the shared
+`CDATASectionElements`/`SuppressIndentElements`/`CharacterMap`/`Normalization` — the shared
 `helium.Writer` (root `writer.go`/`writer_escape.go`) implements those knobs
 (character maps substitute a mapped rune with its raw replacement in text and
 attribute content; cdata-section-elements emit direct text children as CDATA;
@@ -286,25 +286,38 @@ no SENR0001 node-kind restriction); `xhtml` is serialized as `xml` — a defensi
 approximation, as helium implements no XHTML-specific serialization rules.
 
 **Normalization + character maps (all methods incl. JSON).** `normalization-form`
-is APPLIED to the serialized output for the methods that support it —
-xml/xhtml/html/text, the unspecified default, AND `json` (Serialization 3.1
-§9.1.9) — `NFC`/`NFD`/`NFKC`/`NFKD` via `golang.org/x/text/unicode/norm`
-(`applySerializeNormalization`, the last serialization step); `none`/`""` is a
-no-op; the W3C-specific `fully-normalized` form is not provided by that package and
-is the `SESU0011` unsupported-normalization error. Only the `adaptive` method
-ignores it. `use-character-maps` is likewise applicable to the `json` output
-method (§9.1.11, matching Saxon): a mapped character is replaced by its verbatim
-replacement in JSON string content (values and object keys) INSTEAD of being
-JSON-escaped — e.g. a map `"/"→"/"` prevents escaping `/` as `\/`
-(`encodeJSONStringForSerialization` consults `opts.charMap`). A character-map
-REPLACEMENT string is NOT subjected to Unicode Normalization or re-escaping
-(Serialization 3.1 §11): when a normalization pass and a character map are BOTH in
-force, `withCharMapSentinels` substitutes each mapped key with a unique sentinel
-rune (Supplementary Private Use Area-A, unaffected by normalization) during
-serialization (XML/HTML/text/json alike), then `expandCharMapSentinels` restores
-the verbatim replacement AFTER normalization — so replacements pass through
-un-normalized while the surrounding content is normalized. `json-node-output-method`
-is validated against its OWN
+is APPLIED for the methods that support it — xml/xhtml/html/text, the unspecified
+default, AND `json` (Serialization 3.1 §9.1.9) — `NFC`/`NFD`/`NFKC`/`NFKD` via
+`golang.org/x/text/unicode/norm`; `none`/`""` is a no-op; the W3C-specific
+`fully-normalized` form is not provided by that package and is the `SESU0011`
+unsupported-normalization error (rejected up front in `fnSerialize` via
+`isSupportedSerializeNormForm`, so it fires for every applicable method even with
+no text to normalize). Only the `adaptive` method ignores it. Normalization is
+SCOPED to text-node and attribute-value character content (Serialization 3.1 §4
+character-expansion phase) — element/attribute NAMES, comment/PI markup, the
+DOCTYPE, and the XML declaration are NEVER normalized. The markup methods
+(xml/xhtml/html and the unspecified default) apply it INSIDE their writer: the
+`helium` XML writer via `Writer.Normalization(form)` (normalizing each text node
+and attribute value in `escapeText`/`escapeAttrValue`, and CDATA content, before
+escaping) and the `helium/html` writer via `Writer.Normalization(form)`
+(`dumpText`/`dumpAttributes`). The `text` and `json` methods emit pure character
+data (text) or ASCII-delimited character data (json), so
+`applySerializeNormalization` normalizes their WHOLE output — equivalent to
+node-scoped normalization for those methods. `use-character-maps` is likewise
+applicable to the `json` output method (§9.1.11, matching Saxon): a mapped
+character is replaced by its verbatim replacement in JSON string content (values
+and object keys) INSTEAD of being JSON-escaped — e.g. a map `"/"→"/"` prevents
+escaping `/` as `\/` (`encodeJSONStringForSerialization` consults `opts.charMap`).
+A character-map REPLACEMENT string is NOT subjected to Unicode Normalization or
+re-escaping (Serialization 3.1 §11): when a normalization pass and a character map
+are BOTH in force, `withCharMapSentinels` substitutes each mapped key with a unique
+sentinel rune (Supplementary Private Use Area-A, unaffected by normalization)
+during serialization (XML/HTML/text/json alike), then `expandCharMapSentinels`
+restores the verbatim replacement AFTER normalization — so replacements pass
+through un-normalized while the surrounding content is normalized (in the markup
+writers the mapped key is folded to its sentinel BEFORE the per-node normalize
+pass, so the ordering — character mapping precedes normalization — holds).
+`json-node-output-method` is validated against its OWN
 narrower domain (`xml`/`html`/`xhtml`/`text` or an extension QName — NOT
 `json`/`adaptive`, via `serializeJSONNodeOutputMethodValid`); only its default
 (`xml`) is honored, so a non-default value (`html`/`xhtml`/`text`/extension) that

--- a/html/dump.go
+++ b/html/dump.go
@@ -57,6 +57,8 @@ func (w Writer) WriteTo(out io.Writer, node helium.Node) error {
 		escapeControlChars:    cfg.escapeControlChars,
 		nullNamespaceHTMLOnly: cfg.nullNamespaceHTMLOnly,
 		charMap:               cfg.charMap,
+		normalize:             cfg.normalize,
+		normForm:              cfg.normForm,
 	}
 	return d.dumpNode(out, node)
 }
@@ -111,6 +113,11 @@ type htmlDumper struct {
 	// its literal (unescaped) replacement string (Serialization 3.1 character
 	// maps). Empty/nil disables the feature.
 	charMap map[rune]string
+	// normalize / normForm request Unicode normalization of text-node and
+	// attribute-value character content (Serialization 3.1 §4), scoped to text and
+	// attribute nodes. false keeps output byte-identical.
+	normalize bool
+	normForm  norm.Form
 	// err is a sticky serialization error. Once set, all checked write
 	// helpers become no-ops and terminal methods return it. This mirrors
 	// the writeSession sticky-error pattern in writer.go so that a writer
@@ -362,17 +369,67 @@ func (d *htmlDumper) dumpDTD(out io.Writer, dtd *helium.DTD) {
 	d.writeString(out, ">\n")
 }
 
+// htmlNormalizationForm maps a normalization-form parameter name to its
+// golang.org/x/text norm.Form and reports whether normalization is active.
+func htmlNormalizationForm(form string) (norm.Form, bool) {
+	switch form {
+	case "NFC":
+		return norm.NFC, true
+	case "NFD":
+		return norm.NFD, true
+	case "NFKC":
+		return norm.NFKC, true
+	case "NFKD":
+		return norm.NFKD, true
+	}
+	return norm.NFC, false
+}
+
+// normalizeContent applies the dumper's requested Unicode normalization to a text
+// or attribute node's character content, substituting character-map keys with
+// their (normalization-inert sentinel) replacement FIRST so a replacement passes
+// through un-normalized (Serialization 3.1 §4). Because the character map has been
+// applied here, the caller passes a nil map to the escape funnel. Only called when
+// d.normalize is true.
+func (d *htmlDumper) normalizeContent(s []byte) []byte {
+	if len(d.charMap) == 0 {
+		return d.normForm.Bytes(s)
+	}
+	var b bytes.Buffer
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		r, width := utf8.DecodeRune(s[i:])
+		i += width
+		if repl, ok := d.charMap[r]; ok {
+			b.WriteString(repl)
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return d.normForm.Bytes(b.Bytes())
+}
+
 // dumpText outputs text content, escaping &, <, > unless inside a raw text element.
 func (d *htmlDumper) dumpText(out io.Writer, n helium.Node) error {
+	// Unicode normalization is scoped to text nodes: normalize the character
+	// content first (character maps are folded in), then the escape funnel emits it
+	// with a nil map since mapping is already applied.
+	content := n.Content()
+	cm := d.charMap
+	if d.normalize {
+		content = d.normalizeContent(content)
+		cm = nil
+	}
+
 	parent := n.Parent()
 	if parent != nil && parent.Type() == helium.ElementNode {
 		parentName := strings.ToLower(parent.Name())
 		if desc := lookupElement(parentName); desc != nil && desc.dataMode >= dataRawText {
 			// Raw text element: no escaping (character maps still apply).
-			if len(d.charMap) == 0 {
-				d.writeBytes(out, n.Content())
+			if len(cm) == 0 {
+				d.writeBytes(out, content)
 			} else {
-				d.check(writeHTMLCharMapped(out, n.Content(), d.charMap))
+				d.check(writeHTMLCharMapped(out, content, cm))
 			}
 			return d.err
 		}
@@ -382,7 +439,7 @@ func (d *htmlDumper) dumpText(out io.Writer, n helium.Node) error {
 	if d.err != nil {
 		return d.err
 	}
-	d.check(htmlEscapeText(out, n.Content(), d.escapeControlChars, d.charMap))
+	d.check(htmlEscapeText(out, content, d.escapeControlChars, cm))
 	return d.err
 }
 
@@ -751,9 +808,15 @@ func (d *htmlDumper) dumpAttributes(out io.Writer, e *helium.Element) error {
 			// is applied to a URI attribute value (escape-uri-attributes=yes), the
 			// serializer skips character mapping for that value. Character maps
 			// apply to non-URI attributes, and to URI attributes only when URI
-			// escaping is disabled (escape-uri-attributes=no).
+			// escaping is disabled (escape-uri-attributes=no). Unicode normalization
+			// is likewise scoped to the attribute value's character content; a
+			// URI-escaped value is already ASCII (percent-encoded), so normalization
+			// is a no-op there and character mapping is skipped.
 			attrCharMap := d.charMap
 			if uriEscaped {
+				attrCharMap = nil
+			} else if d.normalize {
+				val = string(d.normalizeContent([]byte(val)))
 				attrCharMap = nil
 			}
 			d.check(htmlEscapeAttrValue(out, val, isURI, d.preserveCase, attrCharMap))

--- a/html/dump_normalization_test.go
+++ b/html/dump_normalization_test.go
@@ -1,0 +1,40 @@
+package html_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/html"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWriterNormalization exercises html.Writer.Normalization: Unicode
+// normalization is scoped to text-node and attribute-value character content
+// (Serialization 3.1 §4). Element/attribute names are never normalized.
+func TestWriterNormalization(t *testing.T) {
+	const decomposed = "e\u0301" // "e" + combining acute
+	const composed = "\u00e9"    // U+00E9
+
+	doc := helium.NewHTMLDocument()
+	// Element named "p" + decomposed é, with a decomposed text child.
+	root := doc.CreateElement("p" + decomposed)
+	require.NoError(t, doc.SetDocumentElement(root))
+	require.NoError(t, root.AddChild(doc.CreateText([]byte(decomposed))))
+
+	var buf strings.Builder
+	err := html.NewWriter().DefaultDTD(false).Format(false).PreserveCase(true).
+		Normalization("NFC").WriteTo(&buf, root)
+	require.NoError(t, err)
+	out := buf.String()
+
+	require.Contains(t, out, "<p"+decomposed+">", "element name not normalized: %q", out)
+	require.Contains(t, out, ">"+composed+"<", "text content normalized: %q", out)
+	require.NotContains(t, out, "p"+composed, "name must stay decomposed: %q", out)
+
+	// Without normalization the text stays decomposed (byte-identical default).
+	var raw strings.Builder
+	require.NoError(t, html.NewWriter().DefaultDTD(false).Format(false).PreserveCase(true).WriteTo(&raw, root))
+	require.NotContains(t, raw.String(), composed, "no normalization by default: %q", raw.String())
+}

--- a/html/options.go
+++ b/html/options.go
@@ -1,5 +1,7 @@
 package html
 
+import "golang.org/x/text/unicode/norm"
+
 // parseConfig holds configuration for the HTML parser.
 type parseConfig struct {
 	noImplied bool
@@ -131,6 +133,19 @@ func (w Writer) CharacterMap(m map[rune]string) Writer {
 	return w
 }
 
+// Normalization requests Unicode normalization of text-node and attribute-value
+// character content (the normalization-form serialization parameter). form is one
+// of "NFC", "NFD", "NFKC", "NFKD"; "", "none", or any other value disables it,
+// leaving output byte-identical. Normalization is scoped to text and attribute
+// nodes (Serialization 3.1 §4 character-expansion phase) — element/attribute
+// names, comments, PIs, and the DOCTYPE are never normalized. A character map is
+// expected to carry normalization-inert replacements (fn:serialize substitutes
+// sentinel runes), so a mapped character's replacement is not normalized.
+func (w Writer) Normalization(form string) Writer {
+	w.normForm, w.normalize = htmlNormalizationForm(form)
+	return w
+}
+
 // NullNamespaceHTMLOnly controls whether an element is recognized as an HTML
 // void element (serialized with no closing tag) only when it is in no
 // namespace. When true, an otherwise-void element (e.g. <meta>) in a non-null
@@ -155,4 +170,10 @@ type dumpConfig struct {
 	// its literal replacement string (Serialization 3.1 character maps).
 	// Empty/nil disables the feature.
 	charMap map[rune]string
+	// normalize / normForm request Unicode normalization of text-node and
+	// attribute-value character content (the normalization-form serialization
+	// parameter, Serialization 3.1 §4). Scoped to text and attribute nodes; false
+	// by default, keeping output byte-identical.
+	normalize bool
+	normForm  norm.Form
 }

--- a/writer.go
+++ b/writer.go
@@ -11,6 +11,7 @@ import (
 	henc "github.com/lestrrat-go/helium/internal/encoding"
 	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/xmlchar"
+	"golang.org/x/text/unicode/norm"
 )
 
 // Write serializes a node (document or element) to the given writer using
@@ -75,6 +76,17 @@ type Writer struct {
 	// declaration (the encoding serialization parameter). Empty keeps the
 	// document's own encoding, leaving default output byte-identical.
 	outputEncoding string
+	// normalize / normForm request Unicode normalization of text-node and
+	// attribute-value character content (the normalization-form serialization
+	// parameter, Serialization 3.1 §4 character-expansion phase). Normalization is
+	// scoped to text and attribute nodes ONLY — element/attribute names, comments,
+	// PIs, the DOCTYPE, and the XML declaration are never normalized. A
+	// character-map replacement is assumed to be normalization-inert (fn:serialize
+	// substitutes a sentinel rune for a mapped character), so a replacement passes
+	// through un-normalized. normalize is false by default, keeping output
+	// byte-identical when no normalization is requested.
+	normalize bool
+	normForm  norm.Form
 }
 
 // standaloneMode controls how the writer emits the standalone pseudo-attribute
@@ -373,6 +385,20 @@ func (w Writer) OutputEncoding(v string) Writer {
 	return w
 }
 
+// Normalization requests Unicode normalization of text-node and attribute-value
+// character content (the normalization-form serialization parameter). form is one
+// of "NFC", "NFD", "NFKC", "NFKD"; "", "none", or any other value disables it,
+// leaving output byte-identical. Normalization is scoped to text and attribute
+// nodes (Serialization 3.1 §4 character-expansion phase) — element/attribute
+// names, comments, PIs, the DOCTYPE, and the XML declaration are never normalized.
+// A character map (CharacterMap) is expected to carry normalization-inert
+// replacements (fn:serialize substitutes sentinel runes), so a mapped character's
+// replacement is not normalized.
+func (w Writer) Normalization(form string) Writer {
+	w.normForm, w.normalize = xmlNormalizationForm(form)
+	return w
+}
+
 // effectiveEncoding returns the encoding driving the XML-declaration
 // pseudo-attribute: the OutputEncoding override when set, otherwise the
 // document's own encoding.
@@ -644,10 +670,20 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 			}
 		} else if d.cdataText {
 			// The parent element is a cdata-section-element: emit the text as
-			// one or more CDATA sections instead of escaping it.
+			// one or more CDATA sections instead of escaping it. A CDATA section
+			// serializes a text node, so its content is normalized too (character
+			// maps are not applied inside a CDATA section).
+			if d.normalize {
+				c = d.normForm.Bytes(c)
+			}
 			d.writeCDATASplit(out, c)
 		} else {
-			if err := escapeText(out, c, false, d.escapeNonASCII, d.rejectInvalidChars, d.xml11, d.charMap); err != nil {
+			cm := d.charMap
+			if d.normalize {
+				c = d.normalizeContent(c)
+				cm = nil
+			}
+			if err := escapeText(out, c, false, d.escapeNonASCII, d.rejectInvalidChars, d.xml11, cm); err != nil {
 				return err
 			}
 		}
@@ -655,8 +691,14 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 	case CDATASectionNode:
 		// Mirrors xmlsave.c XML_CDATA_SECTION_NODE handling.
 		// Splits content on "]]>" sequences so the output is well-formed.
-		// Read-only serialization: use the internal slice without a copy.
-		d.writeCDATASplit(out, rawContent(n))
+		// Read-only serialization: use the internal slice without a copy. A CDATA
+		// section serializes a text node, so its content is normalized when
+		// requested (the delimiters are markup and stay verbatim).
+		cdata := rawContent(n)
+		if d.normalize {
+			cdata = d.normForm.Bytes(cdata)
+		}
+		d.writeCDATASplit(out, cdata)
 		return d.err
 	case ElementDeclNode:
 		if edecl, ok := AsNode[*ElementDecl](n); ok {
@@ -747,7 +789,7 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 			for achld := range Children(attr) {
 				count++
 				if achld.Type() == TextNode {
-					if err := escapeAttrValue(out, rawContent(achld), d.escapeNonASCII, d.rejectInvalidChars, d.xml11, d.charMap); err != nil {
+					if err := d.writeAttrValueContent(out, rawContent(achld)); err != nil {
 						return err
 					}
 				} else {

--- a/writer_escape.go
+++ b/writer_escape.go
@@ -1,11 +1,71 @@
 package helium
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"strings"
 	"unicode/utf8"
+
+	"golang.org/x/text/unicode/norm"
 )
+
+// xmlNormalizationForm maps a normalization-form parameter name to its
+// golang.org/x/text norm.Form and reports whether normalization is active. "NFC",
+// "NFD", "NFKC", and "NFKD" enable it; "", "none", and any other value disable it
+// (the caller — fn:serialize — rejects "fully-normalized" as SESU0011 before
+// reaching the writer).
+func xmlNormalizationForm(form string) (norm.Form, bool) {
+	switch form {
+	case "NFC":
+		return norm.NFC, true
+	case "NFD":
+		return norm.NFD, true
+	case "NFKC":
+		return norm.NFKC, true
+	case "NFKD":
+		return norm.NFKD, true
+	}
+	return norm.NFC, false
+}
+
+// normalizeContent applies the writer's requested Unicode normalization to a text
+// or attribute node's character content. When a character map is in force its
+// mapped characters are substituted FIRST (their replacement — a
+// normalization-inert sentinel supplied by fn:serialize — is left un-normalized),
+// matching Serialization 3.1 §4: character mapping precedes normalization and a
+// replacement is not normalized. Because the character map has already been
+// applied here, the caller passes a nil map to the escaper. It must only be
+// called when d.normalize is true.
+func (d *writeSession) normalizeContent(s []byte) []byte {
+	if len(d.charMap) == 0 {
+		return d.normForm.Bytes(s)
+	}
+	var b bytes.Buffer
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		r, width := utf8.DecodeRune(s[i:])
+		i += width
+		if repl, ok := d.charMap[r]; ok {
+			b.WriteString(repl)
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return d.normForm.Bytes(b.Bytes())
+}
+
+// writeAttrValueContent escapes an attribute value's character content, applying
+// the requested Unicode normalization (scoped to attribute nodes) and character
+// maps. Shared by the generic and XHTML serialization paths.
+func (d *writeSession) writeAttrValueContent(out io.Writer, content []byte) error {
+	cm := d.charMap
+	if d.normalize {
+		content = d.normalizeContent(content)
+		cm = nil
+	}
+	return escapeAttrValue(out, content, d.escapeNonASCII, d.rejectInvalidChars, d.xml11, cm)
+}
 
 var (
 	qch_dquote = []byte{'"'}

--- a/writer_test.go
+++ b/writer_test.go
@@ -1208,3 +1208,39 @@ func TestWriteStringWithoutDTD(t *testing.T) {
 	require.True(t, strings.Contains(s, "<root>"))
 	require.Contains(t, s, "&amp;")
 }
+
+// TestWriterNormalization exercises Writer.Normalization: Unicode normalization is
+// scoped to text-node and attribute-value character content (Serialization 3.1
+// §4). Element/attribute names, comments, and PIs are never normalized.
+func TestWriterNormalization(t *testing.T) {
+	t.Parallel()
+	const decomposed = "e\u0301" // "e" + combining acute
+	const composed = "\u00e9"    // U+00E9
+	src := "<caf" + decomposed + " at" + decomposed + "=\"" + decomposed + "\">" +
+		"<!--" + decomposed + "--><?p " + decomposed + "?>" + decomposed +
+		"</caf" + decomposed + ">"
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	var buf strings.Builder
+	// EscapeNonASCII(false) so the composed é appears literally, isolating the
+	// normalization effect from the writer's numeric-reference escaping.
+	err = helium.NewWriter().XMLDeclaration(false).EscapeNonASCII(false).
+		Normalization("NFC").WriteTo(&buf, doc)
+	require.NoError(t, err)
+	out := buf.String()
+
+	// Text and attribute value are composed; names, comment, and PI stay decomposed.
+	require.Contains(t, out, ">"+composed+"</caf"+decomposed+">", "text normalized: %q", out)
+	require.Contains(t, out, "at"+decomposed+"=\""+composed+"\"", "attr value normalized, name not: %q", out)
+	require.Contains(t, out, "<caf"+decomposed, "element name not normalized: %q", out)
+	require.Contains(t, out, "<!--"+decomposed+"-->", "comment not normalized: %q", out)
+	require.Contains(t, out, "<?p "+decomposed+"?>", "PI not normalized: %q", out)
+	require.NotContains(t, out, "caf"+composed, "name must stay decomposed: %q", out)
+
+	// Without normalization the output is byte-identical to the source content.
+	var raw strings.Builder
+	err = helium.NewWriter().XMLDeclaration(false).EscapeNonASCII(false).WriteTo(&raw, doc)
+	require.NoError(t, err)
+	require.NotContains(t, raw.String(), composed, "no normalization by default: %q", raw.String())
+}

--- a/writer_xhtml.go
+++ b/writer_xhtml.go
@@ -228,8 +228,9 @@ func (d *writeSession) dumpXHTMLAttrList(out io.Writer, e *Element) error {
 					// Character maps apply to XHTML attribute values (Serialization
 					// 3.1 §6); this XHTML path performs no URI percent-encoding, so
 					// the §7 URI-attribute character-map exclusion is not reachable
-					// here and the map applies uniformly.
-					d.check(escapeAttrValue(out, rawContent(achld), d.escapeNonASCII, d.rejectInvalidChars, d.xml11, d.charMap))
+					// here and the map applies uniformly. Normalization (when
+					// requested) applies to the attribute value's character content.
+					d.check(d.writeAttrValueContent(out, rawContent(achld)))
 				} else {
 					d.check(d.writeNode(out, achld))
 				}
@@ -240,17 +241,17 @@ func (d *writeSession) dumpXHTMLAttrList(out io.Writer, e *Element) error {
 
 	if nameAttr != nil && idAttr == nil && xhtmlNameIDElements[localName] {
 		d.writeString(out, ` id="`)
-		d.check(escapeAttrValue(out, nameAttr.Content(), d.escapeNonASCII, d.rejectInvalidChars, d.xml11, d.charMap))
+		d.check(d.writeAttrValueContent(out, nameAttr.Content()))
 		d.writeString(out, `"`)
 	}
 
 	if langAttr != nil && xmlLangAttr == nil {
 		d.writeString(out, ` xml:lang="`)
-		d.check(escapeAttrValue(out, langAttr.Content(), d.escapeNonASCII, d.rejectInvalidChars, d.xml11, d.charMap))
+		d.check(d.writeAttrValueContent(out, langAttr.Content()))
 		d.writeString(out, `"`)
 	} else if xmlLangAttr != nil && langAttr == nil {
 		d.writeString(out, ` lang="`)
-		d.check(escapeAttrValue(out, xmlLangAttr.Content(), d.escapeNonASCII, d.rejectInvalidChars, d.xml11, d.charMap))
+		d.check(d.writeAttrValueContent(out, xmlLangAttr.Content()))
 		d.writeString(out, `"`)
 	}
 	return d.err

--- a/xpath3/functions_serialize.go
+++ b/xpath3/functions_serialize.go
@@ -134,6 +134,17 @@ func fnSerialize(ctx context.Context, args []Sequence) (Sequence, error) {
 		return nil, &XPathError{Code: errCodeSEPM0010, Message: "undeclare-prefixes requires output version 1.1"}
 	}
 
+	// Validate the normalization-form up front so an unsupported form
+	// ("fully-normalized" → SESU0011) is reported for every method that applies
+	// normalization, even when the serialized output has no text/attribute content
+	// to normalize (e.g. an empty element under the xml method). NFC/NFD/NFKC/NFKD
+	// are applied later — inside the writer for the markup methods (scoped to
+	// text/attribute nodes) or to the whole output for text/json (pure character
+	// data).
+	if opts.methodAppliesNormalization() && serializeNormalizationActive(opts.normalizationForm) && !isSupportedSerializeNormForm(opts.normalizationForm) {
+		return nil, &XPathError{Code: errCodeSESU0011, Message: fmt.Sprintf("normalization-form %q is not supported", opts.normalizationForm)}
+	}
+
 	// Serialization 3.1 §11: a character-map replacement string is NOT subjected
 	// to Unicode Normalization. When BOTH a normalization pass and a character map
 	// are in force, substitute each mapped key with a unique SENTINEL rune during
@@ -165,17 +176,36 @@ func fnSerialize(ctx context.Context, args []Sequence) (Sequence, error) {
 		return nil, err
 	}
 
-	// Apply the requested Unicode normalization to the serialized output (the
-	// last step, for the methods that support normalization-form). json/adaptive
-	// ignore the parameter; "fully-normalized" is the SESU0011 unsupported form.
-	result, err = applySerializeNormalization(result, dispatchOpts)
-	if err != nil {
-		return nil, err
+	// Unicode normalization (normalization-form). The markup methods
+	// (xml/xhtml/html and the unspecified default) apply it INSIDE the writer,
+	// scoped to text-node and attribute-value character content (Serialization 3.1
+	// §4 character-expansion phase) so element/attribute names, comments, PIs, the
+	// DOCTYPE, and the XML declaration are never normalized. The text and json
+	// methods emit pure character data (no element/attribute names; the json
+	// structure is ASCII), so normalizing the whole output is equivalent to
+	// node-scoped normalization and is applied here. adaptive ignores normalization.
+	switch dispatchOpts.method {
+	case serializeMethodText, serializeMethodJSON:
+		result, err = applySerializeNormalization(result, dispatchOpts)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if charMapSentinels != nil {
 		result = expandCharMapSentinels(result, charMapSentinels)
 	}
 	return SingleString(result), nil
+}
+
+// isSupportedSerializeNormForm reports whether form names a Unicode normalization
+// form helium applies. A valid, active normalization-form (serialize parameter
+// values are validated at parse time by serializeNormalizationFormValid) is one of
+// NFC/NFD/NFKC/NFKD or "fully-normalized"; of these only "fully-normalized" is
+// unsupported — it is not provided by golang.org/x/text/unicode/norm and is the
+// SESU0011 unsupported-normalization serialization error. "none"/"" request no
+// normalization (serializeNormalizationActive is false).
+func isSupportedSerializeNormForm(form string) bool {
+	return serializeNormalizationActive(form) && form != "fully-normalized"
 }
 
 // serializeNormalizationActive reports whether the normalization-form parameter
@@ -218,12 +248,15 @@ func expandCharMapSentinels(s string, replacements map[rune]string) string {
 	return b.String()
 }
 
-// applySerializeNormalization applies the normalization-form parameter to the
-// serialized string. none/"" is a no-op; NFC/NFD/NFKC/NFKD are applied via
-// golang.org/x/text/unicode/norm; the W3C-specific "fully-normalized" form is
-// not provided by that package and is the SESU0011 unsupported-normalization
-// serialization error. The parameter is not applicable to the json/adaptive
-// methods, which ignore it (Serialization 3.1 §9.1.9).
+// applySerializeNormalization applies the normalization-form parameter to a whole
+// serialized string. It is used only by the text and json output methods, whose
+// output is pure character data (text) or ASCII-delimited character data (json),
+// so normalizing the whole string is equivalent to the node-scoped
+// character-expansion phase (Serialization 3.1 §4); the markup methods
+// (xml/xhtml/html) normalize inside their writer instead so element/attribute
+// names and other markup are never touched. none/"" is a no-op;
+// NFC/NFD/NFKC/NFKD are applied via golang.org/x/text/unicode/norm; the
+// W3C-specific "fully-normalized" form is rejected up front (SESU0011).
 func applySerializeNormalization(s string, opts serializeOptions) (string, error) {
 	form := opts.normalizationForm
 	if form == "" || form == "none" || !opts.methodAppliesNormalization() {
@@ -1703,6 +1736,18 @@ func newSerializeXMLWriter(opts serializeOptions) helium.Writer {
 	if len(opts.charMap) > 0 {
 		writer = writer.CharacterMap(opts.charMap)
 	}
+	// normalization-form is applied inside the writer, scoped to text-node and
+	// attribute-value character content (Serialization 3.1 §4), so element/attribute
+	// names, comments, PIs, the DOCTYPE, and the XML declaration are never
+	// normalized. An unsupported form (fully-normalized) is rejected up front, so
+	// the writer only ever sees NFC/NFD/NFKC/NFKD (or none/"" = disabled). Gated to
+	// methods that apply normalization: serializeNodeItem uses this writer for the
+	// xml/xhtml and unspecified-default methods AND for the adaptive method (which
+	// ignores normalization) and json-embedded nodes, so the adaptive method must
+	// not normalize a serialized node's text.
+	if opts.methodAppliesNormalization() {
+		writer = writer.Normalization(opts.normalizationForm)
+	}
 	return writer
 }
 
@@ -1737,7 +1782,8 @@ func serializeHTMLSequence(seq Sequence, opts serializeOptions) (string, error) 
 
 func serializeHTMLNode(node helium.Node, opts serializeOptions) (string, error) {
 	hw := htmlpkg.NewWriter().DefaultDTD(false).Format(false).PreserveCase(true).
-		EscapeURIAttributes(opts.escapeURIAttributes).CharacterMap(opts.charMap)
+		EscapeURIAttributes(opts.escapeURIAttributes).CharacterMap(opts.charMap).
+		Normalization(opts.normalizationForm)
 
 	doc, ok := node.(*helium.Document)
 	if !ok || !htmlDocumentElementIsHTML(doc) {

--- a/xpath3/functions_serialize_params_test.go
+++ b/xpath3/functions_serialize_params_test.go
@@ -1082,7 +1082,13 @@ func TestSerialize_NormalizationJSONNodeAndQNameMethod(t *testing.T) {
 		res, err := evaluate(t.Context(), doc,
 			`serialize(., map{"method":"xml","normalization-form":"NFC"})`)
 		require.NoError(t, err)
-		require.Equal(t, `<e>`+composed+`</e>`, res.StringValue())
+		// Normalization is scoped to the text node and runs BEFORE the XML writer's
+		// escaping: the decomposed "e" + U+0301 composes to é (U+00E9), which the
+		// writer's default non-ASCII escaping then emits as &#xE9; — exactly as a
+		// literal composed é serializes, so normalization is consistent with the
+		// rest of the writer rather than slipping a literal through a post-escape
+		// pass.
+		require.Equal(t, `<e>&#xE9;</e>`, res.StringValue())
 	})
 	t.Run("json applies normalization-form to string content", func(t *testing.T) {
 		// normalization-form IS applicable to the json output method (§9.1.9): the
@@ -1152,6 +1158,67 @@ func TestSerialize_NormalizationJSONNodeAndQNameMethod(t *testing.T) {
 		res, err := evaluate(t.Context(), doc, `serialize(., map{"method":"text"})`)
 		require.NoError(t, err)
 		require.Equal(t, "hi", res.StringValue())
+	})
+}
+
+// TestSerialize_NormalizationScope covers Serialization 3.1 §4: the
+// normalization-form parameter is a step of the character-expansion phase, which
+// is scoped to TEXT and ATTRIBUTE node character content only. Element/attribute
+// NAMES, comment and PI markup, the DOCTYPE, and the XML declaration are NOT
+// normalized even when a non-none normalization-form is set.
+func TestSerialize_NormalizationScope(t *testing.T) {
+	// U+00E9 (composed é) vs "e" + U+0301 (decomposed). The XML writer's default
+	// non-ASCII escaping emits a composed é (U+00E9, < U+0100) as &#xE9;.
+	const decomposed = "e\u0301"
+	const composed = "\u00e9"
+	const composedRef = "&#xE9;"
+
+	t.Run("xml: names, comment, and PI are not normalized; text and attr value are", func(t *testing.T) {
+		src := `<caf` + decomposed + ` at` + decomposed + `="` + decomposed + `">` +
+			`<!--` + decomposed + `--><?p ` + decomposed + `?>` + decomposed + `</caf` + decomposed + `>`
+		doc := mustParseXML(t, src)
+		res, err := evaluate(t.Context(), doc,
+			`serialize(., map{"method":"xml","omit-xml-declaration":true(),"normalization-form":"NFC"})`)
+		require.NoError(t, err)
+		out := res.StringValue()
+		// Element/attribute names, comment content, and PI data stay decomposed.
+		want := `<caf` + decomposed + ` at` + decomposed + `="` + composedRef + `">` +
+			`<!--` + decomposed + `--><?p ` + decomposed + `?>` + composedRef + `</caf` + decomposed + `>`
+		require.Equal(t, want, out)
+		// A whole-string normalization would have composed the name/comment/PI too.
+		require.NotContains(t, out, "caf"+composed, "element name must not be normalized")
+		require.NotContains(t, out, "<!--"+composed, "comment must not be normalized")
+	})
+
+	t.Run("xml: attribute value is normalized", func(t *testing.T) {
+		doc := mustParseXML(t, `<e a="`+decomposed+`"/>`)
+		res, err := evaluate(t.Context(), doc,
+			`serialize(., map{"method":"xml","omit-xml-declaration":true(),"normalization-form":"NFC"})`)
+		require.NoError(t, err)
+		require.Equal(t, `<e a="`+composedRef+`"/>`, res.StringValue())
+	})
+
+	t.Run("html: element name stays decomposed while text is normalized", func(t *testing.T) {
+		// The html writer emits non-ASCII literally (no numeric-reference escaping),
+		// so a normalized text node reads as the literal composed é.
+		doc := mustParseXML(t, `<x`+decomposed+`>`+decomposed+`</x`+decomposed+`>`)
+		res, err := evaluate(t.Context(), doc,
+			`serialize(., map{"method":"html","normalization-form":"NFC"})`)
+		require.NoError(t, err)
+		require.Equal(t, `<x`+decomposed+`>`+composed+`</x`+decomposed+`>`, res.StringValue())
+	})
+
+	t.Run("xml: char-map replacement stays un-normalized while surrounding text is normalized", func(t *testing.T) {
+		// Text "X" + decomposed é; map X -> decomposed é. The mapped replacement is
+		// emitted verbatim (decomposed) while the surrounding decomposed é composes.
+		doc := mustParseXML(t, `<e>X`+decomposed+`</e>`)
+		res, err := evaluate(t.Context(), doc,
+			`serialize(., map{"method":"xml","omit-xml-declaration":true(),"normalization-form":"NFC",`+
+				`"use-character-maps":map{"X": codepoints-to-string((101, 769))}})`)
+		require.NoError(t, err)
+		// Replacement decomposed é (verbatim, U+0301 > U+00FF so not escaped) then
+		// the surrounding é composed to &#xE9;.
+		require.Equal(t, `<e>`+decomposed+composedRef+`</e>`, res.StringValue())
 	})
 }
 


### PR DESCRIPTION
- `normalization-form` now normalizes only text-node and attribute-value character content (Serialization 3.1 §4), never element/attribute names, comment/PI markup, DOCTYPE, or the XML declaration
- xml/xhtml/html apply it inside the writer (`helium.Writer.Normalization` / `html.Writer.Normalization`); text/json keep whole-string normalization (pure character data); adaptive still ignores it
- char-map replacements stay un-normalized (§11) via the existing sentinel scheme, folded before the per-node normalize pass