### PR TITLE
bump Go toolchain to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/lestrrat-go/helium
 
 go 1.26.1
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/dlclark/regexp2 v1.12.0


### PR DESCRIPTION
- clears govulncheck GO-2026-5856 (crypto/tls) and GO-2026 os advisory, both fixed in go1.26.5
- unblocks all helium PR CI (govulncheck currently fails repo-wide on the go1.26.4 stdlib)