### PR TITLE
fix fn:json-to-xml namespace, escaped attrs, key handling

### DIFF
--- a/.claude/docs/xpath3-functions.md
+++ b/.claude/docs/xpath3-functions.md
@@ -160,6 +160,21 @@ JSON numbers differently, gated by `jsonOptions.retainNumberLexical`:
 ### `functions_json_xml.go`
 `json-to-xml`, `xml-to-json`
 
+`json-to-xml` builds every result element (`map`/`array`/`string`/`number`/
+`boolean`/`null`) in the fn namespace (`http://www.w3.org/2005/xpath-functions`)
+and DECLARES that default namespace on EVERY element (not only the root), so a
+descendant selected by an XPath step (e.g. `json-to-xml(...)//j:string`) still
+carries its `xmlns` declaration when `fn:serialize` renders it in isolation
+(`buildJSONToXMLTree`). The `duplicates` option defaults to `retain` (F&O 3.1
+§17.6.1: reject if `validate` is true, else retain) — unlike `fn:parse-json`,
+whose default is `use-first` — so duplicate JSON object keys are preserved as
+repeated entries (`MapItem.entries` keeps duplicates; `forEach0` emits all).
+The `escaped` / `escaped-key` attributes are emitted ONLY under `escape=true()`
+AND ONLY when the string value / key attribute actually contains a backslash
+(F&O 3.1 §17.6.1: "Any string element whose string value contains a backslash
+character must have the attribute value escaped='true'"); a value/key with no
+backslash carries no such attribute, and `escape=false()` never emits either.
+
 `json-to-xml` with the `validate:true()` option type-annotates the result tree:
 each result element records the type defined by the json-to-xml result schema
 (`schema-for-json.xsd`, target namespace = fn namespace) keyed by node into

--- a/xpath3/functions_json_test.go
+++ b/xpath3/functions_json_test.go
@@ -206,3 +206,95 @@ func TestJSONToXML_DeepNestingBounded(t *testing.T) {
 	require.True(t, errors.Is(err, xpath3.ErrRecursionLimit),
 		"expected ErrRecursionLimit, got %v", err)
 }
+
+// Every fn:json-to-xml result element is in the xpath-functions namespace
+// (F&O 3.1 §17.6.1), and the declaration is present on every element so that a
+// descendant selected by an XPath step still serializes with its xmlns
+// declaration (QT3 json-to-xml-011/013/014).
+func TestJSONToXML_Namespace(t *testing.T) {
+	const fnNS = "http://www.w3.org/2005/xpath-functions"
+
+	r, err := evaluate(t.Context(), nil, `namespace-uri(json-to-xml('["x"]')/*)`)
+	require.NoError(t, err)
+	require.Equal(t, fnNS, r.StringValue(), "root element must be in the fn namespace")
+
+	// A descendant string selected on its own must serialize with the xmlns
+	// declaration it inherits, not lose it.
+	r, err = evaluate(t.Context(), nil,
+		`serialize(json-to-xml('["data"]')//*:string, map{'omit-xml-declaration':true()})`)
+	require.NoError(t, err)
+	require.Contains(t, r.StringValue(), `xmlns="`+fnNS+`"`,
+		"extracted descendant must carry the fn namespace declaration")
+	require.Equal(t, fnNS, mustNSURI(t, `namespace-uri(json-to-xml('{"k":"v"}')//*:string)`),
+		"descendant string must be in the fn namespace")
+}
+
+func mustNSURI(t *testing.T, expr string) string {
+	t.Helper()
+	r, err := evaluate(t.Context(), nil, expr)
+	require.NoError(t, err, expr)
+	return r.StringValue()
+}
+
+// fn:json-to-xml preserves duplicate JSON object keys by default: the default
+// value of the duplicates option is "retain" (F&O 3.1 §17.6.1: "if validate is
+// true then reject, otherwise retain"), unlike fn:parse-json whose default is
+// use-first (QT3 json-to-xml-018).
+func TestJSONToXML_DuplicateKeysRetainedByDefault(t *testing.T) {
+	r, err := evaluate(t.Context(), nil,
+		`count(json-to-xml('{"a":3, "b":4, "a":5}')//*:number)`)
+	require.NoError(t, err)
+	require.Equal(t, "3", r.StringValue(), "all three entries, including the duplicate key, must be retained")
+
+	r, err = evaluate(t.Context(), nil,
+		`string-join(json-to-xml('{"a":3, "b":4, "a":5}')//*:number/@key, ",")`)
+	require.NoError(t, err)
+	require.Equal(t, "a,b,a", r.StringValue(), "duplicate key must appear twice in document order")
+}
+
+// The escaped / escaped-key attributes are emitted ONLY under escape=true() and
+// ONLY when the string value / key attribute actually contains a backslash escape
+// (F&O 3.1 §17.6.1). A value or key without a backslash carries no such
+// attribute (QT3 fo-test-fn-json-to-xml-004 / json-to-xml-021 / -024).
+func TestJSONToXML_EscapedAttributesConditional(t *testing.T) {
+	// escape=true(): value "x" decodes to a lone backslash (\), so escaped="true";
+	// value "y" is "%", no backslash, so no escaped attribute.
+	cases := []struct {
+		desc string
+		expr string
+		want string
+	}{
+		{
+			"value with backslash gets escaped=true",
+			`json-to-xml('{"x":"\\", "y":"%"}', map{'escape':true()})//*:string[@key='x']/@escaped`,
+			wantTrue,
+		},
+		{
+			"value without backslash gets no escaped attribute",
+			`string(json-to-xml('{"x":"\\", "y":"%"}', map{'escape':true()})//*:string[@key='y']/@escaped)`,
+			"",
+		},
+		{
+			"key with backslash gets escaped-key=true",
+			`json-to-xml('{"a\\":3}', map{'escape':true()})//*:number/@escaped-key`,
+			wantTrue,
+		},
+		{
+			"key without backslash gets no escaped-key attribute",
+			`string(json-to-xml('{"a":3}', map{'escape':true()})//*:number/@escaped-key)`,
+			"",
+		},
+		{
+			"escape=false() never emits escaped even when the key contains a backslash",
+			`string(json-to-xml('{"a\\":3}', map{'escape':false()})//*:number/@escaped-key)`,
+			"",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			r, err := evaluate(t.Context(), nil, tc.expr)
+			require.NoError(t, err, tc.expr)
+			require.Equal(t, tc.want, r.StringValue(), tc.expr)
+		})
+	}
+}

