### PR TITLE
strip XML whitespace before the NONET scheme check

### DIFF
--- a/parser_confined_fs_test.go
+++ b/parser_confined_fs_test.go
@@ -237,6 +237,52 @@ func TestConfinedDirFSRefusesNetwork(t *testing.T) {
 	require.ErrorIs(t, err, helium.ErrNetworkAccessForbidden)
 }
 
+// A SYSTEM id with leading XML whitespace before a network scheme (" http://x",
+// "\thttp://x") must NOT slip past the NONET gate: the whitespace is stripped
+// before the scheme check, so the network resource is refused before it can
+// reach a network-capable caller fs.FS. A genuine (whitespace-free) relative id
+// still loads normally.
+func TestConfinedFSRefusesWhitespacePrefixedNetworkScheme(t *testing.T) {
+	t.Parallel()
+
+	for _, sysID := range []string{" http://x/evil.dtd", "\thttp://x/evil.dtd"} {
+		doc := `<?xml version="1.0"?>` + "\n" +
+			`<!DOCTYPE doc SYSTEM "` + sysID + `">` + "\n" +
+			`<doc>hello</doc>`
+
+		var opened []string
+		_, err := helium.NewParser().
+			BlockXXE(false).
+			LoadExternalDTD(true).
+			FS(validPathFS{content: []byte("<!ELEMENT doc (#PCDATA)>\n"), opened: &opened}).
+			Parse(t.Context(), []byte(doc))
+
+		require.ErrorIsf(t, err, helium.ErrNetworkAccessForbidden,
+			"whitespace-prefixed network SYSTEM id %q must be refused under NONET", sysID)
+		for _, n := range opened {
+			require.NotContainsf(t, []string{"http", "https", "ftp"}, schemeOf(strings.TrimLeft(n, " \t\r\n")),
+				"a whitespace-prefixed network id %q must be refused before it reaches Open (opened %q)", sysID, n)
+		}
+	}
+
+	// A legitimate relative SYSTEM id (no whitespace) still loads through the same
+	// network-capable FS.
+	doc := `<?xml version="1.0"?>` + "\n" +
+		`<!DOCTYPE doc SYSTEM "sub.dtd">` + "\n" +
+		`<doc>hello</doc>`
+	var opened []string
+	parsed, err := helium.NewParser().
+		BlockXXE(false).
+		LoadExternalDTD(true).
+		FS(validPathFS{content: []byte("<!ELEMENT doc (#PCDATA)>\n"), opened: &opened}).
+		Parse(t.Context(), []byte(doc))
+
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	require.NotNil(t, parsed.ExtSubset(), "a relative SYSTEM id must still load")
+	require.Contains(t, opened, "sub.dtd")
+}
+
 // PermissiveRoot still loads an external subset via its absolute resolved path:
 // the base-relative retry only fires for an fs.ErrInvalid rejection, which
 // os.Open-backed PermissiveRoot never returns, so its behavior is unchanged.

--- a/tree_builder.go
+++ b/tree_builder.go
@@ -355,17 +355,28 @@ func catalogOpenName(ref string) string {
 // network-capable) caller-supplied fs.FS. A name with no scheme, a "file:"
 // scheme, or a bare path is never a network resource and loads as usual; scheme
 // matching is case-insensitive (uripath.URIScheme lowercases its result).
+//
+// Leading/trailing XML whitespace (space, tab, CR, LF) is stripped before the
+// scheme check: a SYSTEM literal is a URI reference (XML §4.2.2), and RFC 3986
+// requires surrounding whitespace to be ignored when a URI is extracted. Without
+// this a whitespace-prefixed id (" http://x") reads as scheme-less to
+// uripath.URIScheme (whose first byte must be an ALPHA) and would slip past the
+// NONET gate to a network-capable caller fs.FS.
 func networkAccessForbidden(ctx *parserCtx, name string) bool {
 	if !ctx.options.IsSet(parseNoNet) {
 		return false
 	}
-	switch uripath.URIScheme(name) {
+	switch uripath.URIScheme(strings.Trim(name, xmlWhitespace)) {
 	case "http", "https", "ftp":
 		return true
 	default:
 		return false
 	}
 }
+
+// xmlWhitespace is the XML whitespace set (S production: #x20 #x9 #xD #xA), used
+// as a cutset to strip whitespace surrounding a SYSTEM-literal URI reference.
+const xmlWhitespace = " \t\r\n"
 
 // systemIDRetryEligible reports whether a declared SYSTEM id is eligible for the
 // confined-FS base-relative retry (openExternalResource). Only an ORIGINALLY


### PR DESCRIPTION
A SYSTEM id with leading XML whitespace before a network scheme (` http://x`, `\thttp://x`) read as scheme-less to `uripath.URIScheme`, so `networkAccessForbidden` skipped the check and the id could slip past the NONET gate to a network-capable caller `fs.FS`. Trim the XML whitespace set (S production) before resolving the scheme. Regression test in parser_confined_fs_test.go.