### PR TITLE
require whitespace between attributes

### DIFF
--- a/.claude/docs/parser-internals.md
+++ b/.claude/docs/parser-internals.md
@@ -130,7 +130,7 @@ error rather than being silently passed through.
 
 - `parserctx.go` owns the parser context, input/cursor stack, SAX callback dispatch, location/error reporting, and other shared parser state.
 - `parser_document.go` owns the top-level parse pipeline (`parseDocument`, `parseContent`, recovery re-sync).
-- `parser_element.go` owns recursive element parsing, start/end tags, attributes, and character data.
+- `parser_element.go` owns recursive element parsing, start/end tags, attributes, and character data. `parseStartTag` enforces XML §3.1 P40/P44 required inter-attribute whitespace: after EVERY attribute — the default-namespace, prefixed-namespace, and regular-attribute branches alike — the next character must close the tag (`>` or `/>`) or be whitespace; a NameStartChar with no intervening `S` is a fatal `ErrSpaceRequired` (mirrors libxml2's uniform `next_attr` check; W3C not-wf `attlist10`/`attlist11`, `o-p40fail1`/`o-p44fail4`, `not-wf-sa-186`).
 - `parser_xml_decl.go` owns byte/rune XML declaration parsing; `parser_decl.go` owns the lower-level declaration token/value helpers and name/QName parsing.
 - `parser_dtd_*` files split DTD handling by declaration kind instead of keeping all markup parsing in one file.
 - `parser_entity_decl.go` handles entity declaration bodies and balanced-chunk parsing; `parser_entity_ref.go` handles references, char refs, replay, and amplification checks.

--- a/parser_element.go
+++ b/parser_element.go
@@ -564,6 +564,20 @@ func (pctx *parserCtx) parseStartTag(ctx context.Context) error {
 		}
 
 		attrs = append(attrs, attr)
+
+		// XML §3.1 P40/P44: attributes in a start/empty-element tag must be
+		// separated by whitespace (STag/EmptyElemTag: '(S Attribute)*'). After
+		// a regular attribute the next character must close the tag ('>' or
+		// '/>') or be whitespace; a NameStartChar beginning the next attribute
+		// with no intervening S is a fatal well-formedness error. The two
+		// namespace-declaration branches above enforce the same rule; this
+		// mirrors libxml2's uniform post-attribute check at next_attr.
+		if cur.Peek() == '>' || (cur.Peek() == '/' && cur.PeekAt(1) == '>') {
+			continue
+		}
+		if !isBlankByte(cur.Peek()) {
+			return pctx.error(ctx, ErrSpaceRequired)
+		}
 	}
 
 	// Attributes defaulting: apply DTD-declared default attribute values.

