### PR TITLE
document char-reference node semantics on CreateCharRef

### DIFF
--- a/document.go
+++ b/document.go
@@ -356,6 +356,11 @@ func (d *Document) SetDocumentElement(root MutableNode) error {
 	return nil
 }
 
+// CreateReference builds an entity-reference node and, when a matching entity
+// is declared in the document, attaches its replacement content — mirroring
+// libxml2's xmlNewReference. Like CreateCharRef (and libxml2's xmlNewCharRef)
+// the node is an EntityRefNode that serializes as "&" + Name() + ";"; the only
+// difference is the declared-entity lookup performed here.
 func (d *Document) CreateReference(name string) (*EntityRef, error) {
 	n, err := d.CreateCharRef(name)
 	if err != nil {
@@ -1000,6 +1005,16 @@ func (d *Document) stringToNodeList(value string) (ret Node, err error) {
 	return
 }
 
+// CreateCharRef builds an entity-reference node, mirroring libxml2's
+// xmlNewCharRef. In the libxml2 DOM (which helium follows) a character
+// reference is NOT a distinct node type: both a character reference (&#123;,
+// &#xAB;) and a named entity reference (&amp;) are represented as an
+// EntityRefNode, and the serializer emits the node as "&" + Name() + ";".
+// The name is the reference body with any surrounding "&"/";" stripped, so a
+// name of "#123"/"#xAB" serializes as the character reference "&#123;"/"&#xAB;"
+// and a name of "amp" serializes as "&amp;". Unlike CreateReference, this does
+// NOT look up a declared entity or attach its replacement content — it only
+// constructs the bare reference node.
 func (d *Document) CreateCharRef(name string) (*EntityRef, error) {
 	if name == "" {
 		return nil, errors.New("empty name")

--- a/parser_charref_test.go
+++ b/parser_charref_test.go
@@ -143,6 +143,37 @@ func TestCreateCharRefForms(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestCreateCharRefSerializes locks the create->serialize round-trip: an
+// EntityRefNode built by CreateCharRef with a "#NNN"/"#xHH" name serializes as
+// a character reference, and a plain name serializes as a named entity
+// reference, mirroring libxml2's xmlNewCharRef (both are XML_ENTITY_REF_NODE).
+func TestCreateCharRefSerializes(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		want string
+	}{
+		{name: "#123", want: "&#123;"},
+		{name: "#xAB", want: "&#xAB;"},
+		{name: "amp", want: "&amp;"},
+	} {
+		doc := helium.NewDocument("1.0", "UTF-8", helium.StandaloneImplicitNo)
+		root := doc.CreateElement("root")
+		require.NoError(t, doc.SetDocumentElement(root))
+
+		ref, err := doc.CreateCharRef(tc.name)
+		require.NoError(t, err)
+		require.Equal(t, helium.EntityRefNode, ref.Type(), "CreateCharRef yields an EntityRefNode (libxml2 xmlNewCharRef)")
+		require.Equal(t, tc.name, ref.Name())
+		require.NoError(t, root.AddChild(ref))
+
+		str, err := helium.WriteString(root)
+		require.NoError(t, err)
+		require.Equal(t, "<root>"+tc.want+"</root>", str)
+	}
+}
+
 // TestValidCharRefForms parses documents with valid hex/decimal char refs to
 // drive the success branches of parseCharRef.
 func TestValidCharRefForms(t *testing.T) {


### PR DESCRIPTION
Finding #21 review turned out REFUTED: CreateCharRef is neither misnamed nor misbehaving. It mirrors libxml2's xmlNewCharRef exactly — in the libxml2 DOM a character reference is an XML_ENTITY_REF_NODE (not a distinct node type), and the serializer emits it as "&" + name + ";", so a name of "#123"/"#xAB" yields "&#123;"/"&#xAB;". CreateReference mirrors xmlNewReference (same node, plus declared-entity lookup). Adds doc comments on both and a create->serialize round-trip test so the false positive doesn't recur.