### PR TITLE
propagate writer errors through xslt3 output

### DIFF
--- a/xslt3/execute_transform.go
+++ b/xslt3/execute_transform.go
@@ -786,11 +786,15 @@ func executeTransform(ctx context.Context, source *helium.Document, ss *Styleshe
 		if outDef == nil {
 			outDef = ss.outputs[""] // fallback to default
 		}
-		if err := SerializeItems(&buf, items, doc, outDef); err == nil {
-			text := doc.CreateText([]byte(buf.String()))
-			if text != nil {
-				_ = doc.AddChild(text)
-			}
+		// A serialization failure (e.g. SERE0006 for a character invalid in the
+		// target XML version) must surface as a transform error, not a silently
+		// empty secondary document.
+		if err := SerializeItems(&buf, items, doc, outDef); err != nil {
+			return nil, err
+		}
+		text := doc.CreateText([]byte(buf.String()))
+		if text != nil {
+			_ = doc.AddChild(text)
 		}
 	}
 

--- a/xslt3/output.go
+++ b/xslt3/output.go
@@ -111,10 +111,9 @@ func SerializeItems(w io.Writer, items xpath3.Sequence, doc *helium.Document, ou
 		}
 		return serializeJSONItems(w, items, doc, outDef)
 	case methodAdaptive:
-		// Adaptive serialization embeds element/document nodes via the XML method,
-		// which inherits the version serialization parameter, so a valid XML
-		// version (e.g. "1.1") flows into the nested writer; html-style versions
-		// never reach here (adaptive Version is an XML VersionNum).
+		// Adaptive serialization uses its version serialization parameter for every
+		// XML fallback and embedded element/document writer. An absent version uses
+		// the XML 1.0 default; html-style versions never reach here.
 		return serializeAdaptiveItems(w, items, doc, outDef.ItemSeparator, validOutputXMLVersion(outDef.Version), outDef.ResolvedCharMap)
 	default:
 		if items != nil && sequence.Len(items) > 0 {

--- a/xslt3/output.go
+++ b/xslt3/output.go
@@ -91,6 +91,10 @@ func (out *outputFrame) captureSequenceItems(items xpath3.ItemSlice) {
 // SerializeItems writes a sequence of items (maps, arrays, atomics, nodes)
 // using the specified output definition's method (json or adaptive).
 // This is used for result-documents with method="json" or method="adaptive".
+// An element or document node item carrying a character invalid for the target
+// XML version fails with the serialization error SERE0006 rather than emitting
+// truncated output. Other item kinds (text/comment/PI nodes and atomics) are not
+// yet range-checked and emit their content unmodified.
 func SerializeItems(w io.Writer, items xpath3.Sequence, doc *helium.Document, outDef *OutputDef) error {
 	if outDef == nil {
 		outDef = defaultOutputDef()
@@ -107,7 +111,11 @@ func SerializeItems(w io.Writer, items xpath3.Sequence, doc *helium.Document, ou
 		}
 		return serializeJSONItems(w, items, doc, outDef)
 	case methodAdaptive:
-		return serializeAdaptiveItems(w, items, doc, outDef.ItemSeparator, outDef.ResolvedCharMap)
+		// Adaptive serialization embeds element/document nodes via the XML method,
+		// which inherits the version serialization parameter, so a valid XML
+		// version (e.g. "1.1") flows into the nested writer; html-style versions
+		// never reach here (adaptive Version is an XML VersionNum).
+		return serializeAdaptiveItems(w, items, doc, outDef.ItemSeparator, validOutputXMLVersion(outDef.Version), outDef.ResolvedCharMap)
 	default:
 		if items != nil && sequence.Len(items) > 0 {
 			return serializeItemsWithSeparator(w, items, doc, outDef)
@@ -137,7 +145,21 @@ func serializeItemsWithSeparator(w io.Writer, items xpath3.Sequence, _ *helium.D
 			var buf bytes.Buffer
 			switch v.Node.(type) {
 			case *helium.Element, *helium.Document:
-				_ = helium.NewWriter().XMLDeclaration(false).WriteTo(&buf, v.Node)
+				writer := helium.NewWriter().XMLDeclaration(false)
+				// The xml output method's version parameter drives the writer's
+				// XML 1.0/1.1 validity rules: under v1.1, U+0001 is a legal
+				// character reference, so a bare (1.0-only) writer would wrongly
+				// reject it with SERE0006. The default branch also serves
+				// html/xhtml/text, whose Version is not an XML VersionNum, so gate
+				// on the xml method with a valid XML version.
+				if outDef.Method == methodXML {
+					if ver := validOutputXMLVersion(outDef.Version); ver != "" {
+						writer = writer.OutputVersion(ver)
+					}
+				}
+				if err := writer.WriteTo(&buf, v.Node); err != nil {
+					return xmlInvalidCharError(err)
+				}
 			default:
 				if v.Node.Type() == helium.CommentNode {
 					buf.WriteString("<!--")
@@ -172,6 +194,32 @@ func serializeItemsWithSeparator(w io.Writer, items xpath3.Sequence, _ *helium.D
 		idx++
 	}
 	return nil
+}
+
+// validOutputXMLVersion returns v when it is a valid XML VersionNum suitable for
+// the writer's OutputVersion override, or "" otherwise. The html/xhtml output
+// methods carry a non-XML Version (e.g. "4.01"), which must never reach
+// OutputVersion (it would fail serialization with ErrInvalidOutputVersion).
+func validOutputXMLVersion(v string) string {
+	if isValidOutputXMLVersion(v) {
+		return v
+	}
+	return ""
+}
+
+// isValidOutputXMLVersion reports whether v is a valid XML VersionNum
+// ("1." followed by one or more digits, XML §2.8).
+func isValidOutputXMLVersion(v string) bool {
+	rest, ok := strings.CutPrefix(v, "1.")
+	if !ok || rest == "" {
+		return false
+	}
+	for i := range len(rest) {
+		if rest[i] < '0' || rest[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // SerializeResult writes the result document to a writer according to the
@@ -293,7 +341,7 @@ func serializeResult(w io.Writer, doc *helium.Document, outDef *OutputDef, charM
 		}
 		_, err = io.WriteString(target, applyCharMapJSON(jsonBuf.String(), serCharMap))
 	case methodAdaptive:
-		err = serializeAdaptiveItems(target, nil, doc, outDef.ItemSeparator, serCharMap)
+		err = serializeAdaptiveItems(target, nil, doc, outDef.ItemSeparator, validOutputXMLVersion(outDef.Version), serCharMap)
 	default:
 		err = serializeXML(target, doc, outDef, serCharMap)
 	}
@@ -356,7 +404,7 @@ func serializeNodeWithMethod(node helium.Node, method, htmlVersion string) (stri
 		outDef := defaultOutputDef()
 		outDef.Method = methodXHTML
 		if err := serializeXHTML(&buf, doc, outDef, nil); err != nil {
-			return "", err
+			return "", xmlInvalidCharError(err)
 		}
 		return buf.String(), nil
 	case methodText:
@@ -365,7 +413,7 @@ func serializeNodeWithMethod(node helium.Node, method, htmlVersion string) (stri
 		switch node.(type) {
 		case *helium.Element, *helium.Document:
 			if err := helium.NewWriter().XMLDeclaration(false).WriteTo(&buf, node); err != nil {
-				return "", err
+				return "", xmlInvalidCharError(err)
 			}
 		default:
 			buf.Write(node.Content())

--- a/xslt3/output.go
+++ b/xslt3/output.go
@@ -146,13 +146,12 @@ func serializeItemsWithSeparator(w io.Writer, items xpath3.Sequence, _ *helium.D
 			switch v.Node.(type) {
 			case *helium.Element, *helium.Document:
 				writer := helium.NewWriter().XMLDeclaration(false)
-				// The xml output method's version parameter drives the writer's
-				// XML 1.0/1.1 validity rules: under v1.1, U+0001 is a legal
-				// character reference, so a bare (1.0-only) writer would wrongly
-				// reject it with SERE0006. The default branch also serves
-				// html/xhtml/text, whose Version is not an XML VersionNum, so gate
-				// on the xml method with a valid XML version.
-				if outDef.Method == methodXML {
+				// The XML and XHTML output methods use their version parameter for
+				// the writer's XML 1.0/1.1 validity rules. Under XML 1.1, U+0001
+				// is a legal character reference, so a default writer would wrongly
+				// reject it with SERE0006. The HTML method uses an HTML version and
+				// must not pass it to OutputVersion.
+				if outDef.Method == methodXML || outDef.Method == methodXHTML {
 					if ver := validOutputXMLVersion(outDef.Version); ver != "" {
 						writer = writer.OutputVersion(ver)
 					}

--- a/xslt3/output_adaptive.go
+++ b/xslt3/output_adaptive.go
@@ -12,7 +12,7 @@ import (
 
 // serializeAdaptiveItems serializes a sequence of items using the adaptive
 // serialization method. Each item is serialized according to its type.
-func serializeAdaptiveItems(w io.Writer, items xpath3.Sequence, doc *helium.Document, itemSep *string, charMaps ...map[rune]string) error {
+func serializeAdaptiveItems(w io.Writer, items xpath3.Sequence, doc *helium.Document, itemSep *string, xmlVersion string, charMaps ...map[rune]string) error {
 	if (items == nil || sequence.Len(items) == 0) && doc != nil {
 		var cm map[rune]string
 		if len(charMaps) > 0 {
@@ -57,7 +57,10 @@ func serializeAdaptiveItems(w io.Writer, items xpath3.Sequence, doc *helium.Docu
 				}
 			}
 		}
-		s := serializeItemAdaptive(item, cm)
+		s, err := serializeItemAdaptive(item, xmlVersion, cm)
+		if err != nil {
+			return err
+		}
 		if _, err := io.WriteString(w, s); err != nil {
 			return err
 		}
@@ -101,7 +104,11 @@ func isAdaptiveQuotedType(typeName string) bool {
 }
 
 // serializeItemAdaptive serializes a single item using the adaptive method.
-func serializeItemAdaptive(item xpath3.Item, charMap map[rune]string) string {
+// xmlVersion is the effective xml-method version (a valid XML VersionNum, or ""
+// for the 1.0 default) applied when embedding element/document nodes, so a v1.1
+// sequence emits U+0001 as a legal character reference instead of a wrongful
+// SERE0006.
+func serializeItemAdaptive(item xpath3.Item, xmlVersion string, charMap map[rune]string) (string, error) {
 	maybeApply := func(s string) string {
 		if len(charMap) > 0 {
 			return applyCharMap(s, charMap)
@@ -110,14 +117,20 @@ func serializeItemAdaptive(item xpath3.Item, charMap map[rune]string) string {
 	}
 	switch v := item.(type) {
 	case xpath3.MapItem:
-		return serializeMapAdaptive(v, charMap)
+		return serializeMapAdaptive(v, xmlVersion, charMap)
 	case xpath3.ArrayItem:
-		return serializeArrayAdaptive(v, charMap)
+		return serializeArrayAdaptive(v, xmlVersion, charMap)
 	case xpath3.NodeItem:
 		var buf bytes.Buffer
 		switch v.Node.(type) {
 		case *helium.Element, *helium.Document:
-			_ = helium.NewWriter().XMLDeclaration(false).WriteTo(&buf, v.Node)
+			writer := helium.NewWriter().XMLDeclaration(false)
+			if xmlVersion != "" {
+				writer = writer.OutputVersion(xmlVersion)
+			}
+			if err := writer.WriteTo(&buf, v.Node); err != nil {
+				return "", xmlInvalidCharError(err)
+			}
 		case *helium.Attribute:
 			attr, _ := helium.AsNode[*helium.Attribute](v.Node)
 			buf.WriteString(attr.Name())
@@ -127,33 +140,37 @@ func serializeItemAdaptive(item xpath3.Item, charMap map[rune]string) string {
 		default:
 			buf.Write(v.Node.Content())
 		}
-		return maybeApply(buf.String())
+		return maybeApply(buf.String()), nil
 	case xpath3.AtomicValue:
 		s, _ := xpath3.AtomicToString(v)
 		s = maybeApply(s)
 		if isAdaptiveQuotedType(v.TypeName) {
-			return adaptiveQuoteString(s)
+			return adaptiveQuoteString(s), nil
 		}
-		return s
+		return s, nil
 	default:
 		if av, ok := item.(xpath3.AtomicValue); ok {
 			s, _ := xpath3.AtomicToString(av)
 			s = maybeApply(s)
 			if isAdaptiveQuotedType(av.TypeName) {
-				return adaptiveQuoteString(s)
+				return adaptiveQuoteString(s), nil
 			}
-			return s
+			return s, nil
 		}
-		return fmt.Sprintf("%v", item)
+		return fmt.Sprintf("%v", item), nil
 	}
 }
 
 // serializeMapAdaptive serializes a map using adaptive serialization.
-func serializeMapAdaptive(m xpath3.MapItem, charMap map[rune]string) string {
+func serializeMapAdaptive(m xpath3.MapItem, xmlVersion string, charMap map[rune]string) (string, error) {
 	var buf bytes.Buffer
 	buf.WriteString("map{")
 	first := true
+	var serErr error
 	_ = m.ForEach(func(k xpath3.AtomicValue, v xpath3.Sequence) error {
+		if serErr != nil {
+			return serErr
+		}
 		if !first {
 			buf.WriteByte(',')
 		}
@@ -167,7 +184,12 @@ func serializeMapAdaptive(m xpath3.MapItem, charMap map[rune]string) string {
 		}
 		switch vLen2 {
 		case 1:
-			buf.WriteString(serializeItemAdaptive(v.Get(0), charMap))
+			s, err := serializeItemAdaptive(v.Get(0), xmlVersion, charMap)
+			if err != nil {
+				serErr = err
+				return err
+			}
+			buf.WriteString(s)
 		case 0:
 			buf.WriteString("()")
 		default:
@@ -176,18 +198,26 @@ func serializeMapAdaptive(m xpath3.MapItem, charMap map[rune]string) string {
 				if i > 0 {
 					buf.WriteByte(',')
 				}
-				buf.WriteString(serializeItemAdaptive(v.Get(i), charMap))
+				s, err := serializeItemAdaptive(v.Get(i), xmlVersion, charMap)
+				if err != nil {
+					serErr = err
+					return err
+				}
+				buf.WriteString(s)
 			}
 			buf.WriteByte(')')
 		}
 		return nil
 	})
+	if serErr != nil {
+		return "", serErr
+	}
 	buf.WriteByte('}')
-	return buf.String()
+	return buf.String(), nil
 }
 
 // serializeArrayAdaptive serializes an array using adaptive serialization.
-func serializeArrayAdaptive(a xpath3.ArrayItem, charMap map[rune]string) string {
+func serializeArrayAdaptive(a xpath3.ArrayItem, xmlVersion string, charMap map[rune]string) (string, error) {
 	var buf bytes.Buffer
 	buf.WriteByte('[')
 	members := a.Members()
@@ -201,7 +231,11 @@ func serializeArrayAdaptive(a xpath3.ArrayItem, charMap map[rune]string) string 
 		}
 		switch mLen2 {
 		case 1:
-			buf.WriteString(serializeItemAdaptive(member.Get(0), charMap))
+			s, err := serializeItemAdaptive(member.Get(0), xmlVersion, charMap)
+			if err != nil {
+				return "", err
+			}
+			buf.WriteString(s)
 		case 0:
 			buf.WriteString("()")
 		default:
@@ -210,11 +244,15 @@ func serializeArrayAdaptive(a xpath3.ArrayItem, charMap map[rune]string) string 
 				if j > 0 {
 					buf.WriteByte(',')
 				}
-				buf.WriteString(serializeItemAdaptive(member.Get(j), charMap))
+				s, err := serializeItemAdaptive(member.Get(j), xmlVersion, charMap)
+				if err != nil {
+					return "", err
+				}
+				buf.WriteString(s)
 			}
 			buf.WriteByte(')')
 		}
 	}
 	buf.WriteByte(']')
-	return buf.String()
+	return buf.String(), nil
 }

--- a/xslt3/output_adaptive.go
+++ b/xslt3/output_adaptive.go
@@ -18,7 +18,9 @@ func serializeAdaptiveItems(w io.Writer, items xpath3.Sequence, doc *helium.Docu
 		if len(charMaps) > 0 {
 			cm = charMaps[0]
 		}
-		return serializeXML(w, doc, defaultOutputDef(), cm)
+		xmlOutDef := defaultOutputDef()
+		xmlOutDef.Version = adaptiveXMLVersion(xmlVersion)
+		return serializeXML(w, doc, xmlOutDef, cm)
 	}
 	var cm map[rune]string
 	if len(charMaps) > 0 {
@@ -50,6 +52,7 @@ func serializeAdaptiveItems(w io.Writer, items xpath3.Sequence, doc *helium.Docu
 						_ = tmpDoc.AddChild(clone)
 					}
 					xmlOutDef := defaultOutputDef()
+					xmlOutDef.Version = adaptiveXMLVersion(xmlVersion)
 					if err := serializeXML(w, tmpDoc, xmlOutDef, cm); err != nil {
 						return err
 					}
@@ -67,6 +70,16 @@ func serializeAdaptiveItems(w io.Writer, items xpath3.Sequence, doc *helium.Docu
 		adaptIdx++
 	}
 	return nil
+}
+
+// adaptiveXMLVersion returns the XML version used whenever adaptive output
+// delegates an element or document item to XML serialization. xmlVersion was
+// validated by validOutputXMLVersion; an absent value uses the XML 1.0 default.
+func adaptiveXMLVersion(xmlVersion string) string {
+	if xmlVersion != "" {
+		return xmlVersion
+	}
+	return defaultOutputDef().Version
 }
 
 // adaptiveQuoteString wraps a string in double quotes for adaptive output.
@@ -104,10 +117,9 @@ func isAdaptiveQuotedType(typeName string) bool {
 }
 
 // serializeItemAdaptive serializes a single item using the adaptive method.
-// xmlVersion is the effective xml-method version (a valid XML VersionNum, or ""
-// for the 1.0 default) applied when embedding element/document nodes, so a v1.1
-// sequence emits U+0001 as a legal character reference instead of a wrongful
-// SERE0006.
+// xmlVersion is the validated xml-method version. Every element and document
+// item uses adaptiveXMLVersion, so the XML 1.0 default does not inherit a
+// document's own version.
 func serializeItemAdaptive(item xpath3.Item, xmlVersion string, charMap map[rune]string) (string, error) {
 	maybeApply := func(s string) string {
 		if len(charMap) > 0 {
@@ -124,10 +136,7 @@ func serializeItemAdaptive(item xpath3.Item, xmlVersion string, charMap map[rune
 		var buf bytes.Buffer
 		switch v.Node.(type) {
 		case *helium.Element, *helium.Document:
-			writer := helium.NewWriter().XMLDeclaration(false)
-			if xmlVersion != "" {
-				writer = writer.OutputVersion(xmlVersion)
-			}
+			writer := helium.NewWriter().XMLDeclaration(false).OutputVersion(adaptiveXMLVersion(xmlVersion))
 			if err := writer.WriteTo(&buf, v.Node); err != nil {
 				return "", xmlInvalidCharError(err)
 			}

--- a/xslt3/output_json.go
+++ b/xslt3/output_json.go
@@ -19,7 +19,7 @@ func serializeJSONItems(w io.Writer, items xpath3.Sequence, doc *helium.Document
 	}
 	if itemsLen == 0 && doc != nil {
 		// No captured items: serialize DOM content as text for JSON
-		return serializeAdaptiveItems(w, items, doc, nil)
+		return serializeAdaptiveItems(w, items, doc, nil, "")
 	}
 	if itemsLen == 1 {
 		s, err := serializeItemJSON(items.Get(0), outDef)

--- a/xslt3/output_xml.go
+++ b/xslt3/output_xml.go
@@ -49,7 +49,12 @@ func serializeXML(w io.Writer, doc *helium.Document, outDef *OutputDef, charMap 
 	// This path only handles XML 1.0-family output (needsXML11 is false above),
 	// so a character invalid in XML 1.0 is a SERE0006 serialization error. The
 	// check is folded into the writer's existing escape pass (no extra traversal).
+	// Apply a valid output definition version so XML 1.0 overrides a document's
+	// own version on this direct writer path.
 	writer := helium.NewWriter().EscapeNonASCII(false).RejectInvalidChars(true)
+	if version := validOutputXMLVersion(outDef.Version); version != "" {
+		writer = writer.OutputVersion(version)
+	}
 	if outDef.Indent {
 		writer = writer.Format(true)
 	}

--- a/xslt3/resultdoc_transaction_test.go
+++ b/xslt3/resultdoc_transaction_test.go
@@ -101,6 +101,32 @@ func TestResultDocumentSecondaryValidationFailRollbackTryCatch(t *testing.T) {
 	require.Equal(t, 1, childCount, "the catch's document must contain only <good/>")
 }
 
+// A secondary xsl:result-document with an item-serialization method (adaptive)
+// stages its element items into resultDocItems and serializes them in the
+// end-of-transform materialization loop. When that serialization fails — here a
+// two-element sequence whose text carries U+0001, an XML-invalid character — the
+// error MUST surface from the transform rather than being swallowed into a
+// silently empty secondary document.
+func TestResultDocumentSecondarySerializationErrorSurfaces(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:variable name="e" as="element()">
+      <r><xsl:value-of select="codepoints-to-string(1)"/></r>
+    </xsl:variable>
+    <xsl:result-document href="out.txt" method="adaptive">
+      <xsl:sequence select="($e, $e)"/>
+    </xsl:result-document>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	collector := &resultDocCollect{docs: map[string]*helium.Document{}}
+	_, err := ss.Transform(parseTransformSource(t)).
+		ResultDocumentHandler(collector).
+		Do(t.Context())
+	requireSERE0006(t, err)
+}
+
 type resultDocCollect struct {
 	docs map[string]*helium.Document
 }

--- a/xslt3/serialize_test.go
+++ b/xslt3/serialize_test.go
@@ -103,6 +103,10 @@ func TestDefaultOutputDefNilStylesheet(t *testing.T) {
 // tests do not add repeated string literals (goconst).
 const outMethodXML = "xml"
 
+// outMethodXHTML is the XHTML output method. Its version parameter uses an XML
+// VersionNum, just like the XML output method's version parameter.
+const outMethodXHTML = "xhtml"
+
 // newBadCharElement builds a small <r> element whose text content carries an
 // XML-invalid control character (U+0001), via the public DOM API. The DOM
 // accepts the control byte; the writer is the enforcement point.
@@ -159,6 +163,27 @@ func TestSerializeItemsXMLInvalidChar(t *testing.T) {
 	requireControlCharRef(t, buf11.String())
 }
 
+// SerializeItems with method="xhtml" passes its XML version to the per-item
+// writer. Under XML 1.1, U+0001 is a legal character reference; the default
+// and XML 1.0 versions reject it as SERE0006.
+func TestSerializeItemsXHTMLInvalidChar(t *testing.T) {
+	root := newBadCharElement(t)
+	items := xpath3.ItemSlice{xpath3.NodeItem{Node: root}}
+
+	var buf bytes.Buffer
+	err := xslt3.SerializeItems(&buf, items, nil, &xslt3.OutputDef{Method: outMethodXHTML})
+	requireSERE0006(t, err)
+
+	var buf10 bytes.Buffer
+	err = xslt3.SerializeItems(&buf10, items, nil, &xslt3.OutputDef{Method: outMethodXHTML, Version: "1.0"})
+	requireSERE0006(t, err)
+
+	var buf11 bytes.Buffer
+	err = xslt3.SerializeItems(&buf11, items, nil, &xslt3.OutputDef{Method: outMethodXHTML, Version: "1.1"})
+	require.NoError(t, err)
+	requireControlCharRef(t, buf11.String())
+}
+
 // SerializeItems with method="json" and json-node-output-method="xml" must
 // propagate the writer's invalid-char rejection as SERE0006.
 func TestSerializeItemsJSONNodeXMLInvalidChar(t *testing.T) {
@@ -167,6 +192,34 @@ func TestSerializeItemsJSONNodeXMLInvalidChar(t *testing.T) {
 	var buf bytes.Buffer
 	err := xslt3.SerializeItems(&buf, items, nil, &xslt3.OutputDef{Method: "json", JSONNodeOutputMethod: outMethodXML})
 	requireSERE0006(t, err)
+}
+
+// messageRecordingHandler records each xsl:message delivered to it.
+type messageRecordingHandler struct {
+	messages []string
+}
+
+func (h *messageRecordingHandler) HandleMessage(msg string, _ bool) error {
+	h.messages = append(h.messages, msg)
+	return nil
+}
+
+// xsl:message must report a node serialization failure as SERE0006 and avoid
+// delivering a partial message to its handler.
+func TestMessageInvalidCharSERE0006(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <xsl:message select="/*"/>
+    <out/>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	root := newBadCharElement(t)
+	handler := &messageRecordingHandler{}
+	_, err := ss.Transform(root.OwnerDocument()).MessageHandler(handler).Do(t.Context())
+	requireSERE0006(t, err)
+	require.Empty(t, handler.messages)
 }
 
 // SerializeItems with method="adaptive" over a multi-item sequence containing a

--- a/xslt3/serialize_test.go
+++ b/xslt3/serialize_test.go
@@ -98,3 +98,96 @@ func TestDefaultOutputDefNilStylesheet(t *testing.T) {
 	outDef := ss.DefaultOutputDef()
 	require.Nil(t, outDef)
 }
+
+// outMethodXML is the "xml" output method, held as a const so these invalid-char
+// tests do not add repeated string literals (goconst).
+const outMethodXML = "xml"
+
+// newBadCharElement builds a small <r> element whose text content carries an
+// XML-invalid control character (U+0001), via the public DOM API. The DOM
+// accepts the control byte; the writer is the enforcement point.
+func newBadCharElement(t *testing.T) *helium.Element {
+	t.Helper()
+	doc := helium.NewDefaultDocument()
+	root, err := doc.CreateElement("r")
+	require.NoError(t, err)
+	require.NoError(t, doc.AddChild(root))
+	require.NoError(t, root.AddChild(doc.CreateText([]byte("a\x01b"))))
+	return root
+}
+
+// requireSERE0006 asserts err is the XSLT serialization error SERE0006 that the
+// serializer raises when the writer rejects an XML-invalid character.
+func requireSERE0006(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var xe *xslt3.XSLTError
+	require.ErrorAs(t, err, &xe)
+	require.Equal(t, "SERE0006", xe.Code)
+}
+
+// requireControlCharRef asserts the serialized output carries a character
+// reference to U+0001 (decimal or hex form) around the surrounding text, i.e.
+// XML 1.1 char-referenced the restricted control instead of rejecting it.
+func requireControlCharRef(t *testing.T, out string) {
+	t.Helper()
+	hasRef := strings.Contains(out, "&#1;") || strings.Contains(out, "&#x1;")
+	require.True(t, hasRef, "expected a U+0001 character reference in %q", out)
+	require.Contains(t, out, "a")
+	require.Contains(t, out, "b")
+}
+
+// SerializeItems with method="xml" must propagate the writer's invalid-char
+// rejection as SERE0006 rather than silently truncating the output. Under an
+// XML 1.1 OutputDef version, U+0001 is a legal character reference, so the same
+// item serializes with nil error and a char reference instead.
+func TestSerializeItemsXMLInvalidChar(t *testing.T) {
+	root := newBadCharElement(t)
+	items := xpath3.ItemSlice{xpath3.NodeItem{Node: root}}
+
+	var buf bytes.Buffer
+	err := xslt3.SerializeItems(&buf, items, nil, &xslt3.OutputDef{Method: outMethodXML})
+	requireSERE0006(t, err)
+
+	var buf10 bytes.Buffer
+	err = xslt3.SerializeItems(&buf10, items, nil, &xslt3.OutputDef{Method: outMethodXML, Version: "1.0"})
+	requireSERE0006(t, err)
+
+	var buf11 bytes.Buffer
+	err = xslt3.SerializeItems(&buf11, items, nil, &xslt3.OutputDef{Method: outMethodXML, Version: "1.1"})
+	require.NoError(t, err)
+	requireControlCharRef(t, buf11.String())
+}
+
+// SerializeItems with method="json" and json-node-output-method="xml" must
+// propagate the writer's invalid-char rejection as SERE0006.
+func TestSerializeItemsJSONNodeXMLInvalidChar(t *testing.T) {
+	root := newBadCharElement(t)
+	items := xpath3.ItemSlice{xpath3.NodeItem{Node: root}}
+	var buf bytes.Buffer
+	err := xslt3.SerializeItems(&buf, items, nil, &xslt3.OutputDef{Method: "json", JSONNodeOutputMethod: outMethodXML})
+	requireSERE0006(t, err)
+}
+
+// SerializeItems with method="adaptive" over a multi-item sequence containing a
+// node with an invalid character must propagate SERE0006 (the single-element
+// path already propagates via serializeXML; this exercises the per-item path).
+// Under an XML 1.1 version, adaptive inherits the version parameter for the
+// embedded node serialization, so U+0001 becomes a char reference with nil error.
+func TestSerializeItemsAdaptiveInvalidChar(t *testing.T) {
+	root := newBadCharElement(t)
+	items := xpath3.ItemSlice{xpath3.NodeItem{Node: root}, xpath3.NodeItem{Node: root}}
+
+	var buf bytes.Buffer
+	err := xslt3.SerializeItems(&buf, items, nil, &xslt3.OutputDef{Method: "adaptive"})
+	requireSERE0006(t, err)
+
+	var buf10 bytes.Buffer
+	err = xslt3.SerializeItems(&buf10, items, nil, &xslt3.OutputDef{Method: "adaptive", Version: "1.0"})
+	requireSERE0006(t, err)
+
+	var buf11 bytes.Buffer
+	err = xslt3.SerializeItems(&buf11, items, nil, &xslt3.OutputDef{Method: "adaptive", Version: "1.1"})
+	require.NoError(t, err)
+	requireControlCharRef(t, buf11.String())
+}

--- a/xslt3/serialize_test.go
+++ b/xslt3/serialize_test.go
@@ -107,6 +107,10 @@ const outMethodXML = "xml"
 // VersionNum, just like the XML output method's version parameter.
 const outMethodXHTML = "xhtml"
 
+// xmlVersion11 is the XML 1.1 output version used by the invalid-character
+// serialization tests.
+const xmlVersion11 = "1.1"
+
 // newBadCharElement builds a small <r> element whose text content carries an
 // XML-invalid control character (U+0001), via the public DOM API. The DOM
 // accepts the control byte; the writer is the enforcement point.
@@ -125,7 +129,7 @@ func newBadCharElement(t *testing.T) *helium.Element {
 func newBadCharDocument(t *testing.T) *helium.Document {
 	t.Helper()
 	doc := newBadCharElement(t).OwnerDocument()
-	doc.SetVersion("1.1")
+	doc.SetVersion(xmlVersion11)
 	return doc
 }
 
@@ -167,7 +171,7 @@ func TestSerializeItemsXMLInvalidChar(t *testing.T) {
 	requireSERE0006(t, err)
 
 	var buf11 bytes.Buffer
-	err = xslt3.SerializeItems(&buf11, items, nil, &xslt3.OutputDef{Method: outMethodXML, Version: "1.1"})
+	err = xslt3.SerializeItems(&buf11, items, nil, &xslt3.OutputDef{Method: outMethodXML, Version: xmlVersion11})
 	require.NoError(t, err)
 	requireControlCharRef(t, buf11.String())
 }
@@ -188,7 +192,7 @@ func TestSerializeItemsXHTMLInvalidChar(t *testing.T) {
 	requireSERE0006(t, err)
 
 	var buf11 bytes.Buffer
-	err = xslt3.SerializeItems(&buf11, items, nil, &xslt3.OutputDef{Method: outMethodXHTML, Version: "1.1"})
+	err = xslt3.SerializeItems(&buf11, items, nil, &xslt3.OutputDef{Method: outMethodXHTML, Version: xmlVersion11})
 	require.NoError(t, err)
 	requireControlCharRef(t, buf11.String())
 }
@@ -249,7 +253,7 @@ func TestSerializeItemsAdaptiveInvalidChar(t *testing.T) {
 	requireSERE0006(t, err)
 
 	var buf11 bytes.Buffer
-	err = xslt3.SerializeItems(&buf11, items, nil, &xslt3.OutputDef{Method: "adaptive", Version: "1.1"})
+	err = xslt3.SerializeItems(&buf11, items, nil, &xslt3.OutputDef{Method: "adaptive", Version: xmlVersion11})
 	require.NoError(t, err)
 	requireControlCharRef(t, buf11.String())
 }
@@ -308,7 +312,7 @@ func TestSerializeItemsAdaptiveXMLVersion(t *testing.T) {
 	}{
 		{name: "Default"},
 		{name: "XML10", version: "1.0"},
-		{name: "XML11", version: "1.1"},
+		{name: "XML11", version: xmlVersion11},
 	}
 
 	for _, tt := range tests {
@@ -328,7 +332,7 @@ func TestSerializeItemsAdaptiveXMLVersion(t *testing.T) {
 						Method:  "adaptive",
 						Version: version.version,
 					})
-					if version.version != "1.1" {
+					if version.version != xmlVersion11 {
 						requireSERE0006(t, err)
 						return
 					}
@@ -336,7 +340,7 @@ func TestSerializeItemsAdaptiveXMLVersion(t *testing.T) {
 					require.NoError(t, err)
 					requireControlCharRef(t, buf.String())
 					if tt.wantXMLDeclaration {
-						require.Contains(t, buf.String(), `<?xml version="1.1"`)
+						require.Contains(t, buf.String(), `<?xml version="`+xmlVersion11+`"`)
 					} else {
 						require.NotContains(t, buf.String(), "<?xml")
 					}

--- a/xslt3/serialize_test.go
+++ b/xslt3/serialize_test.go
@@ -120,6 +120,15 @@ func newBadCharElement(t *testing.T) *helium.Element {
 	return root
 }
 
+// newBadCharDocument records XML 1.1 so the adaptive XML 1.0 default must
+// override the source document's version.
+func newBadCharDocument(t *testing.T) *helium.Document {
+	t.Helper()
+	doc := newBadCharElement(t).OwnerDocument()
+	doc.SetVersion("1.1")
+	return doc
+}
+
 // requireSERE0006 asserts err is the XSLT serialization error SERE0006 that the
 // serializer raises when the writer rejects an XML-invalid character.
 func requireSERE0006(t *testing.T, err error) {
@@ -243,4 +252,96 @@ func TestSerializeItemsAdaptiveInvalidChar(t *testing.T) {
 	err = xslt3.SerializeItems(&buf11, items, nil, &xslt3.OutputDef{Method: "adaptive", Version: "1.1"})
 	require.NoError(t, err)
 	requireControlCharRef(t, buf11.String())
+}
+
+// Adaptive XML serialization uses its output version consistently for each
+// path that delegates element or document items to the XML writer. A source
+// document marked XML 1.1 cannot change the default XML 1.0 result.
+func TestSerializeItemsAdaptiveXMLVersion(t *testing.T) {
+	tests := []struct {
+		name               string
+		items              func(*testing.T) xpath3.Sequence
+		doc                func(*testing.T) *helium.Document
+		wantXMLDeclaration bool
+	}{
+		{
+			name:               "NoItemsDocument",
+			doc:                newBadCharDocument,
+			wantXMLDeclaration: true,
+		},
+		{
+			name: "SingletonElement",
+			items: func(t *testing.T) xpath3.Sequence {
+				return xpath3.ItemSlice{xpath3.NodeItem{Node: newBadCharElement(t)}}
+			},
+			wantXMLDeclaration: true,
+		},
+		{
+			name: "SingletonDocument",
+			items: func(t *testing.T) xpath3.Sequence {
+				return xpath3.ItemSlice{xpath3.NodeItem{Node: newBadCharDocument(t)}}
+			},
+		},
+		{
+			name: "MapContainedDocument",
+			items: func(t *testing.T) xpath3.Sequence {
+				doc := newBadCharDocument(t)
+				return xpath3.ItemSlice{xpath3.NewMap([]xpath3.MapEntry{{
+					Key:   xpath3.AtomicValue{TypeName: xpath3.TypeString, Value: "doc"},
+					Value: xpath3.ItemSlice{xpath3.NodeItem{Node: doc}},
+				}})}
+			},
+		},
+		{
+			name: "ArrayContainedDocument",
+			items: func(t *testing.T) xpath3.Sequence {
+				doc := newBadCharDocument(t)
+				return xpath3.ItemSlice{xpath3.NewArray([]xpath3.Sequence{
+					xpath3.ItemSlice{xpath3.NodeItem{Node: doc}},
+				})}
+			},
+		},
+	}
+	versions := []struct {
+		name    string
+		version string
+	}{
+		{name: "Default"},
+		{name: "XML10", version: "1.0"},
+		{name: "XML11", version: "1.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, version := range versions {
+				t.Run(version.name, func(t *testing.T) {
+					var buf bytes.Buffer
+					var items xpath3.Sequence
+					if tt.items != nil {
+						items = tt.items(t)
+					}
+					var doc *helium.Document
+					if tt.doc != nil {
+						doc = tt.doc(t)
+					}
+					err := xslt3.SerializeItems(&buf, items, doc, &xslt3.OutputDef{
+						Method:  "adaptive",
+						Version: version.version,
+					})
+					if version.version != "1.1" {
+						requireSERE0006(t, err)
+						return
+					}
+
+					require.NoError(t, err)
+					requireControlCharRef(t, buf.String())
+					if tt.wantXMLDeclaration {
+						require.Contains(t, buf.String(), `<?xml version="1.1"`)
+					} else {
+						require.NotContains(t, buf.String(), "<?xml")
+					}
+				})
+			}
+		})
+	}
 }


### PR DESCRIPTION
- Map Writer serialization failures to xslt3 output errors.
- Preserve XML 1.1 character handling in primary and secondary XML/XHTML output.
- Cover result-document rollback, xsl:message, and serializer error propagation.
