### PR TITLE
accept empty attribute-list declaration

### DIFF
--- a/parser_dtd_attr.go
+++ b/parser_dtd_attr.go
@@ -655,19 +655,28 @@ func (pctx *parserCtx) parseAttributeListDecl(ctx context.Context) error {
 		if cur == nil {
 			return pctx.error(ctx, errNoCursor)
 		}
-		if cur.Peek() == '>' {
-			// The whole <!ATTLIST ... > must start and stop in the same input: a
-			// closing '>' supplied by a parameter entity that began mid-declaration
-			// (e.g. `<!ATTLIST foo %e;` with %e; -> "... #IMPLIED>") is a boundary
-			// violation, the same fatal condition <!ELEMENT> enforces.
-			if pctx.currentInputID() != startInput {
-				return pctx.error(ctx,
-					fmt.Errorf("%w: attribute list declaration doesn't start and stop in the same entity", ErrEntityBoundary))
-			}
-			if err := cur.Advance(1); err != nil {
-				return err
-			}
-			break
+	}
+
+	// AttlistDecl ::= '<!ATTLIST' S Name AttDef* S? '>' — AttDef* is
+	// zero-or-more, so an empty `<!ATTLIST name>` (the loop above never ran)
+	// is well-formed and closes here. When instate is psEOF the declaration
+	// was truncated before its '>'; leave it unconsumed so the subset loop
+	// reports the unfinished doctype.
+	cur = pctx.dtdRefetch(cur)
+	if cur == nil {
+		return pctx.error(ctx, errNoCursor)
+	}
+	if cur.Peek() == '>' {
+		// The whole <!ATTLIST ... > must start and stop in the same input: a
+		// closing '>' supplied by a parameter entity that began mid-declaration
+		// (e.g. `<!ATTLIST foo %e;` with %e; -> "... #IMPLIED>") is a boundary
+		// violation, the same fatal condition <!ELEMENT> enforces.
+		if pctx.currentInputID() != startInput {
+			return pctx.error(ctx,
+				fmt.Errorf("%w: attribute list declaration doesn't start and stop in the same entity", ErrEntityBoundary))
+		}
+		if err := cur.Advance(1); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/parser_empty_attlist_test.go
+++ b/parser_empty_attlist_test.go
@@ -1,0 +1,92 @@
+package helium_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// XML 1.0 §3.3: AttlistDecl ::= '<!ATTLIST' S Name AttDef* S? '>'. AttDef* is
+// zero-or-more, so an empty attribute-list declaration `<!ATTLIST name>` (with
+// or without trailing whitespace) declares no attributes and is well-formed.
+func TestEmptyAttlistDeclaration(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name string
+		doc  string
+	}{
+		{
+			name: "no trailing space",
+			doc: `<!DOCTYPE r [
+<!ELEMENT r EMPTY>
+<!ATTLIST r>
+]>
+<r/>`,
+		},
+		{
+			name: "trailing space",
+			doc: `<!DOCTYPE r [
+<!ELEMENT r EMPTY>
+<!ATTLIST r >
+]>
+<r/>`,
+		},
+		{
+			name: "empty then non-empty for same element",
+			doc: `<!DOCTYPE r [
+<!ELEMENT r (#PCDATA)>
+<!ATTLIST r>
+<!ATTLIST r a CDATA #IMPLIED>
+]>
+<r a="x">y</r>`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			parsed, err := helium.NewParser().Parse(t.Context(), []byte(tc.doc))
+			require.NoError(t, err, "an empty <!ATTLIST> is well-formed and must parse")
+			require.NotNil(t, parsed)
+			require.NotNil(t, parsed.DocumentElement())
+		})
+	}
+}
+
+// A non-empty ATTLIST still parses and its declared default is applied, proving
+// the empty-list handling did not regress the AttDef loop.
+func TestNonEmptyAttlistStillWorks(t *testing.T) {
+	t.Parallel()
+
+	const doc = `<!DOCTYPE r [
+<!ELEMENT r (#PCDATA)>
+<!ATTLIST r a CDATA "def">
+]>
+<r>x</r>`
+
+	parsed, err := helium.NewParser().
+		DefaultDTDAttributes(true).
+		Parse(t.Context(), []byte(doc))
+	require.NoError(t, err)
+	a, ok := parsed.DocumentElement().GetAttribute("a")
+	require.True(t, ok, "the declared default attribute must be present")
+	require.Equal(t, "def", a)
+}
+
+// An ATTLIST with no element Name at all is malformed and must still be
+// rejected — the mandatory `S Name` after `<!ATTLIST` is unaffected by allowing
+// an empty AttDef list.
+func TestAttlistWithoutElementNameRejected(t *testing.T) {
+	t.Parallel()
+
+	const doc = `<!DOCTYPE r [
+<!ELEMENT r EMPTY>
+<!ATTLIST>
+]>
+<r/>`
+
+	_, err := helium.NewParser().Parse(t.Context(), []byte(doc))
+	require.Error(t, err, "an <!ATTLIST> with no element name must be rejected")
+}


### PR DESCRIPTION
- XML §3.3 AttlistDecl AttDef* is zero-or-more; parse `<!ATTLIST name>` / `<!ATTLIST name >` (empty) instead of rejecting with "doctype not finished"
- consume the closing `>` after the AttDef loop so an empty list closes; a nameless `<!ATTLIST>` and PE-boundary violations still error
- fixes W3C xml o-p52pass1 and ibm-valid-P52-ibm52v01