### PR TITLE
resolve external-DTD load intent once

### DIFF
--- a/.claude/docs/parser-internals.md
+++ b/.claude/docs/parser-internals.md
@@ -136,7 +136,7 @@ Flow: `parseReference()` → `parseEntityRef()` → `entityCheck()` → parse co
 - `Characters` → AppendText (merges adjacent text)
 - `CDataBlock` → CDATASection; `Comment` → Comment; `ProcessingInstruction` → PI
 - `InternalSubset` → internal DTD
-- `ExternalSubset` → bounded read (`maxExtDTDSize`, `io.LimitReader`), baseURI scoping, TextDecl decode, PE-expanding declaration loop (`parseExternalSubsetDeclStep`), conditional sections — see the function's doc comments
+- `ExternalSubset` → load decision resolved ONCE from three independent intents (matching libxml2): load iff `parseDTDValid` (ValidateDTD) OR `DetectIDs` (LoadExternalDTD → parseDTDLoad) OR `CompleteAttrs` (DefaultDTDAttributes → parseDTDAttr) — so call order never changes whether the subset loads. The `LoadExternalDTD`/`DefaultDTDAttributes`/`ValidateDTD` setters each touch only their own option bit. A requested-but-failed `fsys.Open` (the gate passed, so loading WAS requested) emits a non-fatal `warning` (naming the resolved URI, gated by `parseNoWarning`) instead of a silent drop, then continues; under validation the missing content model surfaces downstream as `ErrDTDValidationFailed`. Then bounded read (`maxExtDTDSize`, `io.LimitReader`), baseURI scoping, TextDecl decode, PE-expanding declaration loop (`parseExternalSubsetDeclStep`), conditional sections — see the function's doc comments
 - `GetEntity`/`GetParameterEntity` → document entity table lookup
 
 Parent selection: DTD subset → add to DTD; no current element → add to document; else → append as child.

--- a/parser.go
+++ b/parser.go
@@ -201,7 +201,10 @@ func (p Parser) LoadExternalDTD(v bool) Parser {
 }
 
 // DefaultDTDAttributes controls whether the parser adds default attributes
-// defined in the DTD. When set to true, also enables LoadExternalDTD.
+// defined in the DTD. The external subset is loaded when default-attribute
+// application, external-DTD loading, or DTD validation is requested; the three
+// intents are independent, so call order does not matter and turning this off
+// does not leave loading stuck on.
 // libxml2: XML_PARSE_DTDATTR
 // Default: false
 func (p Parser) DefaultDTDAttributes(v bool) Parser {
@@ -211,12 +214,14 @@ func (p Parser) DefaultDTDAttributes(v bool) Parser {
 		return p
 	}
 	p.cfg.options.Set(parseDTDAttr)
-	p.cfg.options.Set(parseDTDLoad)
 	return p
 }
 
 // ValidateDTD controls whether the parser validates the document against
-// its DTD after parsing. When set to true, also enables LoadExternalDTD.
+// its DTD after parsing. The external subset is loaded when DTD validation,
+// external-DTD loading, or default-attribute application is requested; the
+// three intents are independent, so call order does not matter and turning
+// this off does not leave loading stuck on.
 // libxml2: XML_PARSE_DTDVALID
 // Default: false
 func (p Parser) ValidateDTD(v bool) Parser {
@@ -226,7 +231,6 @@ func (p Parser) ValidateDTD(v bool) Parser {
 		return p
 	}
 	p.cfg.options.Set(parseDTDValid)
-	p.cfg.options.Set(parseDTDLoad)
 	return p
 }
 

