### PR TITLE
propagate xslt3 serialization errors

### DIFF
--- a/document.go
+++ b/document.go
@@ -430,7 +430,10 @@ func (d *Document) CreateReference(name string) (*EntityRef, error) {
 // CreateAttribute builds an attribute node named name, with value parsed into
 // its child node list, and optional namespace ns. A colon in name is rejected;
 // supply a namespaced name through ns instead. name is not otherwise checked
-// against the XML Name/NCName grammar.
+// against the XML Name/NCName grammar. When d is non-nil the attribute is
+// drawn from the document's slab allocator and records d as its owner
+// document, so it must not outlive a call to Document.Free. A nil receiver
+// allocates a standalone attribute with no owning document.
 func (d *Document) CreateAttribute(name, value string, ns *Namespace) (attr *Attribute, err error) {
 	if strings.ContainsRune(name, ':') {
 		return nil, fmt.Errorf("attribute name %q contains a colon: use CreateAttribute with a local name and Namespace parameter", name)
@@ -501,6 +504,11 @@ func (d *Document) allocAttribute(name string, ns *Namespace) *Attribute {
 	attr.etype = AttributeNode
 	attr.name = name
 	attr.ns = ns
+	// Record the owning document, mirroring CreateElement/CreateText: a
+	// slab-backed attribute must report its owner so a cross-document move can
+	// mark the source document escaped (noteCrossDocumentEscape) and keep Free
+	// from recycling the chunk out from under the moved attribute.
+	attr.doc = d
 	return attr
 }
 

--- a/node_crossdoc_test.go
+++ b/node_crossdoc_test.go
@@ -57,14 +57,19 @@ func TestPlainParseDoesNotEscape(t *testing.T) {
 // land on B with its value, mark A as having escaped storage, and keep its
 // value after A.Free() recycles its slab chunks under allocation pressure. This
 // exercises the noteCrossDocumentEscape path for a property-list (attribute)
-// move, distinct from the child-list moves covered above.
+// move, distinct from the child-list moves covered above. The attribute is
+// built with a.CreateAttribute so both its struct and its value text are
+// slab-backed by A, and the churn below allocates through c.CreateAttribute so
+// the matching attribute/text slabs are actually redrawn from the pool — a
+// wrongly recycled chunk zeroes the moved attribute and fails the assertions.
 func TestCrossDocumentAttributeMoveViaAddChild(t *testing.T) {
 	a := NewDocument("1.0", "UTF-8", StandaloneImplicitNo)
 	aroot, err := a.CreateElement("aroot")
 	require.NoError(t, err)
 	require.NoError(t, a.AddChild(aroot))
-	require.NoError(t, aroot.SetAttribute("moved", "CROSSDOC-VALUE"))
-	attr := aroot.Attributes()[0]
+	attr, err := a.CreateAttribute("moved", "CROSSDOC-VALUE", nil)
+	require.NoError(t, err)
+	require.NoError(t, aroot.AddChild(attr))
 
 	b := NewDocument("1.0", "UTF-8", StandaloneImplicitNo)
 	broot, err := b.CreateElement("broot")
@@ -93,14 +98,17 @@ func TestCrossDocumentAttributeMoveViaAddChild(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, bout, `moved="CROSSDOC-VALUE"`, "doc B does not serialize the moved attribute")
 
-	// Slab-safety: free A, churn allocations in a fresh document to reuse any
-	// recycled chunks, then confirm the moved attribute's storage is intact.
+	// Slab-safety: free A, churn slab allocations (element, attribute, text,
+	// and text-content) in a fresh document to redraw any recycled chunks from
+	// the pool, then confirm the moved attribute's storage is intact.
 	a.Free()
 	c := NewDocument("1.0", "UTF-8", StandaloneImplicitNo)
 	for range 512 {
 		e, err := c.CreateElement("OVERWRITE")
 		require.NoError(t, err)
-		require.NoError(t, e.SetAttribute("k", "XXXXXXXXXXXXXXXX"))
+		ka, err := c.CreateAttribute("k", "XXXXXXXXXXXXXXXX", nil)
+		require.NoError(t, err)
+		require.NoError(t, e.AddChild(ka))
 	}
 
 	got2, ok := broot.GetAttribute("moved")

--- a/node_crossdoc_test.go
+++ b/node_crossdoc_test.go
@@ -51,6 +51,66 @@ func TestPlainParseDoesNotEscape(t *testing.T) {
 	require.False(t, doc.slabEscaped, "a plain single-document parse must not mark the document as escaped")
 }
 
+// TestCrossDocumentAttributeMoveViaAddChild covers a routed-attribute move
+// across documents: an element in document A owns an attribute, and an element
+// in document B adopts it via elem.AddChild(attr). The attribute must leave A,
+// land on B with its value, mark A as having escaped storage, and keep its
+// value after A.Free() recycles its slab chunks under allocation pressure. This
+// exercises the noteCrossDocumentEscape path for a property-list (attribute)
+// move, distinct from the child-list moves covered above.
+func TestCrossDocumentAttributeMoveViaAddChild(t *testing.T) {
+	a := NewDocument("1.0", "UTF-8", StandaloneImplicitNo)
+	aroot, err := a.CreateElement("aroot")
+	require.NoError(t, err)
+	require.NoError(t, a.AddChild(aroot))
+	require.NoError(t, aroot.SetAttribute("moved", "CROSSDOC-VALUE"))
+	attr := aroot.Attributes()[0]
+
+	b := NewDocument("1.0", "UTF-8", StandaloneImplicitNo)
+	broot, err := b.CreateElement("broot")
+	require.NoError(t, err)
+	require.NoError(t, b.AddChild(broot))
+
+	// The cross-document routed-attribute move under test.
+	require.NoError(t, broot.AddChild(attr))
+	require.True(t, a.slabEscaped, "moving an attribute into another document must mark the source escaped")
+
+	// Gone from the old owner.
+	_, ok := aroot.GetAttribute("moved")
+	require.False(t, ok, "attribute still reported by old owner GetAttribute")
+	require.Empty(t, aroot.Attributes(), "old owner still holds the moved attribute")
+
+	// Present on the new owner with the right value.
+	got, ok := broot.GetAttribute("moved")
+	require.True(t, ok, "attribute not reachable on new owner")
+	require.Equal(t, "CROSSDOC-VALUE", got)
+
+	// Both documents serialize correctly.
+	aout, err := WriteString(a)
+	require.NoError(t, err)
+	require.NotContains(t, aout, "moved", "doc A still serializes the moved attribute")
+	bout, err := WriteString(b)
+	require.NoError(t, err)
+	require.Contains(t, bout, `moved="CROSSDOC-VALUE"`, "doc B does not serialize the moved attribute")
+
+	// Slab-safety: free A, churn allocations in a fresh document to reuse any
+	// recycled chunks, then confirm the moved attribute's storage is intact.
+	a.Free()
+	c := NewDocument("1.0", "UTF-8", StandaloneImplicitNo)
+	for range 512 {
+		e, err := c.CreateElement("OVERWRITE")
+		require.NoError(t, err)
+		require.NoError(t, e.SetAttribute("k", "XXXXXXXXXXXXXXXX"))
+	}
+
+	got2, ok := broot.GetAttribute("moved")
+	require.True(t, ok, "attribute lost after A.Free()+churn; slab storage was recycled")
+	require.Equal(t, "CROSSDOC-VALUE", got2, "attribute value overwritten by reused slab storage")
+	bout2, err := WriteString(b)
+	require.NoError(t, err)
+	require.Contains(t, bout2, `moved="CROSSDOC-VALUE"`, "doc B post-Free serialization lost the attribute")
+}
+
 // TestSameDocumentMoveDoesNotEscape moving a node within one document is not a
 // cross-document escape, so the flag stays clear and Free keeps recycling.
 func TestSameDocumentMoveDoesNotEscape(t *testing.T) {

--- a/xslt3/execute_trycatch.go
+++ b/xslt3/execute_trycatch.go
@@ -22,7 +22,12 @@ func (ec *execContext) execMessage(ctx context.Context, inst *messageInst) error
 			value = err.Error()
 		} else {
 			bodySeq = xpath3.ItemSlice(sequence.Materialize(result.Sequence()))
-			value = serializeMessageSequence(bodySeq)
+			s, serr := serializeMessageSequence(bodySeq)
+			if serr != nil {
+				return dynamicErrorCause(errCodeSERE0006, serr,
+					"xsl:message content could not be serialized: %s", serr)
+			}
+			value = s
 		}
 	}
 	if len(inst.Body) > 0 {
@@ -45,7 +50,12 @@ func (ec *execContext) execMessage(ctx context.Context, inst *messageInst) error
 			value += err.Error()
 		} else {
 			bodySeq = append(bodySeq, sequence.Materialize(val)...)
-			value += serializeMessageSequence(val)
+			s, serr := serializeMessageSequence(val)
+			if serr != nil {
+				return dynamicErrorCause(errCodeSERE0006, serr,
+					"xsl:message content could not be serialized: %s", serr)
+			}
+			value += s
 		}
 	}
 
@@ -96,9 +106,9 @@ func (ec *execContext) execMessage(ctx context.Context, inst *messageInst) error
 // xsl:message output. Node items (elements, documents) are serialized as
 // XML so that the message preserves markup structure. Atomic values are
 // converted to their string representations and joined with spaces.
-func serializeMessageSequence(seq xpath3.Sequence) string {
+func serializeMessageSequence(seq xpath3.Sequence) (string, error) {
 	if seq == nil || sequence.Len(seq) == 0 {
-		return ""
+		return "", nil
 	}
 	var sb strings.Builder
 	prevWasAtomic := false
@@ -125,9 +135,13 @@ func serializeMessageSequence(seq xpath3.Sequence) string {
 		var buf bytes.Buffer
 		switch n := ni.Node.(type) {
 		case *helium.Document:
-			_ = helium.NewWriter().XMLDeclaration(false).WriteTo(&buf, n)
+			if err := helium.NewWriter().XMLDeclaration(false).WriteTo(&buf, n); err != nil {
+				return "", err
+			}
 		case *helium.Element:
-			_ = helium.Write(&buf, n)
+			if err := helium.Write(&buf, n); err != nil {
+				return "", err
+			}
 		case *helium.Comment:
 			// Serialize comments as XML so they roundtrip properly
 			buf.WriteString("<!--")
@@ -148,7 +162,7 @@ func serializeMessageSequence(seq xpath3.Sequence) string {
 		}
 		sb.WriteString(strings.TrimSpace(buf.String()))
 	}
-	return sb.String()
+	return sb.String(), nil
 }
 
 func (ec *execContext) execTryCatch(ctx context.Context, inst *tryCatchInst) error {

--- a/xslt3/output.go
+++ b/xslt3/output.go
@@ -332,7 +332,7 @@ func serializeResult(w io.Writer, doc *helium.Document, outDef *OutputDef, charM
 // output. htmlVersion carries the effective html-version serialization
 // parameter (empty when unset) so nested html/xhtml serialization observes the
 // same version as the principal output, e.g. HTML 4.01 minimization rules.
-func serializeNodeWithMethod(node helium.Node, method, htmlVersion string) string {
+func serializeNodeWithMethod(node helium.Node, method, htmlVersion string) (string, error) {
 	var buf bytes.Buffer
 	switch method {
 	case methodHTML:
@@ -341,30 +341,36 @@ func serializeNodeWithMethod(node helium.Node, method, htmlVersion string) strin
 		outDef.Method = methodHTML
 		outDef.OmitDeclaration = true
 		outDef.HTMLVersion = htmlVersion
-		_ = serializeHTML(&buf, doc, outDef)
+		if err := serializeHTML(&buf, doc, outDef); err != nil {
+			return "", err
+		}
 		s := buf.String()
 		// If we wrapped the node in <html>, strip the wrapper tags
 		if elem, ok := node.(*helium.Element); ok && !strings.EqualFold(elem.LocalName(), "html") {
 			s = strings.TrimPrefix(s, "<html>")
 			s = strings.TrimSuffix(s, "</html>")
 		}
-		return s
+		return s, nil
 	case methodXHTML:
 		doc := wrapNodeInDoc(node)
 		outDef := defaultOutputDef()
 		outDef.Method = methodXHTML
-		_ = serializeXHTML(&buf, doc, outDef, nil)
-		return buf.String()
+		if err := serializeXHTML(&buf, doc, outDef, nil); err != nil {
+			return "", err
+		}
+		return buf.String(), nil
 	case methodText:
-		return nodeStringValue(node)
+		return nodeStringValue(node), nil
 	default: // "xml" or empty
 		switch node.(type) {
 		case *helium.Element, *helium.Document:
-			_ = helium.NewWriter().XMLDeclaration(false).WriteTo(&buf, node)
+			if err := helium.NewWriter().XMLDeclaration(false).WriteTo(&buf, node); err != nil {
+				return "", err
+			}
 		default:
 			buf.Write(node.Content())
 		}
-		return buf.String()
+		return buf.String(), nil
 	}
 }
 

--- a/xslt3/output_json.go
+++ b/xslt3/output_json.go
@@ -61,7 +61,11 @@ func serializeItemJSON(item xpath3.Item, outDef *OutputDef) (string, error) {
 			if outDef != nil {
 				htmlVersion = outDef.HTMLVersion
 			}
-			return jsonEscapeString(serializeNodeWithMethod(v.Node, nodeMethod, htmlVersion)), nil
+			s, err := serializeNodeWithMethod(v.Node, nodeMethod, htmlVersion)
+			if err != nil {
+				return "", err
+			}
+			return jsonEscapeString(s), nil
 		}
 		return jsonEscapeString(nodeStringValue(v.Node)), nil
 	case xpath3.AtomicValue:

--- a/xslt3/output_serialize_error_test.go
+++ b/xslt3/output_serialize_error_test.go
@@ -1,0 +1,69 @@
+package xslt3
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xpath3"
+	"github.com/stretchr/testify/require"
+)
+
+// invalidNameElement builds an element whose name is not a well-formed XML
+// name. CreateElement accepts it, but the writer rejects it at emit time with
+// ErrWriterInvalidElementName, giving a node whose serialization must fail.
+func invalidNameElement(t *testing.T) *helium.Element {
+	t.Helper()
+	doc := helium.NewDefaultDocument()
+	el, err := doc.CreateElement(`bad name="x"`)
+	require.NoError(t, err)
+	require.NoError(t, doc.SetDocumentElement(el))
+	return el
+}
+
+// serializeNodeWithMethod must surface a serialization failure rather than
+// discard it. Each output method whose branch drives a serializer (html, xhtml,
+// and the default xml path) must return the serializer's error for an
+// unserializable node. The xhtml and xml paths run the core writer, whose
+// failure is the matchable ErrWriterInvalidElementName sentinel; the html path
+// uses the html serializer, which reports its own (unmatched) error.
+func TestSerializeNodeWithMethodPropagatesWriterError(t *testing.T) {
+	for _, tc := range []struct {
+		method       string
+		writerBacked bool
+	}{
+		{methodHTML, false},
+		{methodXHTML, true},
+		{"xml", true},
+		{"", true},
+	} {
+		t.Run(tc.method, func(t *testing.T) {
+			el := invalidNameElement(t)
+			_, err := serializeNodeWithMethod(el, tc.method, "")
+			require.Error(t, err, "serializeNodeWithMethod must not discard the serializer error")
+			if tc.writerBacked {
+				require.ErrorIs(t, err, helium.ErrWriterInvalidElementName)
+			}
+		})
+	}
+}
+
+// The json-node-output-method path routes a node through serializeNodeWithMethod;
+// a serialization failure there must propagate out of serializeItemJSON instead
+// of yielding a silently truncated JSON string.
+func TestSerializeItemJSONPropagatesNodeSerializationError(t *testing.T) {
+	el := invalidNameElement(t)
+	outDef := &OutputDef{JSONNodeOutputMethod: methodXHTML}
+	_, err := serializeItemJSON(xpath3.NodeItem{Node: el}, outDef)
+	require.Error(t, err, "serializeItemJSON must surface the node serialization error")
+	require.ErrorIs(t, err, helium.ErrWriterInvalidElementName)
+}
+
+// serializeMessageSequence backs xsl:message rendering; an unserializable node
+// in the message body must return the writer error so execMessage can raise a
+// dynamic error instead of reporting silent success.
+func TestSerializeMessageSequencePropagatesWriterError(t *testing.T) {
+	el := invalidNameElement(t)
+	_, err := serializeMessageSequence(xpath3.ItemSlice{xpath3.NodeItem{Node: el}})
+	require.Error(t, err, "serializeMessageSequence must not discard the writer error")
+	require.ErrorIs(t, err, helium.ErrWriterInvalidElementName)
+}


### PR DESCRIPTION
- serializeNodeWithMethod and the json-node output path now return serializer errors instead of discarding them
- xsl:message body serialization failure now raises an SERE0006 dynamic error, not silent success
- add a root-package cross-document routed-attribute move regression test (survives source Free + slab churn)
