### PR TITLE
document shim version-declaration divergence

### DIFF
--- a/.claude/docs/libxml2-parity.md
+++ b/.claude/docs/libxml2-parity.md
@@ -92,7 +92,7 @@ libxml2.
 | Feature | What Works | Gap |
 |---------|-----------|-----|
 | HTML parsing | SAX + DOM, auto-close, void elements, entities, encoding | Structural element nesting not enforced, areBlanks heuristic simpler, attribute deduplication missing |
-| encoding/xml shim | Marshal, Unmarshal, Encoder, Decoder, Token, struct tags | Strict-only, xmlns before regular attrs, InputOffset approximate, undeclared prefixes rejected |
+| encoding/xml shim | Marshal, Unmarshal, Encoder, Decoder, Token, struct tags | Strict-only, xmlns before regular attrs, InputOffset approximate, undeclared prefixes rejected, `version = "2.0"` (spaces around `=`) rejected where encoding/xml accepts it |
 | XSD range comparison | decimal/integer via big.Rat; float/double; date/time/g-types; duration partial order | Non-ordered primitives rejected for range facets; NaN ordinary value comparison remains indeterminate |
 | XSD validation mode | DOM-only | No SAX/streaming validation, no subtree validation |
 | Push parser | Incremental parsing in background goroutine from blocking push stream | Blocking on chunk boundaries; semantics differ from libxml2 push APIs |

--- a/shim/README.md
+++ b/shim/README.md
@@ -48,6 +48,9 @@ source: [examples/shim_marshal_example_test.go](https://github.com/lestrrat-go/h
 - `Decoder.Strict = false` is not supported.
 - `HTMLAutoClose` is omitted and `Decoder.AutoClose` is a no-op.
 - Undeclared namespace prefixes are rejected.
+- A declaration with whitespace around the version pseudo-attribute's `=`
+  (`<?xml version = "2.0"?>`) is rejected as an unsupported version;
+  `encoding/xml` accepts it.
 - Namespace declarations are emitted before regular attributes.
 - `InputOffset` is approximate rather than exact.
 - Empty elements in `,innerxml` may serialize as self-closed tags.

--- a/shim/doc.go
+++ b/shim/doc.go
@@ -25,6 +25,14 @@
 //   - Namespace strictness: undeclared namespace prefixes are rejected.
 //     [encoding/xml] silently accepts undeclared prefixes and places the
 //     raw prefix string in Name.Space.
+//   - Version strictness: a declaration carrying whitespace around the
+//     version pseudo-attribute's "=" (<?xml version = "2.0"?>) is rejected
+//     as an unsupported version. [encoding/xml] accepts it — it searches
+//     for the literal "version=", so a space before the "=" makes the scan
+//     miss the pseudo-attribute and read the document as declaring no
+//     version at all. XML 1.0 permits the whitespace (Eq ::= S? '=' S?),
+//     so the shim reads such a declaration and applies the same
+//     unsupported-version rule it applies without the spaces.
 //   - Attribute ordering: xmlns namespace declarations are emitted before
 //     regular attributes. Source-document attribute order is not preserved
 //     because the SAX parser delivers namespaces and attributes as


### PR DESCRIPTION
- `<?xml version = "2.0"?>` (spaces around `=`) is rejected by shim, accepted by `encoding/xml`.
- Cause is stdlib: `procInst` searches for the literal `version=`, so a space makes its scan miss the pseudo-attribute.
- Documents existing behavior in shim's Known Differences; no code change.
