### PR TITLE
serialize active default namespace declaration

### DIFF
--- a/shim/shim_test.go
+++ b/shim/shim_test.go
@@ -213,6 +213,36 @@ func TestUnmarshalTagSemanticsMatchStdlib(t *testing.T) {
 	require.Equal(t, stdOut.Text, shimOut.Text, "chardata mismatch")
 }
 
+func TestUnmarshalInnerXMLNamespaceParityStdlib(t *testing.T) {
+	type parent struct {
+		Inner string `xml:",innerxml"`
+	}
+	type root struct {
+		Parent parent `xml:"parent"`
+	}
+
+	inputs := []string{
+		// A prefixed prefix inherited from an ancestor but not used on the parent:
+		// the child must not re-declare it (encoding/xml captures raw bytes).
+		`<root xmlns:p="urn:p"><parent><p:child/></parent></root>`,
+		`<root xmlns:p="urn:p"><parent><p:child>text</p:child></parent></root>`,
+		// A default namespace inherited from an ancestor.
+		`<root xmlns="urn:d"><parent><child/></parent></root>`,
+		// A child that genuinely declares its own namespace keeps that declaration.
+		`<root xmlns:p="urn:p"><parent><p:child/><q:c xmlns:q="urn:q"/></parent></root>`,
+		// The parent redeclares the inherited prefix to a different URI.
+		`<root xmlns:p="urn:p"><parent xmlns:p="urn:p2"><p:child/></parent></root>`,
+	}
+
+	for _, in := range inputs {
+		var std root
+		require.NoError(t, stdxml.Unmarshal([]byte(in), &std))
+		var got root
+		require.NoError(t, shim.Unmarshal([]byte(in), &got))
+		require.Equal(t, std.Parent.Inner, got.Parent.Inner, "innerxml mismatch for %s", in)
+	}
+}
+
 func TestUnmarshalRepeatedConsistency(t *testing.T) {
 	type payload struct {
 		XMLName stdxml.Name `xml:"item"`

--- a/shim/unmarshal.go
+++ b/shim/unmarshal.go
@@ -1197,15 +1197,27 @@ func elementText(elem *helium.Element) string {
 }
 
 func innerXML(elem *helium.Element) string {
-	if elem == nil {
+	if elem == nil || elem.FirstChild() == nil {
 		return ""
 	}
+	// Serialize elem as a whole and strip its own start and end tags, rather
+	// than serializing each child in isolation. This keeps elem's in-scope
+	// namespaces (including any inherited from an ancestor) established while the
+	// children are written, so a child inheriting a namespace is not given a
+	// spurious xmlns re-declaration — matching encoding/xml's raw innerxml
+	// capture. Text and attribute values escape '<' and '>', so the first '>'
+	// terminates elem's start tag and the last '<' begins elem's end tag.
 	var b bytes.Buffer
-	w := helium.NewWriter().XMLDeclaration(false)
-	for child := range helium.Children(elem) {
-		_ = w.WriteTo(&b, child)
+	if err := helium.NewWriter().XMLDeclaration(false).WriteTo(&b, elem); err != nil {
+		return ""
 	}
-	return b.String()
+	s := b.String()
+	start := strings.IndexByte(s, '>')
+	end := strings.LastIndexByte(s, '<')
+	if start < 0 || end < 0 || start+1 > end {
+		return ""
+	}
+	return s[start+1 : end]
 }
 
 func elementComment(elem *helium.Element) string {

--- a/shim/unmarshal.go
+++ b/shim/unmarshal.go
@@ -1208,7 +1208,14 @@ func innerXML(elem *helium.Element) string {
 	// capture. Text and attribute values escape '<' and '>', so the first '>'
 	// terminates elem's start tag and the last '<' begins elem's end tag.
 	var b bytes.Buffer
-	if err := helium.NewWriter().XMLDeclaration(false).WriteTo(&b, elem); err != nil {
+	w := helium.NewWriter().XMLDeclaration(false)
+	// Seed the namespaces in force on elem's ancestors so an inherited prefix
+	// elem itself does not use is not re-declared on a child. encoding/xml's raw
+	// ,innerxml capture carries no such re-declaration.
+	if inherited := inheritedNamespaces(elem); len(inherited) > 0 {
+		w = w.InheritedNamespaces(inherited)
+	}
+	if err := w.WriteTo(&b, elem); err != nil {
 		return ""
 	}
 	s := b.String()
@@ -1218,6 +1225,33 @@ func innerXML(elem *helium.Element) string {
 		return ""
 	}
 	return s[start+1 : end]
+}
+
+// inheritedNamespaces collects the namespace bindings in force on elem's
+// ancestors (prefix -> URI; empty prefix = default namespace), with the nearest
+// ancestor winning for a repeated prefix. Seeding these into the serializer keeps
+// an inherited prefix that elem itself does not declare from being re-declared on
+// a child, matching encoding/xml's raw ,innerxml capture. Returns nil when elem
+// has no ancestor namespace declarations.
+func inheritedNamespaces(elem *helium.Element) map[string]string {
+	var out map[string]string
+	for anc := elem.Parent(); anc != nil; anc = anc.Parent() {
+		nser, ok := anc.(helium.Namespacer)
+		if !ok {
+			continue
+		}
+		for _, ns := range nser.Namespaces() {
+			prefix := ns.Prefix()
+			if _, seen := out[prefix]; seen {
+				continue
+			}
+			if out == nil {
+				out = make(map[string]string)
+			}
+			out[prefix] = ns.URI()
+		}
+	}
+	return out
 }
 
 func elementComment(elem *helium.Element) string {

--- a/writer.go
+++ b/writer.go
@@ -431,8 +431,11 @@ func (w Writer) Normalization(form string) Writer {
 // serialized as a self-contained fragment whose in-scope ancestor namespaces are
 // supplied externally (for example, capturing an element's inner XML while its
 // ancestors are not serialized). A nil or empty map leaves output byte-identical.
+//
+// The map is copied, so later mutation of the caller's map does not affect the
+// Writer (the value-style contract above).
 func (w Writer) InheritedNamespaces(bindings map[string]string) Writer {
-	w.initialNSScope = bindings
+	w.initialNSScope = maps.Clone(bindings)
 	return w
 }
 

--- a/writer.go
+++ b/writer.go
@@ -950,9 +950,11 @@ func (d *writeSession) reconcileNamespaces(out io.Writer, n Node, nser Namespace
 		saved = d.nsScopePush(ns.prefix, ns.href, saved)
 	}
 
-	// The element's active namespace.
+	// The element's active namespace. The empty prefix is allowed here so an
+	// element whose active DEFAULT namespace was set (SetActiveNamespace("", uri))
+	// without a matching declaration gets an xmlns="uri" synthesized.
 	if ns := nser.Namespace(); ns != nil {
-		saved = d.reconcileOne(out, ns.prefix, ns.href, saved)
+		saved = d.reconcileOne(out, ns.prefix, ns.href, true, saved)
 	}
 
 	// Namespaced attributes. The per-list seen guard bounds a corrupt attribute
@@ -966,21 +968,26 @@ func (d *writeSession) reconcileNamespaces(out io.Writer, n Node, nser Namespace
 			}
 			seen[key] = struct{}{}
 			if ans := attr.ns; ans != nil {
-				saved = d.reconcileOne(out, ans.prefix, ans.href, saved)
+				saved = d.reconcileOne(out, ans.prefix, ans.href, false, saved)
 			}
 		}
 	}
 	return saved
 }
 
-// reconcileOne emits an "xmlns:prefix" declaration for a namespace used by the
-// current element or one of its attributes when that prefix is not already in
-// the output scope with the same URI, and records the new binding. The default
-// namespace (empty prefix) and the reserved xml/xmlns prefixes are never
-// synthesized: attributes cannot use the default namespace, and xml is
-// implicitly bound. Appends the recorded binding to saved and returns it.
-func (d *writeSession) reconcileOne(out io.Writer, prefix, href string, saved []nsSaved) []nsSaved {
-	if prefix == "" || prefix == lexicon.PrefixXML || prefix == lexicon.PrefixXMLNS || href == "" {
+// reconcileOne emits an xmlns declaration for a namespace used by the current
+// element or one of its attributes when that prefix is not already in the
+// output scope with the same URI, and records the new binding. The reserved
+// xml/xmlns prefixes are never synthesized (xml is implicitly bound). The empty
+// prefix (default namespace) is synthesized only for the element's own active
+// namespace (isElement) as xmlns="href"; an attribute's empty prefix is skipped
+// because an unprefixed attribute is never in a namespace. Appends the recorded
+// binding to saved and returns it.
+func (d *writeSession) reconcileOne(out io.Writer, prefix, href string, isElement bool, saved []nsSaved) []nsSaved {
+	if prefix == lexicon.PrefixXML || prefix == lexicon.PrefixXMLNS || href == "" {
+		return saved
+	}
+	if prefix == "" && !isElement {
 		return saved
 	}
 	if d.nsScope != nil {
@@ -988,13 +995,17 @@ func (d *writeSession) reconcileOne(out io.Writer, prefix, href string, saved []
 			return saved
 		}
 	}
-	// The prefix is emitted verbatim; reject one that is not a valid NCName so a
-	// crafted prefix cannot inject raw markup into the start tag.
-	if !d.checkNamespacePrefix(prefix) {
-		return saved
+	if prefix == "" {
+		d.writeString(out, " xmlns")
+	} else {
+		// The prefix is emitted verbatim; reject one that is not a valid NCName so
+		// a crafted prefix cannot inject raw markup into the start tag.
+		if !d.checkNamespacePrefix(prefix) {
+			return saved
+		}
+		d.writeString(out, " xmlns:")
+		d.writeString(out, prefix)
 	}
-	d.writeString(out, " xmlns:")
-	d.writeString(out, prefix)
 	d.writeString(out, `="`)
 	if d.err == nil {
 		if err := escapeAttrValue(out, []byte(href), d.escapeNonASCII, d.rejectInvalidChars, d.xml11, nil); err != nil {

--- a/writer.go
+++ b/writer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"reflect"
 	"slices"
 	"strings"
@@ -88,6 +89,14 @@ type Writer struct {
 	// byte-identical when no normalization is requested.
 	normalize bool
 	normForm  norm.Form
+	// initialNSScope seeds the serializer's namespace scope with bindings
+	// (prefix -> URI; empty prefix = default namespace) treated as already in
+	// force on an ancestor that is not itself part of the serialized output. A
+	// node using such a prefix is not given a redundant xmlns declaration, so a
+	// subtree can be serialized as a self-contained fragment whose in-scope
+	// ancestor namespaces are supplied externally. Nil/empty leaves output
+	// byte-identical.
+	initialNSScope map[string]string
 }
 
 // standaloneMode controls how the writer emits the standalone pseudo-attribute
@@ -415,6 +424,18 @@ func (w Writer) Normalization(form string) Writer {
 	return w
 }
 
+// InheritedNamespaces seeds the serializer's namespace scope with bindings
+// (prefix -> URI; the empty prefix is the default namespace) treated as already
+// in force on an ancestor outside the serialized output. A node using such a
+// prefix is not given a redundant xmlns re-declaration, so a subtree can be
+// serialized as a self-contained fragment whose in-scope ancestor namespaces are
+// supplied externally (for example, capturing an element's inner XML while its
+// ancestors are not serialized). A nil or empty map leaves output byte-identical.
+func (w Writer) InheritedNamespaces(bindings map[string]string) Writer {
+	w.initialNSScope = bindings
+	return w
+}
+
 // effectiveEncoding returns the encoding driving the XML-declaration
 // pseudo-attribute: the OutputEncoding override when set, otherwise the
 // document's own encoding.
@@ -531,6 +552,7 @@ func (d Writer) WriteTo(out io.Writer, node Node) error {
 	// OutputVersion("1.1") override enables XML 1.1 serialization here; without
 	// it, output stays byte-identical to the prior behavior.
 	s.xml11 = d.outputVersion == "1.1"
+	s.seedNSScope()
 	return s.writeNode(out, node)
 }
 
@@ -774,6 +796,17 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 			name = nser.LocalName()
 		}
 		nslist = nser.Namespaces()
+		// When the element's active namespace is a default (empty prefix) whose
+		// URI differs from a default declaration in its own nsDefs, the active
+		// binding is authoritative — it qualifies the element — so drop the
+		// conflicting declared default. Emitting both would put two xmlns
+		// attributes on the start tag, which is not reparseable. reconcileOne
+		// then synthesizes the single active default. A matching (equal-URI)
+		// declared default is kept, so a normally parsed <e xmlns="u"/> still
+		// declares its default exactly once.
+		if active := nser.Namespace(); active != nil && active.prefix == "" && active.href != "" {
+			nslist = dropConflictingDefaultNS(nslist, active.href)
+		}
 	} else {
 		name = n.Name()
 	}
@@ -938,6 +971,33 @@ func (d *writeSession) writeNode(out io.Writer, n Node) error {
 // returns every binding it added to the scope so the caller can restore the
 // scope after the element's children are serialized, or nil when the element
 // neither declares nor uses a namespace (the plain-XML path stays alloc-free).
+// dropConflictingDefaultNS returns nslist without any default-namespace
+// declaration (empty prefix) whose URI differs from activeHref. The element's
+// active default namespace is authoritative, so a conflicting declared default
+// must not also be emitted — two xmlns attributes on one start tag are not
+// reparseable. When no declaration conflicts, nslist is returned unchanged so the
+// common path allocates nothing. Callers pass a non-empty activeHref.
+func dropConflictingDefaultNS(nslist []*Namespace, activeHref string) []*Namespace {
+	conflict := false
+	for _, ns := range nslist {
+		if ns.prefix == "" && ns.href != activeHref {
+			conflict = true
+			break
+		}
+	}
+	if !conflict {
+		return nslist
+	}
+	out := make([]*Namespace, 0, len(nslist))
+	for _, ns := range nslist {
+		if ns.prefix == "" && ns.href != activeHref {
+			continue
+		}
+		out = append(out, ns)
+	}
+	return out
+}
+
 func (d *writeSession) reconcileNamespaces(out io.Writer, n Node, nser Namespacer, nslist []*Namespace) []nsSaved {
 	var saved []nsSaved
 
@@ -1014,6 +1074,17 @@ func (d *writeSession) reconcileOne(out io.Writer, prefix, href string, isElemen
 	}
 	d.writeString(out, `"`)
 	return d.nsScopePush(prefix, href, saved)
+}
+
+// seedNSScope initializes the output namespace scope from InheritedNamespaces,
+// copying the caller's map so it is never mutated during serialization. It is a
+// no-op (and allocates nothing) when no inherited bindings were supplied.
+func (d *writeSession) seedNSScope() {
+	if len(d.initialNSScope) == 0 {
+		return
+	}
+	d.nsScope = make(map[string]string, len(d.initialNSScope))
+	maps.Copy(d.nsScope, d.initialNSScope)
 }
 
 // nsScopePush binds prefix to href in the output namespace scope, appending the

--- a/writer_test.go
+++ b/writer_test.go
@@ -233,6 +233,63 @@ func TestWriteActiveDefaultNamespace(t *testing.T) {
 		require.NoError(t, err)
 		require.NotContains(t, str, `xmlns=""`)
 	})
+
+	t.Run("conflicting declared and active default emits a single reparseable xmlns", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+		// A declared default that conflicts with the element's active default: the
+		// active binding wins and only one xmlns is emitted, so the output reparses.
+		require.NoError(t, root.DeclareNamespace("", "urn:declared"))
+		require.NoError(t, root.SetActiveNamespace("", "urn:active"))
+
+		str, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.Equal(t, 1, strings.Count(str, "xmlns="), "exactly one default declaration: %s", str)
+		require.Contains(t, str, `xmlns="urn:active"`)
+		require.NotContains(t, str, `xmlns="urn:declared"`)
+
+		_, err = helium.NewParser().Parse(t.Context(), []byte(str))
+		require.NoError(t, err, "serialized output must reparse: %s", str)
+	})
+}
+
+func TestWriteInheritedNamespaces(t *testing.T) {
+	t.Parallel()
+
+	t.Run("seeded prefix is not re-declared on a using element", func(t *testing.T) {
+		t.Parallel()
+		// A fragment whose prefix is bound only on an ancestor outside the output:
+		// seeding that binding suppresses the otherwise-synthesized re-declaration.
+		doc, err := helium.NewParser().Parse(t.Context(),
+			[]byte(`<root xmlns:p="urn:p"><child><p:leaf/></child></root>`))
+		require.NoError(t, err)
+		root := doc.DocumentElement()
+		require.NotNil(t, root)
+		child := root.FirstChild()
+		require.NotNil(t, child)
+
+		var b bytes.Buffer
+		w := helium.NewWriter().XMLDeclaration(false).
+			InheritedNamespaces(map[string]string{"p": "urn:p"})
+		require.NoError(t, w.WriteTo(&b, child))
+		require.Equal(t, `<child><p:leaf/></child>`, b.String())
+	})
+
+	t.Run("without seeding the inherited prefix is re-declared", func(t *testing.T) {
+		t.Parallel()
+		doc, err := helium.NewParser().Parse(t.Context(),
+			[]byte(`<root xmlns:p="urn:p"><child><p:leaf/></child></root>`))
+		require.NoError(t, err)
+		child := doc.DocumentElement().FirstChild()
+		require.NotNil(t, child)
+
+		var b bytes.Buffer
+		w := helium.NewWriter().XMLDeclaration(false)
+		require.NoError(t, w.WriteTo(&b, child))
+		require.Contains(t, b.String(), `xmlns:p="urn:p"`)
+	})
 }
 
 func TestXHTMLWriteRejectsInjectedNames(t *testing.T) {

--- a/writer_test.go
+++ b/writer_test.go
@@ -183,6 +183,58 @@ func TestWriteRejectsInjectedNames(t *testing.T) {
 	})
 }
 
+func TestWriteActiveDefaultNamespace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("active default namespace emits xmlns", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+		require.NoError(t, root.SetActiveNamespace("", "urn:x"))
+
+		str, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.Contains(t, str, `xmlns="urn:x"`)
+	})
+
+	t.Run("active prefixed namespace still emits xmlns:p", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+		require.NoError(t, root.SetActiveNamespace("p", "urn:x"))
+
+		str, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.Contains(t, str, `xmlns:p="urn:x"`)
+	})
+
+	t.Run("parsed default namespace declared exactly once", func(t *testing.T) {
+		t.Parallel()
+		doc, err := helium.NewParser().Parse(t.Context(), []byte(`<x xmlns="urn:x"/>`))
+		require.NoError(t, err)
+
+		str, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.Equal(t, 1, strings.Count(str, `xmlns="urn:x"`))
+	})
+
+	t.Run("unprefixed attribute gains no spurious xmlns", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+		require.NoError(t, root.SetActiveNamespace("p", "urn:x"))
+		_, err := root.SetAttribute("id", "1")
+		require.NoError(t, err)
+
+		str, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.NotContains(t, str, `xmlns=""`)
+	})
+}
+
 func TestXHTMLWriteRejectsInjectedNames(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- reconcileOne emits xmlns="uri" for an element's own active default namespace set via SetActiveNamespace("", uri)
- attribute reconcile still skips the empty prefix; a parsed default-ns already in scope emits nothing extra
- shim innerXML serializes within the parent's ns scope, restoring encoding/xml parity
