### PR TITLE
search external subset for decls regardless of standalone

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -870,7 +870,7 @@ byte-identical to matching on the local name.
 `validateDTDDeclarations` (`valid_dtd_decl.go`) is the declaration-consistency
 pass — the analogue of libxml2's `xmlValidateElementDecl` /
 `xmlValidateAttributeDecl` / `xmlValidateDtdFinal`. It walks both subsets
-(`dtdSubsets`, standalone-independent unlike `docDTDs`) and reports:
+(`dtdSubsets`) and reports:
 
 - **No Duplicate Types** (§3.2.2): a Mixed content model `(#PCDATA|a|b|…)*` may
   not name the same element type (name+prefix) twice (`validateNoDuplicateTypes`
@@ -946,9 +946,21 @@ declaration takes precedence (§3.3). Three sub-cases:
   and the standalone report only fire on the matching declaration. A hit under
   `standalone="yes"` + `ValidateDTD(true)` is appended to `doc.standaloneNormAttrs`,
   which the validation pass reports.
-- **Element-content whitespace** (`checkStandaloneWhitespace`, existing): an
-  element declared element-content in the external subset that contains
-  whitespace-only text nodes.
+- **Element-content whitespace** (`checkStandaloneWhitespace`): an element
+  declared element-content in the external subset that contains whitespace-only
+  character data — a plain text node OR a CDATA section — directly within it. It
+  consults the external subset directly and runs on the normal `validateOneElement`
+  path (the element declaration is normally FOUND, since `docDTDs` searches both
+  subsets regardless of standalone), so the violation is reported even though the
+  element is declared.
+
+`docDTDs` (element/attribute-declaration lookup for `lookupElementDecl` /
+`validateElementAttributes`) searches the internal subset then the external
+subset, **independent of standalone** — a validating processor uses external
+declarations to validate structure regardless of the standalone declaration
+(libxml2 `xmlGetDtdElementDesc`/`xmlGetDtdAttrDesc`). The standalone constraints
+above (external defaults / normalization / element-content whitespace) are what
+enforce §2.9; the external declarations are never hidden from the validator.
 
 ## Comparison
 

--- a/valid.go
+++ b/valid.go
@@ -213,13 +213,21 @@ func (vc *validCtx) addf(ctx context.Context, format string, args ...any) {
 	vc.handler.Handle(ctx, fmt.Errorf(format, args...))
 }
 
-// docDTDs returns the DTDs to search in order, respecting standalone.
+// docDTDs returns the DTDs to search for declarations, internal subset first.
+// Both subsets are always searched, independent of standalone: a validating
+// processor reads the external subset and uses its element/attribute
+// declarations to validate document structure regardless of the standalone
+// declaration (libxml2 xmlGetDtdElementDesc/xmlGetDtdAttrDesc search both). The
+// Standalone Document Declaration VC (§2.9) — that a standalone="yes" document
+// must not DEPEND on external declarations for attribute defaults or value
+// normalization — is enforced separately by checkStandaloneExternalDefaults and
+// checkStandaloneExternalNormalization, not by hiding the external declarations.
 func docDTDs(doc *Document) []*DTD {
 	var dtds []*DTD
 	if doc.intSubset != nil {
 		dtds = append(dtds, doc.intSubset)
 	}
-	if doc.standalone != StandaloneExplicitYes && doc.extSubset != nil {
+	if doc.extSubset != nil {
 		dtds = append(dtds, doc.extSubset)
 	}
 	return dtds
@@ -313,15 +321,19 @@ func validateOneElement(ctx context.Context, doc *Document, elem *Element, vctx 
 	// itself carries an <!ELEMENT> declaration (an ATTLIST may exist without one).
 	checkStandaloneExternalDefaults(ctx, doc, elem, vctx)
 
+	// VC: Standalone Document Declaration — if standalone="yes" and the element
+	// has element-only content declared in the external subset, whitespace-only
+	// text nodes directly within it are a validity error (the external subset
+	// makes that whitespace ignorable). This consults the external subset
+	// directly, so it runs independent of the declaration lookup below — the
+	// element is normally FOUND (both subsets are searched regardless of
+	// standalone), and the violation must still be reported.
+	if doc.standalone == StandaloneExplicitYes && doc.extSubset != nil {
+		checkStandaloneWhitespace(ctx, doc.extSubset, elem, name, vctx)
+	}
+
 	edecl, dtd := lookupElementDecl(doc, name, elem.Prefix())
 	if edecl == nil {
-		// VC: Standalone Document Declaration — if standalone="yes" and the
-		// element is declared in the external subset with element-only content,
-		// whitespace-only text nodes are a validity error (the external subset
-		// would have caused them to be treated as ignorable whitespace).
-		if doc.standalone == StandaloneExplicitYes && doc.extSubset != nil {
-			checkStandaloneWhitespace(ctx, doc.extSubset, elem, name, vctx)
-		}
 		vctx.addf(ctx, "element %s: no declaration found", name)
 		return
 	}
@@ -467,9 +479,15 @@ func checkStandaloneWhitespace(ctx context.Context, extSubset *DTD, elem *Elemen
 		return
 	}
 	for child := range Children(elem) {
-		if child.Type() == TextNode && xmlchar.IsAllSpace(child.Content()) {
-			vctx.addf(ctx, "standalone: element %s declared in the external subset contains white spaces nodes", name)
-			return
+		// Whitespace-only character data — whether written as ordinary text or a
+		// CDATA section — is ignorable only because the external element-content
+		// declaration says so, so either form violates the standalone constraint.
+		switch child.Type() {
+		case TextNode, CDATASectionNode:
+			if xmlchar.IsAllSpace(child.Content()) {
+				vctx.addf(ctx, "standalone: element %s declared in the external subset contains white spaces nodes", name)
+				return
+			}
 		}
 	}
 }

--- a/valid_standalone_test.go
+++ b/valid_standalone_test.go
@@ -333,3 +333,63 @@ func TestDTDElementDeclQNameMatch(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+// TestStandaloneExternalElementContent verifies that DTD validation uses element
+// declarations from the external subset even for a standalone="yes" document
+// (docDTDs searches both subsets regardless of standalone), while the §2.9
+// element-content-whitespace Standalone VC still rejects whitespace — text or
+// CDATA — directly within an externally-declared element-content element.
+func TestStandaloneExternalElementContent(t *testing.T) {
+	t.Parallel()
+
+	// root has element-only content declared ONLY in the external subset.
+	extDTD := `<!ELEMENT root (child)*>
+<!ELEMENT child EMPTY>`
+
+	// standalone="yes" with the element declared externally and NO ignorable
+	// whitespace: the external declaration is used for validation (before this
+	// fix it was hidden, yielding a spurious "no declaration found").
+	t.Run("external element decl found under standalone yes", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseStandalone(t, `<?xml version="1.0" standalone="yes"?>
+<!DOCTYPE root SYSTEM "ext.dtd">
+<root><child/></root>`, extDTD)
+		require.NoError(t, err)
+	})
+
+	// Whitespace text directly within the externally-declared element-content
+	// element violates the standalone constraint.
+	t.Run("whitespace text rejected", func(t *testing.T) {
+		t.Parallel()
+		errs, err := parseStandalone(t, `<?xml version="1.0" standalone="yes"?>
+<!DOCTYPE root SYSTEM "ext.dtd">
+<root>
+  <child/>
+</root>`, extDTD)
+		require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+		require.True(t, containsError(errs, "white spaces nodes"))
+	})
+
+	// The same whitespace written as a CDATA section is equally a violation.
+	t.Run("whitespace CDATA rejected", func(t *testing.T) {
+		t.Parallel()
+		errs, err := parseStandalone(t, `<?xml version="1.0" standalone="yes"?>
+<!DOCTYPE root SYSTEM "ext.dtd">
+<root><![CDATA[
+  ]]><child/></root>`, extDTD)
+		require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+		require.True(t, containsError(errs, "white spaces nodes"))
+	})
+
+	// Near-miss: standalone="no" with the same whitespace is accepted (the
+	// document openly depends on the external subset).
+	t.Run("whitespace under standalone no accepted", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseStandalone(t, `<?xml version="1.0" standalone="no"?>
+<!DOCTYPE root SYSTEM "ext.dtd">
+<root>
+  <child/>
+</root>`, extDTD)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
DTD validation excluded the external subset from element/attribute-declaration lookup when standalone=yes, so a valid standalone document with externally-declared elements was rejected with a spurious "no declaration found". A validating processor uses external declarations regardless of standalone (libxml2 parity); the §2.9 Standalone VC is enforced separately. The element-content-whitespace check now runs on the normal validation path (not only the dead not-found branch) and also flags whitespace-only CDATA. Fixes W3C xml rmt-e2e-36 + sa05, 0 corpus regressions.