### PR TITLE
fix excluded literal namespace rebinding

### DIFF
--- a/xslt3/execute.go
+++ b/xslt3/execute.go
@@ -114,7 +114,7 @@ type execContext struct {
 	primaryResolvedCharMap       map[rune]string                          // resolved character map from parameter-document for primary output
 	primaryOutputOverrides       *OutputDef                               // serialization param overrides from primary xsl:result-document
 	rawResultSequence            xpath3.Sequence                          // raw XDM result sequence (set when initial template has as="...")
-	nsFixupAllowed               map[*helium.Element]struct{}             // elements whose prefix NS was auto-generated (fixup eligible)
+	nsFixupAllowed               map[*helium.Element]struct{}             // elements whose prefix namespace is eligible for fixup
 	overridingTemplate           *template                                // currently executing overriding template (for xsl:original)
 	overridingVarDef             *variable                                // currently evaluating overriding variable (for $xsl:original)
 	originalFunc                 xpath3.Function                          // current xsl:original function (set during overriding function call)

--- a/xslt3/execute_copy.go
+++ b/xslt3/execute_copy.go
@@ -924,7 +924,7 @@ func (ec *execContext) copyNodeToOutput(node helium.Node, copyNamespaces ...bool
 		prefix := nsw.Name()
 		uri := string(nsw.Content())
 		// Check for conflicts (same prefix, different URI) and apply
-		// namespace fixup when allowed (e.g. xsl:element auto-generated ns).
+		// namespace fixup when the current element is eligible.
 		_, fixupOK := ec.nsFixupAllowed[elem]
 		for _, ns := range elem.Namespaces() {
 			if ns.Prefix() == prefix && ns.URI() != uri {

--- a/xslt3/execute_element.go
+++ b/xslt3/execute_element.go
@@ -1415,9 +1415,10 @@ func (ec *execContext) execNamespace(ctx context.Context, inst *namespaceInst) e
 
 	// XTDE0430: it is a non-recoverable dynamic error if two namespace
 	// nodes for the same element have the same prefix but different URIs.
-	// Exception: when the element's prefix namespace was auto-generated
-	// (from xsl:element name resolution), namespace fixup can rename the
-	// element's prefix instead of raising an error.
+	// Exception: when the element's prefix namespace is eligible for
+	// namespace fixup, rename the element's prefix instead of raising an
+	// error. This applies to auto-generated xsl:element names and excluded
+	// literal result element prefixes.
 	_, fixupOK := ec.nsFixupAllowed[elem]
 	for _, ns := range elem.Namespaces() {
 		if ns.Prefix() == name && ns.URI() != value {

--- a/xslt3/execute_lre.go
+++ b/xslt3/execute_lre.go
@@ -66,6 +66,13 @@ func (ec *execContext) execLiteralResultElement(ctx context.Context, inst *liter
 			}
 		} else {
 			prefixExcluded = true
+			// The declaration for the literal result element's own prefix is
+			// intentionally deferred. xsl:namespace may bind that prefix to a
+			// different URI, in which case namespace fixup renames the element.
+			if ec.nsFixupAllowed == nil {
+				ec.nsFixupAllowed = make(map[*helium.Element]struct{})
+			}
+			ec.nsFixupAllowed[elem] = struct{}{}
 		}
 	} else if inst.Prefix == "" && ec.hasDefaultNSInScope() {
 		// No namespace on this LRE but default namespace in scope — undeclare it
@@ -514,12 +521,16 @@ func fixDescendantDefaultNSWalk(parent *helium.Element, activeDefaultNS string) 
 }
 
 // fixupExcludedElementNS handles namespace fixup for a literal result element
-// whose own prefix was excluded via exclude-result-prefixes. After the body
-// (including xsl:namespace instructions) has been executed, the element's
-// prefix may now be bound to a different URI. In that case, invent a new
-// prefix for the element's original namespace. If the prefix is still free,
-// just declare it normally.
+// whose own prefix was excluded via exclude-result-prefixes. If no
+// xsl:namespace instruction claimed the prefix, it declares the element's
+// original namespace after the body. A claimed prefix is fixed up while that
+// instruction executes.
 func (ec *execContext) fixupExcludedElementNS(elem *helium.Element, origPrefix, origURI string) {
+	// xsl:namespace already renamed the element while claiming origPrefix.
+	if elem.Prefix() != origPrefix || elem.URI() != origURI {
+		return
+	}
+
 	// Check if the prefix is now bound to a different URI
 	for _, ns := range elem.Namespaces() {
 		if ns.Prefix() == origPrefix {

--- a/xslt3/namespace_fixup_test.go
+++ b/xslt3/namespace_fixup_test.go
@@ -1,0 +1,64 @@
+package xslt3_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xslt3"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNamespace2614ExcludedLiteralPrefixCanBeRebound covers W3C
+// namespace-2614. An excluded literal result element prefix is available to
+// xsl:namespace, and namespace fixup gives the element's original namespace a
+// generated prefix.
+func TestNamespace2614ExcludedLiteralPrefixCanBeRebound(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="2.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <p:item xmlns:p="http://p.uri/" xsl:exclude-result-prefixes="p">
+      <xsl:namespace name="p">http://q.uri/</xsl:namespace>
+    </p:item>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	out, err := xslt3.TransformString(t.Context(), parseTransformSource(t), ss)
+	require.NoError(t, err)
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(out))
+	require.NoError(t, err)
+	elem := doc.DocumentElement()
+	require.Equal(t, "item", elem.LocalName())
+	require.Equal(t, "http://p.uri/", elem.URI())
+	require.Equal(t, "p_0", elem.Prefix())
+	require.Equal(t, "http://q.uri/", namespaceURI(elem, "p"))
+	require.Equal(t, "http://p.uri/", namespaceURI(elem, elem.Prefix()))
+}
+
+// TestNamespaceRebindOnNonExcludedLiteralResultElementRaisesXTDE0430 keeps
+// the normal conflict rule for a literal result element whose prefix was not
+// excluded from the result tree.
+func TestNamespaceRebindOnNonExcludedLiteralResultElementRaisesXTDE0430(t *testing.T) {
+	ss := compileStylesheetString(t, `
+<xsl:stylesheet version="3.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:template match="/">
+    <p:item xmlns:p="http://p.uri/">
+      <xsl:namespace name="p">http://q.uri/</xsl:namespace>
+    </p:item>
+  </xsl:template>
+</xsl:stylesheet>`)
+
+	_, err := xslt3.TransformString(t.Context(), parseTransformSource(t), ss)
+	require.ErrorContains(t, err, "XTDE0430")
+}
+
+func namespaceURI(elem *helium.Element, prefix string) string {
+	for _, ns := range elem.Namespaces() {
+		if ns.Prefix() == prefix {
+			return ns.URI()
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
- allow namespace fixup when `xsl:namespace` rebinds an excluded literal-result prefix
- cover W3C namespace-2614 and retain XTDE0430 for normal literal-result prefixes
