### PR TITLE
rotate fuzz corpus caches

### DIFF
--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -156,6 +156,8 @@ Run specific test subsets via env vars:
 
 ## Fuzz CI
 
+- Each matrix job restores newest Go fuzz corpus for same `go.mod`/package/ref, then falls back to same `go.mod`/package across refs.
+- Each matrix job saves its corpus under an immutable run/attempt key after success or failure.
 - Pull requests run NO fuzzing — `ci.yml` is normal test/build/lint/vuln verification only, so PR turnaround stays fast and deterministic (live fuzzing is nondeterministic and cannot gate a PR without flaking).
 - `fuzz.yml` runs fuzzing OFF the PR path, always non-gating:
   - on every `push` to `main` (in practice, each PR merge) → short `60s` per target, for a prompt signal attributed to the pushed commit.

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -31,11 +31,12 @@ jobs:
           go-version-file: go.mod
           cache: false
       - name: Restore fuzz cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/go-build/fuzz
-          key: fuzz-${{ hashFiles('go.mod') }}-${{ matrix.package }}-${{ github.ref }}
+          key: fuzz-${{ hashFiles('go.mod') }}-${{ matrix.package }}-${{ github.ref }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
+            fuzz-${{ hashFiles('go.mod') }}-${{ matrix.package }}-${{ github.ref }}-
             fuzz-${{ hashFiles('go.mod') }}-${{ matrix.package }}-
       - name: Run fuzz tests
         run: |
@@ -188,3 +189,10 @@ jobs:
           path: ${{ runner.temp }}/fuzz-failures/
           if-no-files-found: error
           retention-days: 30
+
+      - name: Save fuzz cache
+        if: always()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/go-build/fuzz
+          key: fuzz-${{ hashFiles('go.mod') }}-${{ matrix.package }}-${{ github.ref }}-${{ github.run_id }}-${{ github.run_attempt }}


### PR DESCRIPTION
- restore the newest compatible package corpus before each fuzz job
- save every run's updated corpus after successful and failed jobs
