### PR TITLE
accept duplicate ATTLIST attribute declarations

### DIFF
--- a/parser_dtd_attr.go
+++ b/parser_dtd_attr.go
@@ -403,6 +403,16 @@ func (ctx *parserCtx) addAttributeDecl(dtd *DTD, elem string, name string, prefi
 		}
 	}
 
+	// XML 1.0 §3.3: when more than one definition is provided for the same
+	// attribute of a given element type, the first declaration is binding and
+	// later declarations are ignored. A repeated <!ATTLIST> for an attribute
+	// already declared in this subset is therefore a validity warning, not a
+	// fatal error (libxml2 warns "already defined" and continues); keep the first
+	// declaration and ignore the duplicate.
+	if existing, ok := dtd.LookupAttribute(name, prefix, elem); ok {
+		return existing, nil
+	}
+
 	attr = newAttributeDecl()
 	attr.atype = atype
 	attr.doc = dtd.doc

--- a/parser_dtd_attr.go
+++ b/parser_dtd_attr.go
@@ -356,6 +356,13 @@ func (ctx *parserCtx) addSpecialAttribute(elemName, attrName string, typ enum.At
 		return
 	}
 	key := elemName + ":" + attrName
+	// XML 1.0 §3.3: the first declaration of an attribute is binding. The parse
+	// loop invokes this for every <!ATTLIST> declaration, including an ignored
+	// duplicate; keeping the first-seen type ensures a later duplicate's type
+	// cannot change how the attribute's explicit values are normalized.
+	if _, ok := ctx.attsSpecial[key]; ok {
+		return
+	}
 	ctx.attsSpecial[key] = typ
 }
 
@@ -389,28 +396,28 @@ func (ctx *parserCtx) addAttributeDecl(dtd *DTD, elem string, name string, prefi
 		return
 	}
 
+	// Duplicate detection runs BEFORE validating this declaration's default
+	// value: XML 1.0 §3.3 says a later declaration for the same attribute is
+	// ignored ENTIRELY, so its (possibly invalid) default must not be validated
+	// or abort the parse. The internal subset takes precedence over the external
+	// one; a repeat within the same subset keeps the first declaration. This is a
+	// validity warning, not a fatal error (libxml2 warns "already defined" and
+	// continues).
+	if doc := dtd.doc; doc != nil && doc.extSubset == dtd && doc.intSubset != nil && len(doc.intSubset.attributes) > 0 {
+		if _, ok := doc.intSubset.LookupAttribute(name, prefix, elem); ok {
+			return
+		}
+	}
+	if existing, ok := dtd.LookupAttribute(name, prefix, elem); ok {
+		return existing, nil
+	}
+
 	if defvalue != "" {
 		if err = validateAttributeValueInternal(dtd.doc, atype, defvalue); err != nil {
 			err = fmt.Errorf("attribute %s of %s: invalid default value: %s", elem, name, err)
 			ctx.valid = false
 			return
 		}
-	}
-
-	if doc := dtd.doc; doc != nil && doc.extSubset == dtd && doc.intSubset != nil && len(doc.intSubset.attributes) > 0 {
-		if _, ok := doc.intSubset.LookupAttribute(name, prefix, elem); ok {
-			return
-		}
-	}
-
-	// XML 1.0 §3.3: when more than one definition is provided for the same
-	// attribute of a given element type, the first declaration is binding and
-	// later declarations are ignored. A repeated <!ATTLIST> for an attribute
-	// already declared in this subset is therefore a validity warning, not a
-	// fatal error (libxml2 warns "already defined" and continues); keep the first
-	// declaration and ignore the duplicate.
-	if existing, ok := dtd.LookupAttribute(name, prefix, elem); ok {
-		return existing, nil
 	}
 
 	attr = newAttributeDecl()

