### PR TITLE
fix fn:min/max/seconds-from-*/namespace-uri result types

### DIFF
--- a/xpath3/functions_aggregate.go
+++ b/xpath3/functions_aggregate.go
@@ -404,15 +404,19 @@ func maxMinCommon(atoms []AtomicValue, isMax bool, coll *collationImpl) (Sequenc
 		return SingleAtomic(a), nil
 	}
 	var family string
-	var best AtomicValue
+	var best AtomicValue     // promoted value, used for comparison
+	var bestOrig AtomicValue // original selected item, used to derive the result type
 	widest := TypeInteger
 	first := true
 	hasNaN := false
+	// F&O 3.1 §14.4.7/§14.4.8: xs:anyURI values are converted to xs:string only
+	// when the sequence also contains a value that is (a subtype of) xs:string.
+	sawNonURIString := false
 	var err error
-	for _, a := range atoms {
-		a, err = promoteForAggregate(a)
-		if err != nil {
-			return nil, err
+	for _, orig := range atoms {
+		a, aerr := promoteForAggregate(orig)
+		if aerr != nil {
+			return nil, aerr
 		}
 		newFamily := aggregateTypeFamily(a)
 		if newFamily == "" || newFamily == "duration" {
@@ -429,6 +433,9 @@ func maxMinCommon(atoms []AtomicValue, isMax bool, coll *collationImpl) (Sequenc
 				Message: fmt.Sprintf("incompatible types in %s: %s and %s", fnName, family, newFamily),
 			}
 		}
+		if family == lexicon.TypeString && isStringDerived(a.TypeName) {
+			sawNonURIString = true
+		}
 		if family == familyNumeric && numericTypeWidth(a.TypeName) > numericTypeWidth(widest) {
 			widest = a.TypeName
 		}
@@ -438,6 +445,7 @@ func maxMinCommon(atoms []AtomicValue, isMax bool, coll *collationImpl) (Sequenc
 		}
 		if first {
 			best = a
+			bestOrig = orig
 			first = false
 			continue
 		}
@@ -457,6 +465,7 @@ func maxMinCommon(atoms []AtomicValue, isMax bool, coll *collationImpl) (Sequenc
 		}
 		if cmp {
 			best = a
+			bestOrig = orig
 		}
 	}
 	if hasNaN {
@@ -467,9 +476,20 @@ func maxMinCommon(atoms []AtomicValue, isMax bool, coll *collationImpl) (Sequenc
 		return SingleAtomic(AtomicValue{TypeName: nanType, Value: NewDouble(math.NaN())}), nil
 	}
 	if family == familyNumeric {
-		best = promoteResult(best, widest)
+		// When every value is an xs:integer subtype (widest stays xs:integer),
+		// F&O 3.1 retains the type of the selected item rather than collapsing to
+		// xs:integer; otherwise apply numeric type promotion to the widest type.
+		if widest == TypeInteger {
+			return SingleAtomic(bestOrig), nil
+		}
+		return SingleAtomic(promoteResult(best, widest)), nil
 	}
-	return SingleAtomic(best), nil
+	// xs:anyURI selected item is reported as xs:string when a plain-string value
+	// is present in the sequence; otherwise the selected item's type is retained.
+	if family == lexicon.TypeString && sawNonURIString && bestOrig.TypeName == TypeAnyURI {
+		return SingleAtomic(AtomicValue{TypeName: TypeString, Value: best.StringVal()}), nil
+	}
+	return SingleAtomic(bestOrig), nil
 }
 
 func fnSum(_ context.Context, args []Sequence) (Sequence, error) {

--- a/xpath3/functions_aggregate.go
+++ b/xpath3/functions_aggregate.go
@@ -484,8 +484,13 @@ func maxMinCommon(atoms []AtomicValue, isMax bool, coll *collationImpl) (Sequenc
 		}
 		return SingleAtomic(promoteResult(best, widest)), nil
 	}
-	// xs:anyURI selected item is reported as xs:string when a plain-string value
-	// is present in the sequence; otherwise the selected item's type is retained.
+	// Only the SELECTED item is converted, and only xs:anyURI: when the returned
+	// item is xs:anyURI and a plain (non-anyURI) string value is also present, the
+	// anyURI must be promoted to xs:string, so the result is xs:string (qt3
+	// fn-min-16/fn-max-16). A selected STRING SUBTYPE is never converted — it is
+	// returned unchanged even when an xs:anyURI is present in the sequence (qt3
+	// fn-min-18/fn-max-18, "Strings are not converted"), because that item needs no
+	// promotion. All-anyURI (no plain string) also retains anyURI (fn-min-17/17).
 	if family == lexicon.TypeString && sawNonURIString && bestOrig.TypeName == TypeAnyURI {
 		return SingleAtomic(AtomicValue{TypeName: TypeString, Value: best.StringVal()}), nil
 	}

--- a/xpath3/functions_datetime.go
+++ b/xpath3/functions_datetime.go
@@ -250,8 +250,7 @@ func fnSecondsFromDateTime(_ context.Context, args []Sequence) (Sequence, error)
 	if !ok {
 		return validNilSequence, nil
 	}
-	sec := float64(t.Second()) + float64(t.Nanosecond())/1e9
-	return SingleDouble(sec), nil
+	return SingleDecimal(secondsToRat(t)), nil
 }
 
 func fnTimezoneFromDateTime(_ context.Context, args []Sequence) (Sequence, error) {
@@ -367,8 +366,18 @@ func fnSecondsFromTime(_ context.Context, args []Sequence) (Sequence, error) {
 	if !ok {
 		return validNilSequence, nil
 	}
-	sec := float64(t.Second()) + float64(t.Nanosecond())/1e9
-	return SingleDouble(sec), nil
+	return SingleDecimal(secondsToRat(t)), nil
+}
+
+// secondsToRat returns the seconds component (0..59) plus the fractional
+// nanoseconds of t as an exact rational, for the xs:decimal-typed
+// fn:seconds-from-dateTime / fn:seconds-from-time results (F&O 3.1 §9.5.10/§9.5.14).
+func secondsToRat(t time.Time) *big.Rat {
+	r := new(big.Rat).SetInt64(int64(t.Second()))
+	if ns := t.Nanosecond(); ns != 0 {
+		r.Add(r, new(big.Rat).SetFrac(big.NewInt(int64(ns)), big.NewInt(1_000_000_000)))
+	}
+	return r
 }
 
 func fnTimezoneFromTime(_ context.Context, args []Sequence) (Sequence, error) {

--- a/xpath3/functions_node.go
+++ b/xpath3/functions_node.go
@@ -649,9 +649,9 @@ func fnNamespaceURI(ctx context.Context, args []Sequence) (Sequence, error) {
 		return nil, err
 	}
 	if n == nil {
-		return SingleString(""), nil
+		return SingleAtomic(AtomicValue{TypeName: TypeAnyURI, Value: ""}), nil
 	}
-	return SingleString(ixpath.NodeNamespaceURI(n)), nil
+	return SingleAtomic(AtomicValue{TypeName: TypeAnyURI, Value: ixpath.NodeNamespaceURI(n)}), nil
 }
 
 func fnNumber(ctx context.Context, args []Sequence) (Sequence, error) {

--- a/xpath3/functions_result_types_test.go
+++ b/xpath3/functions_result_types_test.go
@@ -23,13 +23,21 @@ func TestFnResultTypes(t *testing.T) {
 		{"max retains unsignedShort", `max((xs:positiveInteger(123), xs:unsignedShort(124))) instance of xs:unsignedShort`},
 		{"min retains byte", `min((xs:byte(1), xs:byte(2))) instance of xs:byte`},
 		{"max retains byte", `max((xs:byte(1), xs:byte(2))) instance of xs:byte`},
-		// xs:anyURI is converted to xs:string when a plain string is present.
+		// The SELECTED xs:anyURI item is reported as xs:string when a plain string
+		// is also present (qt3 fn-min-16 / fn-max-16, assert-type xs:string).
 		{"min anyURI+string is string", `min((xs:anyURI("http://a.com"), "http://b.com")) instance of xs:string`},
 		{"max anyURI+string is string", `max((xs:anyURI("http://c.com"), "http://b.com")) instance of xs:string`},
-		// All-anyURI: no plain string, so anyURI is retained (not converted).
+		// All-anyURI: no plain string, so anyURI is retained (qt3 fn-min-17 / fn-max-17).
 		{"min all anyURI stays anyURI", `min((xs:anyURI("http://a.com"), xs:anyURI("http://b.com"))) instance of xs:anyURI`},
-		// A selected string subtype is retained (only anyURI is converted).
+		// When the SELECTED item is a string subtype (not anyURI), its subtype is
+		// retained even though an xs:anyURI is present in the sequence — the anyURI
+		// is not the returned item and forces no promotion of it (qt3 fn-min-18 /
+		// fn-max-18, description "Strings are not converted", assert-type xs:token).
+		// "http" < "http://b.com" so xs:token is selected; "zither" > "http://b.com"
+		// so xs:token is selected. These would FAIL if the result were cast to
+		// xs:string, so they lock in that only a selected anyURI is converted.
 		{"min string subtype retained", `min((xs:token("http"), xs:anyURI("http://b.com"))) instance of xs:token`},
+		{"max string subtype retained", `max((xs:token("zither"), xs:anyURI("http://b.com"))) instance of xs:token`},
 		// fn:seconds-from-time / fn:seconds-from-dateTime return xs:decimal.
 		{"seconds-from-time is decimal", `seconds-from-time(xs:time("12:30:45.5")) instance of xs:decimal`},
 		{"seconds-from-dateTime is decimal", `seconds-from-dateTime(xs:dateTime("2020-01-01T12:30:45")) instance of xs:decimal`},

--- a/xpath3/functions_result_types_test.go
+++ b/xpath3/functions_result_types_test.go
@@ -1,0 +1,67 @@
+package xpath3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFnResultTypes pins the spec-correct static/dynamic result types of
+// fn:min/fn:max, fn:seconds-from-time/dateTime, and fn:namespace-uri
+// (XPath 3.1 F&O §14.4.7/§14.4.8, §9.5.10/§9.5.14, §14.5.4).
+func TestFnResultTypes(t *testing.T) {
+	doc := mustParseXML(t, `<e xmlns="urn:x"/>`)
+
+	// instanceOf cases assert the result type via the `instance of` operator.
+	instanceOf := []struct {
+		name string
+		expr string
+	}{
+		// fn:min/fn:max retain the selected item's derived integer subtype.
+		{"min retains positiveInteger", `min((xs:positiveInteger(123), xs:unsignedShort(124))) instance of xs:positiveInteger`},
+		{"min integer common super", `min((xs:positiveInteger(123), xs:unsignedShort(124))) instance of xs:nonNegativeInteger`},
+		{"max retains unsignedShort", `max((xs:positiveInteger(123), xs:unsignedShort(124))) instance of xs:unsignedShort`},
+		{"min retains byte", `min((xs:byte(1), xs:byte(2))) instance of xs:byte`},
+		{"max retains byte", `max((xs:byte(1), xs:byte(2))) instance of xs:byte`},
+		// xs:anyURI is converted to xs:string when a plain string is present.
+		{"min anyURI+string is string", `min((xs:anyURI("http://a.com"), "http://b.com")) instance of xs:string`},
+		{"max anyURI+string is string", `max((xs:anyURI("http://c.com"), "http://b.com")) instance of xs:string`},
+		// All-anyURI: no plain string, so anyURI is retained (not converted).
+		{"min all anyURI stays anyURI", `min((xs:anyURI("http://a.com"), xs:anyURI("http://b.com"))) instance of xs:anyURI`},
+		// A selected string subtype is retained (only anyURI is converted).
+		{"min string subtype retained", `min((xs:token("http"), xs:anyURI("http://b.com"))) instance of xs:token`},
+		// fn:seconds-from-time / fn:seconds-from-dateTime return xs:decimal.
+		{"seconds-from-time is decimal", `seconds-from-time(xs:time("12:30:45.5")) instance of xs:decimal`},
+		{"seconds-from-dateTime is decimal", `seconds-from-dateTime(xs:dateTime("2020-01-01T12:30:45")) instance of xs:decimal`},
+		// fn:namespace-uri returns xs:anyURI.
+		{"namespace-uri is anyURI", `namespace-uri(/*) instance of xs:anyURI`},
+	}
+	for _, tc := range instanceOf {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := evaluate(t.Context(), doc, tc.expr)
+			require.NoError(t, err)
+			b, ok := r.IsBoolean()
+			require.True(t, ok, "expected boolean result for %q", tc.expr)
+			require.True(t, b, "expected %q to be true", tc.expr)
+		})
+	}
+
+	// Value checks: the selected item's value must be preserved unchanged.
+	values := []struct {
+		name string
+		expr string
+		want string
+	}{
+		{"min integer value", `string(min((xs:positiveInteger(123), xs:unsignedShort(124))))`, "123"},
+		{"max integer value", `string(max((xs:positiveInteger(123), xs:unsignedShort(124))))`, "124"},
+		{"min anyURI value", `min((xs:anyURI("http://a.com"), "http://b.com"))`, "http://a.com"},
+		{"max anyURI value", `max((xs:anyURI("http://c.com"), "http://b.com"))`, "http://c.com"},
+		{"seconds-from-time value", `string(seconds-from-time(xs:time("12:30:45.5")))`, "45.5"},
+	}
+	for _, tc := range values {
+		t.Run(tc.name, func(t *testing.T) {
+			got := evalString(t, tc.expr)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
fn:min/fn:max retain the selected item's derived integer subtype instead of collapsing to xs:integer, and convert an xs:anyURI selected item to xs:string when a plain string is also present (F&O 3.1 §14.4.7/§14.4.8); mixed-numeric promotion and string-subtype retention are unchanged. fn:seconds-from-time / fn:seconds-from-dateTime now return xs:decimal, and fn:namespace-uri returns xs:anyURI, per F&O.

Closes qt3 fn-min-14/15/16, fn-max-14/15/16, fn-current-time-4, fn-current-dateTime-24, fn-namespace-uri-16.

Follow-up required: after merge, remove the 9 corresponding xfails from the sibling helium-w3c-tests expectations/qt3.json.