### PR TITLE
document DTD subset accessor naming on Document

### DIFF
--- a/document.go
+++ b/document.go
@@ -271,6 +271,10 @@ func (d *Document) HasProperty(p DocProperties) bool {
 	return d.properties&p == p
 }
 
+// IntSubset returns the document's internal DTD subset, or nil when none is
+// present. The abbreviated name mirrors libxml2's xmlGetIntSubset and the
+// intSubset document field. InternalSubset is the equivalent accessor that
+// reports absence as an error instead of nil.
 func (d *Document) IntSubset() *DTD {
 	return d.intSubset
 }
@@ -287,6 +291,9 @@ func (d *Document) RemoveInternalSubset() {
 	d.intSubset = nil
 }
 
+// ExtSubset returns the document's external DTD subset, or nil when none is
+// present. The abbreviated name mirrors libxml2's extSubset document field,
+// matching the IntSubset accessor.
 func (d *Document) ExtSubset() *DTD {
 	return d.extSubset
 }
@@ -480,6 +487,8 @@ func (d *Document) CreateDTD() (*DTD, error) {
 	return dtd, nil
 }
 
+// InternalSubset returns the document's internal DTD subset, reporting absence
+// as an error. IntSubset is the equivalent accessor that returns nil instead.
 func (d *Document) InternalSubset() (*DTD, error) {
 	// equiv: xmlGetIntSubset (tree.c)
 	if d.intSubset == nil {


### PR DESCRIPTION
The DTD subset accessors on Document mix abbreviated (IntSubset/ExtSubset) and spelled-out (InternalSubset/CreateInternalSubset) forms because they mirror two distinct libxml2 APIs: the tree getters follow xmlGetIntSubset/the intSubset field, while the SAX2 callbacks (sax package, TreeBuilder) follow libxml2's spelled-out SAX handler names. Renaming either would break that parity, so this adds doc comments to IntSubset/ExtSubset/InternalSubset clarifying the naming and cross-referencing the nil-vs-error getter variants. No behavior or API change.