### PR TITLE
reject undeclared and mismatched-fixed attributes

### DIFF
--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -67,7 +67,7 @@ NamespaceDeclNode(18) XIncludeStartNode(19) XIncludeEndNode(20) NamespaceNode(21
 |------|--------|------|----------|---------|----------|----------------|
 | Document | `Document` | docnode | ✓ | — | ✗ | version, encoding, standalone, url, properties, intSubset, extSubset, ids map |
 | Element | `Element` | node | ✓ | via children | ✓ | properties (Attribute linked list), ns, nsDefs |
-| Attribute | `Attribute` | docnode | ✓ (text/entityref for value) | via children | ✓ (linked list) | ns, atype, defaultAttr |
+| Attribute | `Attribute` | docnode | ✓ (text/entityref for value) | via children | ✓ (linked list) | ns, atype, defaultAttr, syntheticBase (parser-injected external-entity xml:base) |
 | Text | `Text` | node | ✗ (merges) | ✓ content | ✓ | Adjacent text nodes auto-merge |
 | CDATASection | `CDATASection` | node | ✗ | ✓ content | ✓ | — |
 | Comment | `Comment` | node | ✗ | ✓ content | ✓ | — |

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -868,11 +868,15 @@ a prefixed instance attribute (`p:id`, `xml:space`, `xml:lang`) is undeclared
 unless an `<!ATTLIST>` declares that exact QName (W3C ibm-invalid-P41-ibm41i01,
 inv-required01/02). One exemption: the synthetic `xml:base` attribute helium
 injects onto the top-level elements of an external parsed entity to record its
-base URI (`parser_entity_decl.go`) is NOT flagged — `isSyntheticEntityBase`
-recognizes it (the owning element's `entityBaseURI` is non-empty and the `xml:base`
-value equals it), because it is not present in the source and libxml2 tracks the
-entity base without materializing an attribute (W3C valid ext-sa-005/013,
-sun/valid/ext01).
+base URI (`parser_entity_decl.go`) is NOT flagged — it carries an
+`Attribute.syntheticBase` marker set ONLY at the injection site (and re-applied by
+`carrySyntheticBase` in `tree_builder.go` when a cached entity subtree is replayed
+under `replaceEntities`), and the loop skips a marked attribute. The check is
+marker-based, not value-based: an AUTHORED `xml:base` — even one whose value
+coincidentally equals the entity base URI — is never marked and is validated
+normally, matching `xmllint --valid --noent`. libxml2 tracks the entity base
+without materializing an attribute, so it never flags the synthetic one (W3C valid
+ext-sa-005/013, sun/valid/ext01).
 
 **Namespace-declaration attributes** (`xmlns` / `xmlns:*`) live in the element's
 `nsDefs`, not its attribute chain, and are handled by

--- a/.claude/docs/validation-pipeline.md
+++ b/.claude/docs/validation-pipeline.md
@@ -829,9 +829,10 @@ test { typ (Assert|Report), expr, compiled *xpath.Expression, message []messageP
 DTD validity (XML 1.0 §3–§4) is validated in `valid.go` post-parse by
 `validateDocument`, reached only under `ValidateDTD(true)`. It runs two kinds of
 check: the **instance-tree** walk (root-name match, per-element declaration
-lookup, `#REQUIRED`/`#FIXED`, attribute lexical type, enumeration/notation value
-membership, ID uniqueness, IDREF cross-reference, ENTITY/ENTITIES declared+
-unparsed, content-model matching) and a **declaration-consistency** pass over the
+lookup, every present attribute declared, `#REQUIRED`/`#FIXED`, attribute lexical
+type, enumeration/notation value membership, ID uniqueness, IDREF cross-reference,
+ENTITY/ENTITIES declared+unparsed, content-model matching) and a
+**declaration-consistency** pass over the
 DTD declarations themselves. A document with neither internal nor external subset
 reports `no DTD found` (libxml2 `XML_DTD_NO_DTD`). Errors go to the configured
 `ErrorHandler` via `validCtx.addf`; a failed validation returns
@@ -857,6 +858,35 @@ unprefixed/differently-prefixed attribute (and vice-versa). Element declarations
 (`ElementDecl`) are stored split into (local, prefix); `lookupElementDecl` looks
 them up by `elem.LocalName()`+`elem.Prefix()` with NO fallback from a prefixed
 element to an unprefixed declaration (a `<p:r>` requires an `<!ELEMENT p:r>`).
+
+**Attribute Value Type — every present attribute must be declared** (§3.1). After
+`validateElementAttributes` checks the declared attributes, it walks the element's
+own attribute chain (`Element.Attributes()`) and reports `no declaration for
+attribute <qname>` for any attribute whose (prefix, local) key has no matching
+`<!ATTLIST>` — libxml2 `xmlValidateOneAttribute`. Prefix-literal keying applies, so
+a prefixed instance attribute (`p:id`, `xml:space`, `xml:lang`) is undeclared
+unless an `<!ATTLIST>` declares that exact QName (W3C ibm-invalid-P41-ibm41i01,
+inv-required01/02). One exemption: the synthetic `xml:base` attribute helium
+injects onto the top-level elements of an external parsed entity to record its
+base URI (`parser_entity_decl.go`) is NOT flagged — `isSyntheticEntityBase`
+recognizes it (the owning element's `entityBaseURI` is non-empty and the `xml:base`
+value equals it), because it is not present in the source and libxml2 tracks the
+entity base without materializing an attribute (W3C valid ext-sa-005/013,
+sun/valid/ext01).
+
+**Namespace-declaration attributes** (`xmlns` / `xmlns:*`) live in the element's
+`nsDefs`, not its attribute chain, and are handled by
+`validateElementNamespaceDecls` against an `<!ATTLIST>` keyed as `xmlns` (default
+declaration) or, for `xmlns:p`, local name `p` with declared prefix `xmlns`. Only
+the **Fixed Attribute Default** VC is enforced: a `#FIXED` namespace declaration
+whose value differs from the declared value is rejected (W3C attr08). The
+"must be declared" VC is deliberately NOT enforced for a namespace declaration —
+helium is namespace-aware, so a DTD-validated namespaced document need not declare
+its `xmlns` attributes in the DTD; flagging an undeclared `xmlns:*` would
+over-reject the ordinary case of validating a namespaced document against a
+namespace-agnostic DTD. (W3C hst-bh-005/hst-bh-006, which assert a namespace-UNAWARE
+processor rejects an undeclared `xmlns:*`, are therefore out of scope; helium's
+parser also drops a redundant `xmlns:xml` re-declaration before validation.)
 
 **Content-model matching is raw-QName-based too** (`valid.go`
 `collectChildElements`/`matchContentModel`/`matchElement` for element-only

--- a/attribute.go
+++ b/attribute.go
@@ -9,7 +9,13 @@ type Attribute struct {
 	docnode
 	atype       enum.AttributeType
 	defaultAttr bool
-	ns          *Namespace
+	// syntheticBase is set only on the xml:base attribute the parser injects onto
+	// the top-level elements of an external parsed entity (parser_entity_decl.go)
+	// to record the entity's base URI. It is not present in the source, so DTD
+	// validation exempts it from the "attribute must be declared" VC. An AUTHORED
+	// xml:base is never marked and is validated normally.
+	syntheticBase bool
+	ns            *Namespace
 }
 
 func newAttribute(name string, ns *Namespace) *Attribute {

--- a/parser_entity_decl.go
+++ b/parser_entity_decl.go
@@ -921,7 +921,14 @@ func (pctx *parserCtx) parseExternalEntityPrivate(ctx context.Context, uri, exte
 					if !pctx.options.IsSet(parseNoBaseFix) {
 						if elem, ok := e.(*Element); ok {
 							if _, exists := elem.GetAttributeNS("base", lexicon.NamespaceXML); !exists {
-								_, _ = elem.SetAttributeNS("base", uri, newNamespace("xml", lexicon.NamespaceXML))
+								if _, err := elem.SetAttributeNS("base", uri, newNamespace("xml", lexicon.NamespaceXML)); err == nil {
+									// Mark this xml:base as parser-synthesized so DTD
+									// validation does not treat it as an undeclared
+									// attribute (an authored xml:base is never marked).
+									if injected := elem.GetAttributeNodeNS("base", lexicon.NamespaceXML); injected != nil {
+										injected.syntheticBase = true
+									}
+								}
 							}
 						}
 					}

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -153,6 +153,7 @@ func (t *TreeBuilder) StartElementNS(ctxif context.Context, localname, prefix, u
 				// value. Use literal mode to avoid re-parsing & as
 				// new entity reference starts.
 				_ = e.SetLiteralAttributeNS(attr.LocalName(), attr.Value(), ns)
+				carrySyntheticBase(e, attr, ns)
 			} else {
 				if _, err := e.SetAttributeNS(attr.LocalName(), attr.Value(), ns); err != nil {
 					return err
@@ -528,6 +529,27 @@ func (t *TreeBuilder) GetParameterEntity(ctxif context.Context, name string) (sa
 	}
 
 	return nil, ErrEntityNotFound
+}
+
+// carrySyntheticBase re-marks a replayed xml:base attribute as parser-synthesized.
+// When an external-entity subtree is replayed under replaceEntities, the tree
+// builder rebuilds each attribute fresh, so the syntheticBase marker on the cached
+// source attribute (set by parseExternalEntityPrivate) must be copied onto the
+// newly built one — otherwise DTD validation would flag the synthetic xml:base as
+// an undeclared attribute. An authored xml:base is never marked, so it is not
+// carried and remains subject to the "attribute must be declared" VC.
+func carrySyntheticBase(e *Element, src sax.Attribute, ns *Namespace) {
+	srcAttr, ok := src.(*Attribute)
+	if !ok || !srcAttr.syntheticBase {
+		return
+	}
+	var uri string
+	if ns != nil {
+		uri = ns.URI()
+	}
+	if a := e.GetAttributeNodeNS(srcAttr.LocalName(), uri); a != nil {
+		a.syntheticBase = true
+	}
 }
 
 func (t *TreeBuilder) AttributeDecl(ctxif context.Context, eName string, aName string, typ enum.AttributeType, deftype enum.AttributeDefault, value string, enumif sax.Enumeration) error {

--- a/valid.go
+++ b/valid.go
@@ -489,7 +489,11 @@ func validateElementAttributes(ctx context.Context, doc *Document, elem *Element
 	// (xmlns / xmlns:*) are stored in nsDefs, not the attribute chain, so they are
 	// checked separately by validateElementNamespaceDecls.
 	for _, a := range attrs {
-		if isSyntheticEntityBase(elem, a) {
+		// The xml:base the parser injects onto external-entity elements is not in
+		// the source; libxml2 tracks the entity base without a materialized
+		// attribute, so it is exempt from this VC. An AUTHORED xml:base is not
+		// marked and is validated normally.
+		if a.syntheticBase {
 			continue
 		}
 		if !seen[a.Prefix()+":"+a.LocalName()] {
@@ -498,24 +502,6 @@ func validateElementAttributes(ctx context.Context, doc *Document, elem *Element
 	}
 
 	validateElementNamespaceDecls(ctx, doc, elem, ename, vctx)
-}
-
-// isSyntheticEntityBase reports whether a is the xml:base attribute helium
-// injects onto the top-level elements of an external parsed entity to record the
-// entity's base URI (parser_entity_decl.go). Such an attribute is not present in
-// the source and is not subject to the "must be declared" VC — libxml2 tracks the
-// entity base without a materialized attribute, so it never flags one. The
-// injection sets the value to the element's entityBaseURI, so an attribute is
-// synthetic exactly when the owning element originates from an external entity
-// (entityBaseURI != "") and its xml:base value equals that URI.
-func isSyntheticEntityBase(elem *Element, a *Attribute) bool {
-	if elem.entityBaseURI == "" {
-		return false
-	}
-	if a.LocalName() != "base" || a.Prefix() != "xml" {
-		return false
-	}
-	return a.Value() == elem.entityBaseURI
 }
 
 // validateElementNamespaceDecls enforces the Fixed Attribute Default VC on the

--- a/valid.go
+++ b/valid.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/lestrrat-go/helium/enum"
+	"github.com/lestrrat-go/helium/internal/lexicon"
 	"github.com/lestrrat-go/helium/internal/xmlchar"
 )
 
@@ -476,6 +477,78 @@ func validateElementAttributes(ctx context.Context, doc *Document, elem *Element
 					}
 				}
 			}
+		}
+	}
+
+	// VC: Attribute Value Type (XML §3.1) — every attribute present on the
+	// instance must have been declared. libxml2 xmlValidateOneAttribute reports
+	// XML_DTD_UNKNOWN_ATTRIBUTE ("No declaration for attribute %s of element %s")
+	// for an ordinary attribute with no matching <!ATTLIST>. After the loop above,
+	// `seen` holds every declared attribute key ("prefix:local"), the same key
+	// form used for present attributes. Namespace-declaration attributes
+	// (xmlns / xmlns:*) are stored in nsDefs, not the attribute chain, so they are
+	// checked separately by validateElementNamespaceDecls.
+	for _, a := range attrs {
+		if isSyntheticEntityBase(elem, a) {
+			continue
+		}
+		if !seen[a.Prefix()+":"+a.LocalName()] {
+			vctx.addf(ctx, "element %s: no declaration for attribute %s", ename, a.Name())
+		}
+	}
+
+	validateElementNamespaceDecls(ctx, doc, elem, ename, vctx)
+}
+
+// isSyntheticEntityBase reports whether a is the xml:base attribute helium
+// injects onto the top-level elements of an external parsed entity to record the
+// entity's base URI (parser_entity_decl.go). Such an attribute is not present in
+// the source and is not subject to the "must be declared" VC — libxml2 tracks the
+// entity base without a materialized attribute, so it never flags one. The
+// injection sets the value to the element's entityBaseURI, so an attribute is
+// synthetic exactly when the owning element originates from an external entity
+// (entityBaseURI != "") and its xml:base value equals that URI.
+func isSyntheticEntityBase(elem *Element, a *Attribute) bool {
+	if elem.entityBaseURI == "" {
+		return false
+	}
+	if a.LocalName() != "base" || a.Prefix() != "xml" {
+		return false
+	}
+	return a.Value() == elem.entityBaseURI
+}
+
+// validateElementNamespaceDecls enforces the Fixed Attribute Default VC on the
+// namespace-declaration attributes (xmlns and xmlns:*) declared directly on an
+// element. An <!ATTLIST> declaration for a namespace declaration is keyed as
+// `xmlns` (default declaration) or, for a prefixed declaration `xmlns:p`, as
+// local name `p` with declared prefix `xmlns` (matching how the ATTLIST parser
+// splits the qualified name). A #FIXED declaration whose value differs from the
+// declared value is VC: Fixed Attribute Default (W3C attr08).
+//
+// helium deliberately does NOT enforce the "must be declared" VC (Attribute
+// Value Type) for a namespace declaration that lacks an <!ATTLIST>: a
+// namespace-declaration attribute is exempt, so a DTD-validated namespaced
+// document need not declare its xmlns attributes. Flagging an undeclared xmlns
+// here would over-reject the ordinary case of validating a namespaced document
+// against a namespace-agnostic DTD. (This is why W3C hst-bh-005/hst-bh-006 —
+// which assert a namespace-UNAWARE processor rejects an undeclared xmlns:* — are
+// out of scope for helium's namespace-aware validator.)
+func validateElementNamespaceDecls(ctx context.Context, doc *Document, elem *Element, ename string, vctx *validCtx) {
+	for _, ns := range elem.Namespaces() {
+		declName, declPrefix, label := lexicon.PrefixXMLNS, "", lexicon.PrefixXMLNS
+		if p := ns.Prefix(); p != "" {
+			declName, declPrefix, label = p, lexicon.PrefixXMLNS, lexicon.PrefixXMLNS+":"+p
+		}
+
+		adecl := lookupAttributeDecl(doc, declName, declPrefix, ename)
+		if adecl == nil {
+			continue
+		}
+		// VC: Fixed Attribute Default — a #FIXED namespace declaration must
+		// match the declared value.
+		if adecl.def == enum.AttrDefaultFixed && ns.URI() != adecl.defvalue {
+			vctx.addf(ctx, "element %s: attribute %s has value %q but must be %q", ename, label, ns.URI(), adecl.defvalue)
 		}
 	}
 }

--- a/valid_attr_test.go
+++ b/valid_attr_test.go
@@ -146,6 +146,7 @@ func TestExternalEntitySyntheticBaseNotFlagged(t *testing.T) {
 	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
 	_, err := helium.NewParser().
 		BaseURI("doc.xml").
+		BlockXXE(false).
 		LoadExternalDTD(true).
 		DefaultDTDAttributes(true).
 		SubstituteEntities(true).
@@ -154,4 +155,43 @@ func TestExternalEntitySyntheticBaseNotFlagged(t *testing.T) {
 		ErrorHandler(collector).
 		Parse(t.Context(), []byte(src))
 	require.NoError(t, err, "external-entity elements carry a synthetic xml:base that must not be flagged as undeclared; errors=%v", collector.Errors())
+}
+
+// TestExternalEntityAuthoredBaseFlagged is the adversarial counterpart: only the
+// parser-injected xml:base is exempt. An AUTHORED xml:base on an external-entity
+// element — even one whose value coincidentally equals the entity's base URI, so
+// the parser suppresses its own injection — is a real attribute and must be
+// rejected when undeclared (VC: Attribute Value Type), matching
+// `xmllint --valid --noent`. The exemption is marker-based, not value-based.
+func TestExternalEntityAuthoredBaseFlagged(t *testing.T) {
+	t.Parallel()
+
+	// The entity's base URI resolves to "e.ent" (relative to BaseURI "doc.xml"),
+	// and the authored xml:base value is exactly that, so a value-equality
+	// exemption would wrongly accept it.
+	fsys := fstest.MapFS{
+		"e.ent": {Data: []byte(`<e xml:base="e.ent"/>`)},
+	}
+	src := `<?xml version="1.0"?>
+<!DOCTYPE doc [
+  <!ELEMENT doc (e*)>
+  <!ELEMENT e EMPTY>
+  <!ENTITY e SYSTEM "e.ent">
+]>
+<doc>&e;</doc>`
+
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	_, err := helium.NewParser().
+		BaseURI("doc.xml").
+		BlockXXE(false).
+		LoadExternalDTD(true).
+		DefaultDTDAttributes(true).
+		SubstituteEntities(true).
+		ValidateDTD(true).
+		FS(fsys).
+		ErrorHandler(collector).
+		Parse(t.Context(), []byte(src))
+	require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+	require.True(t, containsError(collector.Errors(), "no declaration for attribute xml:base"),
+		"authored undeclared xml:base must be flagged; errors=%v", collector.Errors())
 }

--- a/valid_attr_test.go
+++ b/valid_attr_test.go
@@ -1,0 +1,157 @@
+package helium_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAttributeValidityCompleteness exercises the per-instance attribute VCs
+// enforced in validateElementAttributes: Attribute Value Type (every present
+// attribute must be declared, for ordinary attributes and for xmlns/xmlns:*
+// namespace declarations) and Fixed Attribute Default (a #FIXED namespace
+// declaration must match). Each VC has a rejecting case and a valid near-miss so
+// the check does not over-reject.
+func TestAttributeValidityCompleteness(t *testing.T) {
+	t.Parallel()
+
+	// VC: Attribute Value Type — an ordinary undeclared attribute is invalid
+	// (W3C ibm-invalid-P41-ibm41i01.xml).
+	t.Run("undeclared ordinary attribute", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("rejected", func(t *testing.T) {
+			t.Parallel()
+			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root (#PCDATA|b)*>
+  <!ELEMENT b (#PCDATA)>
+  <!ATTLIST b attr2 (abc|def) "abc">
+]>
+<root><b attr1="value1" attr2="def">x</b></root>`)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "no declaration for attribute attr1"))
+		})
+
+		t.Run("declared attribute accepted", func(t *testing.T) {
+			t.Parallel()
+			_, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root (#PCDATA|b)*>
+  <!ELEMENT b (#PCDATA)>
+  <!ATTLIST b attr1 CDATA #IMPLIED attr2 (abc|def) "abc">
+]>
+<root><b attr1="value1" attr2="def">x</b></root>`)
+			require.NoError(t, err)
+		})
+	})
+
+	// VC: Attribute Value Type applied to attributes in the reserved xml
+	// namespace (W3C inv-required01/inv-required02). xml:space / xml:lang are
+	// ordinary attributes that still require declaration.
+	t.Run("undeclared reserved xml attribute", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("xml:space rejected", func(t *testing.T) {
+			t.Parallel()
+			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root EMPTY>
+]>
+<root xml:space='preserve'/>`)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "no declaration for attribute xml:space"))
+		})
+
+		t.Run("declared xml:space accepted", func(t *testing.T) {
+			t.Parallel()
+			_, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE root [
+  <!ELEMENT root EMPTY>
+  <!ATTLIST root xml:space (default|preserve) #IMPLIED>
+]>
+<root xml:space='preserve'/>`)
+			require.NoError(t, err)
+		})
+	})
+
+	// A namespace declaration (xmlns:*) is EXEMPT from the "must be declared" VC:
+	// a namespaced document may DTD-validate against a namespace-agnostic DTD that
+	// never declares its xmlns attributes. This is the over-rejection guard for
+	// the namespace-declaration path (helium diverges from a namespace-UNAWARE
+	// validator here, so W3C hst-bh-005/hst-bh-006 stay out of scope).
+	t.Run("undeclared namespace declaration accepted", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE r [
+  <!ELEMENT r (p:a)>
+  <!ELEMENT p:a EMPTY>
+]>
+<r xmlns:p='http://example.org'><p:a/></r>`)
+		require.NoError(t, err)
+	})
+
+	// VC: Fixed Attribute Default applied to a default (xmlns) namespace
+	// declaration (W3C attr08). A #FIXED xmlns must match the declared value.
+	t.Run("fixed namespace declaration", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("differing value rejected", func(t *testing.T) {
+			t.Parallel()
+			errs, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE palimpest [
+  <!ELEMENT palimpest EMPTY>
+  <!ATTLIST palimpest xmlns CDATA #FIXED "http://java.sun.com/historical">
+]>
+<palimpest xmlns="http://over.the.rainbow.com/somewhere"/>`)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "attribute xmlns has value"))
+		})
+
+		t.Run("matching value accepted", func(t *testing.T) {
+			t.Parallel()
+			_, err := parseValidatingDTD(t, `<?xml version="1.0"?>
+<!DOCTYPE palimpest [
+  <!ELEMENT palimpest EMPTY>
+  <!ATTLIST palimpest xmlns CDATA #FIXED "http://java.sun.com/historical">
+]>
+<palimpest xmlns="http://java.sun.com/historical"/>`)
+			require.NoError(t, err)
+		})
+	})
+}
+
+// TestExternalEntitySyntheticBaseNotFlagged is the over-rejection guard for the
+// "must be declared" VC: helium injects a synthetic xml:base attribute onto the
+// top-level elements of an external parsed entity to record the entity's base
+// URI. That attribute is not in the source and must not trip the Attribute Value
+// Type VC (W3C valid ext-sa-005/013, sun/valid/ext01). libxml2 tracks the entity
+// base without materializing an attribute, so it never flags one.
+func TestExternalEntitySyntheticBaseNotFlagged(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"e.ent": {Data: []byte(`<e/><e/>`)},
+	}
+	src := `<?xml version="1.0"?>
+<!DOCTYPE doc [
+  <!ELEMENT doc (e*)>
+  <!ELEMENT e EMPTY>
+  <!ENTITY e SYSTEM "e.ent">
+]>
+<doc>&e;</doc>`
+
+	collector := helium.NewErrorCollector(t.Context(), helium.ErrorLevelNone)
+	_, err := helium.NewParser().
+		BaseURI("doc.xml").
+		LoadExternalDTD(true).
+		DefaultDTDAttributes(true).
+		SubstituteEntities(true).
+		ValidateDTD(true).
+		FS(fsys).
+		ErrorHandler(collector).
+		Parse(t.Context(), []byte(src))
+	require.NoError(t, err, "external-entity elements carry a synthetic xml:base that must not be flagged as undeclared; errors=%v", collector.Errors())
+}

