### PR TITLE
fix fn:serialize source-DTD leak and isolated-node namespaces

### DIFF
--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -269,6 +269,34 @@ internal-subset DTD named after the document element on a COPY via
 between the declaration and the root). The map form defaults `omit-xml-declaration`
 to true (an empty map equals omitting the argument; W3C serialize-xml-127a); the
 element form keeps the Serialization-spec default (declaration emitted).
+The DTD / internal subset of a SOURCE document node is NOT part of the XDM data
+model (a document node's children are element/PI/comment/text nodes only), so
+`fn:serialize` never reproduces it: `newSerializeXMLWriter` sets
+`Writer.IncludeDTD(opts.doctypeSystem != "")`, dropping any source DTD unless a
+`doctype-system` param is present (in which case the writer emits the freshly
+injected empty-internal-subset DTD from the doctype path). W3C
+fn-doc-25/26/29, parse-xml-006/008/009/013.
+
+**In-scope namespaces on an isolated element.** `fn:serialize` serializes an
+element as if it were the root of a tree, so an element selected from a larger
+document must carry the namespace declarations for EVERY namespace in scope on
+it — including those inherited from ancestors OUTSIDE the serialized subtree (in
+XDM an element node's namespace nodes comprise ALL its in-scope namespaces, and
+the XML output method emits a declaration for each, matching Saxon). helium's DOM
+stores only the declarations literal on each element, so `serializeNodeItem`
+routes an `*helium.Element` through `elementWithInScopeNamespaces`: an element
+with no inherited in-scope namespace is returned unchanged (byte-identical — a
+document root, root element, or standalone element), otherwise a namespace-
+complete deep COPY is serialized. `inheritedInScopeNamespaces` walks the
+ancestor chain collecting each PREFIXED (non-empty prefix + non-empty URI)
+declaration not shadowed closer to the element and not already on it; the
+over-declaring deep copy re-declares the element's own/active namespaces and the
+inherited prefixes are added on top. Only prefixed declarations are force-added
+(a prefixed decl never rebinds the element's own name); the default (empty-prefix)
+namespace and undeclarations are left to the copy's active-namespace binding. This
+runs BEFORE the doctype handling so `applyDoctype` copies the namespace-complete
+element. W3C fn-union-node-args-015/016/017, fn-intersect-node-args-015/016,
+XQueryComment002.
 
 **SEPM0009** (`fnSerialize`, gated to `methodEmitsXMLDeclaration` — the xml/xhtml/
 default methods) fires when `omit-xml-declaration=yes` AND EITHER (a) `standalone`

--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -288,10 +288,14 @@ routes an `*helium.Element` through `elementWithInScopeNamespaces`: an element
 with no inherited in-scope namespace is returned unchanged (byte-identical — a
 document root, root element, or standalone element), otherwise a namespace-
 complete deep COPY is serialized. `inheritedInScopeNamespaces` walks the
-ancestor chain collecting each PREFIXED (non-empty prefix + non-empty URI)
-declaration not shadowed closer to the element and not already on it; the
-over-declaring deep copy re-declares the element's own/active namespaces and the
-inherited prefixes are added on top. Only prefixed declarations are force-added
+ancestor chain collecting each PREFIXED declaration not shadowed closer to the
+element and not already on it; the NEAREST ancestor declaration for a prefix
+decides it, so an XML 1.1 undeclaration (`xmlns:p=""`, empty URI) marks the prefix
+decided and removes it from scope BEFORE the empty-URI skip — a further-out
+ancestor binding for that prefix cannot resurrect it. Only a nearest declaration
+with a non-empty URI is added. The over-declaring deep copy re-declares the
+element's own/active namespaces and the inherited prefixes are added on top. Only
+prefixed declarations are force-added
 (a prefixed decl never rebinds the element's own name); the default (empty-prefix)
 namespace and undeclarations are left to the copy's active-namespace binding. This
 runs BEFORE the doctype handling so `applyDoctype` copies the namespace-complete

--- a/xpath3/functions_serialize.go
+++ b/xpath3/functions_serialize.go
@@ -2348,9 +2348,14 @@ func elementWithInScopeNamespaces(elem *helium.Element) (helium.Node, error) {
 
 // inheritedInScopeNamespaces returns the namespace declarations that are in
 // scope on elem by virtue of an ANCESTOR declaration (i.e. not declared on elem
-// itself), with a non-empty prefix and non-empty URI, closest-ancestor wins per
-// prefix. A prefix declared on elem itself shadows any ancestor declaration and
-// is omitted (the copy already reproduces elem's own declarations).
+// itself), with a non-empty prefix, closest-ancestor wins per prefix. A prefix
+// declared on elem itself shadows any ancestor declaration and is omitted (the
+// copy already reproduces elem's own declarations). The NEAREST ancestor
+// declaration for a prefix decides it: if that declaration is an XML 1.1
+// undeclaration (empty URI, xmlns:p="") the prefix is NOT in scope, so it is
+// recorded as decided and NOT added — and a further-out ancestor binding for the
+// same prefix cannot resurrect it (marking "seen" happens BEFORE the empty-URI
+// skip).
 func inheritedInScopeNamespaces(elem *helium.Element) []*helium.Namespace {
 	seen := map[string]struct{}{}
 	// elem's own declarations shadow ancestors and are reproduced by the copy, so
@@ -2366,13 +2371,21 @@ func inheritedInScopeNamespaces(elem *helium.Element) []*helium.Namespace {
 		}
 		for _, ns := range e.Namespaces() {
 			prefix := ns.Prefix()
-			if prefix == "" || ns.URI() == "" {
+			// The default (empty-prefix) namespace is left to the copy's active-
+			// namespace binding, never force-added here.
+			if prefix == "" {
 				continue
 			}
 			if _, dup := seen[prefix]; dup {
 				continue
 			}
+			// This is the nearest ancestor declaration for prefix: it decides
+			// whether prefix is in scope, so mark it decided BEFORE the
+			// undeclaration skip so an outer binding cannot revive it.
 			seen[prefix] = struct{}{}
+			if ns.URI() == "" {
+				continue
+			}
 			result = append(result, ns)
 		}
 	}

--- a/xpath3/functions_serialize.go
+++ b/xpath3/functions_serialize.go
@@ -1829,6 +1829,17 @@ func newSerializeXMLWriter(opts serializeOptions) helium.Writer {
 	// declaration). When the param is unset it is empty, and the writer keeps the
 	// document's own encoding, leaving default output byte-identical.
 	writer = writer.OutputEncoding(opts.encoding)
+	// The DTD / internal subset of a source document node is NOT part of the XDM
+	// data model (an XDM document node's children are element/PI/comment/text
+	// nodes only), so fn:serialize must never reproduce it. A document type
+	// declaration is emitted ONLY when the doctype-system parameter is specified
+	// (Serialization 3.1 §5.1.7: the XML output method MUST output a document type
+	// declaration immediately before the first element; the internal subset MUST be
+	// empty). When doctype-system is set, serializeNodeItem/applyDoctype inject a
+	// fresh empty-internal-subset DTD carrying the requested identifiers, and the
+	// writer must emit that; otherwise any DTD present on the source tree is
+	// dropped.
+	writer = writer.IncludeDTD(opts.doctypeSystem != "")
 	if opts.omitXMLDeclaration {
 		writer = writer.XMLDeclaration(false)
 	}
@@ -2188,6 +2199,26 @@ func serializeNodeItem(item NodeItem, opts serializeOptions) (string, error) {
 		return fmt.Sprintf(`%s="%s"`, attr.Name(), attr.Value()), nil
 	}
 	node := item.Node
+	// fn:serialize serializes the node as if it were the root of a tree, so an
+	// element selected from a larger document must carry the namespace
+	// declarations for every namespace in scope on it — including those inherited
+	// from ancestors that are NOT part of the serialized subtree. In XDM an
+	// element node's namespace nodes comprise ALL its in-scope namespaces, and the
+	// XML output method emits a namespace declaration for each. helium's DOM stores
+	// only the declarations that appear literally on each element, so an isolated
+	// element would otherwise drop its inherited (ancestor-declared) namespaces and
+	// serialize with unbound prefixes. elementWithInScopeNamespaces returns the
+	// element unchanged when it has no inherited in-scope namespaces (a document
+	// root, or a standalone element — byte-identical), otherwise a namespace-
+	// complete deep copy. This runs before the doctype handling so applyDoctype
+	// copies the namespace-complete element.
+	if elem, ok := node.(*helium.Element); ok {
+		aug, err := elementWithInScopeNamespaces(elem)
+		if err != nil {
+			return "", err
+		}
+		node = aug
+	}
 	// The xml method emits a document type declaration when doctype-system is
 	// specified (Serialization 3.1 §5.1.7: "If the doctype-system parameter is
 	// specified, the XML output method MUST output a document type declaration
@@ -2269,6 +2300,83 @@ func wrapElementInDocument(elem *helium.Element) (*helium.Document, error) {
 		return nil, err
 	}
 	return dst, nil
+}
+
+// elementWithInScopeNamespaces returns elem unchanged when it inherits no
+// in-scope namespace declarations from ancestors outside itself, otherwise a
+// deep copy carrying those inherited declarations so the serialized element is
+// namespace-complete (fn:serialize serializes an element as if it were the root
+// of a tree; the element's in-scope namespaces become namespace declarations on
+// it). Only PREFIXED namespaces with a non-empty URI are added: a prefixed
+// declaration never rebinds the element's own name, so adding one is always
+// safe, while the default (empty-prefix) namespace and namespace undeclarations
+// are handled by the deep copy's own active-namespace binding and are not
+// force-added here (adding an inherited default could rebind a no-namespace
+// element). Declarations that already appear on the element are left to the copy.
+func elementWithInScopeNamespaces(elem *helium.Element) (helium.Node, error) {
+	inherited := inheritedInScopeNamespaces(elem)
+	if len(inherited) == 0 {
+		return elem, nil
+	}
+	dst := helium.NewDocument("1.0", "", helium.StandaloneImplicitNo)
+	copied, err := helium.CopyNode(elem, dst)
+	if err != nil {
+		return nil, err
+	}
+	copyElem, ok := copied.(*helium.Element)
+	if !ok {
+		return elem, nil
+	}
+	// The over-declaring deep copy already re-declares the element's active
+	// namespace and its literal declarations; add only the inherited prefixes it
+	// does not already carry.
+	declared := map[string]struct{}{}
+	for _, ns := range copyElem.Namespaces() {
+		declared[ns.Prefix()] = struct{}{}
+	}
+	for _, ns := range inherited {
+		if _, dup := declared[ns.Prefix()]; dup {
+			continue
+		}
+		if err := copyElem.DeclareNamespace(ns.Prefix(), ns.URI()); err != nil {
+			return nil, err
+		}
+		declared[ns.Prefix()] = struct{}{}
+	}
+	return copyElem, nil
+}
+
+// inheritedInScopeNamespaces returns the namespace declarations that are in
+// scope on elem by virtue of an ANCESTOR declaration (i.e. not declared on elem
+// itself), with a non-empty prefix and non-empty URI, closest-ancestor wins per
+// prefix. A prefix declared on elem itself shadows any ancestor declaration and
+// is omitted (the copy already reproduces elem's own declarations).
+func inheritedInScopeNamespaces(elem *helium.Element) []*helium.Namespace {
+	seen := map[string]struct{}{}
+	// elem's own declarations shadow ancestors and are reproduced by the copy, so
+	// seed the seen set with them (they are never re-added as "inherited").
+	for _, ns := range elem.Namespaces() {
+		seen[ns.Prefix()] = struct{}{}
+	}
+	var result []*helium.Namespace
+	for cur := elem.Parent(); cur != nil; cur = cur.Parent() {
+		e, ok := cur.(*helium.Element)
+		if !ok {
+			continue
+		}
+		for _, ns := range e.Namespaces() {
+			prefix := ns.Prefix()
+			if prefix == "" || ns.URI() == "" {
+				continue
+			}
+			if _, dup := seen[prefix]; dup {
+				continue
+			}
+			seen[prefix] = struct{}{}
+			result = append(result, ns)
+		}
+	}
+	return result
 }
 
 // encodeJSONStringForSerialization escapes s as JSON string content for the json

--- a/xpath3/functions_serialize_test.go
+++ b/xpath3/functions_serialize_test.go
@@ -215,6 +215,28 @@ func TestSerialize_IsolatedElementInScopeNamespaces(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, `<a xmlns:p="urn:P"><p:b/></a>`, res.StringValue())
 	})
+
+	// An ancestor that UNDECLARES a prefix (XML 1.1 xmlns:p="") removes it from
+	// the inner element's in-scope namespace set, so a further-out ancestor's
+	// binding for the same prefix must NOT be resurrected on the serialized
+	// element: the nearest declaration (the undeclaration) decides the prefix
+	// (XDM namespace-node rules; fn-in-scope-prefixes-29).
+	t.Run("xml 1.1 undeclaration is not resurrected", func(t *testing.T) {
+		doc := mustParseXML(t, `<?xml version="1.1"?><outer xmlns:p="urn"><mid xmlns:p=""><child/></mid></outer>`)
+		res, err := evaluate(t.Context(), doc,
+			`serialize(/*/*/*[1], map{"version":"1.1","undeclare-prefixes":true()})`)
+		require.NoError(t, err)
+		require.Equal(t, `<child/>`, res.StringValue())
+	})
+
+	// The symmetric positive case: an outer prefix binding with NO inner
+	// undeclaration IS inherited onto the serialized element.
+	t.Run("outer binding without inner undeclaration is inherited", func(t *testing.T) {
+		doc := mustParseXML(t, `<outer xmlns:p="urn"><mid><child/></mid></outer>`)
+		res, err := evaluate(t.Context(), doc, `serialize(/*/*/*[1])`)
+		require.NoError(t, err)
+		require.Equal(t, `<child xmlns:p="urn"/>`, res.StringValue())
+	})
 }
 
 // fn:serialize with no serialization parameters uses the xml output method

--- a/xpath3/functions_serialize_test.go
+++ b/xpath3/functions_serialize_test.go
@@ -130,6 +130,93 @@ func TestSerialize_ItemSeparatorNormalization(t *testing.T) {
 	})
 }
 
