### PR TITLE
make the zero-value Parser behave like NewParser

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -74,6 +74,11 @@ type XIncludeProcessor interface {
 // Parser holds configuration for XML parsing (libxml2: xmlParserCtxt).
 // It uses clone-on-write semantics: each builder method returns
 // a new Parser sharing the underlying config until mutation.
+//
+// The zero value is usable and behaves exactly like [NewParser]: a
+// `var p Parser` parses with the same secure defaults (see NewParser) and can
+// head an option-method chain. NewParser remains the explicit, self-documenting
+// way to construct one.
 type Parser struct {
 	cfg *parserConfig
 }
@@ -96,6 +101,14 @@ const defaultMaxDepth = 256
 // likewise off by default. Opt back in explicitly per setting, e.g.
 // NewParser().BlockXXE(false).LoadExternalDTD(true).FS(helium.PermissiveFS()).
 func NewParser() Parser {
+	return Parser{cfg: newParserConfig()}
+}
+
+// newParserConfig builds the default parser configuration — the secure defaults
+// documented on [NewParser]. It is also what a zero-value Parser resolves to
+// (see [Parser.normalized]), so `var p Parser` parses identically to
+// NewParser().
+func newParserConfig() *parserConfig {
 	cfg := &parserConfig{
 		sax:      NewTreeBuilder(),
 		fsys:     iofs.DenyAll{},
@@ -103,7 +116,19 @@ func NewParser() Parser {
 	}
 	cfg.options.Set(parseNoXXE)
 	cfg.options.Set(parseNoNet)
-	return Parser{cfg: cfg}
+	return cfg
+}
+
+// normalized resolves a zero-value Parser (nil config) to one carrying the same
+// secure defaults NewParser installs, so `var p Parser` behaves like
+// NewParser(). An already-configured Parser is returned unchanged. The returned
+// config is shared, not cloned — safe because every method that MUTATES the
+// config goes through clone first.
+func (p Parser) normalized() Parser {
+	if p.cfg == nil {
+		return Parser{cfg: newParserConfig()}
+	}
+	return p
 }
 
 // PermissiveFS returns an [fs.FS] that opens any path via [os.Open] — absolute,
@@ -127,6 +152,7 @@ func PermissiveFS() fs.FS {
 }
 
 func (p Parser) clone() Parser {
+	p = p.normalized()
 	cp := *p.cfg
 	return Parser{cfg: &cp}
 }
@@ -718,6 +744,8 @@ func (p Parser) Parse(ctx context.Context, b []byte) (*Document, error) { //noli
 		ctx = context.Background()
 	}
 
+	p = p.normalized()
+
 	pctx := &parserCtx{rawInput: b, baseURI: p.cfg.baseURI}
 	if err := pctx.init(p.cfg, bytes.NewReader(b)); err != nil {
 		return nil, err
@@ -790,6 +818,8 @@ func (p Parser) parseReader(ctx context.Context, r io.Reader, srcSize int64) (*D
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	p = p.normalized()
 
 	// Honor an already-cancelled context BEFORE touching r: the EBCDIC sniff
 	// below reads from r, and r may be a non-context-aware reader that blocks
@@ -1018,6 +1048,8 @@ func (p Parser) ParseInNodeContext(ctx context.Context, node Node, data []byte) 
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	p = p.normalized()
 
 	if node == nil {
 		return nil, errors.New("node must not be nil")

--- a/parser_zerovalue_test.go
+++ b/parser_zerovalue_test.go
@@ -1,0 +1,71 @@
+package helium_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParserZeroValue verifies that a zero-value helium.Parser behaves
+// identically to one returned by helium.NewParser() — same secure defaults,
+// same parse results, and usable both directly and as the head of an
+// option-method chain, without panicking on its nil config.
+func TestParserZeroValue(t *testing.T) {
+	serialize := func(t *testing.T, doc *helium.Document) string {
+		t.Helper()
+		var buf bytes.Buffer
+		require.NoError(t, helium.NewWriter().WriteTo(&buf, doc))
+		return buf.String()
+	}
+
+	t.Run("Parse matches NewParser", func(t *testing.T) {
+		const src = `<root att="v"><child>text</child><child/></root>`
+		var zero helium.Parser
+		zdoc, err := zero.Parse(context.Background(), []byte(src))
+		require.NoError(t, err)
+		ndoc, err := helium.NewParser().Parse(context.Background(), []byte(src))
+		require.NoError(t, err)
+		require.Equal(t, serialize(t, ndoc), serialize(t, zdoc))
+	})
+
+	t.Run("ParseReader does not panic", func(t *testing.T) {
+		var zero helium.Parser
+		doc, err := zero.ParseReader(context.Background(), strings.NewReader(`<r><a/></r>`))
+		require.NoError(t, err)
+		require.NotNil(t, doc)
+	})
+
+	t.Run("option chaining works and matches NewParser", func(t *testing.T) {
+		const src = `<r>  <a/>  </r>`
+		var zero helium.Parser
+		zdoc, err := zero.StripBlanks(true).Parse(context.Background(), []byte(src))
+		require.NoError(t, err)
+		ndoc, err := helium.NewParser().StripBlanks(true).Parse(context.Background(), []byte(src))
+		require.NoError(t, err)
+		require.Equal(t, serialize(t, ndoc), serialize(t, zdoc))
+	})
+
+	t.Run("secure defaults: element depth cap matches NewParser", func(t *testing.T) {
+		// NewParser caps nesting at 256; a zero-value Parser must apply the same
+		// cap, so a document nested well past it fails for both, identically.
+		var b strings.Builder
+		const depth = 400
+		for range depth {
+			b.WriteString("<a>")
+		}
+		for range depth {
+			b.WriteString("</a>")
+		}
+		src := []byte(b.String())
+
+		var zero helium.Parser
+		_, zerr := zero.Parse(context.Background(), src)
+		_, nerr := helium.NewParser().Parse(context.Background(), src)
+		require.Error(t, nerr, "NewParser should reject nesting past its depth cap")
+		require.Error(t, zerr, "zero-value Parser must apply the same depth cap")
+	})
+}


### PR DESCRIPTION
- a zero-value `helium.Parser` panicked on a nil config instead of parsing like `NewParser()`
- resolve a nil config to the NewParser secure defaults (via `normalized`) in `clone` and the parse entries
- the zero value now parses identically to `NewParser()` and can head an option chain