--- a/valid_standalone_test.go
+++ b/valid_standalone_test.go
@@ -139,14 +139,18 @@ func TestStandaloneExternalDecl(t *testing.T) {
 		})
 
 		// An external UNPREFIXED tokenized declaration does not apply to a PREFIXED
-		// instance attribute of the same local name, so the standalone check must
-		// not fire (main accepts this document — no new false positive).
-		t.Run("prefixed instance vs unprefixed external decl accepted", func(t *testing.T) {
+		// instance attribute of the same local name, so the standalone
+		// normalization check must NOT fire. The prefixed p:id is itself undeclared
+		// (VC: Attribute Value Type — the id declaration is prefix-literal), so the
+		// document is rejected for that reason, not for external normalization.
+		t.Run("prefixed instance vs unprefixed external decl not normalized", func(t *testing.T) {
 			t.Parallel()
-			_, err := parseStandalone(t, `<?xml version="1.0" standalone="yes"?>
+			errs, err := parseStandalone(t, `<?xml version="1.0" standalone="yes"?>
 <!DOCTYPE r SYSTEM "ext.dtd" [ <!ELEMENT r EMPTY> ]>
 <r xmlns:p="urn:p" p:id="  spacedvalue  "/>`, `<!ATTLIST r id NMTOKEN #IMPLIED>`)
-			require.NoError(t, err)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "no declaration for attribute p:id"))
+			require.False(t, containsError(errs, "normalization"))
 		})
 
 		// The genuine case (unprefixed instance matching the unprefixed external
@@ -273,13 +277,18 @@ func TestStandaloneExternalDecl(t *testing.T) {
 		})
 
 		// A declaration for the PREFIXED element `p:r` does not apply to an
