### PR TITLE
fix ENTITY attribute lookup in external subset

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -902,7 +902,15 @@ pass — the analogue of libxml2's `xmlValidateElementDecl` /
 The instance-tree `AttrNotation` branch additionally enforces the **Notation
 Attributes** VC (§3.3.1): the instance value must be one of the notation names
 listed in *this* attribute's declaration (`slices.Contains(adecl.tree, val)`),
-not merely a declared notation. All DTD-declaration data comes from the DOM model
+not merely a declared notation. The instance-tree `AttrEntity`/`AttrEntities`
+branches enforce the **Entity Name** VC (§3.3.1): each referenced name must be a
+declared UNPARSED general entity (`Entity.EntityType() ==
+ExternalGeneralUnparsedEntity`). The lookup goes through `lookupDTDEntity`, which
+searches BOTH subsets via `docDTDs` **independent of standalone** — an unparsed
+entity in the external subset must be found even for a `standalone="yes"`
+document (unlike `Document.GetEntity`, which suppresses the external subset for
+`StandaloneExplicitYes`); an undeclared name or a PARSED (non-`NDATA`) entity is
+a validity error. All DTD-declaration data comes from the DOM model
 (`AttributeDecl.{atype,def,defvalue,tree,elem}`, `ElementDecl.{decltype,content}`,
 `Entity` content for NDATA, `DTD.LookupNotation`).
 

--- a/valid.go
+++ b/valid.go
@@ -242,6 +242,21 @@ func docDTDs(doc *Document) []*DTD {
 	return dtds
 }
 
+// lookupDTDEntity searches both intSubset and extSubset for a general entity
+// declaration, regardless of the document's standalone status. DTD validity
+// (VC: Entity Name) requires the referenced entity to be declared in either
+// subset — an unparsed entity in the external subset must be found even for a
+// standalone="yes" document — so this deliberately does NOT gate on standalone
+// the way Document.GetEntity does.
+func lookupDTDEntity(doc *Document, name string) (*Entity, bool) {
+	for _, dtd := range docDTDs(doc) {
+		if ent, ok := dtd.LookupEntity(name); ok {
+			return ent, true
+		}
+	}
+	return nil, false
+}
+
 // lookupElementDecl searches both intSubset and extSubset for an element
 // declaration. DTD validation compares raw qualified names, not namespaces, so a
 // prefixed element requires an <!ELEMENT> declaration for the SAME QName — there is
@@ -428,7 +443,7 @@ func validateElementAttributes(ctx context.Context, doc *Document, elem *Element
 						vctx.idrefs[ref] = true
 					}
 				case enum.AttrEntity:
