### PR TITLE
fix dtd content-model matcher backtracking

### DIFF
--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -867,6 +867,33 @@ and each content leaf's declared name is reconstructed by
 `<p:a/>` but not `<a/>`, and `(a)` does not match `<p:a/>`; an unprefixed model is
 byte-identical to matching on the local name.
 
+`matchContentModel` runs a **greedy recursive-descent fast path**
+(`matchContent`/`matchElement`/`matchSeq`/`matchOr`) — correct and
+allocation-free for the deterministic (1-unambiguous) content models the XML
+spec requires (§3.2.1, Appendix E), where a single particle matches at each
+position — and, **only when that greedy pass fails, an exact reachability
+fallback** (`matchContentModelExact`/`contentReacher`). Greedy descent cannot
+backtrack, so a greedy `*`/`+` sub-particle consuming maximally can starve a
+later iteration of an OUTER repetition that needs those tokens (e.g.
+`(lhs,(rhs,(com|wfc|vc)*)+)` over `lhs rhs com rhs vc`). The fallback is an
+NFA-style acceptor: `contentReacher.reach(node,pos)` returns the SET of end
+positions reachable by matching `node` (honoring its occurrence) from `pos`,
+composing sequences left-to-right over position sets, unioning choice
+alternatives, and taking a frontier closure for `*`/`+`; results are memoized
+per `(node,pos)` so the work is bounded by `(nodes × positions)` — polynomial,
+no exponential blowup, and the closure's "if not already seen" guard makes an
+empty-matchable inner term terminate. The document matches iff `len(children)`
+is in the top node's reachable set. Because the fallback is exact for the
+regular language the model denotes and runs only on a greedy MISS, it converts
+over-rejections into accepts **only** for genuine language members and never
+accepts a non-member — a genuinely invalid content model is still rejected by
+both passes. The occurrence-aware flatteners `flattenSeq`/`flattenOr` (shared
+by both paths) merge a right-nested `c2` continuation only when it is a bare
+`Once` group of the same compositor; a `c2` carrying an EXPLICIT occurrence
+(`+`/`*`/`?`) is a distinct grouped sub-particle kept whole (mirroring the
+sub-group parenthesization test in `writer_dtd.go`), so a nested group's
+occurrence is never silently flattened away.
+
 `validateDTDDeclarations` (`valid_dtd_decl.go`) is the declaration-consistency
 pass — the analogue of libxml2's `xmlValidateElementDecl` /
 `xmlValidateAttributeDecl` / `xmlValidateDtdFinal`. It walks both subsets