--- a/parser_test.go
+++ b/parser_test.go
@@ -261,6 +261,10 @@ func TestParseRejectsMissingSpaceBetweenAttributes(t *testing.T) {
 		// A missing space before a namespace-declaration attribute is also
 		// caught (the namespace branch already enforced this; keep it covered).
 		`<doc att="val"xmlns:p="urn:x"/>`,
+		// Namespace-declaration attribute FIRST, then a regular attribute with no
+		// separating space: the new regular-attribute check must fire after the
+		// namespace attribute is consumed (proves the two checks compose).
+		`<doc xmlns:p="urn:x"att="val"/>`,
 	}
 	for _, input := range reject {
 		_, err := helium.NewParser().Parse(t.Context(), []byte(input))
@@ -277,10 +281,14 @@ func TestParseRejectsMissingSpaceBetweenAttributes(t *testing.T) {
 		`<doc att="val" att2="val2"></doc>`,
 		"<doc att=\"val\"\natt2=\"val2\"/>",
 		"<doc att=\"val\"\t att2=\"val2\"/>",
+		"<doc att=\"val\"\ratt2=\"val2\"/>",
 		`<doc att="val"/>`,
 		`<doc att="val"></doc>`,
 		`<doc/>`,
 		`<doc att="val" ></doc>`,
+		// A space between a namespace-declaration attribute and a following
+		// regular attribute must still parse (well-formed composition).
+		`<doc xmlns:p="urn:x" att="val"/>`,
 	}
 	for _, input := range accept {
 		_, err := helium.NewParser().Parse(t.Context(), []byte(input))

--- a/parser_test.go
+++ b/parser_test.go
@@ -244,6 +244,50 @@ func TestParseRejectsDuplicateAttribute(t *testing.T) {
 	}
 }
 
+func TestParseRejectsMissingSpaceBetweenAttributes(t *testing.T) {
+	// XML §3.1 P40/P44: attributes in a start/empty-element tag must be
+	// separated by whitespace ('(S Attribute)*'). Two attributes written back
+	// to back with no intervening S are a fatal well-formedness error. This
+	// covers W3C xml-suite cases sun/attlist10, sun/attlist11, oasis/p40fail1,
+	// oasis/p44fail4 and xmltest/not-wf/sa/186.
+	reject := []string{
+		// STag (P40) and EmptyElemTag (P44), no DTD.
+		`<doc att="val"att2="val2"></doc>`,
+		`<doc att="val"att2="val2"/>`,
+		// With an internal DTD declaring the attributes (sun attlist10/11, sa186).
+		"<!DOCTYPE root [\n<!ELEMENT root ANY>\n<!ATTLIST root att1 CDATA #IMPLIED>\n<!ATTLIST root att2 CDATA #IMPLIED>\n]>\n<root att1=\"value1\"att2=\"value2\"></root>",
+		"<!DOCTYPE root [\n<!ELEMENT root ANY>\n<!ATTLIST root att1 CDATA #IMPLIED>\n<!ATTLIST root att2 CDATA #IMPLIED>\n]>\n<root att1=\"value1\"att2=\"value2\"/>",
+		"<!DOCTYPE a [\n<!ELEMENT a EMPTY>\n<!ATTLIST a b CDATA #IMPLIED d CDATA #IMPLIED>\n]>\n<a b=\"c\"d=\"e\"/>",
+		// A missing space before a namespace-declaration attribute is also
+		// caught (the namespace branch already enforced this; keep it covered).
+		`<doc att="val"xmlns:p="urn:x"/>`,
+	}
+	for _, input := range reject {
+		_, err := helium.NewParser().Parse(t.Context(), []byte(input))
+		require.Error(t, err, "Parse should reject missing space between attributes in %q", input)
+		require.ErrorIs(t, err, helium.ErrSpaceRequired, "should be a space-required error for %q", input)
+	}
+
+	// The well-formed counterparts — attributes separated by a space, a
+	// newline, or any XML whitespace — must still parse cleanly (no
+	// over-rejection). A single attribute and the two tag-close forms are
+	// included to exercise the '>' / '/>' branches of the new check.
+	accept := []string{
+		`<doc att="val" att2="val2"/>`,
+		`<doc att="val" att2="val2"></doc>`,
+		"<doc att=\"val\"\natt2=\"val2\"/>",
+		"<doc att=\"val\"\t att2=\"val2\"/>",
+		`<doc att="val"/>`,
+		`<doc att="val"></doc>`,
+		`<doc/>`,
+		`<doc att="val" ></doc>`,
+	}
+	for _, input := range accept {
+		_, err := helium.NewParser().Parse(t.Context(), []byte(input))
+		require.NoError(t, err, "Parse should accept space-separated attributes in %q", input)
+	}
+}
+
 func TestParseXML11PrefixUndeclaration(t *testing.T) {
 	// Namespaces in XML 1.1 §5: a prefixed namespace declaration with an empty
 	// value (xmlns:pfx="") undeclares the prefix. This is well-formed only in an


### PR DESCRIPTION
- Enforce XML §3.1 P40/P44 required inter-attribute whitespace in `parseStartTag`; back-to-back attributes with no separating `S` are now a fatal `ErrSpaceRequired`, matching libxml2's `next_attr` check.
- Fixes W3C not-wf cases attlist10, attlist11, o-p40fail1, o-p44fail4, not-wf-sa-186.
- Space/newline-separated attributes still parse unchanged; full suite + W3C xml suite show zero regressions.