### PR TITLE
validate DTD declaration consistency

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -848,7 +848,10 @@ pass — the analogue of libxml2's `xmlValidateElementDecl` /
   `collectMixedLeaves`).
 - **Attribute Default Legal** (§3.3.2): an enumerated/NOTATION attribute's
   default value must be one of the declared tokens (`validateAttributeDeclLegal`,
-  gated on `defvalue != "" && len(tree) > 0`).
+  gated on `attrHasDefaultValue(adecl.def) && len(tree) > 0` — `AttrDefaultNone`
+  and `AttrDefaultFixed` carry a value, INCLUDING a literal empty `""`, so an
+  empty default not among the tokens is still rejected; `#IMPLIED`/`#REQUIRED`
+  carry no value).
 - **ID Attribute Default** (§3.3.1): an `ID` attribute's default must be
   `#IMPLIED` or `#REQUIRED` — never a literal default or `#FIXED`
   (`validateAttributeDeclLegal`).

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -846,9 +846,18 @@ pass — the analogue of libxml2's `xmlValidateElementDecl` /
   not name the same element type (name+prefix) twice (`validateNoDuplicateTypes`
   over each `MixedElementType` `ElementDecl`, leaves gathered by
   `collectMixedLeaves`).
+- **Attribute Default Value Syntactically Correct** (§3.3.2): a declared default
+  must satisfy the attribute's tokenized type. The check keys off the DefaultDecl
+  kind (`attrHasDefaultValue`: a bare default or `#FIXED`), NOT `defvalue != ""` —
+  helium collapses "no default" and an empty default to the same empty string and
+  its parse-time syntactic check skips an empty default, so a literal empty
+  `IDREF`/`NMTOKEN` default is re-validated here via `validateAttributeValueInternal`.
 - **Attribute Default Legal** (§3.3.2): an enumerated/NOTATION attribute's
-  default value must be one of the declared tokens (`validateAttributeDeclLegal`,
-  gated on `defvalue != "" && len(tree) > 0`).
+  default value must be one of the declared tokens (`validateAttributeDeclLegal`).
+- **No Notation on Empty Element** (§3.3.1): an attribute of type NOTATION may
+  not be declared on an element whose content type is EMPTY
+  (`validateNotationNotOnEmptyElement`, resolving the owning element via
+  `elementDeclForAttr` across both subsets).
 - **ID Attribute Default** (§3.3.1): an `ID` attribute's default must be
   `#IMPLIED` or `#REQUIRED` — never a literal default or `#FIXED`
   (`validateAttributeDeclLegal`).

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -824,6 +824,49 @@ rule { context string, contextExpr *xpath.Expression, tests []*test, lets []*let
 test { typ (Assert|Report), expr, compiled *xpath.Expression, message []messagePart }
 ```
 
+## DTD Validation
+
+DTD validity (XML 1.0 §3–§4) is validated in `valid.go` post-parse by
+`validateDocument`, reached only under `ValidateDTD(true)`. It runs two kinds of
+check: the **instance-tree** walk (root-name match, per-element declaration
+lookup, `#REQUIRED`/`#FIXED`, attribute lexical type, enumeration/notation value
+membership, ID uniqueness, IDREF cross-reference, ENTITY/ENTITIES declared+
+unparsed, content-model matching) and a **declaration-consistency** pass over the
+DTD declarations themselves. A document with neither internal nor external subset
+reports `no DTD found` (libxml2 `XML_DTD_NO_DTD`). Errors go to the configured
+`ErrorHandler` via `validCtx.addf`; a failed validation returns
+`ErrDTDValidationFailed`.
+
+`validateDTDDeclarations` (`valid_dtd_decl.go`) is the declaration-consistency
+pass — the analogue of libxml2's `xmlValidateElementDecl` /
+`xmlValidateAttributeDecl` / `xmlValidateDtdFinal`. It walks both subsets
+(`dtdSubsets`, standalone-independent unlike `docDTDs`) and reports:
+
+- **No Duplicate Types** (§3.2.2): a Mixed content model `(#PCDATA|a|b|…)*` may
+  not name the same element type (name+prefix) twice (`validateNoDuplicateTypes`
+  over each `MixedElementType` `ElementDecl`, leaves gathered by
+  `collectMixedLeaves`).
+- **Attribute Default Legal** (§3.3.2): an enumerated/NOTATION attribute's
+  default value must be one of the declared tokens (`validateAttributeDeclLegal`,
+  gated on `defvalue != "" && len(tree) > 0`).
+- **ID Attribute Default** (§3.3.1): an `ID` attribute's default must be
+  `#IMPLIED` or `#REQUIRED` — never a literal default or `#FIXED`
+  (`validateAttributeDeclLegal`).
+- **One ID per Element Type** (§3.3.1): an element type may declare at most one
+  `ID` attribute; internal- and external-subset ID declarations for the same
+  element are counted together (`validateOneIDPerElement`).
+- **Notation Declared** (§4.7): a notation named in a NOTATION attribute's
+  enumeration (`validateNotationEnumDeclared`) or in an unparsed entity's `NDATA`
+  clause (`validateUnparsedEntityNotation`; the notation name is the entity
+  content) must be declared in either subset (`notationDeclared`).
+
+The instance-tree `AttrNotation` branch additionally enforces the **Notation
+Attributes** VC (§3.3.1): the instance value must be one of the notation names
+listed in *this* attribute's declaration (`slices.Contains(adecl.tree, val)`),
+not merely a declared notation. All DTD-declaration data comes from the DOM model
+(`AttributeDecl.{atype,def,defvalue,tree,elem}`, `ElementDecl.{decltype,content}`,
+`Entity` content for NDATA, `DTD.LookupNotation`).
+
 ## Comparison
 
 | Aspect | XSD | RELAX NG | Schematron |