--- a/valid.go
+++ b/valid.go
@@ -693,15 +693,164 @@ func collectChildElements(elem *Element) []string {
 // matchContentModel validates a sequence of child element names against
 // an ElementContent tree. Returns true if the children match.
 //
-// This uses a greedy recursive descent approach, which is correct for
-// deterministic content models as required by the XML spec (Section 3.2.1,
-// Appendix E). At each position only one particle can match the next
-// element, so greedy consumption and first-match-wins in choices always
-// produce the correct result. Non-deterministic content models (which
-// violate the XML spec) may be matched incorrectly.
+// The fast path is a greedy recursive descent (matchContent), which is
+// correct for the overwhelmingly common deterministic content models the
+// XML spec requires (Section 3.2.1, Appendix E): at each position only one
+// particle matches the next element, so greedy consumption and
+// first-match-wins in choices produce the right answer with no allocation.
+//
+// Greedy descent cannot backtrack, though, so a greedy `*`/`+` sub-particle
+// that consumes maximally can starve a later iteration of an OUTER
+// repetition that needs some of those tokens (e.g. (lhs,(rhs,(com|wfc|vc)*)+)
+// over lhs rhs com rhs vc). When the greedy pass FAILS we fall back to
+// matchContentModelExact, an NFA-style reachable-position acceptor that is
+// exact for the regular language the model denotes. The fallback only ever
+// turns a greedy reject into an accept when the string is genuinely in the
+// language, so it fixes over-rejection without ever accepting a non-member —
+// a genuinely invalid content model is still rejected by both passes. The
+// fallback is bounded (position-set memoized, no exponential blowup) and runs
+// only on the rare greedy miss, so the common path stays fast.
 func matchContentModel(content *ElementContent, children []string) bool {
 	consumed, ok := matchContent(content, children, 0)
-	return ok && consumed == len(children)
+	if ok && consumed == len(children) {
+		return true
+	}
+	return matchContentModelExact(content, children)
+}
+
+// matchContentModelExact reports whether children is in the regular language
+// denoted by the content model, using exact NFA-style reachability over child
+// positions. It backtracks correctly across nested repetitions where the
+// greedy matcher cannot.
+func matchContentModelExact(content *ElementContent, children []string) bool {
+	if content == nil {
+		return len(children) == 0
+	}
+	m := &contentReacher{children: children, memo: make(map[reachKey]map[int]struct{})}
+	ends := m.reach(content, 0)
+	_, ok := ends[len(children)]
+	return ok
+}
+
+type reachKey struct {
+	content *ElementContent
+	pos     int
+}
+
+// contentReacher computes, per (content node, start position), the SET of end
+// positions reachable by matching that node (honoring its occurrence) starting
+// at that position. Results are memoized so the total work is bounded by
+// (nodes × positions), guaranteeing polynomial time with no exponential blowup
+// even for deeply nested repetition groups.
+type contentReacher struct {
+	children []string
+	memo     map[reachKey]map[int]struct{}
+}
+
+// reach returns the set of end positions reachable by matching content
+// (including its occurrence indicator) starting at pos.
+func (m *contentReacher) reach(content *ElementContent, pos int) map[int]struct{} {
+	if content == nil {
+		return map[int]struct{}{pos: {}}
+	}
+
+	key := reachKey{content: content, pos: pos}
+	if cached, ok := m.memo[key]; ok {
+		return cached
+	}
+
+	var result map[int]struct{}
+	switch content.coccur {
+	case ElementContentOnce:
+		result = m.reachOnce(content, pos)
+	case ElementContentOpt:
+		result = map[int]struct{}{pos: {}}
+		unionInto(result, m.reachOnce(content, pos))
+	case ElementContentMult:
+		result = m.closure(content, pos, true)
+	case ElementContentPlus:
+		result = m.closure(content, pos, false)
+	default:
+		result = map[int]struct{}{}
+	}
+
+	m.memo[key] = result
+	return result
+}
+
+// reachOnce returns the end positions of exactly ONE application of content,
+// ignoring its occurrence indicator.
+func (m *contentReacher) reachOnce(content *ElementContent, pos int) map[int]struct{} {
+	switch content.ctype {
+	case ElementContentElement:
+		if pos < len(m.children) && m.children[pos] == content.rawName() {
+			return map[int]struct{}{pos + 1: {}}
+		}
+		return map[int]struct{}{}
+	case ElementContentSeq:
+		cur := map[int]struct{}{pos: {}}
+		for _, part := range flattenSeq(content) {
+			next := map[int]struct{}{}
+			for p := range cur {
+				unionInto(next, m.reach(part, p))
+			}
+			cur = next
+			if len(cur) == 0 {
+				break
+			}
+		}
+		return cur
+	case ElementContentOr:
+		res := map[int]struct{}{}
+		for _, alt := range flattenOr(content) {
+			unionInto(res, m.reach(alt, pos))
+		}
+		return res
+	case ElementContentPCDATA:
+		// #PCDATA in element content consumes nothing.
+		return map[int]struct{}{pos: {}}
+	}
+	return map[int]struct{}{}
+}
+
+// closure computes the transitive closure of reachOnce from pos. includeStart
+// adds pos itself to the result (ElementContentMult, "zero or more"); when
+// false (ElementContentPlus, "one or more") at least one application is
+// required. The "if not already seen" frontier guard bounds the iteration by
+// the number of positions, so an inner term that can match empty cannot loop
+// forever.
+func (m *contentReacher) closure(content *ElementContent, pos int, includeStart bool) map[int]struct{} {
+	result := map[int]struct{}{}
+	var frontier []int
+	if includeStart {
+		result[pos] = struct{}{}
+		frontier = append(frontier, pos)
+	} else {
+		for q := range m.reachOnce(content, pos) {
+			if _, seen := result[q]; !seen {
+				result[q] = struct{}{}
+				frontier = append(frontier, q)
+			}
+		}
+	}
+	for len(frontier) > 0 {
+		p := frontier[len(frontier)-1]
+		frontier = frontier[:len(frontier)-1]
+		for q := range m.reachOnce(content, p) {
+			if _, seen := result[q]; !seen {
+				result[q] = struct{}{}
+				frontier = append(frontier, q)
+			}
+		}
+	}
+	return result
+}
+
+// unionInto adds every element of src into dst.
+func unionInto(dst, src map[int]struct{}) {
+	for k := range src {
+		dst[k] = struct{}{}
+	}
 }
 
 // matchContent tries to match children[pos:] against the content model,
@@ -876,33 +1025,55 @@ func matchOr(content *ElementContent, children []string, pos int) (int, bool) {
 	return 0, false
 }
 
-// flattenSeq collects all parts of a right-nested sequence into a slice.
+// flattenSeq collects the parts of a right-nested sequence into a slice.
+//
+// The tree stores a sequence's continuation in c2. A continuation node is a
+// bare Seq with the default Once occurrence, so it is merged into the same
+// part list; but a c2 that is a Seq carrying an EXPLICIT occurrence (+/*/?) is
+// a distinct grouped sub-particle — e.g. the (rhs,...)+ group in
+// (lhs,(rhs,...)+) — and must be kept whole as ONE part, not flattened away
+// (which would silently discard its occurrence and corrupt matching). Any
+// non-Seq c2 (element leaf, choice group, or occurrence-bearing seq group) is
+// likewise appended as a single part. This mirrors the sub-group test the DTD
+// writer uses (writer_dtd.go).
 func flattenSeq(content *ElementContent) []*ElementContent {
 	var parts []*ElementContent
-	for cur := content; cur != nil && cur.ctype == ElementContentSeq; cur = cur.c2 {
+	for cur := content; ; {
 		if cur.c1 != nil {
 			parts = append(parts, cur.c1)
 		}
-		// If c2 is not a seq, it's the last element
-		if cur.c2 != nil && cur.c2.ctype != ElementContentSeq {
-			parts = append(parts, cur.c2)
-			break
+		c2 := cur.c2
+		if c2 != nil && c2.ctype == ElementContentSeq && c2.coccur == ElementContentOnce {
+			cur = c2
+			continue
 		}
+		if c2 != nil {
+			parts = append(parts, c2)
+		}
+		break
 	}
 	return parts
 }
 
-// flattenOr collects all alternatives of a right-nested choice into a slice.
+// flattenOr collects the alternatives of a right-nested choice into a slice.
+// A c2 that is a bare Once choice is a continuation merged into the same
+// alternative list; a c2 that is a choice carrying an explicit occurrence, or
+// any non-choice node, is a distinct alternative kept whole (see flattenSeq).
 func flattenOr(content *ElementContent) []*ElementContent {
 	var alts []*ElementContent
-	for cur := content; cur != nil && cur.ctype == ElementContentOr; cur = cur.c2 {
+	for cur := content; ; {
 		if cur.c1 != nil {
 			alts = append(alts, cur.c1)
 		}
-		if cur.c2 != nil && cur.c2.ctype != ElementContentOr {
-			alts = append(alts, cur.c2)
-			break
+		c2 := cur.c2
+		if c2 != nil && c2.ctype == ElementContentOr && c2.coccur == ElementContentOnce {
+			cur = c2
+			continue
 		}
+		if c2 != nil {
+			alts = append(alts, c2)
+		}
+		break
 	}
 	return alts
 }

--- a/valid_content_backtrack_test.go
+++ b/valid_content_backtrack_test.go
@@ -1,0 +1,114 @@
+package helium_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateNestedRepetitionBacktracking exercises content models where a
+// greedy inner repetition would starve a later iteration of an outer
+// repetition, which the greedy recursive-descent matcher cannot resolve on its
+// own. The exact reachability fallback must accept the language members and
+// still reject genuine non-members.
+func TestValidateNestedRepetitionBacktracking(t *testing.T) {
+	t.Parallel()
+
+	t.Run("(lhs,(rhs,(com|wfc|vc)*)+)", func(t *testing.T) {
+		t.Parallel()
+		const dtd = `<!DOCTYPE prod [
+<!ELEMENT prod (lhs,(rhs,(com|wfc|vc)*)+)>
+<!ELEMENT lhs EMPTY>
+<!ELEMENT rhs EMPTY>
+<!ELEMENT com EMPTY>
+<!ELEMENT wfc EMPTY>
+<!ELEMENT vc EMPTY>
+]>`
+		// Single iteration of the outer plus-group.
+		require.Empty(t, parseValidating(t, dtd+`<prod><lhs/><rhs/><com/></prod>`),
+			"single iteration is valid")
+
+		// Two iterations: [rhs com] then [rhs vc]. The inner (com|wfc|vc)* of
+		// the first iteration must NOT greedily swallow the second rhs.
+		require.Empty(t, parseValidating(t, dtd+`<prod><lhs/><rhs/><com/><rhs/><vc/></prod>`),
+			"two iterations is valid")
+
+		// A bare rhs with no trailing choice items (choice group is *).
+		require.Empty(t, parseValidating(t, dtd+`<prod><lhs/><rhs/></prod>`),
+			"rhs with zero choice items is valid")
+
+		// Missing the mandatory leading lhs.
+		require.NotEmpty(t, parseValidating(t, dtd+`<prod><rhs/><com/></prod>`),
+			"missing lhs is invalid")
+
+		// A trailing element outside the model.
+		require.NotEmpty(t, parseValidating(t, dtd+`<prod><lhs/><rhs/><com/><bogus/></prod>`),
+			"trailing undeclared element is invalid")
+
+		// Only lhs: the outer group requires at least one rhs.
+		require.NotEmpty(t, parseValidating(t, dtd+`<prod><lhs/></prod>`),
+			"missing mandatory rhs is invalid")
+	})
+
+	t.Run("(a,(b,c*)+)", func(t *testing.T) {
+		t.Parallel()
+		const dtd = `<!DOCTYPE r [
+<!ELEMENT r (a,(b,c*)+)>
+<!ELEMENT a EMPTY>
+<!ELEMENT b EMPTY>
+<!ELEMENT c EMPTY>
+]>`
+		require.Empty(t, parseValidating(t, dtd+`<r><a/><b/></r>`), "a,b valid")
+		require.Empty(t, parseValidating(t, dtd+`<r><a/><b/><c/><b/><c/><c/></r>`),
+			"a then (b,c*) twice valid")
+		require.Empty(t, parseValidating(t, dtd+`<r><a/><b/><c/><c/></r>`), "a,b,c,c valid")
+		require.NotEmpty(t, parseValidating(t, dtd+`<r><a/></r>`), "missing b invalid")
+		require.NotEmpty(t, parseValidating(t, dtd+`<r><a/><c/></r>`), "c before b invalid")
+	})
+
+	t.Run("(a|b)+", func(t *testing.T) {
+		t.Parallel()
+		const dtd = `<!DOCTYPE r [
+<!ELEMENT r (a|b)+>
+<!ELEMENT a EMPTY>
+<!ELEMENT b EMPTY>
+]>`
+		require.Empty(t, parseValidating(t, dtd+`<r><a/></r>`), "single a valid")
+		require.Empty(t, parseValidating(t, dtd+`<r><a/><b/><a/><a/><b/></r>`), "mixed valid")
+		require.NotEmpty(t, parseValidating(t, dtd+`<r></r>`), "empty invalid (needs one)")
+		require.NotEmpty(t, parseValidating(t, dtd+`<r><a/><c/></r>`), "undeclared c invalid")
+	})
+
+	t.Run("((a,b)|c)*", func(t *testing.T) {
+		t.Parallel()
+		const dtd = `<!DOCTYPE r [
+<!ELEMENT r ((a,b)|c)*>
+<!ELEMENT a EMPTY>
+<!ELEMENT b EMPTY>
+<!ELEMENT c EMPTY>
+]>`
+		require.Empty(t, parseValidating(t, dtd+`<r></r>`), "empty valid (star)")
+		require.Empty(t, parseValidating(t, dtd+`<r><c/></r>`), "single c valid")
+		require.Empty(t, parseValidating(t, dtd+`<r><a/><b/></r>`), "a,b valid")
+		require.Empty(t, parseValidating(t, dtd+`<r><a/><b/><c/><a/><b/></r>`),
+			"interleaved groups valid")
+		require.NotEmpty(t, parseValidating(t, dtd+`<r><a/></r>`), "a without b invalid")
+		require.NotEmpty(t, parseValidating(t, dtd+`<r><a/><c/></r>`), "a then c (no b) invalid")
+		require.NotEmpty(t, parseValidating(t, dtd+`<r><b/><a/></r>`), "b before a invalid")
+	})
+
+	// A genuine backtracking case the greedy matcher alone cannot handle even
+	// with correct grouping: the optional a? greedily consumes the only a,
+	// leaving the required a unmatched. The exact fallback must accept it.
+	t.Run("(a?,a) backtracking", func(t *testing.T) {
+		t.Parallel()
+		const dtd = `<!DOCTYPE r [
+<!ELEMENT r (a?,a)>
+<!ELEMENT a EMPTY>
+]>`
+		require.Empty(t, parseValidating(t, dtd+`<r><a/></r>`), "single a satisfies (a?,a)")
+		require.Empty(t, parseValidating(t, dtd+`<r><a/><a/></r>`), "two a satisfies (a?,a)")
+		require.NotEmpty(t, parseValidating(t, dtd+`<r></r>`), "empty invalid (needs one a)")
+		require.NotEmpty(t, parseValidating(t, dtd+`<r><a/><a/><a/></r>`), "three a invalid")
+	})
+}


### PR DESCRIPTION
- Add exact NFA-reachability fallback to `matchContentModel` when greedy descent fails; fix occurrence-aware `flattenSeq`/`flattenOr` so a nested `+`/`*`/`?` group is not flattened away
- Fixes over-rejection of valid W3C xml cases pr-xml-utf-8, pr-xml-little, pr-xml-utf-16
- Fallback is exact and bounded (per-position memoized), runs only on greedy miss; invalid models still rejected