-		// unprefixed element `<r>`, so no normalization and no report.
-		t.Run("prefixed decl vs unprefixed element accepted", func(t *testing.T) {
+		// unprefixed element `<r>`, so the external declaration never normalizes
+		// `<r>`'s id. Because that declaration does not apply, id is undeclared on
+		// `<r>` (VC: Attribute Value Type) — the document is rejected for the
+		// undeclared attribute, not for external normalization.
+		t.Run("prefixed decl vs unprefixed element not applied", func(t *testing.T) {
 			t.Parallel()
-			_, err := parseStandalone(t, `<?xml version="1.0" standalone="yes"?>
+			errs, err := parseStandalone(t, `<?xml version="1.0" standalone="yes"?>
 <!DOCTYPE r SYSTEM "ext.dtd" [ <!ELEMENT r EMPTY> ]>
 <r id="  spacedvalue  "/>`, extDTD)
-			require.NoError(t, err)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "no declaration for attribute id"))
+			require.False(t, containsError(errs, "normalization"))
 		})
 
 		// External default declared for a prefixed element applies to that element.
@@ -297,14 +306,18 @@ func TestStandaloneExternalDecl(t *testing.T) {
 		// identically do not cross-contaminate: a declaration for element `p:r`,
 		// attribute `id` (concat "p:r:id") must NOT apply to element `p`, attribute
 		// `r:id` (also concat "p:r:id"). If it did, `r:id` would be treated as an
-		// external NMTOKEN, normalized, and wrongly reported — so acceptance proves
-		// the keys are disambiguated.
+		// external NMTOKEN, normalized, and wrongly reported. Because it does not
+		// apply, `r:id` is undeclared on `<p>` (VC: Attribute Value Type): the absence
+		// of a normalization report — with an undeclared-attribute rejection instead —
+		// proves the keys are disambiguated.
 		t.Run("ambiguous element/attr key does not cross-contaminate", func(t *testing.T) {
 			t.Parallel()
-			_, err := parseStandalone(t, `<?xml version="1.0" standalone="yes"?>
+			errs, err := parseStandalone(t, `<?xml version="1.0" standalone="yes"?>
 <!DOCTYPE p SYSTEM "ext.dtd" [ <!ELEMENT p EMPTY> ]>
 <p xmlns:r="urn:r" r:id="  spacedvalue  "/>`, `<!ATTLIST p:r id NMTOKEN #IMPLIED>`)
-			require.NoError(t, err)
+			require.ErrorIs(t, err, helium.ErrDTDValidationFailed)
+			require.True(t, containsError(errs, "no declaration for attribute r:id"))
+			require.False(t, containsError(errs, "normalization"))
 		})
 	})
 }


### PR DESCRIPTION
- Enforce VC: Attribute Value Type — a present attribute with no `<!ATTLIST>` is now a validity error (W3C ibm-invalid-P41-ibm41i01, inv-required01, inv-required02)
- Enforce VC: Fixed Attribute Default on a declared `xmlns` namespace declaration (W3C attr08)
- Exempt the synthetic `xml:base` helium injects on external-entity elements, and exempt undeclared `xmlns:*` (namespace-aware), so valid namespaced/external-entity docs still validate