--- a/valid.go
+++ b/valid.go
@@ -248,6 +248,10 @@ func validateDocument(ctx context.Context, doc *Document, handler ErrorHandler) 
 		}
 	}
 
+	// Validate the DTD declarations themselves (declaration-consistency VCs)
+	// before walking the instance tree.
+	validateDTDDeclarations(ctx, doc, vctx)
+
 	// Walk the document tree and validate each element. A cycle in the tree
 	// (ErrWalkCycle) leaves the walk partial, so the document cannot be
 	// considered valid.
@@ -385,6 +389,11 @@ func validateElementAttributes(ctx context.Context, doc *Document, elem *Element
 					}
 					if notFound {
 						vctx.addf(ctx, "element %s: attribute %s references undeclared notation %q", ename, aname, val)
+					}
+					// VC: Notation Attributes — the value must be one of the
+					// notation names listed in this attribute's declaration.
+					if len(adecl.tree) > 0 && !slices.Contains(adecl.tree, val) {
+						vctx.addf(ctx, "element %s: attribute %s value %q is not among the enumerated notations", ename, aname, val)
 					}
 				}
 			}

--- a/valid_dtd_decl.go
+++ b/valid_dtd_decl.go
@@ -65,6 +65,7 @@ func validateDTDDeclarations(ctx context.Context, doc *Document, vctx *validCtx)
 		for _, adecl := range dtd.attributes {
 			validateAttributeDeclLegal(ctx, adecl, vctx)
 			validateNotationEnumDeclared(ctx, doc, adecl, vctx)
+			validateNotationNotOnEmptyElement(ctx, doc, adecl, vctx)
 		}
 		for name, ent := range dtd.entities {
 			validateUnparsedEntityNotation(ctx, doc, name, ent, vctx)
@@ -112,10 +113,12 @@ func collectMixedLeaves(content *ElementContent, out *[]*ElementContent) {
 	collectMixedLeaves(content.c2, out)
 }
 
-// validateAttributeDeclLegal implements two declaration-time attribute VCs:
+// validateAttributeDeclLegal implements the declaration-time attribute VCs:
 //
 //   - ID Attribute Default (§3.3.1): an ID attribute's declared default must be
 //     #IMPLIED or #REQUIRED.
+//   - Attribute Default Value Syntactically Correct (§3.3.2): a declared default
+//     must satisfy the attribute's declared (tokenized) type.
 //   - Attribute Default Legal (§3.3.2): an enumerated or NOTATION attribute's
 //     default value must be one of the declared tokens.
 func validateAttributeDeclLegal(ctx context.Context, adecl *AttributeDecl, vctx *validCtx) {
@@ -125,13 +128,26 @@ func validateAttributeDeclLegal(ctx context.Context, adecl *AttributeDecl, vctx 
 		vctx.addf(ctx, "element %s: ID attribute %s must be declared #IMPLIED or #REQUIRED", adecl.elem, adecl.name)
 	}
 
-	// The default-value check runs whenever a default VALUE is declared — a bare
+	// The default-value checks run whenever a default VALUE is declared — a bare
 	// default or a #FIXED value — not merely when the value is non-empty: a
-	// literal empty default `""` is still a default and must be in the set.
-	// #IMPLIED/#REQUIRED carry no default value, so presence is decided by the
-	// DefaultDecl kind, NOT by defvalue != "" (helium collapses "no default" and
-	// an empty default to the same empty string).
-	if !attrHasDefaultValue(adecl.def) || len(adecl.tree) == 0 {
+	// literal empty default `""` is still a default (e.g. an empty IDREF/NMTOKEN
+	// default is syntactically invalid). #IMPLIED/#REQUIRED carry no default
+	// value, so presence is decided by the DefaultDecl kind, NOT by defvalue != ""
+	// (helium collapses "no default" and an empty default to the same empty
+	// string, and its parse-time syntactic check skips an empty default).
+	if !attrHasDefaultValue(adecl.def) {
+		return
+	}
+
+	// The default must satisfy the declared type for EVERY tokenized type
+	// (ID/IDREF/IDREFS/ENTITY/ENTITIES/NMTOKEN/NMTOKENS); CDATA accepts anything.
+	if err := validateAttributeValueInternal(nil, adecl.atype, adecl.defvalue); err != nil {
+		vctx.addf(ctx, "element %s: default value %q for attribute %s is not valid: %s", adecl.elem, adecl.defvalue, adecl.name, err)
+	}
+
+	// Attribute Default Legal: an enumerated/NOTATION default must be one of the
+	// declared tokens.
+	if len(adecl.tree) == 0 {
 		return
 	}
 	switch adecl.atype {
@@ -160,6 +176,31 @@ func validateNotationEnumDeclared(ctx context.Context, doc *Document, adecl *Att
 		if !notationDeclared(doc, nname) {
 			vctx.addf(ctx, "element %s: attribute %s enumerates undeclared notation %q", adecl.elem, adecl.name, nname)
 		}
+	}
+}
+
+// elementDeclForAttr looks up the declaration of the element that owns adecl,
+// searching both subsets. It returns nil when the element is undeclared or only
+// forward-referenced (UndefinedElementType).
+func elementDeclForAttr(doc *Document, elemName string) *ElementDecl {
+	for _, dtd := range dtdSubsets(doc) {
+		if e, ok := dtd.GetElementDesc(elemName); ok && e.decltype != enum.UndefinedElementType {
+			return e
+		}
+	}
+	return nil
+}
+
+// validateNotationNotOnEmptyElement implements the No Notation on Empty Element
+// VC (§3.3.1): an attribute of type NOTATION must not be declared on an element
+// whose content type is EMPTY.
+func validateNotationNotOnEmptyElement(ctx context.Context, doc *Document, adecl *AttributeDecl, vctx *validCtx) {
+	if adecl.atype != enum.AttrNotation {
+		return
+	}
+	edecl := elementDeclForAttr(doc, adecl.elem)
+	if edecl != nil && edecl.decltype == enum.EmptyElementType {
+		vctx.addf(ctx, "element %s: NOTATION attribute %s is not allowed on an EMPTY element", adecl.elem, adecl.name)
 	}
 }
 

--- a/valid_dtd_decl.go
+++ b/valid_dtd_decl.go
@@ -125,7 +125,13 @@ func validateAttributeDeclLegal(ctx context.Context, adecl *AttributeDecl, vctx 
 		vctx.addf(ctx, "element %s: ID attribute %s must be declared #IMPLIED or #REQUIRED", adecl.elem, adecl.name)
 	}
 
-	if adecl.defvalue == "" || len(adecl.tree) == 0 {
+	// The default-value check runs whenever a default VALUE is declared — a bare
+	// default or a #FIXED value — not merely when the value is non-empty: a
+	// literal empty default `""` is still a default and must be in the set.
+	// #IMPLIED/#REQUIRED carry no default value, so presence is decided by the
+	// DefaultDecl kind, NOT by defvalue != "" (helium collapses "no default" and
+	// an empty default to the same empty string).
+	if !attrHasDefaultValue(adecl.def) || len(adecl.tree) == 0 {
 		return
 	}
 	switch adecl.atype {
@@ -134,6 +140,13 @@ func validateAttributeDeclLegal(ctx context.Context, adecl *AttributeDecl, vctx 
 			vctx.addf(ctx, "element %s: default value %q for attribute %s is not among the enumerated set", adecl.elem, adecl.defvalue, adecl.name)
 		}
 	}
+}
+
+// attrHasDefaultValue reports whether a DefaultDecl carries an actual default
+// value (a bare default or #FIXED value) as opposed to #IMPLIED/#REQUIRED which
+// carry none.
+func attrHasDefaultValue(def enum.AttributeDefault) bool {
+	return def == enum.AttrDefaultNone || def == enum.AttrDefaultFixed
 }
 
 // validateNotationEnumDeclared implements the Notation Declared VC (§4.7) for a

--- a/valid_dtd_decl.go
+++ b/valid_dtd_decl.go
@@ -1,0 +1,183 @@
+package helium
+
+import (
+	"context"
+	"slices"
+
+	"github.com/lestrrat-go/helium/enum"
+)
+
+// dtdSubsets returns the internal and external subsets to validate, in order.
+// Unlike docDTDs it does NOT honor standalone="yes": the declaration-consistency
+// VCs apply to every declaration the DTD contains regardless of the standalone
+// declaration (libxml2's xmlValidateDtdFinal scans both subsets unconditionally).
+func dtdSubsets(doc *Document) []*DTD {
+	var dtds []*DTD
+	if doc.intSubset != nil {
+		dtds = append(dtds, doc.intSubset)
+	}
+	if doc.extSubset != nil {
+		dtds = append(dtds, doc.extSubset)
+	}
+	return dtds
+}
+
+// notationDeclared reports whether a notation named name is declared in either
+// subset. Notation lookup is standalone-independent (libxml2:
+// xmlValidateNotationUse scans intSubset then extSubset).
+func notationDeclared(doc *Document, name string) bool {
+	if doc.intSubset != nil {
+		if _, ok := doc.intSubset.LookupNotation(name); ok {
+			return true
+		}
+	}
+	if doc.extSubset != nil {
+		if _, ok := doc.extSubset.LookupNotation(name); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// validateDTDDeclarations validates the DTD declarations themselves — as opposed
+// to the instance tree — against the XML 1.0 validity constraints libxml2 checks
+// in xmlValidateElementDecl / xmlValidateAttributeDecl / xmlValidateDtdFinal. It
+// runs only under ValidateDTD(true), after the no-DTD guard in validateDocument,
+// and reports:
+//
+//   - No Duplicate Types (§3.2.2): a Mixed content model may not name the same
+//     element type twice.
+//   - Attribute Default Legal (§3.3.2): the default value of an enumerated or
+//     NOTATION attribute must be one of the declared tokens.
+//   - ID Attribute Default (§3.3.1): an ID attribute's default must be #IMPLIED
+//     or #REQUIRED (never a value or #FIXED).
+//   - One ID per Element Type (§3.3.1): an element type may declare at most one
+//     ID attribute.
+//   - Notation Declared (§4.7): a notation named in a NOTATION attribute's
+//     enumeration, or in an unparsed entity's NDATA clause, must be declared.
+func validateDTDDeclarations(ctx context.Context, doc *Document, vctx *validCtx) {
+	subsets := dtdSubsets(doc)
+
+	for _, dtd := range subsets {
+		for _, edecl := range dtd.elements {
+			validateNoDuplicateTypes(ctx, edecl, vctx)
+		}
+		for _, adecl := range dtd.attributes {
+			validateAttributeDeclLegal(ctx, adecl, vctx)
+			validateNotationEnumDeclared(ctx, doc, adecl, vctx)
+		}
+		for name, ent := range dtd.entities {
+			validateUnparsedEntityNotation(ctx, doc, name, ent, vctx)
+		}
+	}
+
+	validateOneIDPerElement(ctx, subsets, vctx)
+}
+
+// validateNoDuplicateTypes implements the No Duplicate Types VC (§3.2.2): a Mixed
+// content model (#PCDATA|a|b|...)* must not name the same element type twice.
+func validateNoDuplicateTypes(ctx context.Context, edecl *ElementDecl, vctx *validCtx) {
+	if edecl.decltype != enum.MixedElementType {
+		return
+	}
+	var leaves []*ElementContent
+	collectMixedLeaves(edecl.content, &leaves)
+
+	seen := make(map[string]struct{}, len(leaves))
+	for _, leaf := range leaves {
+		key := leaf.prefix + ":" + leaf.name
+		if _, dup := seen[key]; dup {
+			name := leaf.name
+			if leaf.prefix != "" {
+				name = leaf.prefix + ":" + leaf.name
+			}
+			vctx.addf(ctx, "element %s: definition has duplicate references of %s in mixed content", edecl.name, name)
+			return
+		}
+		seen[key] = struct{}{}
+	}
+}
+
+// collectMixedLeaves appends every named-element leaf of a mixed content tree to
+// out, in document order.
+func collectMixedLeaves(content *ElementContent, out *[]*ElementContent) {
+	if content == nil {
+		return
+	}
+	if content.ctype == ElementContentElement {
+		*out = append(*out, content)
+		return
+	}
+	collectMixedLeaves(content.c1, out)
+	collectMixedLeaves(content.c2, out)
+}
+
+// validateAttributeDeclLegal implements two declaration-time attribute VCs:
+//
+//   - ID Attribute Default (§3.3.1): an ID attribute's declared default must be
+//     #IMPLIED or #REQUIRED.
+//   - Attribute Default Legal (§3.3.2): an enumerated or NOTATION attribute's
+//     default value must be one of the declared tokens.
+func validateAttributeDeclLegal(ctx context.Context, adecl *AttributeDecl, vctx *validCtx) {
+	if adecl.atype == enum.AttrID &&
+		adecl.def != enum.AttrDefaultImplied &&
+		adecl.def != enum.AttrDefaultRequired {
+		vctx.addf(ctx, "element %s: ID attribute %s must be declared #IMPLIED or #REQUIRED", adecl.elem, adecl.name)
+	}
+
+	if adecl.defvalue == "" || len(adecl.tree) == 0 {
+		return
+	}
+	switch adecl.atype {
+	case enum.AttrEnumeration, enum.AttrNotation:
+		if !slices.Contains(adecl.tree, adecl.defvalue) {
+			vctx.addf(ctx, "element %s: default value %q for attribute %s is not among the enumerated set", adecl.elem, adecl.defvalue, adecl.name)
+		}
+	}
+}
+
+// validateNotationEnumDeclared implements the Notation Declared VC (§4.7) for a
+// NOTATION attribute: every notation name listed in the attribute's enumeration
+// must be declared.
+func validateNotationEnumDeclared(ctx context.Context, doc *Document, adecl *AttributeDecl, vctx *validCtx) {
+	if adecl.atype != enum.AttrNotation {
+		return
+	}
+	for _, nname := range adecl.tree {
+		if !notationDeclared(doc, nname) {
+			vctx.addf(ctx, "element %s: attribute %s enumerates undeclared notation %q", adecl.elem, adecl.name, nname)
+		}
+	}
+}
+
+// validateUnparsedEntityNotation implements the Notation Declared VC (§4.7) for
+// an unparsed entity: the notation named in its NDATA clause must be declared.
+// For an unparsed entity the notation name is stored as the entity content.
+func validateUnparsedEntityNotation(ctx context.Context, doc *Document, name string, ent *Entity, vctx *validCtx) {
+	if ent.EntityType() != enum.ExternalGeneralUnparsedEntity {
+		return
+	}
+	notation := string(ent.Content())
+	if notation != "" && !notationDeclared(doc, notation) {
+		vctx.addf(ctx, "entity %s: NDATA notation %q is not declared", name, notation)
+	}
+}
+
+// validateOneIDPerElement implements the One ID per Element Type VC (§3.3.1): an
+// element type may declare at most one attribute of type ID. IDs declared in the
+// internal and external subsets for the same element type are counted together.
+func validateOneIDPerElement(ctx context.Context, subsets []*DTD, vctx *validCtx) {
+	counts := make(map[string]int)
+	for _, dtd := range subsets {
+		for _, adecl := range dtd.attributes {
+			if adecl.atype == enum.AttrID {
+				counts[adecl.elem]++
+			}
+		}
+	}
+	for elem, n := range counts {
+		if n > 1 {
+			vctx.addf(ctx, "element %s has more than one ID attribute defined", elem)
+		}
+	}
+}

--- a/valid_dtd_decl_test.go
+++ b/valid_dtd_decl_test.go
@@ -76,9 +76,12 @@ func TestDTDDeclValidation(t *testing.T) {
 
 		t.Run("enumerated notation accepted", func(t *testing.T) {
 			t.Parallel()
+			// The element uses ANY content, not EMPTY: a NOTATION attribute on an
+			// EMPTY element is itself invalid (No Notation on Empty Element VC), so
+			// it would not be a genuine no-over-rejection witness.
 			_, err := parseValidatingDTD(t, `<?xml version="1.0"?>
 <!DOCTYPE root [
-  <!ELEMENT root EMPTY>
+  <!ELEMENT root ANY>
   <!ATTLIST root type NOTATION (fruit|vegetable) #REQUIRED>
   <!NOTATION fruit SYSTEM "f">
   <!NOTATION vegetable SYSTEM "v">
@@ -114,6 +117,20 @@ func TestDTDDeclValidation(t *testing.T) {
   <!NOTATION not2 SYSTEM "n2">
 ]>
 <foo a="not"/>`)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "not among the enumerated set"))
+		})
+
+		t.Run("empty-string enumeration default rejected", func(t *testing.T) {
+			t.Parallel()
+			// A literal empty default is still a default value and must be one of
+			// the enumerated tokens; the empty string never is.
+			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root EMPTY>
+  <!ATTLIST root v (one|two) "">
+]>
+<root v="one"/>`)
 			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
 			require.True(t, containsError(errs, "not among the enumerated set"))
 		})

--- a/valid_dtd_decl_test.go
+++ b/valid_dtd_decl_test.go
@@ -1,0 +1,228 @@
+package helium_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// parseValidatingDTD parses src as a validating processor with an internal
+// subset, returning any collected validity errors and the parse error.
+func parseValidatingDTD(t *testing.T, src string) ([]error, error) {
+	t.Helper()
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	p := helium.NewParser().
+		ValidateDTD(true).
+		DefaultDTDAttributes(true).
+		ErrorHandler(collector)
+	_, err := p.Parse(t.Context(), []byte(src))
+	return collector.Errors(), err
+}
+
+// TestDTDDeclValidation exercises the DTD-declaration-consistency VCs added in
+// validateDTDDeclarations. Each VC has a rejecting case and a valid near-miss to
+// prove there is no over-rejection.
+func TestDTDDeclValidation(t *testing.T) {
+	t.Parallel()
+
+	// No Duplicate Types (§3.2.2)
+	t.Run("no duplicate types", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("duplicate rejected", func(t *testing.T) {
+			t.Parallel()
+			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root (#PCDATA|a|a)*>
+  <!ELEMENT a (#PCDATA)>
+]>
+<root/>`)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "duplicate references of a"))
+		})
+
+		t.Run("distinct names accepted", func(t *testing.T) {
+			t.Parallel()
+			_, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root (#PCDATA|a|b)*>
+  <!ELEMENT a (#PCDATA)>
+  <!ELEMENT b (#PCDATA)>
+]>
+<root/>`)
+			require.NoError(t, err)
+		})
+	})
+
+	// Notation Attributes — value among the enumerated notations (§3.3.1)
+	t.Run("notation value in enum", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("declared notation outside the attr enum rejected", func(t *testing.T) {
+			t.Parallel()
+			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root EMPTY>
+  <!ATTLIST root type NOTATION (fruit|vegetable) #REQUIRED>
+  <!NOTATION fruit SYSTEM "f">
+  <!NOTATION vegetable SYSTEM "v">
+  <!NOTATION candy SYSTEM "c">
+]>
+<root type="candy"/>`)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "not among the enumerated notations"))
+		})
+
+		t.Run("enumerated notation accepted", func(t *testing.T) {
+			t.Parallel()
+			_, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root EMPTY>
+  <!ATTLIST root type NOTATION (fruit|vegetable) #REQUIRED>
+  <!NOTATION fruit SYSTEM "f">
+  <!NOTATION vegetable SYSTEM "v">
+]>
+<root type="fruit"/>`)
+			require.NoError(t, err)
+		})
+	})
+
+	// Attribute Default Legal (§3.3.2)
+	t.Run("attribute default legal", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("enumeration default outside set rejected", func(t *testing.T) {
+			t.Parallel()
+			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root EMPTY>
+  <!ATTLIST root v (one|two|three) "four">
+]>
+<root v="one"/>`)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "not among the enumerated set"))
+		})
+
+		t.Run("notation default outside set rejected", func(t *testing.T) {
+			t.Parallel()
+			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE foo [
+  <!ELEMENT foo ANY>
+  <!ATTLIST foo a NOTATION (not) "not2">
+  <!NOTATION not SYSTEM "n">
+  <!NOTATION not2 SYSTEM "n2">
+]>
+<foo a="not"/>`)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "not among the enumerated set"))
+		})
+
+		t.Run("legal default accepted", func(t *testing.T) {
+			t.Parallel()
+			_, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root EMPTY>
+  <!ATTLIST root v (one|two|three) "two">
+]>
+<root/>`)
+			require.NoError(t, err)
+		})
+	})
+
+	// ID Attribute Default + One ID per Element Type (§3.3.1)
+	t.Run("id attribute rules", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("fixed ID default rejected", func(t *testing.T) {
+			t.Parallel()
+			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root ANY>
+  <!ATTLIST root id ID #FIXED "x23">
+]>
+<root/>`)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "must be declared #IMPLIED or #REQUIRED"))
+		})
+
+		t.Run("literal ID default rejected", func(t *testing.T) {
+			t.Parallel()
+			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root ANY>
+  <!ATTLIST root id ID "bogus">
+]>
+<root/>`)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "must be declared #IMPLIED or #REQUIRED"))
+		})
+
+		t.Run("two ID attributes rejected", func(t *testing.T) {
+			t.Parallel()
+			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root ANY>
+  <!ELEMENT a EMPTY>
+  <!ATTLIST a first ID #REQUIRED>
+  <!ATTLIST a second ID #REQUIRED>
+]>
+<root><a first="x1" second="x2"/></root>`)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "more than one ID attribute"))
+		})
+
+		t.Run("single implied ID accepted", func(t *testing.T) {
+			t.Parallel()
+			_, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root EMPTY>
+  <!ATTLIST root id ID #IMPLIED>
+]>
+<root id="x1"/>`)
+			require.NoError(t, err)
+		})
+	})
+
+	// Notation Declared (§4.7)
+	t.Run("notation declared", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("undeclared NDATA notation rejected", func(t *testing.T) {
+			t.Parallel()
+			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE paper [
+  <!ELEMENT paper EMPTY>
+  <!ENTITY pic SYSTEM "pic.gif" NDATA gif>
+]>
+<paper/>`)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, `NDATA notation "gif" is not declared`))
+		})
+
+		t.Run("undeclared notation in attr enum rejected", func(t *testing.T) {
+			t.Parallel()
+			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root EMPTY>
+  <!ATTLIST root type NOTATION (fruit|vegetable) #REQUIRED>
+  <!NOTATION fruit SYSTEM "f">
+]>
+<root type="fruit"/>`)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, `enumerates undeclared notation "vegetable"`))
+		})
+
+		t.Run("declared NDATA notation accepted", func(t *testing.T) {
+			t.Parallel()
+			_, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE paper [
+  <!ELEMENT paper EMPTY>
+  <!NOTATION gif SYSTEM "gif">
+  <!ENTITY pic SYSTEM "pic.gif" NDATA gif>
+]>
+<paper/>`)
+			require.NoError(t, err)
+		})
+	})
+}

--- a/valid_dtd_decl_test.go
+++ b/valid_dtd_decl_test.go
@@ -61,9 +61,10 @@ func TestDTDDeclValidation(t *testing.T) {
 
 		t.Run("declared notation outside the attr enum rejected", func(t *testing.T) {
 			t.Parallel()
+			// ANY (not EMPTY) content isolates this to the enumerated-value VC.
 			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
 <!DOCTYPE root [
-  <!ELEMENT root EMPTY>
+  <!ELEMENT root ANY>
   <!ATTLIST root type NOTATION (fruit|vegetable) #REQUIRED>
   <!NOTATION fruit SYSTEM "f">
   <!NOTATION vegetable SYSTEM "v">
@@ -72,6 +73,20 @@ func TestDTDDeclValidation(t *testing.T) {
 <root type="candy"/>`)
 			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
 			require.True(t, containsError(errs, "not among the enumerated notations"))
+		})
+
+		t.Run("notation attribute on EMPTY element rejected", func(t *testing.T) {
+			t.Parallel()
+			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root EMPTY>
+  <!ATTLIST root type NOTATION (fruit|vegetable) #IMPLIED>
+  <!NOTATION fruit SYSTEM "f">
+  <!NOTATION vegetable SYSTEM "v">
+]>
+<root/>`)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "not allowed on an EMPTY element"))
 		})
 
 		t.Run("enumerated notation accepted", func(t *testing.T) {
@@ -133,6 +148,45 @@ func TestDTDDeclValidation(t *testing.T) {
 <root v="one"/>`)
 			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
 			require.True(t, containsError(errs, "not among the enumerated set"))
