### PR TITLE
accept colon in DTD NMTOKEN validation

### DIFF
--- a/valid.go
+++ b/valid.go
@@ -119,13 +119,18 @@ func isValidName(s string) bool {
 
 // isValidNmtoken checks whether s matches the XML Nmtoken production:
 // Nmtoken ::= (NameChar)+
+//
+// DTD validation is NOT namespace-aware, so an Nmtoken uses the full XML 1.0
+// NameChar production, which INCLUDES the colon (e.g. `x:image` is a valid
+// NMTOKEN). Unlike the ID/IDREF/ENTITY Name checks, this must not use the
+// namespace-aware NCNameChar production.
 func isValidNmtoken(s string) bool {
 	if s == "" {
 		return false
 	}
 	for i := 0; i < len(s); {
 		r, size := utf8.DecodeRuneInString(s[i:])
-		if (r == utf8.RuneError && size == 1) || !isValidNameChar(r) {
+		if (r == utf8.RuneError && size == 1) || !isValidNmtokenChar(r) {
 			return false
 		}
 		i += size
@@ -138,6 +143,10 @@ func isValidNameStartChar(r rune) bool { return xmlchar.IsNCNameStartChar(r) }
 
 // isValidNameChar checks the XML 1.0 NameChar production (without colon).
 func isValidNameChar(r rune) bool { return xmlchar.IsNCNameChar(r) }
+
+// isValidNmtokenChar checks the XML 1.0 NameChar production INCLUDING the colon.
+// NameChar ::= NCNameChar | ":"
+func isValidNmtokenChar(r rune) bool { return xmlchar.IsNCNameChar(r) || r == ':' }
 
 // validateAttributeValueInternal validates that defvalue is legal for the
 // declared attribute type. Mirrors xmlValidateAttributeDecl() in libxml2.

--- a/valid_test.go
+++ b/valid_test.go
@@ -625,6 +625,39 @@ func TestValidateAttributeTypes(t *testing.T) {
 		dtd+`<doc><item id="a" ref="missing"/></doc>`))
 }
 
+// TestValidateNmtokenColon verifies that DTD (non-namespace-aware) NMTOKEN /
+// NMTOKENS validation accepts the colon, which is part of the XML 1.0 NameChar
+// production, so a value like `x:image` is a valid NMTOKEN and must not be
+// rejected. A token with a genuinely illegal char still fails.
+func TestValidateNmtokenColon(t *testing.T) {
+	t.Parallel()
+
+	const dtd = `<!DOCTYPE doc [
+<!ELEMENT doc EMPTY>
+<!ATTLIST doc
+  tok  NMTOKEN  #IMPLIED
+  toks NMTOKENS #IMPLIED>
+]>`
+
+	// An NMTOKEN value containing a colon is valid (DTD is not namespace-aware).
+	require.Empty(t, parseValidating(t, dtd+`<doc tok="x:image"/>`),
+		"a colon is a valid NMTOKEN NameChar")
+
+	// An unprefixed NMTOKEN is unchanged.
+	require.Empty(t, parseValidating(t, dtd+`<doc tok="x1"/>`),
+		"an unprefixed NMTOKEN still validates")
+
+	// Each space-separated NMTOKENS token may carry a colon.
+	require.Empty(t, parseValidating(t, dtd+`<doc toks="x:image y:photo z1"/>`),
+		"colons are valid in each NMTOKENS token")
+
+	// A token with a genuinely illegal char (@) is still rejected.
+	require.NotEmpty(t, parseValidating(t, dtd+`<doc tok="a@b"/>`),
+		"an illegal NameChar is not a valid NMTOKEN")
+	require.NotEmpty(t, parseValidating(t, dtd+`<doc toks="ok x@y"/>`),
+		"an illegal NameChar in one NMTOKENS token is rejected")
+}
+
 // TestValidateNotationAttribute exercises NOTATION-typed attribute validation.
 func TestValidateNotationAttribute(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
- XML 1.0 `NameChar` includes `:`; DTD validation is not namespace-aware, so an NMTOKEN/NMTOKENS value like `x:image` is valid. `isValidNmtoken` now uses a colon-inclusive NameChar check (`isValidNmtokenChar`) instead of the NCNameChar predicate.
- Fixes over-rejection of valid W3C xml cases: ibm-valid-P56-ibm56v09/v10, oasis p08pass1, eduni errata-4e ibm07v01.
- ID/IDREF/ENTITY `Name` validation is unchanged (still colon-excluding).