--- a/parser_dtd_load_resolution_test.go
+++ b/parser_dtd_load_resolution_test.go
@@ -1,0 +1,131 @@
+package helium_test
+
+import (
+	"context"
+	"testing"
+	"testing/fstest"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+// dtdLoadDoc references an external subset by SYSTEM id. A valid content model
+// for <doc> is declared in the external subset so a validating parse succeeds
+// once the subset is actually loaded.
+const dtdLoadDocName = "sub.dtd"
+
+func dtdLoadDoc() string {
+	return `<?xml version="1.0"?>` + "\n" +
+		`<!DOCTYPE doc SYSTEM "` + dtdLoadDocName + `">` + "\n" +
+		`<doc>hello</doc>`
+}
+
+func dtdLoadFS() fstest.MapFS {
+	return fstest.MapFS{
+		dtdLoadDocName: &fstest.MapFile{Data: []byte("<!ELEMENT doc (#PCDATA)>\n")},
+	}
+}
+
+// warnCaptureSAX embeds the default TreeBuilder (so the full DOM is still
+// built) and records every SAX Warning delivered during the parse. A wrapping
+// SAX handler takes the generic SAX-dispatch path (pctx.treeBuilder stays nil),
+// which is a supported configuration.
+type warnCaptureSAX struct {
+	*helium.TreeBuilder
+	warnings []error
+}
+
+func (w *warnCaptureSAX) Warning(_ context.Context, err error) error {
+	w.warnings = append(w.warnings, err)
+	return nil
+}
+
+// The external subset is loaded when load, default-attributes, or validation is
+// requested; the three intents are independent and the load decision does not
+// depend on the order the setters were called. ValidateDTD(true) must cause the
+// external subset to load even when LoadExternalDTD(false) is also set, and the
+// result must be identical regardless of call order.
+func TestExternalDTDLoadOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	validateThenNoLoad := helium.NewParser().
+		BlockXXE(false).
+		FS(dtdLoadFS()).
+		ValidateDTD(true).
+		LoadExternalDTD(false)
+
+	noLoadThenValidate := helium.NewParser().
+		BlockXXE(false).
+		FS(dtdLoadFS()).
+		LoadExternalDTD(false).
+		ValidateDTD(true)
+
+	doc1, err1 := validateThenNoLoad.Parse(t.Context(), []byte(dtdLoadDoc()))
+	require.NoError(t, err1, "validation should succeed once the external subset is loaded")
+	require.NotNil(t, doc1)
+
+	doc2, err2 := noLoadThenValidate.Parse(t.Context(), []byte(dtdLoadDoc()))
+	require.NoError(t, err2)
+	require.NotNil(t, doc2)
+
+	// Both orders resolve the load decision the same way: validation causes the
+	// external subset to load, LoadExternalDTD(false) notwithstanding.
+	require.NotNil(t, doc1.ExtSubset(), "validation must load the external subset regardless of LoadExternalDTD(false)")
+	require.NotNil(t, doc2.ExtSubset(), "call order must not change the load decision")
+}
+
+// Turning DefaultDTDAttributes back off must clear the load intent it set. A
+// DefaultDTDAttributes(true) followed by DefaultDTDAttributes(false) must leave
+// the parser NOT loading the external subset — the load bit does not get stuck
+// on. DefaultDTDAttributes(true) on its own does load.
+func TestExternalDTDDefaultAttrsToggleClearsLoad(t *testing.T) {
+	t.Parallel()
+
+	toggledOff := helium.NewParser().
+		BlockXXE(false).
+		FS(dtdLoadFS()).
+		DefaultDTDAttributes(true).
+		DefaultDTDAttributes(false)
+
+	doc, err := toggledOff.Parse(t.Context(), []byte(dtdLoadDoc()))
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	require.Nil(t, doc.ExtSubset(), "toggling DefaultDTDAttributes off must not leave the load bit stuck on")
+
+	on := helium.NewParser().
+		BlockXXE(false).
+		FS(dtdLoadFS()).
+		DefaultDTDAttributes(true)
+
+	doc2, err2 := on.Parse(t.Context(), []byte(dtdLoadDoc()))
+	require.NoError(t, err2)
+	require.NotNil(t, doc2)
+	require.NotNil(t, doc2.ExtSubset(), "DefaultDTDAttributes(true) must load the external subset")
+}
+
+// A requested external-subset load that fails to open must surface a non-fatal
+// warning instead of being silently swallowed. The parse stays lenient (no
+// fatal error, document still returned), matching libxml2.
+func TestExternalDTDFailedLoadWarns(t *testing.T) {
+	t.Parallel()
+
+	capture := &warnCaptureSAX{TreeBuilder: helium.NewTreeBuilder()}
+
+	// Empty filesystem: the SYSTEM "sub.dtd" open fails.
+	doc, err := helium.NewParser().
+		BlockXXE(false).
+		FS(fstest.MapFS{}).
+		SAXHandler(capture).
+		LoadExternalDTD(true).
+		Parse(t.Context(), []byte(dtdLoadDoc()))
+
+	require.NoError(t, err, "a failed external-subset load stays non-fatal")
+	require.NotNil(t, doc)
+	require.NotEmpty(t, capture.warnings, "a requested-but-failed external-subset load must emit a warning")
+
+	var lvl helium.ErrorLeveler
+	require.ErrorAs(t, capture.warnings[0], &lvl)
+	require.Equal(t, helium.ErrorLevelWarning, lvl.ErrorLevel())
+	require.Contains(t, capture.warnings[0].Error(), dtdLoadDocName,
+		"the warning must name the external DTD that failed to load")
+}

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -350,7 +350,16 @@ func (t *TreeBuilder) ExternalSubset(ctxif context.Context, name, eid, uri strin
 		return nil
 	}
 
-	if !ctx.loadsubset.IsSet(DetectIDs) {
+	// Resolve the load decision once from three independent intents, matching
+	// libxml2 (parser.c xmlSAX2ExternalSubset / SAX2.c): the external subset is
+	// loaded iff DTD validation (parseDTDValid), external-DTD loading (DetectIDs,
+	// from LoadExternalDTD), or default-attribute application (CompleteAttrs,
+	// from DefaultDTDAttributes) was requested. Reading all three here — rather
+	// than a single bit that the setters coupled together — makes the decision
+	// independent of the order the setters were called.
+	if !ctx.options.IsSet(parseDTDValid) &&
+		!ctx.loadsubset.IsSet(DetectIDs) &&
+		!ctx.loadsubset.IsSet(CompleteAttrs) {
 		return nil
 	}
 
@@ -388,7 +397,14 @@ func (t *TreeBuilder) ExternalSubset(ctxif context.Context, name, eid, uri strin
 	// a catalog-resolved file: URI is handled. A plain path is returned verbatim.
 	f, err := ctx.fsys.Open(catalogOpenName(resolved))
 	if err != nil {
-		// Silently ignore missing external DTDs
+		// Loading was requested (the resolve-once gate above passed), so a failed
+		// open is a requested-but-failed load, not an absent DTD. Surface it as a
+		// non-fatal warning rather than swallowing it silently — a caller that
+		// asked to load/validate against the external subset gets a signal, while
+		// the parse stays lenient (matching libxml2, which warns but continues).
+		// Under DTD validation the missing content model then surfaces downstream
+		// as a validation failure. The warning is gated by parseNoWarning.
+		_ = ctx.warning(ctxif, "failed to load external DTD subset %q: %s", resolved, err)
 		return nil
 	}
 


### PR DESCRIPTION
- resolve the external-subset load decision once as `validate OR DetectIDs OR CompleteAttrs`
- `DefaultDTDAttributes`/`ValidateDTD` no longer touch `parseDTDLoad`, so intents are independent of call order
- a requested-but-failed external-subset open now warns (naming the DTD) instead of a silent drop
