### PR TITLE
fix panic on undefined entity in attribute value

### DIFF
--- a/parser_attr_entity_undefined_test.go
+++ b/parser_attr_entity_undefined_test.go
@@ -1,0 +1,27 @@
+package helium_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// An internal general entity whose replacement text references an undefined
+// entity, referenced from an attribute value, must be reported as a
+// well-formedness error — not crash the parser. getEntity returns a typed-nil
+// *Entity for the undefined inner entity, which a naive interface nil-check
+// misses. (W3C not-wf-sa-077.)
+func TestAttributeValueUndefinedNestedEntityDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	const doc = `<!DOCTYPE doc [
+<!ENTITY foo "&bar;">
+]>
+<doc a="&foo;"></doc>`
+
+	require.NotPanics(t, func() {
+		_, err := helium.NewParser().Parse(t.Context(), []byte(doc))
+		require.Error(t, err, "a reference to an undefined entity must be a well-formedness error")
+	})
+}

--- a/parser_element.go
+++ b/parser_element.go
@@ -940,7 +940,15 @@ func (pctx *parserCtx) parseAttributeValueInternal(ctx context.Context, qch byte
 					}
 				} else {
 					if ent.checked == 0 && strings.ContainsRune(ent.content, '&') {
-						_, _ = pctx.decodeEntities(ctx, ent.Content(), SubstituteRef)
+						// Validate the entity's replacement text: a general entity
+						// referenced from an attribute value must expand to
+						// well-formed content, so an undefined entity nested in it
+						// (WFC: Entity Declared) is a fatal error, not something to
+						// swallow. (W3C not-wf-sa-077.)
+						if _, derr := pctx.decodeEntities(ctx, ent.Content(), SubstituteRef); derr != nil {
+							err = pctx.error(ctx, derr)
+							return
+						}
 						ent.checked = 2
 					}
 					// Route the unresolved reference through the bounded helper:

--- a/parser_entity_ref.go
+++ b/parser_entity_ref.go
@@ -418,6 +418,20 @@ func (ctx *parserCtx) getEntity(name string) (*Entity, error) {
 	return ret, nil
 }
 
+// isNilEntity reports whether e is nil, including a non-nil sax.Entity interface
+// value that wraps a nil *Entity. getEntity returns a concrete (*Entity)(nil)
+// for an undefined entity; assigned to a sax.Entity interface that becomes a
+// typed nil that a plain `== nil` check misses, so any method call on it panics.
+func isNilEntity(e sax.Entity) bool {
+	if e == nil {
+		return true
+	}
+	if ce, ok := e.(*Entity); ok {
+		return ce == nil
+	}
+	return false
+}
+
 func (pctx *parserCtx) parseStringEntityRef(ctx context.Context, s []byte) (sax.Entity, int, error) {
 	if len(s) == 0 || s[0] != '&' {
 		return nil, 0, errors.New("invalid entity ref")
@@ -454,7 +468,13 @@ func (pctx *parserCtx) parseStringEntityRef(ctx context.Context, s []byte) (sax.
 			}
 		}
 	}
-	if loadedEnt == nil {
+	// getEntity returns a concrete (*Entity)(nil) for an undefined entity, which
+	// becomes a non-nil sax.Entity interface holding a nil pointer when assigned
+	// above. A plain `== nil` check misses that typed nil and the EntityType()
+	// call below would panic (e.g. an internal entity whose replacement text
+	// references an undefined entity, referenced from an attribute value), so
+	// detect the typed nil too and treat it as "not defined".
+	if isNilEntity(loadedEnt) {
 		if pctx.standalone == StandaloneExplicitYes || (!pctx.hasExternalSubset && !pctx.hasPERefs) {
 			return nil, 0, fmt.Errorf("entity '%s' not defined", name)
 		}


### PR DESCRIPTION
- an internal entity whose replacement references an undefined entity, referenced from an attribute value, crashed the parser: getEntity returns a (*Entity)(nil) that becomes a typed-nil sax.Entity interface, so the == nil guard missed it and EntityType() panicked
- detect the typed nil (isNilEntity), and propagate the entity-content well-formedness error the attribute path previously swallowed (_, _ =)
- clears W3C not-wf-sa-077; no regressions