--- a/parser_dup_attlist_test.go
+++ b/parser_dup_attlist_test.go
@@ -1,0 +1,37 @@
+package helium_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// XML 1.0 §3.3: "When more than one definition is provided for the same
+// attribute of a given element type, the first declaration is binding and later
+// declarations are ignored." A repeated <!ATTLIST> for the same attribute is a
+// validity warning, not a fatal error — libxml2 accepts such documents. helium
+// must accept them too and keep the first declaration's default.
+func TestDuplicateAttlistDeclaration(t *testing.T) {
+	t.Parallel()
+
+	const doc = `<!DOCTYPE doc [
+<!ELEMENT doc (#PCDATA)>
+<!ATTLIST doc a1 CDATA "first">
+<!ATTLIST doc a1 CDATA "second">
+]>
+<doc></doc>`
+
+	parsed, err := helium.NewParser().
+		DefaultDTDAttributes(true).
+		Parse(t.Context(), []byte(doc))
+	require.NoError(t, err, "a duplicate ATTLIST attribute definition must not be a fatal error")
+	require.NotNil(t, parsed)
+
+	root := parsed.DocumentElement()
+	require.NotNil(t, root)
+	// The first declaration is binding: the defaulted value is "first".
+	a1, ok := root.GetAttribute("a1")
+	require.True(t, ok, "the defaulted attribute from the first ATTLIST must be present")
+	require.Equal(t, "first", a1)
+}

--- a/parser_dup_attlist_test.go
+++ b/parser_dup_attlist_test.go
@@ -35,3 +35,48 @@ func TestDuplicateAttlistDeclaration(t *testing.T) {
 	require.True(t, ok, "the defaulted attribute from the first ATTLIST must be present")
 	require.Equal(t, "first", a1)
 }
+
+// A later, ignored duplicate declaration must not have its (possibly invalid)
+// default value validated — §3.3 ignores the whole declaration, so an invalid
+// default in the duplicate cannot abort the parse.
+func TestDuplicateAttlistIgnoresInvalidDuplicateDefault(t *testing.T) {
+	t.Parallel()
+
+	const doc = `<!DOCTYPE doc [
+<!ELEMENT doc (#PCDATA)>
+<!ATTLIST doc a1 CDATA "ok">
+<!ATTLIST doc a1 NMTOKEN "not a token">
+]>
+<doc></doc>`
+
+	parsed, err := helium.NewParser().
+		DefaultDTDAttributes(true).
+		Parse(t.Context(), []byte(doc))
+	require.NoError(t, err, "the ignored duplicate's invalid default must not abort the parse")
+	require.NotNil(t, parsed)
+	a1, ok := parsed.DocumentElement().GetAttribute("a1")
+	require.True(t, ok)
+	require.Equal(t, "ok", a1, "the first (CDATA) declaration is binding")
+}
+
+// The first declaration's type governs attribute-value normalization; a later
+// duplicate with a different type must not change it. First CDATA keeps explicit
+// whitespace; a duplicate NMTOKEN must not cause collapsing.
+func TestDuplicateAttlistTypeDoesNotAffectNormalization(t *testing.T) {
+	t.Parallel()
+
+	const doc = `<!DOCTYPE doc [
+<!ELEMENT doc (#PCDATA)>
+<!ATTLIST doc a2 CDATA #IMPLIED>
+<!ATTLIST doc a2 NMTOKEN #IMPLIED>
+]>
+<doc a2="  x   y  "></doc>`
+
+	parsed, err := helium.NewParser().Parse(t.Context(), []byte(doc))
+	require.NoError(t, err)
+	a2, ok := parsed.DocumentElement().GetAttribute("a2")
+	require.True(t, ok)
+	// CDATA (the first, binding type) preserves the explicit whitespace; had the
+	// duplicate NMTOKEN won, the value would have been collapsed to "x y".
+	require.Equal(t, "  x   y  ", a2)
+}


### PR DESCRIPTION
- XML 1.0 §3.3: a repeated <!ATTLIST> for the same attribute keeps the first declaration and ignores the later one (a validity warning, not a fatal error)
- helium errored with "duplicate attribute declared"; libxml2 warns and accepts
- fixes ~5 W3C XML-conformance valid cases