### PR TITLE
format mixed-content elements inline

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -487,10 +487,11 @@ func hasOnlyTextChildren(n Node) bool {
 
 // hasTextlikeChild returns true when any DIRECT child of n is a text, CDATA, or
 // entity-reference node. This mirrors libxml2's xmlNodeDumpOutputInternal
-// (xmlsave.c): an element with any such child has formatting of its children
-// disabled, so mixed content (non-whitespace text alongside element children)
-// is serialized inline rather than having indentation whitespace injected around
-// the children — which would alter the text content and not be idempotent.
+// (xmlsave.c): an element with any such child is mixed content, so it is marked
+// suppressed and formatting is disabled for its ENTIRE subtree (via suppressDepth)
+// until it closes — the children, and their descendants, are serialized inline
+// rather than having indentation whitespace injected. Formatting a mixed element's
+// subtree would alter the text content and not be idempotent.
 func hasTextlikeChild(n Node) bool {
 	for c := range Children(n) {
 		switch c.Type() {
@@ -876,7 +877,8 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 	// section-elements: an element named in the cdata set has its direct text
 	// children emitted as CDATA sections. Both flags are saved/restored around
 	// the children so sibling and ancestor state is unaffected.
-	elemSuppressed := d.suppressDepth > 0 || matchesNameSet(d.suppressIndent, n)
+	elemSuppressed := d.suppressDepth > 0 || matchesNameSet(d.suppressIndent, n) ||
+		(d.format && hasTextlikeChild(n))
 	effFormat := d.format && !elemSuppressed
 	savedCDATA := d.cdataText
 	d.cdataText = matchesNameSet(d.cdataElements, n)
@@ -885,7 +887,7 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 	}
 
 	if n.FirstChild() != nil {
-		textOnly := effFormat && (hasOnlyTextChildren(n) || hasTextlikeChild(n))
+		textOnly := effFormat && hasOnlyTextChildren(n)
 		if effFormat && !textOnly {
 			d.writeString(out, "\n")
 			d.indent++

--- a/writer.go
+++ b/writer.go
@@ -485,6 +485,22 @@ func hasOnlyTextChildren(n Node) bool {
 	return true
 }
 
+// hasTextlikeChild returns true when any DIRECT child of n is a text, CDATA, or
+// entity-reference node. This mirrors libxml2's xmlNodeDumpOutputInternal
+// (xmlsave.c): an element with any such child has formatting of its children
+// disabled, so mixed content (non-whitespace text alongside element children)
+// is serialized inline rather than having indentation whitespace injected around
+// the children — which would alter the text content and not be idempotent.
+func hasTextlikeChild(n Node) bool {
+	for c := range Children(n) {
+		switch c.Type() {
+		case TextNode, CDATASectionNode, EntityRefNode:
+			return true
+		}
+	}
+	return false
+}
+
 // isNilNode reports whether node is nil, covering both a literal nil interface
 // and a typed-nil concrete pointer wrapped in a non-nil Node interface
 // (Go's interface nil trap).
@@ -869,7 +885,7 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 	}
 
 	if n.FirstChild() != nil {
-		textOnly := effFormat && hasOnlyTextChildren(n)
+		textOnly := effFormat && (hasOnlyTextChildren(n) || hasTextlikeChild(n))
 		if effFormat && !textOnly {
 			d.writeString(out, "\n")
 			d.indent++

--- a/writer_test.go
+++ b/writer_test.go
@@ -709,6 +709,46 @@ func TestFormatOutput(t *testing.T) {
 		expected := "<?xml version=\"1.0\"?>\n<a>\n  <b>\n    <c>\n      <d>text</d>\n    </c>\n  </b>\n</a>\n"
 		require.Equal(t, expected, str)
 	})
+
+	t.Run("mixed content stays inline", func(t *testing.T) {
+		t.Parallel()
+
+		const input = `<resources><string name="welcome">Hello <b>world</b></string><version>1.0</version></resources>`
+
+		doc, err := helium.NewParser().StripBlanks(true).Parse(t.Context(), []byte(input))
+		require.NoError(t, err)
+
+		var buf strings.Builder
+		require.NoError(t, helium.NewWriter().Format(true).IndentString("  ").XMLDeclaration(false).WriteTo(&buf, doc))
+
+		// The mixed-content <string> element (non-whitespace text alongside a <b>
+		// child) must not have indentation injected around its children — doing so
+		// would corrupt "Hello " into "Hello\n      ". Only the pure-element
+		// container <resources> is formatted.
+		expected := "<resources>\n  <string name=\"welcome\">Hello <b>world</b></string>\n  <version>1.0</version>\n</resources>\n"
+		require.Equal(t, expected, buf.String())
+	})
+
+	t.Run("mixed content format is idempotent", func(t *testing.T) {
+		t.Parallel()
+
+		const input = `<resources><string name="welcome">Hello <b>world</b></string><version>1.0</version></resources>`
+
+		format := func(src []byte) string {
+			doc, err := helium.NewParser().StripBlanks(true).Parse(t.Context(), src)
+			require.NoError(t, err)
+			var buf strings.Builder
+			require.NoError(t, helium.NewWriter().Format(true).IndentString("  ").XMLDeclaration(false).WriteTo(&buf, doc))
+			return buf.String()
+		}
+
+		first := format([]byte(input))
+		// Re-parsing and re-formatting the already-formatted output must yield the
+		// exact same bytes; injected whitespace inside mixed content would become a
+		// real text node on reparse and compound on each pass.
+		second := format([]byte(first))
+		require.Equal(t, first, second)
+	})
 }
 
 func TestXHTML(t *testing.T) {

--- a/writer_test.go
+++ b/writer_test.go
@@ -749,6 +749,25 @@ func TestFormatOutput(t *testing.T) {
 		second := format([]byte(first))
 		require.Equal(t, first, second)
 	})
+
+	t.Run("mixed content suppresses formatting subtree-wide", func(t *testing.T) {
+		t.Parallel()
+
+		// A pure-element descendant (<b> holding only <i/>) nested inside a
+		// mixed-content element (<p>) must NOT be formatted: libxml2 disables
+		// formatting for the whole subtree of a mixed element until it closes, so
+		// no whitespace may be injected anywhere inside <p>.
+		const input = `<p>left<b><i/></b>right</p>`
+
+		doc, err := helium.NewParser().StripBlanks(true).Parse(t.Context(), []byte(input))
+		require.NoError(t, err)
+
+		var buf strings.Builder
+		require.NoError(t, helium.NewWriter().Format(true).IndentString("  ").XMLDeclaration(false).WriteTo(&buf, doc))
+
+		expected := "<p>left<b><i/></b>right</p>\n"
+		require.Equal(t, expected, buf.String())
+	})
 }
 
 func TestXHTML(t *testing.T) {

--- a/writer_xhtml.go
+++ b/writer_xhtml.go
@@ -103,6 +103,18 @@ func (d *writeSession) dumpXHTMLNode(out io.Writer, n Node) error {
 		return err
 	}
 
+	// Mixed-content / suppress-indentation, computed exactly as writeNode does so
+	// both serializers agree (libxml2 applies the rule in xmlNodeDumpOutputInternal
+	// AND xhtmlNodeDumpOutput). An element with any text-like direct child (mixed
+	// content), a name in the suppress set, or any suppressed ancestor is emitted
+	// without indentation. suppressDepth propagates the suppression across the whole
+	// subtree — both the recursive dumpXHTMLNode child path and the plain writeNode
+	// child path consult it — so text content stays byte-for-byte and a second
+	// format pass is idempotent.
+	elemSuppressed := d.suppressDepth > 0 || matchesNameSet(d.suppressIndent, n) ||
+		(d.format && hasTextlikeChild(e))
+	effFormat := d.format && !elemSuppressed
+
 	addMeta := false
 	if localName == "head" {
 		if parent := e.parent; parent != nil {
@@ -120,13 +132,13 @@ func (d *writeSession) dumpXHTMLNode(out io.Writer, n Node) error {
 		} else {
 			if addMeta {
 				d.writeString(out, ">")
-				if d.format {
+				if effFormat {
 					d.writeString(out, "\n")
 					d.indent++
 					d.writeIndent(out)
 				}
 				d.writeMetaContentType(out)
-				if d.format {
+				if effFormat {
 					d.writeString(out, "\n")
 					d.indent--
 					d.writeIndent(out)
@@ -143,43 +155,59 @@ func (d *writeSession) dumpXHTMLNode(out io.Writer, n Node) error {
 
 	d.writeString(out, ">")
 
-	textOnly := d.format && hasOnlyTextChildren(e)
-	if d.format && !textOnly {
+	// Suppress formatting across the whole subtree while the children are written,
+	// restoring on every return path (matching writeNode).
+	if elemSuppressed {
+		d.suppressDepth++
+	}
+
+	textOnly := effFormat && hasOnlyTextChildren(e)
+	if effFormat && !textOnly {
 		d.writeString(out, "\n")
 		d.indent++
 	}
 
 	if addMeta {
-		if d.format && !textOnly {
+		if effFormat && !textOnly {
 			d.writeIndent(out)
 		}
 		d.writeMetaContentType(out)
-		if d.format && !textOnly {
+		if effFormat && !textOnly {
 			d.writeString(out, "\n")
 		}
 	}
 
 	for child := range Children(e) {
-		if d.format && !textOnly {
+		if effFormat && !textOnly {
 			d.writeIndent(out)
 		}
 		if child.Type() == ElementNode {
 			if err := d.dumpXHTMLNode(out, child); err != nil {
+				if elemSuppressed {
+					d.suppressDepth--
+				}
 				return err
 			}
 		} else {
 			if err := d.writeNode(out, child); err != nil {
+				if elemSuppressed {
+					d.suppressDepth--
+				}
 				return err
 			}
 		}
-		if d.format && !textOnly {
+		if effFormat && !textOnly {
 			d.writeString(out, "\n")
 		}
 	}
 
-	if d.format && !textOnly {
+	if effFormat && !textOnly {
 		d.indent--
 		d.writeIndent(out)
+	}
+
+	if elemSuppressed {
+		d.suppressDepth--
 	}
 
 	d.writeString(out, "</")

--- a/writer_xhtml_test.go
+++ b/writer_xhtml_test.go
@@ -64,6 +64,42 @@ func TestSerializeXHTMLFormatted(t *testing.T) {
 	require.Contains(t, buf.String(), "<html")
 }
 
+// TestSerializeXHTMLMixedContent verifies the XHTML serializer honors the
+// mixed-content rule: an element with any text-like child (mixed content) is
+// serialized inline with no injected indentation whitespace, and the suppression
+// propagates across the whole subtree — matching the regular writeNode path and
+// libxml2's xhtmlNodeDumpOutput. A second parse+format pass must be byte-identical
+// (idempotent); injected whitespace would corrupt the text content on each pass.
+func TestSerializeXHTMLMixedContent(t *testing.T) {
+	t.Parallel()
+
+	const src = `<?xml version="1.0"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<body><p>left<b><i/></b>right</p></body>
+</html>`
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err, "parse XHTML document")
+
+	var buf strings.Builder
+	err = helium.NewWriter().Format(true).WriteTo(&buf, doc)
+	require.NoError(t, err, "serialize XHTML with formatting")
+	out := buf.String()
+
+	// The mixed-content <p> (and the nested <b>) serialize inline: the text runs
+	// abut their sibling elements with no injected newline/indent.
+	require.Contains(t, out, "<p>left<b><i></i></b>right</p>", "output:\n%s", out)
+
+	// A second parse+format pass must reproduce the first byte-for-byte.
+	doc2, err := helium.NewParser().Parse(t.Context(), []byte(out))
+	require.NoError(t, err, "re-parse serialized XHTML")
+	var buf2 strings.Builder
+	err = helium.NewWriter().Format(true).WriteTo(&buf2, doc2)
+	require.NoError(t, err, "re-serialize XHTML with formatting")
+	require.Equal(t, out, buf2.String(), "XHTML mixed-content formatting must be idempotent")
+}
+
 // TestSerializeXHTMLCharacterMap verifies Writer.CharacterMap applies to XHTML
 // attribute values (including the synthesized id-from-name attribute) and text
 // content in the XHTML serialization path (Serialization 3.1 §6). This XHTML path


### PR DESCRIPTION
- fix `Writer.Format(true)` injecting whitespace inside mixed-content elements (#1188)
- add libxml2's rule: any direct text/CDATA/entity-ref child disables child formatting
- pure-element and pure-text output unchanged; fixes #1188
