### PR TITLE
gate network-scheme external resources

### DIFF
--- a/.claude/docs/libxml2-parity.md
+++ b/.claude/docs/libxml2-parity.md
@@ -123,7 +123,7 @@ libxml2.
 | PedanticErrors(bool) | XML_PARSE_PEDANTIC | ✅ | Pedantic error reporting |
 | StripBlanks(bool) | XML_PARSE_NOBLANKS | ✅ | Remove blank nodes |
 | XInclude(XIncludeProcessor) | XML_PARSE_XINCLUDE | ✅ | XInclude substitution; inject a configured `xinclude.Processor`, run over the tree during Parse (dependency-inversion seam — helium can't import xinclude) |
-| AllowNetwork(bool) | XML_PARSE_NONET | ✅ | Inverted: false → forbid network. **Default false** (NONET set by NewParser); cosmetic — core parser has no network loader |
+| AllowNetwork(bool) | XML_PARSE_NONET | ✅ | Inverted: false → forbid network. **Default false** (NONET set by NewParser). helium has no dedicated network loader; every external load (DTD subset, general/parameter entity) goes through the configured `fs.FS`. When false, the three `fs.FS.Open` sites in `tree_builder.go` (`ExternalSubset`, `ResolveEntity`) refuse a name whose URI scheme is `http`/`https`/`ftp` (case-insensitive) with `ErrNetworkAccessForbidden` before reaching the FS — defense-in-depth for a caller-supplied network-capable FS. A schemeless name, a `file:` scheme, or a bare path is not a network resource and loads as usual |
 | CleanNamespaces(bool) | XML_PARSE_NSCLEAN | ✅ | Remove redundant NS decls |
 | MergeCDATA(bool) | XML_PARSE_NOCDATA | ✅ | Merge CDATA as text |
 | XIncludeNodes(bool) | XML_PARSE_NOXINCNODE | ✅ | Inverted: false → skip markers |

--- a/errors.go
+++ b/errors.go
@@ -80,8 +80,17 @@ var (
 	// blank-run cap. The cap fires during accumulation, before the whole run is
 	// buffered; match with errors.Is.
 	ErrNodeContentTooLarge = errors.New("node content exceeds maximum allowed size")
-	errParserStopped       = errors.New("parser stopped")
-	errNoCursor            = errors.New("parser has no input")
+	// ErrNetworkAccessForbidden is returned when an external resource (an
+	// external DTD subset or external parsed entity) names a network URI —
+	// an http, https, or ftp scheme — but the parser was configured to forbid
+	// network access via Parser.AllowNetwork(false) (libxml2 XML_PARSE_NONET,
+	// the default). helium has no dedicated network loader; every external load
+	// goes through the configured fs.FS, so this guard refuses a network-scheme
+	// name before it reaches a (possibly network-capable) caller-supplied FS.
+	// Match with errors.Is.
+	ErrNetworkAccessForbidden = errors.New("network access forbidden")
+	errParserStopped          = errors.New("parser stopped")
+	errNoCursor               = errors.New("parser has no input")
 )
 
 // isParseAbort reports whether err signals that parsing must stop immediately

--- a/parser_network_gate_test.go
+++ b/parser_network_gate_test.go
@@ -1,0 +1,152 @@
+package helium_test
+
+import (
+	"bytes"
+	"io/fs"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// netGateFS serves the same content for ANY name and records every name it is
+// asked to open. It stands in for a caller-supplied, network-capable fs.FS: its
+// Open never fails, so a network-scheme name reaches it unless the parser's
+// AllowNetwork(false) gate refuses the load first.
+type netGateFS struct {
+	content []byte
+	opened  *[]string
+}
+
+func (fsys netGateFS) Open(name string) (fs.File, error) {
+	*fsys.opened = append(*fsys.opened, name)
+	return &netGateFile{Reader: bytes.NewReader(fsys.content)}, nil
+}
+
+type netGateFile struct {
+	*bytes.Reader
+}
+
+func (f *netGateFile) Stat() (fs.FileInfo, error) { return netGateInfo{size: f.Size()}, nil }
+func (f *netGateFile) Close() error               { return nil }
+
+type netGateInfo struct{ size int64 }
+
+func (netGateInfo) Name() string       { return "resource" }
+func (i netGateInfo) Size() int64      { return i.size }
+func (netGateInfo) Mode() fs.FileMode  { return 0 }
+func (netGateInfo) ModTime() time.Time { return time.Time{} }
+func (netGateInfo) IsDir() bool        { return false }
+func (netGateInfo) Sys() any           { return nil }
+
+func openedNetwork(names []string) bool {
+	for _, n := range names {
+		low := strings.ToLower(n)
+		if strings.HasPrefix(low, "http://") ||
+			strings.HasPrefix(low, "https://") ||
+			strings.HasPrefix(low, "ftp://") {
+			return true
+		}
+	}
+	return false
+}
+
+// A network-scheme external general entity must not reach the fs.FS when
+// AllowNetwork is false (the default), and must reach it when AllowNetwork is
+// true. The fs.FS here would happily serve any name, so the only thing that can
+// keep the network id from being opened is the NONET scheme gate.
+func TestAllowNetworkGatesExternalEntity(t *testing.T) {
+	t.Parallel()
+
+	doc := `<?xml version="1.0"?>` + "\n" +
+		`<!DOCTYPE root [<!ENTITY e SYSTEM "http://example.com/x.ent">]>` + "\n" +
+		`<root>&e;</root>`
+	entity := []byte(`<child>net</child>`)
+
+	// Default (AllowNetwork off): the network entity must be refused before Open.
+	var openedOff []string
+	_, err := helium.NewParser().
+		BlockXXE(false).
+		LoadExternalDTD(true).
+		SubstituteEntities(true).
+		FS(netGateFS{content: entity, opened: &openedOff}).
+		Parse(t.Context(), []byte(doc))
+	require.Error(t, err, "a network-scheme entity must be refused when AllowNetwork is off")
+	require.False(t, openedNetwork(openedOff), "the network id must never reach the fs.FS when AllowNetwork is off")
+
+	// AllowNetwork on: the entity load reaches the fs.FS and expands.
+	var openedOn []string
+	parsed, err := helium.NewParser().
+		BlockXXE(false).
+		LoadExternalDTD(true).
+		SubstituteEntities(true).
+		AllowNetwork(true).
+		FS(netGateFS{content: entity, opened: &openedOn}).
+		Parse(t.Context(), []byte(doc))
+	require.NoError(t, err, "a network-scheme entity must load when AllowNetwork is on")
+	require.True(t, openedNetwork(openedOn), "the network id must reach the fs.FS when AllowNetwork is on")
+	require.NotNil(t, parsed)
+	root := parsed.DocumentElement()
+	require.NotNil(t, root)
+	child := root.FirstChild()
+	require.NotNil(t, child, "the network entity replacement text must have expanded")
+	require.Equal(t, "child", child.(*helium.Element).LocalName())
+}
+
+// A network-scheme external DTD subset must not reach the fs.FS when
+// AllowNetwork is false, and must reach it when AllowNetwork is true.
+func TestAllowNetworkGatesExternalDTD(t *testing.T) {
+	t.Parallel()
+
+	doc := `<?xml version="1.0"?>` + "\n" +
+		`<!DOCTYPE root SYSTEM "http://example.com/x.dtd">` + "\n" +
+		`<root/>`
+	dtd := []byte(`<!ELEMENT root EMPTY>`)
+
+	var openedOff []string
+	_, err := helium.NewParser().
+		BlockXXE(false).
+		LoadExternalDTD(true).
+		FS(netGateFS{content: dtd, opened: &openedOff}).
+		Parse(t.Context(), []byte(doc))
+	require.False(t, openedNetwork(openedOff), "the network DTD id must never reach the fs.FS when AllowNetwork is off")
+	_ = err
+
+	var openedOn []string
+	_, err = helium.NewParser().
+		BlockXXE(false).
+		LoadExternalDTD(true).
+		AllowNetwork(true).
+		FS(netGateFS{content: dtd, opened: &openedOn}).
+		Parse(t.Context(), []byte(doc))
+	require.NoError(t, err)
+	require.True(t, openedNetwork(openedOn), "the network DTD id must reach the fs.FS when AllowNetwork is on")
+}
+
+// A non-network (bare filename) external entity must load regardless of the
+// AllowNetwork setting: the scheme gate only bites http/https/ftp.
+func TestAllowNetworkAllowsLocalEntity(t *testing.T) {
+	t.Parallel()
+
+	doc := `<?xml version="1.0"?>` + "\n" +
+		`<!DOCTYPE root [<!ENTITY e SYSTEM "local.ent">]>` + "\n" +
+		`<root>&e;</root>`
+	entity := []byte(`<child>local</child>`)
+
+	for _, allow := range []bool{false, true} {
+		var opened []string
+		p := helium.NewParser().
+			BlockXXE(false).
+			LoadExternalDTD(true).
+			SubstituteEntities(true).
+			FS(netGateFS{content: entity, opened: &opened})
+		p = p.AllowNetwork(allow)
+		parsed, err := p.Parse(t.Context(), []byte(doc))
+		require.NoErrorf(t, err, "a non-network entity must load with AllowNetwork(%v)", allow)
+		require.NotNil(t, parsed)
+		require.NotEmptyf(t, opened, "the local id must reach the fs.FS with AllowNetwork(%v)", allow)
+		require.Falsef(t, openedNetwork(opened), "a bare filename is not a network id (AllowNetwork(%v))", allow)
+	}
+}

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -343,6 +343,27 @@ func catalogOpenName(ref string) string {
 	return p
 }
 
+// networkAccessForbidden reports whether opening name must be refused because it
+// names a network resource and the parser was configured to forbid network
+// access (Parser.AllowNetwork(false) → parseNoNet / libxml2 XML_PARSE_NONET,
+// the default). It is the enforcement point for NONET: helium has no dedicated
+// network loader, so every external-resource load goes through fs.FS.Open, and
+// this guard refuses a network-scheme name before it reaches the (possibly
+// network-capable) caller-supplied fs.FS. A name with no scheme, a "file:"
+// scheme, or a bare path is never a network resource and loads as usual; scheme
+// matching is case-insensitive (uripath.URIScheme lowercases its result).
+func networkAccessForbidden(ctx *parserCtx, name string) bool {
+	if !ctx.options.IsSet(parseNoNet) {
+		return false
+	}
+	switch uripath.URIScheme(name) {
+	case "http", "https", "ftp":
+		return true
+	default:
+		return false
+	}
+}
+
 func (t *TreeBuilder) ExternalSubset(ctxif context.Context, name, eid, uri string) error {
 	ctx := t.pctx(ctxif)
 
@@ -386,7 +407,11 @@ func (t *TreeBuilder) ExternalSubset(ctxif context.Context, name, eid, uri strin
 	// resolved may be a "file:" URI (e.g. "file:///C:/dir/inc.dtd" from a
 	// drive-rooted base); convert it to a native path before Open, the same way
 	// a catalog-resolved file: URI is handled. A plain path is returned verbatim.
-	f, err := ctx.fsys.Open(catalogOpenName(resolved))
+	openName := catalogOpenName(resolved)
+	if networkAccessForbidden(ctx, openName) {
+		return ErrNetworkAccessForbidden
+	}
+	f, err := ctx.fsys.Open(openName)
 	if err != nil {
 		// Silently ignore missing external DTDs
 		return nil
@@ -667,6 +692,9 @@ func (t *TreeBuilder) ResolveEntity(ctxif context.Context, publicID string, syst
 			// A catalog may resolve to a "file:" URI; convert it to a local
 			// path before opening (CAT-001).
 			openName := catalogOpenName(resolved)
+			if networkAccessForbidden(ctx, openName) {
+				return nil, ErrNetworkAccessForbidden
+			}
 			f, err := ctx.fsys.Open(openName)
 			if err == nil {
 				return &fileParseInput{ReadCloser: f, uri: resolved}, nil
@@ -678,6 +706,9 @@ func (t *TreeBuilder) ResolveEntity(ctxif context.Context, publicID string, syst
 	// is the entity's resolved URI (built from system ID + base URI in
 	// EntityDecl). Try opening it as a file path.
 	if systemID != "" {
+		if networkAccessForbidden(ctx, systemID) {
+			return nil, ErrNetworkAccessForbidden
+		}
 		f, err := ctx.fsys.Open(systemID)
 		if err == nil {
 			return &fileParseInput{ReadCloser: f, uri: systemID}, nil


### PR DESCRIPTION
- `AllowNetwork(false)` (default) now refuses external DTD/entity loads with an http/https/ftp SYSTEM id
- previously a silent no-op; gated at the three `fs.FS.Open` sites in `tree_builder.go`
- refusal returns `ErrNetworkAccessForbidden`; schemeless/`file:`/bare paths load as before
