### PR TITLE
give comment nodes the (comment) sentinel name

### DIFF
--- a/node_leaf.go
+++ b/node_leaf.go
@@ -61,6 +61,7 @@ func newComment(b []byte) *Comment {
 	t := Comment{}
 	t.etype = CommentNode
 	t.content = bytes.Clone(b)
+	t.name = "(comment)"
 	return &t
 }
 

--- a/node_leaf_test.go
+++ b/node_leaf_test.go
@@ -732,6 +732,11 @@ func TestCommentNodeMethods(t *testing.T) {
 	doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
 	c := doc.CreateComment([]byte("hello"))
 	require.Equal(t, []byte("hello"), c.Content())
+	// A comment carries the "(comment)" sentinel name, matching the parenthesized
+	// sentinel convention its sibling leaf types (Text "(text)", CDATA "(CDATA)")
+	// use for nodes without a real XML name.
+	require.Equal(t, "(comment)", c.Name(), "comment sentinel name")
+	require.Equal(t, "(comment)", c.LocalName(), "comment sentinel local name")
 
 	// Merging another (unlinked) comment appends its content.
 	other := doc.CreateComment([]byte(" world"))


### PR DESCRIPTION
Text, CDATA and Document set a parenthesized sentinel name for nodes without a real XML name ("(text)", "(CDATA)", "(document)"), and node-types.md documents "(comment)" as part of that convention, but newComment never set it — Comment.Name()/LocalName() returned the empty zero value while its sibling leaf types returned a sentinel. Set it so the leaf types agree. No consumer compares against these sentinels (XPath name()/node-name() special-case node type and never read a comment's name; the serializer switches on node type), so behavior is unchanged for those paths.