-					ent, ok := doc.GetEntity(val)
+					ent, ok := lookupDTDEntity(doc, val)
 					if !ok {
 						vctx.addf(ctx, "element %s: attribute %s references undeclared entity %q", ename, aname, val)
 					} else if ent.EntityType() != enum.ExternalGeneralUnparsedEntity {
@@ -436,7 +451,7 @@ func validateElementAttributes(ctx context.Context, doc *Document, elem *Element
 					}
 				case enum.AttrEntities:
 					for entName := range strings.FieldsSeq(val) {
-						ent, ok := doc.GetEntity(entName)
+						ent, ok := lookupDTDEntity(doc, entName)
 						if !ok {
 							vctx.addf(ctx, "element %s: attribute %s references undeclared entity %q", ename, aname, entName)
 						} else if ent.EntityType() != enum.ExternalGeneralUnparsedEntity {

--- a/valid_entity_attr_test.go
+++ b/valid_entity_attr_test.go
@@ -1,0 +1,81 @@
+package helium_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEntityAttrExternalSubset exercises the VC: Entity Name for ENTITY/ENTITIES
+// attributes whose referenced unparsed entity is declared in the EXTERNAL
+// subset. A validating processor loads the external subset even for a
+// standalone="yes" document, so the entity lookup must search both subsets
+// regardless of standalone (W3C xml sun/valid/sa03, sa04). Parsed and
+// undeclared references must still be rejected.
+func TestEntityAttrExternalSubset(t *testing.T) {
+	t.Parallel()
+
+	// External subset declaring an unparsed entity plus a parsed one, and the
+	// ENTITY/ENTITIES attribute declarations that reference them.
+	const extDTD = `<!ELEMENT doc EMPTY>
+<!NOTATION nonce SYSTEM "nonce.exe">
+<!ENTITY unparsed-1 SYSTEM "u1.dat" NDATA nonce>
+<!ENTITY unparsed-2 PUBLIC "pub-u2" "u2.dat" NDATA nonce>
+<!ENTITY parsed-1 SYSTEM "p1.xml">
+<!ATTLIST doc one ENTITY #IMPLIED
+              many ENTITIES #IMPLIED>`
+
+	// The core fix: an ENTITY attribute referencing an externally-declared
+	// unparsed entity validates even under standalone="yes".
+	t.Run("ENTITY referencing external unparsed entity accepted", func(t *testing.T) {
+		t.Parallel()
+		errs, err := parseStandalone(t, `<?xml version="1.0" standalone="yes"?>
+<!DOCTYPE doc SYSTEM "ext.dtd">
+<doc one="unparsed-1"/>`, extDTD)
+		require.NoError(t, err)
+		require.Empty(t, errs)
+	})
+
+	t.Run("ENTITIES referencing external unparsed entities accepted", func(t *testing.T) {
+		t.Parallel()
+		errs, err := parseStandalone(t, `<?xml version="1.0" standalone="yes"?>
+<!DOCTYPE doc SYSTEM "ext.dtd">
+<doc many="unparsed-1 unparsed-2"/>`, extDTD)
+		require.NoError(t, err)
+		require.Empty(t, errs)
+	})
+
+	// Guard: an undeclared entity reference is still a validity error.
+	t.Run("ENTITY referencing undeclared entity rejected", func(t *testing.T) {
+		t.Parallel()
+		errs, err := parseStandalone(t, `<?xml version="1.0" standalone="yes"?>
+<!DOCTYPE doc SYSTEM "ext.dtd">
+<doc one="nonexistent"/>`, extDTD)
+		require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+		require.True(t, containsError(errs, `references undeclared entity "nonexistent"`))
+	})
+
+	// Guard: a PARSED entity (external, no NDATA) is not a valid ENTITY value.
+	t.Run("ENTITY referencing external parsed entity rejected", func(t *testing.T) {
+		t.Parallel()
+		errs, err := parseStandalone(t, `<?xml version="1.0" standalone="yes"?>
+<!DOCTYPE doc SYSTEM "ext.dtd">
+<doc one="parsed-1"/>`, extDTD)
+		require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+		require.True(t, containsError(errs, `references entity "parsed-1" which is not unparsed`))
+	})
+
+	// Guard: a PARSED entity declared in the INTERNAL subset is likewise not a
+	// valid ENTITY value (the not-unparsed check spans both subsets).
+	t.Run("ENTITY referencing internal parsed entity rejected", func(t *testing.T) {
+		t.Parallel()
+		errs, err := parseStandalone(t, `<?xml version="1.0" standalone="no"?>
+<!DOCTYPE doc SYSTEM "ext.dtd" [
+  <!ENTITY internal-parsed "text">
+]>
+<doc one="internal-parsed"/>`, extDTD)
+		require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+		require.True(t, containsError(errs, `references entity "internal-parsed" which is not unparsed`))
+	})
+}


### PR DESCRIPTION
- ENTITY/ENTITIES attribute validation now resolves the referenced unparsed entity against BOTH DTD subsets regardless of standalone (was standalone-gated via `Document.GetEntity`), so an `NDATA` entity declared in the external subset is found.
- Fixes W3C xml `sun/valid/sa03` and `sa04` (previously xfail: helium rejected a valid standalone document).
- Undeclared and parsed (non-`NDATA`) references still rejected.