--- a/xpath3/functions_json_xml.go
+++ b/xpath3/functions_json_xml.go
@@ -76,7 +76,7 @@ func fnJSONToXML(ctx context.Context, args []Sequence) (Sequence, error) {
 		annotations = make(map[helium.Node]string)
 	}
 
-	root, err := buildJSONToXMLTree(doc, item, opts, true, annotations)
+	root, err := buildJSONToXMLTree(doc, item, opts, annotations)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func jsonToXMLTypeAnnotation(name string) string {
 	}
 }
 
-func buildJSONToXMLTree(doc *helium.Document, item Item, opts jsonOptions, root bool, annotations map[helium.Node]string) (*helium.Element, error) {
+func buildJSONToXMLTree(doc *helium.Document, item Item, opts jsonOptions, annotations map[helium.Node]string) (*helium.Element, error) {
 	name := jsonKindNull
 	switch v := item.(type) {
 	case MapItem:
@@ -155,10 +155,13 @@ func buildJSONToXMLTree(doc *helium.Document, item Item, opts jsonOptions, root 
 			annotations[elem] = ann
 		}
 	}
-	if root {
-		if err := elem.DeclareNamespace("", NSFn); err != nil {
-			return nil, &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("json-to-xml: failed to build result: %v", err)}
-		}
+	// Declare the fn namespace on every element (not just the root) so that a
+	// descendant element extracted by an XPath step (e.g. json-to-xml(...)//j:string)
+	// still carries the xmlns="http://www.w3.org/2005/xpath-functions" declaration
+	// when serialized in isolation. Redundant declarations on descendants are
+	// namespace-equivalent to the root-only form.
+	if err := elem.DeclareNamespace("", NSFn); err != nil {
+		return nil, &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("json-to-xml: failed to build result: %v", err)}
 	}
 	if err := elem.SetActiveNamespace("", NSFn); err != nil {
 		return nil, &XPathError{Code: errCodeFOER0000, Message: fmt.Sprintf("json-to-xml: failed to build result: %v", err)}
@@ -176,13 +179,17 @@ func buildJSONToXMLTree(doc *helium.Document, item Item, opts jsonOptions, root 
 		}
 	case MapItem:
 		if err := v.forEach0(func(key AtomicValue, value Sequence) error {
-			child, err := buildJSONToXMLTree(doc, jsonSequenceToItem(value), opts, false, annotations)
+			child, err := buildJSONToXMLTree(doc, jsonSequenceToItem(value), opts, annotations)
 			if err != nil {
 				return err
 			}
 			keyText := key.StringVal()
 			_ = child.SetLiteralAttribute("key", keyText)
-			if opts.escape {
+			// escaped-key is emitted only under escape=true AND only when the key
+			// actually contains a backslash escape (F&O 3.1 §17.6.1): "Any element
+			// that contains a key attribute whose string value contains a backslash
+			// character must have the attribute escaped-key='true'."
+			if opts.escape && strings.Contains(keyText, "\\") {
 				_ = child.SetLiteralAttribute("escaped-key", lexicon.ValueTrue)
 			}
 			if err := elem.AddChild(child); err != nil {
@@ -194,7 +201,7 @@ func buildJSONToXMLTree(doc *helium.Document, item Item, opts jsonOptions, root 
 		}
 	case ArrayItem:
 		for _, member := range v.members0() {
-			child, err := buildJSONToXMLTree(doc, jsonSequenceToItem(member), opts, false, annotations)
+			child, err := buildJSONToXMLTree(doc, jsonSequenceToItem(member), opts, annotations)
 			if err != nil {
 				return nil, err
 			}
@@ -205,7 +212,12 @@ func buildJSONToXMLTree(doc *helium.Document, item Item, opts jsonOptions, root 
 	case AtomicValue:
 		switch v.TypeName {
 		case TypeString:
-			if opts.escape {
+			// escaped is emitted only under escape=true AND only when the string
+			// value actually contains a backslash escape (F&O 3.1 §17.6.1): "Any
+			// string element whose string value contains a backslash character must
+			// have the attribute value escaped='true'." When escape is false the
+			// attribute is never present.
+			if opts.escape && strings.Contains(v.StringVal(), "\\") {
 				_ = elem.SetLiteralAttribute("escaped", lexicon.ValueTrue)
 			}
 			if err := elem.AppendText([]byte(v.StringVal())); err != nil {
@@ -244,7 +256,11 @@ func jsonSequenceToItem(seq Sequence) Item {
 
 func parseJSONToXMLOptions(ctx context.Context, args []Sequence) (jsonOptions, error) {
 	opts := jsonOptions{
-		duplicates:          duplicatesUseFirst,
+		// F&O 3.1 §17.6.1: the default for the duplicates option is "if validate is
+		// true then reject, otherwise retain". The validate=true adjustment to
+		// reject is applied below; retain is the standalone default (unlike
+		// fn:parse-json, whose default is use-first).
+		duplicates:          "retain",
 		retainNumberLexical: true,
 	}
 	if len(args) <= 1 || seqLen(args[1]) == 0 {


### PR DESCRIPTION
- Declare the fn namespace on every json-to-xml result element so a descendant selected by an XPath step keeps its xmlns when serialized standalone
- Emit escaped/escaped-key only under escape=true() and only when the value/key actually contains a backslash (F&O 3.1 §17.6.1)
- Default the duplicates option to retain (not use-first), preserving repeated JSON object keys
- Closes 7 of 8 qt3 assert-xml xfails (fo-test-fn-json-to-xml-004, json-to-xml-011/013/014/018/021/024); json-to-xml-016 remains a schema/PSVI validate=true gap