### PR TITLE
unexport internal parser sentinels from public godoc

### DIFF
--- a/.claude/docs/node-types.md
+++ b/.claude/docs/node-types.md
@@ -113,7 +113,7 @@ The QName→(name, prefix) split (`AddElementDecl`/`GetElementDesc`) splits on t
 The text-bearing leaves (Text, Comment, CDATASection) store content in an internal mutable `content []byte`. Their exported `Content()` returns a **defensive copy** (`bytes.Clone`) so a caller mutating the result cannot corrupt the DOM. Internal read-only hot paths (serializers in `writer.go`/`writer_xhtml.go`) use the package-level `rawContent(Node)` helper — backed by an unexported `rawContent()` method on each of those three leaf types — to get the raw slice without the copy. The `rawContentNode` interface gates the no-copy path; for any other node `rawContent` falls back to `Content()`. PI/EntityRef/Entity/NamespaceNodeWrapper already returned string-derived copies and are unaffected.
 
 ### Predefined Entities
-5 singletons: `EntityLT`, `EntityGT`, `EntityAmpersand`, `EntityApostrophe`, `EntityQuote`. Type `InternalPredefinedEntity`. Cannot be redeclared.
+5 unexported singletons: `entityLT`, `entityGT`, `entityAmpersand`, `entityApostrophe`, `entityQuote` (resolved by name through `resolvePredefinedEntity`). Type `InternalPredefinedEntity`. Cannot be redeclared.
 
 ### NamespaceDeclNode Special Case
 Skipped in `setTreeDoc()` — sentinel type rarely instantiated.

--- a/entity.go
+++ b/entity.go
@@ -59,12 +59,14 @@ type Entity struct {
 	 * and if it contains '<' */
 }
 
+// Predefined XML entity singletons (XML §4.6). Internal: callers resolve
+// these through the parser, never by name from outside the package.
 var (
-	EntityLT         = newEntity("lt", enum.InternalPredefinedEntity, "", "", "<", "&lt;")
-	EntityGT         = newEntity("gt", enum.InternalPredefinedEntity, "", "", ">", "&gt;")
-	EntityAmpersand  = newEntity("amp", enum.InternalPredefinedEntity, "", "", "&", "&amp;")
-	EntityApostrophe = newEntity("apos", enum.InternalPredefinedEntity, "", "", "'", "&apos;")
-	EntityQuote      = newEntity("quot", enum.InternalPredefinedEntity, "", "", `"`, "&quot;")
+	entityLT         = newEntity("lt", enum.InternalPredefinedEntity, "", "", "<", "&lt;")
+	entityGT         = newEntity("gt", enum.InternalPredefinedEntity, "", "", ">", "&gt;")
+	entityAmpersand  = newEntity("amp", enum.InternalPredefinedEntity, "", "", "&", "&amp;")
+	entityApostrophe = newEntity("apos", enum.InternalPredefinedEntity, "", "", "'", "&apos;")
+	entityQuote      = newEntity("quot", enum.InternalPredefinedEntity, "", "", `"`, "&quot;")
 )
 
 // predefinedEntityContent maps predefined entity names to their required
@@ -135,15 +137,15 @@ func resolveCharRefs(s string) string {
 func resolvePredefinedEntity(name string) (*Entity, error) {
 	switch name {
 	case "lt":
-		return EntityLT, nil
+		return entityLT, nil
 	case "gt":
-		return EntityGT, nil
+		return entityGT, nil
 	case "amp":
-		return EntityAmpersand, nil
+		return entityAmpersand, nil
 	case "apos":
-		return EntityApostrophe, nil
+		return entityApostrophe, nil
 	case "quot":
-		return EntityQuote, nil
+		return entityQuote, nil
 	default:
 		return nil, errors.New("entity not found")
 	}

--- a/parser_entity_decl.go
+++ b/parser_entity_decl.go
@@ -997,10 +997,13 @@ func (pctx *parserCtx) parseExternalEntityPrivate(ctx context.Context, uri, decl
 		}
 	}
 
-	return nil, ErrParseSucceeded
+	return nil, errParseSucceeded
 }
 
-var ErrParseSucceeded = errors.New("parse succeeded")
+// errParseSucceeded is an internal control-flow sentinel: an entity-parse
+// helper returns it (in place of nil) to signal a successful parse to its
+// caller's error switch. It never escapes the package.
+var errParseSucceeded = errors.New("parse succeeded")
 
 func (pctx *parserCtx) parseBalancedChunkInternal(ctx context.Context, chunk []byte) (Node, error) {
 	pctx.depth++
@@ -1089,5 +1092,5 @@ func (pctx *parserCtx) parseBalancedChunkInternal(ctx context.Context, chunk []b
 		}
 	}
 
-	return nil, ErrParseSucceeded
+	return nil, errParseSucceeded
 }

--- a/parser_entity_ref.go
+++ b/parser_entity_ref.go
@@ -90,14 +90,14 @@ func (pctx *parserCtx) parseReference(ctx context.Context) error {
 		if ent.EntityType() == enum.InternalGeneralEntity {
 			parsedEnt, err = pctx.parseBalancedChunkInternal(ctx, ent.Content())
 			switch err {
-			case nil, ErrParseSucceeded:
+			case nil, errParseSucceeded:
 			default:
 				return err
 			}
 		} else if ent.EntityType() == enum.ExternalGeneralParsedEntity {
 			parsedEnt, err = pctx.parseExternalEntityPrivate(ctx, ent.uri, ent.systemID, ent.externalID)
 			switch err {
-			case nil, ErrParseSucceeded:
+			case nil, errParseSucceeded:
 			default:
 				return err
 			}
@@ -137,7 +137,7 @@ func (pctx *parserCtx) parseReference(ctx context.Context) error {
 				parsedEnt, err = pctx.parseBalancedChunkInternal(ctx, ent.Content())
 				_ = parsedEnt
 				switch err {
-				case nil, ErrParseSucceeded:
+				case nil, errParseSucceeded:
 				default:
 					return err
 				}
@@ -145,7 +145,7 @@ func (pctx *parserCtx) parseReference(ctx context.Context) error {
 				parsedEnt, err = pctx.parseExternalEntityPrivate(ctx, ent.uri, ent.systemID, ent.externalID)
 				_ = parsedEnt
 				switch err {
-				case nil, ErrParseSucceeded:
+				case nil, errParseSucceeded:
 				default:
 					return err
 				}


### PR DESCRIPTION
The predefined-entity singletons (`EntityLT`/`GT`/`Ampersand`/`Apostrophe`/`Quote`) and the `ErrParseSucceeded` parse-control sentinel were exported but undocumented, used only inside the root package, and referenced by no sibling package, test, or example. They cluttered the public godoc surface without serving external callers, so they are unexported. Build/vet/test/lint pass across the module.