+// The DTD / internal subset of a source document node is not part of the XDM
+// data model, so fn:serialize (xml method) must never reproduce it. With no
+// doctype-system parameter, serializing a document that has a DOCTYPE / internal
+// subset emits no <!DOCTYPE> (Serialization 3.1 §5.1.7; W3C parse-xml-006/008,
+// fn-doc-25/26/29).
+func TestSerialize_NoSourceDoctypeLeak(t *testing.T) {
+	run := func(t *testing.T, xml string) string {
+		t.Helper()
+		doc := mustParseXML(t, xml)
+		res, err := evaluate(t.Context(), doc, `serialize(.)`)
+		require.NoError(t, err)
+		return res.StringValue()
+	}
+
+	t.Run("external subset (SYSTEM)", func(t *testing.T) {
+		out := run(t, `<!DOCTYPE root SYSTEM "x.dtd">`+"\n"+`<root><child/></root>`)
+		require.NotContains(t, out, "DOCTYPE")
+		require.Contains(t, out, "<root><child/></root>")
+	})
+	t.Run("internal subset", func(t *testing.T) {
+		out := run(t, `<!DOCTYPE a [<!ELEMENT a (#PCDATA)>]><a>foo</a>`)
+		require.NotContains(t, out, "DOCTYPE")
+		require.Contains(t, out, "<a>foo</a>")
+	})
+
+	// With doctype-system specified, the DOCTYPE IS emitted (from the parameter,
+	// not the source tree), naming the document element with an empty internal
+	// subset.
+	t.Run("doctype-system emits DOCTYPE", func(t *testing.T) {
+		doc := mustParseXML(t, `<!DOCTYPE a [<!ELEMENT a (#PCDATA)>]><a>foo</a>`)
+		res, err := evaluate(t.Context(), doc, `serialize(., map{"doctype-system":"here.dtd"})`)
+		require.NoError(t, err)
+		out := res.StringValue()
+		require.Contains(t, out, `<!DOCTYPE a SYSTEM "here.dtd">`)
+		require.Contains(t, out, "<a>foo</a>")
+		require.NotContains(t, out, "ELEMENT")
+	})
+}
+
+// fn:serialize serializes an element as if it were the root of a tree, so an
+// element selected from a larger document must carry the namespace declarations
+// for every namespace in scope on it — including those inherited from ancestors
+// outside the serialized subtree (XDM: an element node's namespace nodes are ALL
+// its in-scope namespaces; W3C fn-union-node-args-015/016/017,
+// fn-intersect-node-args-015/016, XQueryComment002).
+func TestSerialize_IsolatedElementInScopeNamespaces(t *testing.T) {
+	t.Run("used inherited prefix is declared", func(t *testing.T) {
+		doc := mustParseXML(t, `<a xmlns:p="urn:P"><p:b/></a>`)
+		res, err := evaluate(t.Context(), doc, `serialize(/a/*[1])`)
+		require.NoError(t, err)
+		require.Equal(t, `<p:b xmlns:p="urn:P"/>`, res.StringValue())
+	})
+
+	// All in-scope namespaces are declared, including ones inherited but not used
+	// by the element itself (matching Saxon / the XDM data model).
+	t.Run("unused inherited prefixes are also declared", func(t *testing.T) {
+		doc := mustParseXML(t,
+			`<atomic:root xmlns:atomic="urn:A" xmlns:foo="urn:F" xmlns:xsi="urn:X">`+
+				`<atomic:integer>12</atomic:integer></atomic:root>`)
+		res, err := evaluate(t.Context(), doc, `serialize(/*/*[1])`)
+		require.NoError(t, err)
+		out := res.StringValue()
+		require.Contains(t, out, `xmlns:atomic="urn:A"`)
+		require.Contains(t, out, `xmlns:foo="urn:F"`)
+		require.Contains(t, out, `xmlns:xsi="urn:X"`)
+		require.Contains(t, out, `>12</atomic:integer>`)
+	})
+
+	// A document root (no element ancestor) is serialized byte-identically — no
+	// spurious extra declarations.
+	t.Run("document root is unchanged", func(t *testing.T) {
+		doc := mustParseXML(t, `<a xmlns:p="urn:P"><p:b/></a>`)
+		res, err := evaluate(t.Context(), doc, `serialize(.)`)
+		require.NoError(t, err)
+		require.Equal(t, "<?xml version=\"1.0\"?>\n"+`<a xmlns:p="urn:P"><p:b/></a>`, res.StringValue())
+	})
+
+	// The document root ELEMENT (not the document node) also has no element
+	// ancestor, so it too is serialized without spurious extra declarations.
+	t.Run("root element is unchanged", func(t *testing.T) {
+		doc := mustParseXML(t, `<a xmlns:p="urn:P"><p:b/></a>`)
+		res, err := evaluate(t.Context(), doc, `serialize(/a)`)
+		require.NoError(t, err)
+		require.Equal(t, `<a xmlns:p="urn:P"><p:b/></a>`, res.StringValue())
+	})
+}
+
 // fn:serialize with no serialization parameters uses the xml output method
 // (adaptive is opt-in), under which serializing an attribute or namespace node
 // is err:SENR0001 (W3C serialize-xml-002/011/012).


### PR DESCRIPTION
- fn:serialize (xml method) no longer reproduces a source document node's DTD/internal subset; a DOCTYPE appears only from the doctype-system param (Serialization 3.1 §5.1.7)
- an element selected from a larger document now serializes with the in-scope namespace declarations it inherits from ancestors (XDM: all in-scope namespaces become declarations on the serialized root)
- closes 13 qt3 assert-xml cases: fn-doc-25/26/29, parse-xml-006/008/009/013, fn-union-node-args-015/016/017, fn-intersect-node-args-015/016, XQueryComment002