### PR TITLE
make conformance CI resilient to helium dep bumps

### DIFF
--- a/.github/workflows/conformance-ledger.yml
+++ b/.github/workflows/conformance-ledger.yml
@@ -36,6 +36,15 @@ jobs:
   ledger:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # The drift-check runs helium-w3c-tests' tests against the PR's helium via
+    # its `replace => ../helium`. When a helium PR bumps a shared dependency
+    # (e.g. a Dependabot golang.org/x/* bump), helium-w3c-tests@main's go.mod /
+    # go.sum still pin the old version, so the combined module graph is
+    # inconsistent and the default readonly mode fails with "updates to go.mod
+    # needed; go mod tidy". -mod=mod lets the build reconcile the graph in the
+    # ephemeral checkout instead of failing the PR.
+    env:
+      GOFLAGS: -mod=mod
     steps:
       # helium at the triggering ref (the code under test), as a sibling of the
       # harness so helium-w3c-tests' `replace => ../helium` resolves.

--- a/.github/workflows/conformance-run.yml
+++ b/.github/workflows/conformance-run.yml
@@ -36,6 +36,12 @@ jobs:
       # HELIUM_SLOW_TESTS is treated as "enabled" whenever it is non-empty, so
       # it must be left EMPTY (never "0") when slow tests are off.
       HELIUM_SLOW_TESTS: ${{ inputs.slow && '1' || '' }}
+      # This suite runs helium-w3c-tests against the PR's helium via its
+      # `replace => ../helium`. When a helium PR bumps a shared dependency,
+      # helium-w3c-tests@main's go.mod/go.sum lag and the readonly module graph
+      # is inconsistent ("updates to go.mod needed"). -mod=mod reconciles it in
+      # the ephemeral checkout.
+      GOFLAGS: -mod=mod
     steps:
       # Check out this helium repo at the triggering ref (the code under test).
       # No repository:/ref: so it uses the ref the calling workflow ran against.


### PR DESCRIPTION
- the ledger + conformance-run jobs test helium-w3c-tests against the PR's helium via `replace => ../helium`; a helium dependency bump leaves helium-w3c-tests@main's go.mod/go.sum lagging, so readonly module mode fails with "updates to go.mod needed" (breaks every Dependabot dep-bump PR, e.g. #1142)
- set `GOFLAGS: -mod=mod` on both jobs so the ephemeral checkout reconciles the module graph
- verified: reproduced the failure against #1142 (x/text 0.40.0) and confirmed -mod=mod passes