+		})
+
+		t.Run("empty IDREF default rejected", func(t *testing.T) {
+			t.Parallel()
+			// A literal empty default must still satisfy the declared type; an empty
+			// string is not a valid Name for an IDREF.
+			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root ANY>
+  <!ELEMENT unused EMPTY>
+  <!ATTLIST unused ref IDREF "">
+]>
+<root/>`)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "is not valid"))
+		})
+
+		t.Run("empty NMTOKEN default rejected", func(t *testing.T) {
+			t.Parallel()
+			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root ANY>
+  <!ELEMENT unused EMPTY>
+  <!ATTLIST unused tok NMTOKEN "">
+]>
+<root/>`)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "is not valid"))
+		})
+
+		t.Run("valid NMTOKEN default accepted", func(t *testing.T) {
+			t.Parallel()
+			_, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root ANY>
+  <!ATTLIST root tok NMTOKEN "abc">
+]>
+<root/>`)
+			require.NoError(t, err)
 		})
 
 		t.Run("legal default accepted", func(t *testing.T) {
@@ -219,9 +273,10 @@ func TestDTDDeclValidation(t *testing.T) {
 
 		t.Run("undeclared notation in attr enum rejected", func(t *testing.T) {
 			t.Parallel()
+			// ANY (not EMPTY) content isolates this to the Notation Declared VC.
 			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
 <!DOCTYPE root [
-  <!ELEMENT root EMPTY>
+  <!ELEMENT root ANY>
   <!ATTLIST root type NOTATION (fruit|vegetable) #REQUIRED>
   <!NOTATION fruit SYSTEM "f">
 ]>

--- a/valid_test.go
+++ b/valid_test.go
@@ -251,9 +251,11 @@ func TestNotationAttributeValidation(t *testing.T) {
 	t.Run("valid notation", func(t *testing.T) {
 		t.Parallel()
 
+		// A NOTATION attribute is not allowed on an EMPTY element (No Notation on
+		// Empty Element VC), so the element uses ANY content.
 		xml := `<?xml version="1.0"?>
 <!DOCTYPE root [
-  <!ELEMENT root EMPTY>
+  <!ELEMENT root ANY>
   <!NOTATION gif SYSTEM "image/gif">
   <!NOTATION png SYSTEM "image/png">
   <!ATTLIST root fmt NOTATION (gif|png) #REQUIRED>
@@ -269,7 +271,7 @@ func TestNotationAttributeValidation(t *testing.T) {
 
 		xml := `<?xml version="1.0"?>
 <!DOCTYPE root [
-  <!ELEMENT root EMPTY>
+  <!ELEMENT root ANY>
   <!NOTATION gif SYSTEM "image/gif">
   <!ATTLIST root fmt NOTATION (gif|png) #REQUIRED>
 ]>
@@ -627,9 +629,11 @@ func TestValidateAttributeTypes(t *testing.T) {
 func TestValidateNotationAttribute(t *testing.T) {
 	t.Parallel()
 
+	// A NOTATION attribute is not allowed on an EMPTY element (No Notation on
+	// Empty Element VC), so the element uses ANY content.
 	const dtd = `<!DOCTYPE doc [
 <!NOTATION gif SYSTEM "viewer">
-<!ELEMENT doc EMPTY>
+<!ELEMENT doc ANY>
 <!ATTLIST doc kind NOTATION (gif) #IMPLIED>
 ]>`
 


### PR DESCRIPTION
- add DTD-declaration validation pass (`valid_dtd_decl.go`) run from `validateDocument`: No Duplicate Types, Attribute Default Legal, ID Attribute Default, One ID per Element Type, Notation Declared (NDATA + NOTATION-enum)
- enforce the Notation Attributes VC on instance values (value must be among this attribute's enumerated notations)
- clears 18 W3C `xml`-suite invalid cases with zero valid-case regressions