### PR TITLE
fix fn:serialize separator between adjacent nodes

### DIFF
--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -289,17 +289,33 @@ raises `SEPM0016` at dispatch rather than silently falling through to xml. The
 supported XML output version (`1.0`/`1.1`); any other value is `SESU0013`
 (`isSupportedXMLOutputVersion`), not a bogus version pseudo-attribute.
 
+**Item separator (sequence normalization §2, step 3).** The join between adjacent
+serialized items is `joinSerializedItems`, shared by the xml/xhtml/html/text
+sequence functions and the unspecified-default path (`serializeAdaptiveSequence`
+with `method==""`). When the `item-separator` parameter is EXPLICITLY specified
+(`opts.itemSeparatorSet`, set in both the map and element parse paths) it is
+inserted between EVERY adjacent pair of items regardless of kind. When ABSENT, a
+single space is inserted ONLY between two adjacent atomic-value-derived strings —
+never between two nodes, nor between a node and an atomic value — so
+`serialize((1,2,3))` is `1 2 3` while `serialize((<a/>,<b/>))` is `<a/><b/>` with
+no spurious separator. Each sequence function tracks a parallel `atomic []bool`
+(true iff the item is an `AtomicValue`) to drive the rule. The EXPLICIT `adaptive`
+method (and nested map/array serialization) is exempt and joins every item with
+the `item-separator` directly.
+
 **Output methods.** `xml` (default) and `adaptive`/`json` are full; `html` is
 applied as above; `text` (`serializeTextSequence`) concatenates the string values
-of the items with the `item-separator` and no markup (character maps applied);
+of the items (joined per the item-separator rule above) and no markup (character
+maps applied);
 `xhtml` is serialized as `xml` — a defensible approximation, as helium implements
 no XHTML-specific serialization rules. Sequence normalization (Serialization 3.1
 §2) governs maps/arrays/functions under EVERY markup method —
 `xml`/`xhtml`/`html`/`text` and the unspecified default — in two steps.
 (1) **Array flattening** (`flattenSerializeArrays`, reusing `ArrayItem.Flatten`):
 an array is NOT a rejected kind; it is replaced by its member items RECURSIVELY
-(nested arrays flatten too), which then serialize as if supplied directly — atomic
-members space-separated by the `item-separator`, node members as nodes. (2) The
+(nested arrays flatten too), which then serialize as if supplied directly — the
+flattened atomic/node members then obey the item-separator rule above (adjacent
+atomics space-separated when the separator is absent, nodes never separated). (2) The
 shared `serializeItemKindError` guard then rejects with `SENR0001` a bare attribute
 node, a namespace node, OR a function item — INCLUDING a map (a map is a function
 item; an array is not) — delegating node kinds to `serializeNodeKindError`. So a

