### PR TITLE
make SetAttributeNS replace duplicates in place

### DIFF
--- a/attr_test.go
+++ b/attr_test.go
@@ -62,6 +62,68 @@ func TestSetAttribute(t *testing.T) {
 		err = elem.SetLiteralAttribute("lang", "en")
 		require.NoError(t, err)
 	})
+
+	t.Run("parse setters resolve entity references; literal setters store verbatim", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		elem := doc.CreateElement("root")
+		ns := helium.NewNamespace("p", "urn:x")
+
+		// SetAttribute / SetAttributeNS parse the value as attribute-value
+		// content, so "&amp;" is resolved to a single '&'.
+		_, err := elem.SetAttribute("a", "x&amp;y")
+		require.NoError(t, err)
+		v, ok := elem.GetAttribute("a")
+		require.True(t, ok)
+		require.Equal(t, "x&y", v)
+
+		_, err = elem.SetAttributeNS("c", "x&amp;y", ns)
+		require.NoError(t, err)
+		v, ok = elem.GetAttributeNS("c", "urn:x")
+		require.True(t, ok)
+		require.Equal(t, "x&y", v)
+
+		// The literal setters store the value verbatim (no entity parsing).
+		require.NoError(t, elem.SetLiteralAttribute("b", "x&amp;y"))
+		v, ok = elem.GetAttribute("b")
+		require.True(t, ok)
+		require.Equal(t, "x&amp;y", v)
+
+		require.NoError(t, elem.SetLiteralAttributeNS("d", "x&amp;y", ns))
+		v, ok = elem.GetAttributeNS("d", "urn:x")
+		require.True(t, ok)
+		require.Equal(t, "x&amp;y", v)
+	})
+
+	t.Run("all four setters replace an existing attribute in place", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		ns := helium.NewNamespace("p", "urn:x")
+
+		e1 := doc.CreateElement("r")
+		_, err := e1.SetAttribute("a", "1")
+		require.NoError(t, err)
+		_, err = e1.SetAttribute("a", "2")
+		require.NoError(t, err)
+		require.Len(t, e1.Attributes(), 1)
+
+		e2 := doc.CreateElement("r")
+		require.NoError(t, e2.SetLiteralAttribute("a", "1"))
+		require.NoError(t, e2.SetLiteralAttribute("a", "2"))
+		require.Len(t, e2.Attributes(), 1)
+
+		e3 := doc.CreateElement("r")
+		_, err = e3.SetAttributeNS("a", "1", ns)
+		require.NoError(t, err)
+		_, err = e3.SetAttributeNS("a", "2", ns)
+		require.NoError(t, err)
+		require.Len(t, e3.Attributes(), 1)
+
+		e4 := doc.CreateElement("r")
+		require.NoError(t, e4.SetLiteralAttributeNS("a", "1", ns))
+		require.NoError(t, e4.SetLiteralAttributeNS("a", "2", ns))
+		require.Len(t, e4.Attributes(), 1)
+	})
 }
 
 func TestAttributeAType(t *testing.T) {
@@ -590,7 +652,7 @@ func TestGetAttributeNodeNS(t *testing.T) {
 func TestSetAttributeNSDuplicate(t *testing.T) {
 	t.Parallel()
 
-	t.Run("same namespace URI via different Namespace pointers is a duplicate", func(t *testing.T) {
+	t.Run("same namespace URI via different Namespace pointers replaces in place", func(t *testing.T) {
 		t.Parallel()
 		doc := helium.NewDefaultDocument()
 		e := doc.CreateElement("root")
@@ -598,7 +660,9 @@ func TestSetAttributeNSDuplicate(t *testing.T) {
 		// Two distinct *Namespace values that share the same URI. Per XML
 		// rules an element may not carry two attributes with the same
 		// (namespace URI, local name), regardless of which namespace
-		// declaration (pointer) they reference.
+		// declaration (pointer) they reference. Like every other Set*Attribute
+		// entry point, SetAttributeNS treats these as the SAME attribute and
+		// replaces in place rather than appending a second property or erroring.
 		ns1 := helium.NewNamespace("a", "http://example.com/ns")
 		ns2 := helium.NewNamespace("b", "http://example.com/ns")
 
@@ -606,7 +670,14 @@ func TestSetAttributeNSDuplicate(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = e.SetAttributeNS("attr", "second", ns2)
-		require.ErrorIs(t, err, helium.ErrDuplicateAttribute)
+		require.NoError(t, err)
+
+		attrs := e.Attributes()
+		require.Len(t, attrs, 1)
+		require.Equal(t, "second", attrs[0].Value())
+		v, ok := e.GetAttributeNS("attr", "http://example.com/ns")
+		require.True(t, ok)
+		require.Equal(t, "second", v)
 	})
 
 	t.Run("genuinely different namespaces are not duplicates", func(t *testing.T) {

--- a/attr_test.go
+++ b/attr_test.go
@@ -95,34 +95,124 @@ func TestSetAttribute(t *testing.T) {
 		require.Equal(t, "x&amp;y", v)
 	})
 
-	t.Run("all four setters replace an existing attribute in place", func(t *testing.T) {
+	// Each of the four setters must REPLACE a same-name attribute in place:
+	// no duplicate appended, the second value wins (not the stale first), the
+	// target keeps its original position between its siblings, and the original
+	// attribute node is detached. Siblings are added before and after the target
+	// so a re-ordering or append regression is caught, and the second value
+	// differs from the first so a "success without replacing" regression fails.
+	t.Run("SetAttribute replaces in place", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		e := doc.CreateElement("r")
+
+		require.NoError(t, e.SetLiteralAttribute("before", "b0"))
+		_, err := e.SetAttribute("a", "1")
+		require.NoError(t, err)
+		require.NoError(t, e.SetLiteralAttribute("after", "a0"))
+
+		orig, ok := e.FindAttribute(helium.LocalNamePredicate("a"))
+		require.True(t, ok)
+		require.Equal(t, "1", orig.Value())
+
+		_, err = e.SetAttribute("a", "2")
+		require.NoError(t, err)
+
+		attrs := e.Attributes()
+		require.Len(t, attrs, 3, "replacement must not append a duplicate")
+		require.Equal(t,
+			[]string{"before", "a", "after"},
+			[]string{attrs[0].LocalName(), attrs[1].LocalName(), attrs[2].LocalName()},
+			"order preserved, target stays between its siblings")
+		require.Equal(t, "2", attrs[1].Value(), "target holds the second value, not the stale first")
+		require.Equal(t, "b0", attrs[0].Value(), "sibling before the target untouched")
+		require.Equal(t, "a0", attrs[2].Value(), "sibling after the target untouched")
+		require.Nil(t, orig.Parent(), "original target node detached after replacement")
+	})
+
+	t.Run("SetLiteralAttribute replaces in place", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		e := doc.CreateElement("r")
+
+		require.NoError(t, e.SetLiteralAttribute("before", "b0"))
+		require.NoError(t, e.SetLiteralAttribute("a", "1"))
+		require.NoError(t, e.SetLiteralAttribute("after", "a0"))
+
+		orig, ok := e.FindAttribute(helium.LocalNamePredicate("a"))
+		require.True(t, ok)
+		require.Equal(t, "1", orig.Value())
+
+		require.NoError(t, e.SetLiteralAttribute("a", "2"))
+
+		attrs := e.Attributes()
+		require.Len(t, attrs, 3, "replacement must not append a duplicate")
+		require.Equal(t,
+			[]string{"before", "a", "after"},
+			[]string{attrs[0].LocalName(), attrs[1].LocalName(), attrs[2].LocalName()},
+			"order preserved, target stays between its siblings")
+		require.Equal(t, "2", attrs[1].Value(), "target holds the second value, not the stale first")
+		require.Equal(t, "b0", attrs[0].Value(), "sibling before the target untouched")
+		require.Equal(t, "a0", attrs[2].Value(), "sibling after the target untouched")
+		require.Nil(t, orig.Parent(), "original target node detached after replacement")
+	})
+
+	t.Run("SetAttributeNS replaces in place", func(t *testing.T) {
 		t.Parallel()
 		doc := helium.NewDefaultDocument()
 		ns := helium.NewNamespace("p", "urn:x")
+		e := doc.CreateElement("r")
 
-		e1 := doc.CreateElement("r")
-		_, err := e1.SetAttribute("a", "1")
+		require.NoError(t, e.SetLiteralAttribute("before", "b0"))
+		_, err := e.SetAttributeNS("a", "1", ns)
 		require.NoError(t, err)
-		_, err = e1.SetAttribute("a", "2")
-		require.NoError(t, err)
-		require.Len(t, e1.Attributes(), 1)
+		require.NoError(t, e.SetLiteralAttribute("after", "a0"))
 
-		e2 := doc.CreateElement("r")
-		require.NoError(t, e2.SetLiteralAttribute("a", "1"))
-		require.NoError(t, e2.SetLiteralAttribute("a", "2"))
-		require.Len(t, e2.Attributes(), 1)
+		orig := e.GetAttributeNodeNS("a", "urn:x")
+		require.NotNil(t, orig)
+		require.Equal(t, "1", orig.Value())
 
-		e3 := doc.CreateElement("r")
-		_, err = e3.SetAttributeNS("a", "1", ns)
+		_, err = e.SetAttributeNS("a", "2", ns)
 		require.NoError(t, err)
-		_, err = e3.SetAttributeNS("a", "2", ns)
-		require.NoError(t, err)
-		require.Len(t, e3.Attributes(), 1)
 
-		e4 := doc.CreateElement("r")
-		require.NoError(t, e4.SetLiteralAttributeNS("a", "1", ns))
-		require.NoError(t, e4.SetLiteralAttributeNS("a", "2", ns))
-		require.Len(t, e4.Attributes(), 1)
+		attrs := e.Attributes()
+		require.Len(t, attrs, 3, "replacement must not append a duplicate")
+		require.Equal(t,
+			[]string{"before", "a", "after"},
+			[]string{attrs[0].LocalName(), attrs[1].LocalName(), attrs[2].LocalName()},
+			"order preserved, target stays between its siblings")
+		require.Equal(t, "2", attrs[1].Value(), "target holds the second value, not the stale first")
+		require.Equal(t, "b0", attrs[0].Value(), "sibling before the target untouched")
+		require.Equal(t, "a0", attrs[2].Value(), "sibling after the target untouched")
+		require.Nil(t, orig.Parent(), "original target node detached after replacement")
+	})
+
+	t.Run("SetLiteralAttributeNS replaces in place", func(t *testing.T) {
+		t.Parallel()
+		doc := helium.NewDefaultDocument()
+		ns := helium.NewNamespace("p", "urn:x")
+		e := doc.CreateElement("r")
+
+		require.NoError(t, e.SetLiteralAttribute("before", "b0"))
+		require.NoError(t, e.SetLiteralAttributeNS("a", "1", ns))
+		require.NoError(t, e.SetLiteralAttribute("after", "a0"))
+
+		orig := e.GetAttributeNodeNS("a", "urn:x")
+		require.NotNil(t, orig)
+		require.Equal(t, "1", orig.Value())
+
+		require.NoError(t, e.SetLiteralAttributeNS("a", "2", ns))
+
+		attrs := e.Attributes()
+		require.Len(t, attrs, 3, "replacement must not append a duplicate")
+		require.Equal(t,
+			[]string{"before", "a", "after"},
+			[]string{attrs[0].LocalName(), attrs[1].LocalName(), attrs[2].LocalName()},
+			"order preserved, target stays between its siblings")
+		require.Equal(t, "2", attrs[1].Value(), "target holds the second value, not the stale first")
+		require.Equal(t, "b0", attrs[0].Value(), "sibling before the target untouched")
+		require.Equal(t, "a0", attrs[2].Value(), "sibling after the target untouched")
+		require.Nil(t, orig.Parent(), "original target node detached after replacement")
 	})
 }
 

--- a/element.go
+++ b/element.go
@@ -53,8 +53,10 @@ func (n *Element) SetTreeDoc(doc *Document) {
 }
 
 // SetAttribute creates or replaces the attribute named name, parsing value for
-// entity references, and returns the element for chaining. The name must not
-// contain a colon; use SetAttributeNS for namespaced attributes.
+// entity references, and returns the element for chaining. An existing
+// attribute with the same QName is replaced in place. The name must not
+// contain a colon; use SetAttributeNS for namespaced attributes, or
+// SetLiteralAttribute to store value verbatim without parsing.
 func (n *Element) SetAttribute(name, value string) (*Element, error) {
 	attr, err := n.doc.CreateAttribute(name, value, nil)
 	if err != nil {
@@ -107,9 +109,10 @@ func (n *Element) SetBooleanAttribute(name string) error {
 // q:a both bound to {urn:x}a); the QName test catches duplicates among
 // no-namespace attributes and any other identical serialization.
 //
-// This is the single attribute-identity check shared by every
-// attribute-creation entry point (addProperty, which backs SetAttribute
-// and SetLiteralAttribute(NS), and SetAttributeNS).
+// This is the single attribute-identity check used by addProperty, which
+// backs every attribute-creation entry point (SetAttribute, SetAttributeNS,
+// SetLiteralAttribute, and SetLiteralAttributeNS). A matching attribute is
+// replaced in place; a new one is appended.
 func attrMatches(existing *Attribute, qname, nsURI, localName string) bool {
 	if existing.URI() == nsURI && existing.LocalName() == localName {
 		return true
@@ -182,40 +185,19 @@ func (n *Element) SetLiteralAttributeNS(localname, value string, ns *Namespace) 
 	return nil
 }
 
-// SetAttributeNS creates an attribute with the given local name, value, and namespace.
+// SetAttributeNS creates or replaces the attribute with the given local name
+// and namespace, parsing value for entity references, and returns the element
+// for chaining. An existing attribute with the same expanded name (namespace
+// URI + local name) or serialized QName is replaced in place. The local name
+// must not contain a colon. This is the namespaced analogue of SetAttribute;
+// use SetLiteralAttributeNS to store value verbatim without parsing.
 func (n *Element) SetAttributeNS(localname, value string, ns *Namespace) (*Element, error) {
 	attr, err := n.doc.CreateAttribute(localname, value, ns)
 	if err != nil {
 		return nil, err
 	}
 
-	p := n.properties
-	if p == nil {
-		n.properties = attr
-		attr.parent = n
-		return n, nil
-	}
-
-	// Use the same attribute-identity check as addProperty: an attribute is
-	// a duplicate when EITHER its expanded name (namespace URI + local name)
-	// OR its serialized QName matches an existing one. Comparing by URI
-	// value rather than *Namespace pointer identity means distinct namespace
-	// declarations carrying the same URI still collide.
-	qname := attr.Name()
-	nsURI := attr.URI()
-
-	var last *Attribute
-	for ; p != nil; p = p.NextAttribute() {
-		if attrMatches(p, qname, nsURI, localname) {
-			return nil, ErrDuplicateAttribute
-		}
-		last = p
-	}
-
-	last.next = attr
-	attr.prev = last
-	attr.parent = n
-
+	n.addProperty(attr)
 	return n, nil
 }
 

--- a/errors.go
+++ b/errors.go
@@ -37,10 +37,9 @@ const (
 
 // Sentinel errors for DOM operations.
 var (
-	ErrNilNode            = errors.New("nil node")
-	ErrInvalidOperation   = errors.New("operation cannot be performed")
-	ErrDuplicateAttribute = errors.New("duplicate attribute")
-	ErrEntityBoundary     = errors.New("entity boundary violation")
+	ErrNilNode          = errors.New("nil node")
+	ErrInvalidOperation = errors.New("operation cannot be performed")
+	ErrEntityBoundary   = errors.New("entity boundary violation")
 	// ErrEntityVersionMismatch is returned when an external parsed entity (or
 	// the external DTD subset) declares, in its TextDecl, an XML version later
 	// than the referencing document's (XML §4.3.4). Helium targets XML 1.0, so a


### PR DESCRIPTION
- `SetAttributeNS` replaces a same-name attribute in place, matching the other three setters, instead of erroring
- remove the now-unused exported `ErrDuplicateAttribute`; duplicates are already rejected at parse time
- document the four-setter contract and add tests locking parse-vs-verbatim and replace-in-place