--- a/xpath3/functions_serialize.go
+++ b/xpath3/functions_serialize.go
@@ -283,8 +283,15 @@ func applySerializeNormalization(s string, opts serializeOptions) (string, error
 }
 
 type serializeOptions struct {
-	method              string
+	method string
+	// itemSeparator is the item-separator parameter value; itemSeparatorSet
+	// records whether it was explicitly specified. Per Serialization 3.1 §2
+	// (sequence normalization, step 3) an ABSENT item-separator inserts a single
+	// space ONLY between two adjacent atomic-value-derived strings (never between
+	// nodes, nor between a node and an atomic value); a PRESENT item-separator is
+	// inserted between EVERY adjacent pair of items regardless of kind.
 	itemSeparator       string
+	itemSeparatorSet    bool
 	indent              bool
 	omitXMLDeclaration  bool
 	allowDuplicateNames bool
@@ -431,6 +438,7 @@ func parseSerializeOptionsMap(ctx context.Context, opts serializeOptions, m MapI
 		return opts, err
 	} else if found {
 		opts.itemSeparator = sep
+		opts.itemSeparatorSet = true
 	}
 	if indent, found, err := readBool("indent"); err != nil {
 		return opts, err
@@ -806,6 +814,7 @@ func parseSerializeOptionsNode(opts serializeOptions, n helium.Node) (serializeO
 				return opts, err
 			}
 			opts.itemSeparator = value
+			opts.itemSeparatorSet = true
 		case "indent":
 			value, err := readSerializeParamYesNo(param)
 			if err != nil {
@@ -1476,12 +1485,23 @@ func resolveSerializeCharacterMaps(v Sequence) (map[rune]string, error) {
 
 func serializeAdaptiveSequence(seq Sequence, opts serializeOptions) (string, error) {
 	parts := make([]string, 0, seqLen(seq))
+	atomic := make([]bool, 0, seqLen(seq))
 	for item := range seqItems(seq) {
 		s, err := serializeAdaptiveItem(item, opts)
 		if err != nil {
 			return "", err
 		}
 		parts = append(parts, s)
+		_, isAtomic := item.(AtomicValue)
+		atomic = append(atomic, isAtomic)
+	}
+	// The unspecified default method ("") is the xml family and obeys sequence
+	// normalization (Serialization 3.1 §2): an absent item-separator separates
+	// only adjacent atomic-value strings, not adjacent nodes. The explicit
+	// adaptive method (and nested map/array serialization) is exempt and joins
+	// every item with the item-separator.
+	if opts.method == "" {
+		return joinSerializedItems(parts, atomic, opts), nil
 	}
 	return strings.Join(parts, opts.itemSeparator), nil
 }
@@ -1690,14 +1710,17 @@ func serializeTextSequence(seq Sequence, opts serializeOptions) (string, error) 
 	// their members before serialization.
 	seq = flattenSerializeArrays(seq)
 	parts := make([]string, 0, seqLen(seq))
+	atomic := make([]bool, 0, seqLen(seq))
 	for item := range seqItems(seq) {
 		s, err := serializeTextItem(item)
 		if err != nil {
 			return "", err
 		}
 		parts = append(parts, s)
+		_, isAtomic := item.(AtomicValue)
+		atomic = append(atomic, isAtomic)
 	}
-	return applyCharMapToString(strings.Join(parts, opts.itemSeparator), opts.charMap), nil
+	return applyCharMapToString(joinSerializedItems(parts, atomic, opts), opts.charMap), nil
 }
 
 func serializeTextItem(item Item) (string, error) {
@@ -1736,11 +1759,34 @@ func applyCharMapToString(s string, charMap map[rune]string) string {
 	return b.String()
 }
 
+// joinSerializedItems joins the serialized item strings under sequence
+// normalization (Serialization 3.1 §2, step 3). When the item-separator
+// parameter is explicitly specified, it is inserted between EVERY adjacent pair
+// of items regardless of kind. Otherwise a single space is inserted ONLY between
+// two adjacent atomic-value-derived strings — never between two nodes, nor
+// between a node and an atomic value (atomic[i] reports whether parts[i] came
+// from an atomic value). This preserves serialize((1,2,3)) → "1 2 3" while
+// producing serialize((<a/>,<b/>)) → "<a/><b/>" with no spurious separator.
+func joinSerializedItems(parts []string, atomic []bool, opts serializeOptions) string {
+	if opts.itemSeparatorSet {
+		return strings.Join(parts, opts.itemSeparator)
+	}
+	var b strings.Builder
+	for i, p := range parts {
+		if i > 0 && atomic[i-1] && atomic[i] {
+			b.WriteByte(' ')
+		}
+		b.WriteString(p)
+	}
+	return b.String()
+}
+
 func serializeXMLSequence(seq Sequence, opts serializeOptions) (string, error) {
 	// Sequence normalization (Serialization 3.1 §2) flattens array inputs into
 	// their members before serialization.
 	seq = flattenSerializeArrays(seq)
 	parts := make([]string, 0, seqLen(seq))
+	atomic := make([]bool, 0, seqLen(seq))
 	for item := range seqItems(seq) {
 		// Sequence normalization (Serialization 3.1 §2) rejects a bare attribute
 		// node, a namespace node, or a function item under the xml/xhtml methods
@@ -1755,15 +1801,17 @@ func serializeXMLSequence(seq Sequence, opts serializeOptions) (string, error) {
 				return "", err
 			}
 			parts = append(parts, text)
+			atomic = append(atomic, false)
 		default:
 			s, err := serializeAdaptiveItem(item, opts)
 			if err != nil {
 				return "", err
 			}
 			parts = append(parts, s)
+			atomic = append(atomic, true)
 		}
 	}
-	return strings.Join(parts, opts.itemSeparator), nil
+	return joinSerializedItems(parts, atomic, opts), nil
 }
 
 // newSerializeXMLWriter builds a helium.Writer configured from the serialization
@@ -1842,6 +1890,7 @@ func serializeHTMLSequence(seq Sequence, opts serializeOptions) (string, error) 
 	// their members before serialization.
 	seq = flattenSerializeArrays(seq)
 	parts := make([]string, 0, seqLen(seq))
+	atomic := make([]bool, 0, seqLen(seq))
 	doctypeEmitted := false
 	for item := range seqItems(seq) {
 		// Sequence normalization (Serialization 3.1 §2) rejects a bare attribute
@@ -1858,6 +1907,7 @@ func serializeHTMLSequence(seq Sequence, opts serializeOptions) (string, error) 
 				return "", err
 			}
 			parts = append(parts, s)
+			atomic = append(atomic, true)
 			continue
 		}
 		text, emitted, err := serializeHTMLNode(node.Node, opts, !doctypeEmitted)
@@ -1868,8 +1918,9 @@ func serializeHTMLSequence(seq Sequence, opts serializeOptions) (string, error) 
 			doctypeEmitted = true
 		}
 		parts = append(parts, text)
+		atomic = append(atomic, false)
 	}
-	return strings.Join(parts, opts.itemSeparator), nil
+	return joinSerializedItems(parts, atomic, opts), nil
 }
 
 // serializeHTMLNode serializes a single node under the html output method,

--- a/xpath3/functions_serialize_test.go
+++ b/xpath3/functions_serialize_test.go
@@ -90,6 +90,46 @@ func mustCompile(t *testing.T, expr string) *xpath3.Expression {
 	return c
 }
 
+// Sequence normalization (Serialization 3.1 §2, step 3): with an absent
+// item-separator a single space separates only adjacent atomic-value strings,
+// never adjacent nodes nor a node-and-atomic pair. A specified item-separator is
+// inserted between every adjacent pair of items regardless of kind.
+func TestSerialize_ItemSeparatorNormalization(t *testing.T) {
+	doc := mustParseXML(t, `<r><a/><b/></r>`)
+
+	run := func(t *testing.T, ctx helium.Node, expr string) string {
+		t.Helper()
+		res, err := evaluate(t.Context(), ctx, expr)
+		require.NoError(t, err)
+		return res.StringValue()
+	}
+
+	t.Run("adjacent nodes get no separator (xml)", func(t *testing.T) {
+		require.Equal(t, "<a/><b/>", run(t, doc, `serialize(/r/*, map{"method":"xml"})`))
+	})
+	t.Run("adjacent nodes get no separator (default method)", func(t *testing.T) {
+		require.Equal(t, "<a/><b/>", run(t, doc, `serialize(/r/*)`))
+	})
+	t.Run("adjacent atomics keep the space", func(t *testing.T) {
+		require.Equal(t, "1 2 3", run(t, doc, `serialize((1,2,3), map{"method":"xml"})`))
+	})
+	t.Run("node adjacent to atomic gets no separator", func(t *testing.T) {
+		require.Equal(t, "<a/>1", run(t, doc, `serialize((/r/a, 1), map{"method":"xml"})`))
+	})
+	t.Run("array flattens to nodes with no separator", func(t *testing.T) {
+		require.Equal(t, "<a/><b/>", run(t, doc, `serialize([/r/a, /r/b], map{"method":"xml"})`))
+	})
+	t.Run("specified item-separator joins all items", func(t *testing.T) {
+		require.Equal(t, "<a/>,<b/>", run(t, doc, `serialize(/r/*, map{"method":"xml","item-separator":","})`))
+	})
+	t.Run("specified item-separator joins atomics", func(t *testing.T) {
+		require.Equal(t, "1|2|3|4", run(t, doc, `serialize(1 to 4, map{"method":"xml","item-separator":"|"})`))
+	})
+	t.Run("html adjacent nodes get no separator", func(t *testing.T) {
+		require.Equal(t, "<a></a><b></b>", run(t, doc, `serialize(/r/*, map{"method":"html"})`))
+	})
+}
+
 // fn:serialize with no serialization parameters uses the xml output method
 // (adaptive is opt-in), under which serializing an attribute or namespace node
 // is err:SENR0001 (W3C serialize-xml-002/011/012).


### PR DESCRIPTION
- fn:serialize inserted a spurious space between adjacent serialized nodes; per Serialization 3.1 §2 an absent item-separator separates only adjacent atomic values, never nodes or a node/atomic pair
- track per-item atomic-ness and join accordingly; a specified item-separator still joins every item
- closes 53 qt3 assert-xml separator-space divergences