### PR TITLE
emit entity replacement text in c14n output

### DIFF
--- a/c14n/c14n_test.go
+++ b/c14n/c14n_test.go
@@ -369,6 +369,69 @@ func TestEntityReferenceReplacementNamespaceContextPerSite(t *testing.T) {
 		string(got))
 }
 
+func TestEntityReferenceReplacementNamespaceContextPerSiteExclusive(t *testing.T) {
+	t.Parallel()
+	// Exclusive C14N: the same entity, whose replacement is an unprefixed element
+	// carrying a q-prefixed attribute, is referenced twice under DIFFERENT q
+	// bindings. Exclusive mode emits a namespace only where it is visibly utilized;
+	// the q:a attribute utilizes q on the entity-replacement element. Each expansion
+	// must render ITS OWN reference-site binding for q, not the binding cached on the
+	// shared Entity declaration node at first parse.
+	src := `<!DOCTYPE r [<!ENTITY x "<e q:a=&#34;v&#34;/>">]>` +
+		`<r><a xmlns:q="urn:one">&x;</a><b xmlns:q="urn:two">&x;</b></r>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	got, err := c14n.NewCanonicalizer(c14n.ExclusiveC14N10).CanonicalizeTo(doc)
+	require.NoError(t, err)
+	require.Equal(t,
+		`<r><a><e xmlns:q="urn:one" q:a="v"></e></a><b><e xmlns:q="urn:two" q:a="v"></e></b></r>`,
+		string(got))
+}
+
+func TestEntityReferenceReplacementNamespaceContextPerSiteNodeSet(t *testing.T) {
+	t.Parallel()
+	// Node-set C14N: the same entity, whose replacement is a q-prefixed element, is
+	// referenced twice under DIFFERENT q bindings, with the whole tree selected. The
+	// node-set namespace rendering must reflect each reference site's own binding for
+	// q rather than the URI cached on the shared Entity declaration node.
+	src := `<!DOCTYPE r [<!ENTITY x "<p:x/>">]>` +
+		`<r xmlns:p="urn:default"><a xmlns:p="urn:one">&x;</a><b xmlns:p="urn:two">&x;</b></r>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	nodes := evaluateNodeSet(t, doc, "//. | //@* | //namespace::*", nil)
+	got, err := c14n.NewCanonicalizer(c14n.C14N10).NodeSet(nodes).CanonicalizeTo(doc)
+	require.NoError(t, err)
+	require.Equal(t,
+		`<r xmlns:p="urn:default"><a xmlns:p="urn:one"><p:x></p:x></a><b xmlns:p="urn:two"><p:x></p:x></b></r>`,
+		string(got))
+}
+
+func TestEntityReferenceReplacementDefaultNamespaceContextPerSiteExclusive(t *testing.T) {
+	t.Parallel()
+	// Exclusive C14N: the same entity, whose replacement is an unprefixed element, is
+	// referenced first inside an element with default namespace urn:one and then
+	// inside a sibling with NO default namespace. At the first site the replacement
+	// element is in urn:one and visibly utilizes the default namespace; at the second
+	// it is in no namespace. The default-namespace resolution must follow each
+	// reference site, not the default binding cached on the shared Entity node.
+	src := `<!DOCTYPE r [<!ENTITY x "<c/>">]>` +
+		`<r><a xmlns="urn:one">&x;</a><b>&x;</b></r>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	got, err := c14n.NewCanonicalizer(c14n.ExclusiveC14N10).CanonicalizeTo(doc)
+	require.NoError(t, err)
+	// <a> itself is in urn:one (unprefixed under the default namespace) so it
+	// visibly utilizes and emits xmlns="urn:one"; the replacement <c> inherits it
+	// and adds nothing. At <b> there is no default namespace, so the replacement
+	// <c> is in no namespace and must NOT re-emit the first site's urn:one.
+	require.Equal(t,
+		`<r><a xmlns="urn:one"><c></c></a><b><c></c></b></r>`,
+		string(got))
+}
+
 func TestRelativeNamespaceURIRejected(t *testing.T) {
 	t.Parallel()
 	// C14N spec requires failure on relative namespace URIs.

--- a/c14n/c14n_test.go
+++ b/c14n/c14n_test.go
@@ -389,6 +389,55 @@ func TestEntityReferenceReplacementNamespaceContextPerSiteExclusive(t *testing.T
 		string(got))
 }
 
+func TestEntityReferenceReplacementUnprefixedAttrSortOrder(t *testing.T) {
+	t.Parallel()
+	// An entity-replacement element carries an unprefixed attribute and a prefixed
+	// one, expanded under an in-scope default namespace. An unprefixed attribute is
+	// in NO namespace — the default namespace never applies to attributes — so it
+	// must sort ahead of the prefixed attribute (empty namespace URI sorts first).
+	// The canonical output must match the equivalent fully-expanded document.
+	entitySrc := `<!DOCTYPE r [<!ENTITY x "<e z=&#34;0&#34; p:a=&#34;1&#34;/>">]>` +
+		`<r><a xmlns="urn:def" xmlns:p="urn:a">&x;</a></r>`
+	expandedSrc := `<r><a xmlns="urn:def" xmlns:p="urn:a"><e z="0" p:a="1"/></a></r>`
+
+	entityDoc, err := helium.NewParser().Parse(t.Context(), []byte(entitySrc))
+	require.NoError(t, err)
+	expandedDoc, err := helium.NewParser().Parse(t.Context(), []byte(expandedSrc))
+	require.NoError(t, err)
+
+	entityGot, err := c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(entityDoc)
+	require.NoError(t, err)
+	expandedGot, err := c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(expandedDoc)
+	require.NoError(t, err)
+
+	require.Equal(t, string(expandedGot), string(entityGot))
+	require.Equal(t,
+		`<r><a xmlns="urn:def" xmlns:p="urn:a"><e z="0" p:a="1"></e></a></r>`,
+		string(entityGot))
+}
+
+func TestEntityReferenceReplacementUnboundPrefixAtSecondSiteErrors(t *testing.T) {
+	t.Parallel()
+	// The same entity, whose replacement carries a q-prefixed attribute, is
+	// referenced first where q is bound and then where q is UNBOUND. The second
+	// expansion cannot borrow the first site's cached binding — a prefixed name
+	// whose prefix is not in scope at the reference site is not namespace-well-formed
+	// there, so canonicalization must error rather than emit a borrowed binding.
+	src := `<!DOCTYPE r [<!ENTITY x "<e q:a=&#34;v&#34;/>">]>` +
+		`<r><a xmlns:q="urn:one">&x;</a><b>&x;</b></r>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	_, err = c14n.NewCanonicalizer(c14n.ExclusiveC14N10).CanonicalizeTo(doc)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not in scope")
+
+	// Inclusive C14N10 reaches the same out-of-scope prefix via the attribute axis.
+	_, err = c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(doc)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not in scope")
+}
+
 func TestEntityReferenceReplacementNamespaceContextPerSiteNodeSet(t *testing.T) {
 	t.Parallel()
 	// Node-set C14N: the same entity, whose replacement is a q-prefixed element, is

--- a/c14n/c14n_test.go
+++ b/c14n/c14n_test.go
@@ -308,6 +308,47 @@ func TestNoNodeSetEmitsFullDocument(t *testing.T) {
 	require.Equal(t, `<root><child></child></root>`, string(got))
 }
 
+func TestEntityReferenceReplacementTextInContent(t *testing.T) {
+	t.Parallel()
+	// The default parser leaves internal general entity references unexpanded,
+	// so an EntityRef node is present in element content. Canonicalization must
+	// emit the entity's replacement text per the W3C Canonical XML spec, or the
+	// content is excluded from any digest computed over the canonical output.
+	src := `<!DOCTYPE r [<!ENTITY x "hello-entity-content">]><r>before-&x;-after</r>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	got, err := c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(doc)
+	require.NoError(t, err)
+	require.Equal(t, `<r>before-hello-entity-content-after</r>`, string(got))
+}
+
+func TestEntityReferenceReplacementTextWithMarkup(t *testing.T) {
+	t.Parallel()
+	// An internal entity whose replacement text contains markup must have that
+	// markup canonicalized (nested element emitted), not dropped.
+	src := `<!DOCTYPE r [<!ENTITY x "<b>bold</b>">]><r>a&x;b</r>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	got, err := c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(doc)
+	require.NoError(t, err)
+	require.Equal(t, `<r>a<b>bold</b>b</r>`, string(got))
+}
+
+func TestEntityReferenceReplacementTextInAttribute(t *testing.T) {
+	t.Parallel()
+	// Attribute-context entity expansion already works; lock it in alongside
+	// the element-content fix.
+	src := `<!DOCTYPE r [<!ENTITY x "hello-entity-content">]><r a="before-&x;-after"/>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	got, err := c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(doc)
+	require.NoError(t, err)
+	require.Equal(t, `<r a="before-hello-entity-content-after"></r>`, string(got))
+}
+
 func TestRelativeNamespaceURIRejected(t *testing.T) {
 	t.Parallel()
 	// C14N spec requires failure on relative namespace URIs.

--- a/c14n/c14n_test.go
+++ b/c14n/c14n_test.go
@@ -432,6 +432,28 @@ func TestEntityReferenceReplacementDefaultNamespaceContextPerSiteExclusive(t *te
 		string(got))
 }
 
+func TestEntityReferenceReplacementDefaultNamespaceReverseOrderExclusive(t *testing.T) {
+	t.Parallel()
+	// Exclusive C14N, reverse order of the case above: the same entity, whose
+	// replacement is an unprefixed element, is referenced first inside an element
+	// with NO default namespace and then inside a sibling that declares a default
+	// namespace. Parsing caches the replacement element's active namespace at the
+	// first (no-default) site as nil, so the second site must re-derive the
+	// element's own namespace from the reference-site default binding rather than
+	// trusting the cached nil. At the first site <e> is in no namespace; at the
+	// second it is in urn:two and must emit xmlns="urn:two".
+	src := `<!DOCTYPE r [<!ENTITY x "<e/>">]>` +
+		`<r xmlns:p="urn:p"><p:a>&x;</p:a><p:b xmlns="urn:two">&x;</p:b></r>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	got, err := c14n.NewCanonicalizer(c14n.ExclusiveC14N10).CanonicalizeTo(doc)
+	require.NoError(t, err)
+	require.Equal(t,
+		`<r><p:a xmlns:p="urn:p"><e></e></p:a><p:b xmlns:p="urn:p"><e xmlns="urn:two"></e></p:b></r>`,
+		string(got))
+}
+
 func TestRelativeNamespaceURIRejected(t *testing.T) {
 	t.Parallel()
 	// C14N spec requires failure on relative namespace URIs.

--- a/c14n/c14n_test.go
+++ b/c14n/c14n_test.go
@@ -349,6 +349,26 @@ func TestEntityReferenceReplacementTextInAttribute(t *testing.T) {
 	require.Equal(t, `<r a="before-hello-entity-content-after"></r>`, string(got))
 }
 
+func TestEntityReferenceReplacementNamespaceContextPerSite(t *testing.T) {
+	t.Parallel()
+	// The same entity, whose replacement text is a namespace-prefixed element,
+	// is referenced twice under DIFFERENT in-scope bindings for that prefix.
+	// Per W3C Canonical XML the replacement is canonicalized as if textually
+	// substituted at each reference site, so each expansion must reflect ITS OWN
+	// binding for the prefix — the second must not inherit the first site's
+	// namespace resolution cached on the shared Entity declaration node.
+	src := `<!DOCTYPE r [<!ENTITY x "<p:x/>">]>` +
+		`<r xmlns:p="urn:default"><a xmlns:p="urn:one">&x;</a><b xmlns:p="urn:two">&x;</b></r>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	got, err := c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(doc)
+	require.NoError(t, err)
+	require.Equal(t,
+		`<r xmlns:p="urn:default"><a xmlns:p="urn:one"><p:x></p:x></a><b xmlns:p="urn:two"><p:x></p:x></b></r>`,
+		string(got))
+}
+
 func TestRelativeNamespaceURIRejected(t *testing.T) {
 	t.Parallel()
 	// C14N spec requires failure on relative namespace URIs.

--- a/c14n/c14n_test.go
+++ b/c14n/c14n_test.go
@@ -438,6 +438,41 @@ func TestEntityReferenceReplacementUnboundPrefixAtSecondSiteErrors(t *testing.T)
 	require.Contains(t, err.Error(), "not in scope")
 }
 
+func TestEntityReferenceReplacementElementUnboundPrefixAtSecondSiteErrors(t *testing.T) {
+	t.Parallel()
+	// The same entity, whose replacement is a p-prefixed ELEMENT, is referenced
+	// first where p is bound and then where p is UNBOUND. The second expansion
+	// cannot borrow the first site's cached binding — an element name whose prefix
+	// is not in scope at the reference site is not namespace-well-formed there, so
+	// canonicalization must error rather than emit a dangling prefix. This mirrors
+	// the attribute-axis case on the element-name axis and must hold in every mode.
+	src := `<!DOCTYPE r [<!ENTITY x "<p:e/>">]>` +
+		`<r><a xmlns:p="urn:one">&x;</a><b>&x;</b></r>`
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+
+	_, err = c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(doc)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not in scope")
+
+	_, err = c14n.NewCanonicalizer(c14n.C14N11).CanonicalizeTo(doc)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not in scope")
+
+	_, err = c14n.NewCanonicalizer(c14n.ExclusiveC14N10).CanonicalizeTo(doc)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not in scope")
+
+	nodes := evaluateNodeSet(t, doc, "//. | //@* | //namespace::*", nil)
+	_, err = c14n.NewCanonicalizer(c14n.C14N10).NodeSet(nodes).CanonicalizeTo(doc)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not in scope")
+
+	_, err = c14n.NewCanonicalizer(c14n.ExclusiveC14N10).NodeSet(nodes).CanonicalizeTo(doc)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not in scope")
+}
+
 func TestEntityReferenceReplacementNamespaceContextPerSiteNodeSet(t *testing.T) {
 	t.Parallel()
 	// Node-set C14N: the same entity, whose replacement is a q-prefixed element, is

--- a/c14n/c14n_test.go
+++ b/c14n/c14n_test.go
@@ -538,6 +538,132 @@ func TestEntityReferenceReplacementDefaultNamespaceReverseOrderExclusive(t *test
 		string(got))
 }
 
+func TestEntityReferenceReplacementReservedXMLPrefixAttr(t *testing.T) {
+	t.Parallel()
+	// The reserved "xml" prefix is implicitly bound to the XML namespace
+	// everywhere in the data model, so an entity-replacement element carrying an
+	// xml:lang attribute is namespace-well-formed at any reference site and must
+	// canonicalize successfully. Its output must be byte-identical to the
+	// equivalent fully-expanded document in every mode (the xml namespace is
+	// never emitted as an explicit xmlns:xml declaration on the inclusive and
+	// node-set axes, matching the non-entity xml:* path).
+	entitySrc := `<!DOCTYPE r [<!ENTITY x "<e xml:lang=&#34;en&#34;/>">]><r>&x;</r>`
+	expandedSrc := `<r><e xml:lang="en"/></r>`
+
+	entityDoc, err := helium.NewParser().Parse(t.Context(), []byte(entitySrc))
+	require.NoError(t, err)
+	expandedDoc, err := helium.NewParser().Parse(t.Context(), []byte(expandedSrc))
+	require.NoError(t, err)
+
+	for _, mode := range []c14n.Mode{c14n.C14N10, c14n.C14N11, c14n.ExclusiveC14N10} {
+		entityGot, err := c14n.NewCanonicalizer(mode).CanonicalizeTo(entityDoc)
+		require.NoError(t, err, "mode %d", mode)
+		expandedGot, err := c14n.NewCanonicalizer(mode).CanonicalizeTo(expandedDoc)
+		require.NoError(t, err, "mode %d", mode)
+		require.Equal(t, string(expandedGot), string(entityGot),
+			"entity expansion must match the fully-expanded document, mode %d", mode)
+	}
+
+	// Inclusive C14N 1.0/1.1 never emit an explicit xmlns:xml declaration.
+	inclusive, err := c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(entityDoc)
+	require.NoError(t, err)
+	require.Equal(t, `<r><e xml:lang="en"></e></r>`, string(inclusive))
+	require.NotContains(t, string(inclusive), "xmlns:xml")
+
+	// Node-set (inclusive + exclusive) with the whole tree selected.
+	inclusiveNodes := evaluateNodeSet(t, entityDoc, "//. | //@* | //namespace::*", nil)
+	inclusiveNS, err := c14n.NewCanonicalizer(c14n.C14N10).NodeSet(inclusiveNodes).CanonicalizeTo(entityDoc)
+	require.NoError(t, err)
+	require.Equal(t, `<r><e xml:lang="en"></e></r>`, string(inclusiveNS))
+	require.NotContains(t, string(inclusiveNS), "xmlns:xml")
+
+	exclusiveNodes := evaluateNodeSet(t, entityDoc, "//. | //@* | //namespace::*", nil)
+	_, err = c14n.NewCanonicalizer(c14n.ExclusiveC14N10).NodeSet(exclusiveNodes).CanonicalizeTo(entityDoc)
+	require.NoError(t, err)
+}
+
+func TestEntityReferenceReplacementReservedXMLPrefixElementName(t *testing.T) {
+	t.Parallel()
+	// An entity-replacement element whose NAME uses the reserved "xml" prefix is
+	// namespace-well-formed at any reference site (the prefix is implicitly
+	// bound) and must canonicalize successfully rather than erroring as an
+	// out-of-scope prefix. Output must be byte-identical to the fully-expanded
+	// document in every mode.
+	entitySrc := `<!DOCTYPE r [<!ENTITY x "<xml:e/>">]><r>&x;</r>`
+	expandedSrc := `<r><xml:e/></r>`
+
+	entityDoc, err := helium.NewParser().Parse(t.Context(), []byte(entitySrc))
+	require.NoError(t, err)
+	expandedDoc, err := helium.NewParser().Parse(t.Context(), []byte(expandedSrc))
+	require.NoError(t, err)
+
+	for _, mode := range []c14n.Mode{c14n.C14N10, c14n.C14N11, c14n.ExclusiveC14N10} {
+		entityGot, err := c14n.NewCanonicalizer(mode).CanonicalizeTo(entityDoc)
+		require.NoError(t, err, "mode %d", mode)
+		expandedGot, err := c14n.NewCanonicalizer(mode).CanonicalizeTo(expandedDoc)
+		require.NoError(t, err, "mode %d", mode)
+		require.Equal(t, string(expandedGot), string(entityGot),
+			"entity expansion must match the fully-expanded document, mode %d", mode)
+	}
+
+	// Inclusive C14N 1.0 writes the xml-prefixed name without an xmlns:xml decl.
+	inclusive, err := c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(entityDoc)
+	require.NoError(t, err)
+	require.Equal(t, `<r><xml:e></xml:e></r>`, string(inclusive))
+	require.NotContains(t, string(inclusive), "xmlns:xml")
+
+	nodes := evaluateNodeSet(t, entityDoc, "//. | //@* | //namespace::*", nil)
+	inclusiveNS, err := c14n.NewCanonicalizer(c14n.C14N10).NodeSet(nodes).CanonicalizeTo(entityDoc)
+	require.NoError(t, err)
+	require.Equal(t, `<r><xml:e></xml:e></r>`, string(inclusiveNS))
+	require.NotContains(t, string(inclusiveNS), "xmlns:xml")
+}
+
+func TestEntityReferenceReplacementReservedXMLPrefixRegressionGuards(t *testing.T) {
+	t.Parallel()
+	// Guard the other three enumerated prefix classes alongside the new xml
+	// handling: a bound non-xml prefix still resolves, a non-empty non-xml
+	// unbound prefix still errors on both the element-name and attribute axes,
+	// and a plain document with no entity references stays byte-identical.
+
+	// A bound non-xml prefix resolves normally.
+	bound := `<!DOCTYPE r [<!ENTITY x "<p:e p:a=&#34;v&#34;/>">]>` +
+		`<r xmlns:p="urn:p">&x;</r>`
+	boundDoc, err := helium.NewParser().Parse(t.Context(), []byte(bound))
+	require.NoError(t, err)
+	boundGot, err := c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(boundDoc)
+	require.NoError(t, err)
+	require.Equal(t, `<r xmlns:p="urn:p"><p:e p:a="v"></p:e></r>`, string(boundGot))
+
+	// A non-empty non-xml unbound prefix on the element name still errors. The
+	// prefix is bound at the first reference site (so the entity parses) but
+	// unbound at the second, where canonicalization must error.
+	elemUnbound := `<!DOCTYPE r [<!ENTITY x "<q:e/>">]>` +
+		`<r><a xmlns:q="urn:one">&x;</a><b>&x;</b></r>`
+	elemDoc, err := helium.NewParser().Parse(t.Context(), []byte(elemUnbound))
+	require.NoError(t, err)
+	_, err = c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(elemDoc)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not in scope")
+
+	// A non-empty non-xml unbound prefix on an attribute still errors.
+	attrUnbound := `<!DOCTYPE r [<!ENTITY x "<e q:a=&#34;v&#34;/>">]>` +
+		`<r><a xmlns:q="urn:one">&x;</a><b>&x;</b></r>`
+	attrDoc, err := helium.NewParser().Parse(t.Context(), []byte(attrUnbound))
+	require.NoError(t, err)
+	_, err = c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(attrDoc)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not in scope")
+
+	// A document with no entity references is unaffected by the entity path.
+	plain := `<r><e xml:lang="en">t</e></r>`
+	plainDoc, err := helium.NewParser().Parse(t.Context(), []byte(plain))
+	require.NoError(t, err)
+	plainGot, err := c14n.NewCanonicalizer(c14n.C14N10).CanonicalizeTo(plainDoc)
+	require.NoError(t, err)
+	require.Equal(t, `<r><e xml:lang="en">t</e></r>`, string(plainGot))
+}
+
 func TestRelativeNamespaceURIRejected(t *testing.T) {
 	t.Parallel()
 	// C14N spec requires failure on relative namespace URIs.

--- a/c14n/canonicalizer.go
+++ b/c14n/canonicalizer.go
@@ -766,7 +766,11 @@ func (c *canonicalizer) renderNamespacesExclusive(e *helium.Element) error {
 	// Attribute namespaces
 	for _, attr := range e.Attributes() {
 		if p := attr.Prefix(); p != "" {
-			utilized[p] = c.resolvedAttrNSURI(e, attr)
+			uri, err := c.resolvedAttrNSURI(e, attr)
+			if err != nil {
+				return err
+			}
+			utilized[p] = uri
 		}
 	}
 
@@ -911,17 +915,29 @@ func (c *canonicalizer) entityDefaultNSURI(e *helium.Element) string {
 	return c.collectInScopeNamespaces(e)[""]
 }
 
-// resolvedAttrNSURI returns the URI of a namespaced attribute's prefix, resolved
-// against the reference site inside an entity expansion (where the attribute's
-// cached URI reflects the first reference site) and from the cached URI otherwise.
-func (c *canonicalizer) resolvedAttrNSURI(e *helium.Element, attr *helium.Attribute) string {
+// resolvedAttrNSURI returns the URI of an attribute's namespace. Outside an
+// entity expansion the cached URI is authoritative. Inside an entity expansion
+// the attribute's cached URI reflects the first reference site, so re-resolve
+// against the current reference site instead.
+//
+// An unprefixed attribute is in no namespace — the default namespace never
+// applies to attributes — so it always resolves to the empty URI (mirroring the
+// non-entity attr.URI()). A prefixed entity attribute whose prefix is not in
+// scope at the current reference site cannot be canonicalized (a prefixed name
+// with an out-of-scope prefix is namespace-not-well-formed for that expansion),
+// so this is an error rather than a borrowed stale first-site binding.
+func (c *canonicalizer) resolvedAttrNSURI(e *helium.Element, attr *helium.Attribute) (string, error) {
 	if c.currentEntityFrame() == nil {
-		return attr.URI()
+		return attr.URI(), nil
 	}
-	if uri, ok := c.collectInScopeNamespaces(e)[attr.Prefix()]; ok {
-		return uri
+	prefix := attr.Prefix()
+	if prefix == "" {
+		return "", nil
 	}
-	return attr.URI()
+	if uri, ok := c.collectInScopeNamespaces(e)[prefix]; ok {
+		return uri, nil
+	}
+	return "", fmt.Errorf("c14n: namespace prefix %q of entity-replacement attribute %q is not in scope at the reference site", prefix, attr.Name())
 }
 
 // collectInScopeNamespaces collects all in-scope namespace bindings for an element
@@ -989,10 +1005,14 @@ func (c *canonicalizer) renderAttributes(e *helium.Element) error {
 		if c.nodeSet != nil && !c.isVisible(attr) {
 			continue
 		}
+		uri, err := c.resolvedAttrNSURI(e, attr)
+		if err != nil {
+			return err
+		}
 		entries = append(entries, attrSortEntry{
 			attr:      attr,
 			localName: attr.LocalName(),
-			nsURI:     c.resolvedAttrNSURI(e, attr),
+			nsURI:     uri,
 		})
 	}
 

--- a/c14n/canonicalizer.go
+++ b/c14n/canonicalizer.go
@@ -24,14 +24,25 @@ type canonicalizer struct {
 	// nsNodesByElement indexes NamespaceNodeWrapper nodes by their parent element.
 	// Built once during process() when nodeSet is non-nil.
 	nsNodesByElement map[helium.Node][]nsSortEntry
-	// entityNSContext is a stack of reference-site in-scope namespace bindings
-	// (prefix→URI), pushed when the walk descends through an EntityRef. While
-	// non-empty, an entity-replacement element resolves the prefixes it does not
-	// itself declare against the reference site's bindings rather than the shared
-	// Entity declaration node's DTD-context parent chain and its cached
-	// active-namespace pointers (both resolved once at parse time against the
-	// first reference site).
-	entityNSContext []map[string]string
+	// entityNSContext is a stack of entity-expansion frames, pushed when the walk
+	// descends through an EntityRef. While non-empty, an entity-replacement element
+	// resolves the prefixes it does not itself declare against the reference site's
+	// bindings rather than the shared Entity declaration node's DTD-context parent
+	// chain and its cached active-namespace pointers (both resolved once at parse
+	// time against the first reference site). The frame also carries the reference
+	// site's visibility so, in node-set mode, the replacement subtree is emitted iff
+	// the reference site is selected — helium's XPath cannot place entity-internal
+	// nodes in a node set, so their visibility is inherited from the reference site.
+	entityNSContext []entityFrame
+}
+
+// entityFrame records the reference-site context for one entity expansion.
+type entityFrame struct {
+	// ns is the reference-site in-scope namespace bindings (prefix→URI).
+	ns map[string]string
+	// visible is whether the replacement subtree is emitted. In whole-document mode
+	// it is always true; in node-set mode it mirrors the reference site's selection.
+	visible bool
 }
 
 func (c *canonicalizer) process() error {
@@ -57,9 +68,15 @@ func (c *canonicalizer) process() error {
 }
 
 // isVisible returns true if the node is in the node set (or if no node set filter is active).
+// Inside an entity expansion the replacement subtree is not independently selectable
+// (helium's XPath cannot address entity-internal nodes), so every node in it inherits
+// the reference site's visibility recorded on the active entity frame.
 func (c *canonicalizer) isVisible(n helium.Node) bool {
 	if c.nodeSet == nil {
 		return true
+	}
+	if fr := c.currentEntityFrame(); fr != nil {
+		return fr.visible
 	}
 	_, ok := c.nodeSet[n]
 	return ok
@@ -273,7 +290,11 @@ func (c *canonicalizer) processNode(n helium.Node) error {
 		// textually substituted here), so a prefix in the replacement resolves
 		// against the site's in-scope bindings.
 		c.pushEntityContext(n)
+		seeded := c.seedEntityNSStack()
 		err := c.processChildren(n)
+		if seeded {
+			c.nsStack.restore()
+		}
 		c.popEntityContext()
 		return err
 	case helium.EntityNode:
@@ -294,15 +315,25 @@ func (c *canonicalizer) processChildren(n helium.Node) error {
 	return nil
 }
 
-// currentEntityContext returns the reference-site namespace bindings for the
-// entity expansion currently being walked, or nil when the walk is not inside
-// one.
-func (c *canonicalizer) currentEntityContext() map[string]string {
+// currentEntityFrame returns the active entity-expansion frame, or nil when the
+// walk is not inside an entity.
+func (c *canonicalizer) currentEntityFrame() *entityFrame {
 	n := len(c.entityNSContext)
 	if n == 0 {
 		return nil
 	}
-	return c.entityNSContext[n-1]
+	return &c.entityNSContext[n-1]
+}
+
+// currentEntityContext returns the reference-site namespace bindings for the
+// entity expansion currently being walked, or nil when the walk is not inside
+// one.
+func (c *canonicalizer) currentEntityContext() map[string]string {
+	fr := c.currentEntityFrame()
+	if fr == nil {
+		return nil
+	}
+	return fr.ns
 }
 
 // pushEntityContext records the in-scope namespace bindings at an entity
@@ -315,23 +346,59 @@ func (c *canonicalizer) currentEntityContext() map[string]string {
 func (c *canonicalizer) pushEntityContext(entityRef helium.Node) {
 	ctx := make(map[string]string)
 	parent, ok := helium.AsNode[*helium.Element](entityRef.Parent())
-	outer := c.currentEntityContext()
+	outer := c.currentEntityFrame()
+	// Whole-document mode always emits; node-set mode inherits the reference site's
+	// selection (the enclosing entity's for a nested reference, else the parent
+	// element's node-set membership).
+	visible := c.nodeSet == nil
 	switch {
 	case outer == nil && ok:
 		for prefix, ns := range domutil.InScopeNamespaces(parent, c.nodeSet == nil) {
 			ctx[prefix] = ns.URI()
 		}
+		if c.nodeSet != nil {
+			visible = c.isVisible(parent)
+		}
 	case outer != nil:
-		maps.Copy(ctx, outer)
+		maps.Copy(ctx, outer.ns)
 		if ok {
 			c.overlayEntityNSDecls(ctx, parent)
 		}
+		visible = outer.visible
 	}
-	c.entityNSContext = append(c.entityNSContext, ctx)
+	c.entityNSContext = append(c.entityNSContext, entityFrame{ns: ctx, visible: visible})
 }
 
 func (c *canonicalizer) popEntityContext() {
 	c.entityNSContext = c.entityNSContext[:len(c.entityNSContext)-1]
+}
+
+// seedEntityNSStack primes the rendered-namespace stack with the reference site's
+// in-scope bindings before an entity replacement is walked, and reports whether a
+// frame was pushed (so the caller pops it afterwards). It applies only to inclusive
+// node-set canonicalization: there the ancestor elements render their namespaces via
+// the node-set path, which tracks membership through nsNodesByElement and never
+// populates nsStack, so an entity-replacement element — rendered through the
+// reference-site (whole-document) algorithm — would otherwise re-declare namespaces
+// already in scope at the reference site. Whole-document mode already carries the
+// ancestor bindings on nsStack, and every exclusive path populates nsStack directly,
+// so neither needs seeding.
+func (c *canonicalizer) seedEntityNSStack() bool {
+	if c.mode == ExclusiveC14N10 || c.nodeSet == nil {
+		return false
+	}
+	fr := c.currentEntityFrame()
+	if fr == nil {
+		return false
+	}
+	c.nsStack.save()
+	for prefix, uri := range fr.ns {
+		if prefix == lexicon.PrefixXML {
+			continue
+		}
+		c.nsStack.add(prefix, uri)
+	}
+	return true
 }
 
 // overlayEntityNSDecls applies the xmlns declarations physically present in the
@@ -446,11 +513,22 @@ func (c *canonicalizer) renderNamespaces(e *helium.Element) error {
 		return c.renderNamespacesExclusive(e)
 	}
 
-	if c.nodeSet != nil {
+	// Entity-replacement elements are canonicalized as if substituted at the
+	// reference site, so their namespace axis is resolved through the reference-site
+	// (whole-document) algorithm even under a node set — the node-set path keys off
+	// nsNodesByElement, which cannot hold entity-internal namespace nodes.
+	if c.nodeSet != nil && c.currentEntityFrame() == nil {
 		return c.renderNamespacesNodeSet(e)
 	}
 
-	// Whole-document mode: collect in-scope namespaces
+	return c.renderNamespacesInclusive(e)
+}
+
+// renderNamespacesInclusive outputs the namespace axis for whole-document (and
+// entity-replacement) inclusive canonicalization using in-scope bindings and the
+// rendered-namespace stack.
+func (c *canonicalizer) renderNamespacesInclusive(e *helium.Element) error {
+	// Collect in-scope namespaces
 	nsMap := c.collectInScopeNamespaces(e)
 
 	// Determine which need to be output (not yet on the rendered stack)
@@ -655,7 +733,12 @@ func (c *canonicalizer) findNearestRenderedDefaultNS(e *helium.Element) string {
 }
 
 func (c *canonicalizer) renderNamespacesExclusive(e *helium.Element) error {
-	if c.nodeSet != nil {
+	// Entity-replacement elements resolve their visibly-utilized namespaces against
+	// the reference site, so they use the whole-document exclusive algorithm even
+	// under a node set (the node-set path keys off nsNodesByElement, which cannot
+	// hold entity-internal namespace nodes; every exclusive path populates nsStack,
+	// so redundancy suppression against ancestors still holds).
+	if c.nodeSet != nil && c.currentEntityFrame() == nil {
 		return c.renderNamespacesExclusiveNodeSet(e)
 	}
 
@@ -676,7 +759,7 @@ func (c *canonicalizer) renderNamespacesExclusive(e *helium.Element) error {
 	// Attribute namespaces
 	for _, attr := range e.Attributes() {
 		if p := attr.Prefix(); p != "" {
-			utilized[p] = attr.URI()
+			utilized[p] = c.resolvedAttrNSURI(e, attr)
 		}
 	}
 
@@ -795,15 +878,28 @@ func (c *canonicalizer) renderNamespacesExclusiveNodeSet(e *helium.Element) erro
 // entity expansion the element's cached active-namespace pointer was resolved
 // once at parse time against the first reference site, so re-resolve the
 // element's prefix against the current reference-site context; outside an entity
-// the cached pointer is authoritative.
+// the cached pointer is authoritative. When the prefix is not bound at the
+// reference site the element is in no namespace there (an empty default, or an
+// unbound prefix in malformed input), so return the empty URI rather than the
+// stale cached value.
 func (c *canonicalizer) resolvedNSURI(e *helium.Element, ns *helium.Namespace) string {
-	if c.currentEntityContext() == nil {
+	if c.currentEntityFrame() == nil {
 		return ns.URI()
 	}
-	if uri, ok := c.collectInScopeNamespaces(e)[ns.Prefix()]; ok {
+	return c.collectInScopeNamespaces(e)[ns.Prefix()]
+}
+
+// resolvedAttrNSURI returns the URI of a namespaced attribute's prefix, resolved
+// against the reference site inside an entity expansion (where the attribute's
+// cached URI reflects the first reference site) and from the cached URI otherwise.
+func (c *canonicalizer) resolvedAttrNSURI(e *helium.Element, attr *helium.Attribute) string {
+	if c.currentEntityFrame() == nil {
+		return attr.URI()
+	}
+	if uri, ok := c.collectInScopeNamespaces(e)[attr.Prefix()]; ok {
 		return uri
 	}
-	return ns.URI()
+	return attr.URI()
 }
 
 // collectInScopeNamespaces collects all in-scope namespace bindings for an element
@@ -874,7 +970,7 @@ func (c *canonicalizer) renderAttributes(e *helium.Element) error {
 		entries = append(entries, attrSortEntry{
 			attr:      attr,
 			localName: attr.LocalName(),
-			nsURI:     attr.URI(),
+			nsURI:     c.resolvedAttrNSURI(e, attr),
 		})
 	}
 

--- a/c14n/canonicalizer.go
+++ b/c14n/canonicalizer.go
@@ -749,6 +749,13 @@ func (c *canonicalizer) renderNamespacesExclusive(e *helium.Element) error {
 	// Element's own namespace
 	if ns := e.Namespace(); ns != nil {
 		utilized[ns.Prefix()] = c.resolvedNSURI(e, ns)
+	} else if uri := c.entityDefaultNSURI(e); uri != "" {
+		// Inside an entity expansion an unprefixed replacement element has a nil
+		// cached active namespace when the FIRST reference site had no default
+		// namespace. At THIS reference site the in-scope default namespace may be
+		// non-empty, so the element is actually in that namespace and visibly
+		// utilizes the default prefix — the cached nil is not authoritative here.
+		utilized[""] = uri
 	} else {
 		// Check if default namespace needs to be undeclared
 		if existingURI, found := c.nsStack.lookup(""); found && existingURI != "" {
@@ -887,6 +894,21 @@ func (c *canonicalizer) resolvedNSURI(e *helium.Element, ns *helium.Namespace) s
 		return ns.URI()
 	}
 	return c.collectInScopeNamespaces(e)[ns.Prefix()]
+}
+
+// entityDefaultNSURI returns the reference-site default-namespace URI for an
+// unprefixed entity-replacement element whose cached active namespace is nil.
+// The parser resolves and caches the replacement element's active namespace
+// against the first reference site, so a nil pointer only means "no default
+// namespace at the first site"; the element may still be under a default
+// namespace at the site currently being walked. It returns "" outside an entity
+// expansion (the cached nil is authoritative there) and when the reference site
+// has no default namespace in scope.
+func (c *canonicalizer) entityDefaultNSURI(e *helium.Element) string {
+	if c.currentEntityFrame() == nil {
+		return ""
+	}
+	return c.collectInScopeNamespaces(e)[""]
 }
 
 // resolvedAttrNSURI returns the URI of a namespaced attribute's prefix, resolved

--- a/c14n/canonicalizer.go
+++ b/c14n/canonicalizer.go
@@ -257,7 +257,18 @@ func (c *canonicalizer) processNode(n helium.Node) error {
 		}
 		return c.writeComment(cm)
 	case helium.EntityRefNode:
-		// Expand entity ref children
+		// Expand entity ref children. For an unexpanded reference the child is
+		// the shared Entity declaration node, handled by the EntityNode case.
+		for child := range helium.Children(n) {
+			if err := c.processNode(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	case helium.EntityNode:
+		// The Entity declaration node holds the parsed replacement content as
+		// its children; emit it so the reference contributes its replacement
+		// text (and any markup) to the canonical output.
 		for child := range helium.Children(n) {
 			if err := c.processNode(child); err != nil {
 				return err

--- a/c14n/canonicalizer.go
+++ b/c14n/canonicalizer.go
@@ -901,18 +901,29 @@ func (c *canonicalizer) renderNamespacesExclusiveNodeSet(e *helium.Element) erro
 // first reference site, so re-resolve the element's prefix against the current
 // reference-site context.
 //
-// An unprefixed entity-replacement element is governed by the reference-site
-// default namespace normally (unlike an attribute), so it resolves to the
-// in-scope default URI, or the empty URI when no default is in scope. A prefixed
-// entity element whose prefix is not in scope at the current reference site
-// cannot be canonicalized (a prefixed name with an out-of-scope prefix is
-// namespace-not-well-formed for that expansion), so this is an error rather than
-// a borrowed stale first-site binding or a dangling prefix.
+// The reserved "xml" prefix is always implicitly in scope and resolves to the
+// XML namespace. An unprefixed entity-replacement element is governed by the
+// reference-site default namespace normally (unlike an attribute), so it
+// resolves to the in-scope default URI, or the empty URI when no default is in
+// scope. Any other prefixed entity element whose prefix is not in scope at the
+// current reference site cannot be canonicalized (a prefixed name with an
+// out-of-scope prefix is namespace-not-well-formed for that expansion), so this
+// is an error rather than a borrowed stale first-site binding or a dangling
+// prefix.
 func (c *canonicalizer) resolvedNSURI(e *helium.Element, ns *helium.Namespace) (string, error) {
 	if c.currentEntityFrame() == nil {
 		return ns.URI(), nil
 	}
 	prefix := ns.Prefix()
+	if prefix == lexicon.PrefixXML {
+		// The reserved "xml" prefix is implicitly bound to the XML namespace at
+		// every point in the data model, so it is always in scope at the
+		// reference site regardless of the site's declared bindings. Resolve it
+		// to that implicit URI; like a non-entity xml:* name it is never emitted
+		// as an explicit xmlns:xml declaration (collectInScopeNamespaces drops it
+		// on the inclusive/node-set paths, matching the non-entity axis).
+		return lexicon.NamespaceXML, nil
+	}
 	if uri, ok := c.collectInScopeNamespaces(e)[prefix]; ok {
 		return uri, nil
 	}
@@ -944,10 +955,12 @@ func (c *canonicalizer) entityDefaultNSURI(e *helium.Element) string {
 //
 // An unprefixed attribute is in no namespace — the default namespace never
 // applies to attributes — so it always resolves to the empty URI (mirroring the
-// non-entity attr.URI()). A prefixed entity attribute whose prefix is not in
-// scope at the current reference site cannot be canonicalized (a prefixed name
-// with an out-of-scope prefix is namespace-not-well-formed for that expansion),
-// so this is an error rather than a borrowed stale first-site binding.
+// non-entity attr.URI()). The reserved "xml" prefix (xml:lang, xml:space) is
+// always implicitly in scope and resolves to the XML namespace. Any other
+// prefixed entity attribute whose prefix is not in scope at the current
+// reference site cannot be canonicalized (a prefixed name with an out-of-scope
+// prefix is namespace-not-well-formed for that expansion), so this is an error
+// rather than a borrowed stale first-site binding.
 func (c *canonicalizer) resolvedAttrNSURI(e *helium.Element, attr *helium.Attribute) (string, error) {
 	if c.currentEntityFrame() == nil {
 		return attr.URI(), nil
@@ -955,6 +968,14 @@ func (c *canonicalizer) resolvedAttrNSURI(e *helium.Element, attr *helium.Attrib
 	prefix := attr.Prefix()
 	if prefix == "" {
 		return "", nil
+	}
+	if prefix == lexicon.PrefixXML {
+		// The reserved "xml" prefix (e.g. xml:lang, xml:space) is implicitly
+		// bound to the XML namespace everywhere, so it is always in scope at the
+		// reference site. Resolve it to that implicit URI; like a non-entity
+		// xml:* attribute it is never emitted as an explicit xmlns:xml
+		// declaration on the inclusive/node-set paths.
+		return lexicon.NamespaceXML, nil
 	}
 	if uri, ok := c.collectInScopeNamespaces(e)[prefix]; ok {
 		return uri, nil

--- a/c14n/canonicalizer.go
+++ b/c14n/canonicalizer.go
@@ -496,6 +496,12 @@ func (c *canonicalizer) writeComment(cm *helium.Comment) error {
 func (c *canonicalizer) writeQualifiedName(e *helium.Element) error {
 	ns := e.Namespace()
 	if ns != nil && ns.Prefix() != "" {
+		// Resolve the element prefix against the reference site. For an
+		// entity-replacement element whose prefix is out of scope at this
+		// reference site this errors rather than emitting a dangling prefix.
+		if _, err := c.resolvedNSURI(e, ns); err != nil {
+			return err
+		}
 		if _, err := io.WriteString(c.out, ns.Prefix()); err != nil {
 			return err
 		}
@@ -748,7 +754,11 @@ func (c *canonicalizer) renderNamespacesExclusive(e *helium.Element) error {
 
 	// Element's own namespace
 	if ns := e.Namespace(); ns != nil {
-		utilized[ns.Prefix()] = c.resolvedNSURI(e, ns)
+		uri, err := c.resolvedNSURI(e, ns)
+		if err != nil {
+			return err
+		}
+		utilized[ns.Prefix()] = uri
 	} else if uri := c.entityDefaultNSURI(e); uri != "" {
 		// Inside an entity expansion an unprefixed replacement element has a nil
 		// cached active namespace when the FIRST reference site had no default
@@ -885,19 +895,31 @@ func (c *canonicalizer) renderNamespacesExclusiveNodeSet(e *helium.Element) erro
 	return nil
 }
 
-// resolvedNSURI returns the URI of the element's name namespace. Inside an
-// entity expansion the element's cached active-namespace pointer was resolved
-// once at parse time against the first reference site, so re-resolve the
-// element's prefix against the current reference-site context; outside an entity
-// the cached pointer is authoritative. When the prefix is not bound at the
-// reference site the element is in no namespace there (an empty default, or an
-// unbound prefix in malformed input), so return the empty URI rather than the
-// stale cached value.
-func (c *canonicalizer) resolvedNSURI(e *helium.Element, ns *helium.Namespace) string {
+// resolvedNSURI returns the URI of the element's name namespace. Outside an
+// entity expansion the cached active-namespace pointer is authoritative. Inside
+// an entity expansion that pointer was resolved once at parse time against the
+// first reference site, so re-resolve the element's prefix against the current
+// reference-site context.
+//
+// An unprefixed entity-replacement element is governed by the reference-site
+// default namespace normally (unlike an attribute), so it resolves to the
+// in-scope default URI, or the empty URI when no default is in scope. A prefixed
+// entity element whose prefix is not in scope at the current reference site
+// cannot be canonicalized (a prefixed name with an out-of-scope prefix is
+// namespace-not-well-formed for that expansion), so this is an error rather than
+// a borrowed stale first-site binding or a dangling prefix.
+func (c *canonicalizer) resolvedNSURI(e *helium.Element, ns *helium.Namespace) (string, error) {
 	if c.currentEntityFrame() == nil {
-		return ns.URI()
+		return ns.URI(), nil
 	}
-	return c.collectInScopeNamespaces(e)[ns.Prefix()]
+	prefix := ns.Prefix()
+	if uri, ok := c.collectInScopeNamespaces(e)[prefix]; ok {
+		return uri, nil
+	}
+	if prefix != "" {
+		return "", fmt.Errorf("c14n: namespace prefix %q of entity-replacement element %q is not in scope at the reference site", prefix, e.Name())
+	}
+	return "", nil
 }
 
 // entityDefaultNSURI returns the reference-site default-namespace URI for an

--- a/c14n/canonicalizer.go
+++ b/c14n/canonicalizer.go
@@ -3,6 +3,7 @@ package c14n
 import (
 	"fmt"
 	"io"
+	"maps"
 	"net/url"
 	"slices"
 
@@ -23,6 +24,14 @@ type canonicalizer struct {
 	// nsNodesByElement indexes NamespaceNodeWrapper nodes by their parent element.
 	// Built once during process() when nodeSet is non-nil.
 	nsNodesByElement map[helium.Node][]nsSortEntry
+	// entityNSContext is a stack of reference-site in-scope namespace bindings
+	// (prefix→URI), pushed when the walk descends through an EntityRef. While
+	// non-empty, an entity-replacement element resolves the prefixes it does not
+	// itself declare against the reference site's bindings rather than the shared
+	// Entity declaration node's DTD-context parent chain and its cached
+	// active-namespace pointers (both resolved once at parse time against the
+	// first reference site).
+	entityNSContext []map[string]string
 }
 
 func (c *canonicalizer) process() error {
@@ -259,24 +268,93 @@ func (c *canonicalizer) processNode(n helium.Node) error {
 	case helium.EntityRefNode:
 		// Expand entity ref children. For an unexpanded reference the child is
 		// the shared Entity declaration node, handled by the EntityNode case.
-		for child := range helium.Children(n) {
-			if err := c.processNode(child); err != nil {
-				return err
-			}
-		}
-		return nil
+		// Canonicalize the replacement subtree in the namespace context of THIS
+		// reference site (per W3C Canonical XML the replacement is included as if
+		// textually substituted here), so a prefix in the replacement resolves
+		// against the site's in-scope bindings.
+		c.pushEntityContext(n)
+		err := c.processChildren(n)
+		c.popEntityContext()
+		return err
 	case helium.EntityNode:
 		// The Entity declaration node holds the parsed replacement content as
 		// its children; emit it so the reference contributes its replacement
 		// text (and any markup) to the canonical output.
-		for child := range helium.Children(n) {
-			if err := c.processNode(child); err != nil {
-				return err
-			}
-		}
-		return nil
+		return c.processChildren(n)
 	}
 	return nil
+}
+
+func (c *canonicalizer) processChildren(n helium.Node) error {
+	for child := range helium.Children(n) {
+		if err := c.processNode(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// currentEntityContext returns the reference-site namespace bindings for the
+// entity expansion currently being walked, or nil when the walk is not inside
+// one.
+func (c *canonicalizer) currentEntityContext() map[string]string {
+	n := len(c.entityNSContext)
+	if n == 0 {
+		return nil
+	}
+	return c.entityNSContext[n-1]
+}
+
+// pushEntityContext records the in-scope namespace bindings at an entity
+// reference site so the replacement subtree canonicalizes as if the text were
+// inserted there. In ordinary document content the reference site's ancestors
+// carry reliable bindings. For a reference nested inside another entity, inherit
+// the enclosing entity's reference-site context and overlay the xmlns
+// declarations physically present in the enclosing entity subtree (the cached
+// active-namespace pointers there are unreliable).
+func (c *canonicalizer) pushEntityContext(entityRef helium.Node) {
+	ctx := make(map[string]string)
+	parent, ok := helium.AsNode[*helium.Element](entityRef.Parent())
+	outer := c.currentEntityContext()
+	switch {
+	case outer == nil && ok:
+		for prefix, ns := range domutil.InScopeNamespaces(parent, c.nodeSet == nil) {
+			ctx[prefix] = ns.URI()
+		}
+	case outer != nil:
+		maps.Copy(ctx, outer)
+		if ok {
+			c.overlayEntityNSDecls(ctx, parent)
+		}
+	}
+	c.entityNSContext = append(c.entityNSContext, ctx)
+}
+
+func (c *canonicalizer) popEntityContext() {
+	c.entityNSContext = c.entityNSContext[:len(c.entityNSContext)-1]
+}
+
+// overlayEntityNSDecls applies the xmlns declarations physically present in the
+// entity subtree onto ctx: the element and its ancestors up to the entity
+// boundary (the first non-element parent — the shared Entity declaration node),
+// outermost first so an inner declaration wins. Only real declarations
+// (nsDefs) are consulted; the elements' cached active-namespace pointers are
+// not, since those were resolved at parse time against a specific reference
+// site.
+func (c *canonicalizer) overlayEntityNSDecls(ctx map[string]string, e *helium.Element) {
+	var chain []*helium.Element
+	for n := helium.Node(e); ; n = n.Parent() {
+		el, ok := helium.AsNode[*helium.Element](n)
+		if !ok {
+			break
+		}
+		chain = append(chain, el)
+	}
+	for _, el := range slices.Backward(chain) {
+		for _, ns := range el.Namespaces() {
+			ctx[ns.Prefix()] = ns.URI()
+		}
+	}
 }
 
 func (c *canonicalizer) processText(n helium.Node) error {
@@ -587,7 +665,7 @@ func (c *canonicalizer) renderNamespacesExclusive(e *helium.Element) error {
 
 	// Element's own namespace
 	if ns := e.Namespace(); ns != nil {
-		utilized[ns.Prefix()] = ns.URI()
+		utilized[ns.Prefix()] = c.resolvedNSURI(e, ns)
 	} else {
 		// Check if default namespace needs to be undeclared
 		if existingURI, found := c.nsStack.lookup(""); found && existingURI != "" {
@@ -713,9 +791,40 @@ func (c *canonicalizer) renderNamespacesExclusiveNodeSet(e *helium.Element) erro
 	return nil
 }
 
+// resolvedNSURI returns the URI of the element's name namespace. Inside an
+// entity expansion the element's cached active-namespace pointer was resolved
+// once at parse time against the first reference site, so re-resolve the
+// element's prefix against the current reference-site context; outside an entity
+// the cached pointer is authoritative.
+func (c *canonicalizer) resolvedNSURI(e *helium.Element, ns *helium.Namespace) string {
+	if c.currentEntityContext() == nil {
+		return ns.URI()
+	}
+	if uri, ok := c.collectInScopeNamespaces(e)[ns.Prefix()]; ok {
+		return uri
+	}
+	return ns.URI()
+}
+
 // collectInScopeNamespaces collects all in-scope namespace bindings for an element
 // by walking up the ancestor chain.
 func (c *canonicalizer) collectInScopeNamespaces(e *helium.Element) map[string]string {
+	// Inside an entity expansion the element's parent chain stops at the shared
+	// Entity declaration node, so its own parent-chain walk (and its cached
+	// active-namespace pointer) can only see the entity declaration's context.
+	// Resolve against the reference site instead: start from the reference-site
+	// bindings and overlay the xmlns declarations physically present in the
+	// entity subtree.
+	if ctx := c.currentEntityContext(); ctx != nil {
+		nsMap := make(map[string]string, len(ctx))
+		maps.Copy(nsMap, ctx)
+		c.overlayEntityNSDecls(nsMap, e)
+		if c.nodeSet == nil {
+			delete(nsMap, lexicon.PrefixXML)
+		}
+		return nsMap
+	}
+
 	// Remove the xml namespace (never explicitly output per C14N spec) unless
 	// it's inherited via xml:* attributes in node-set mode.
 	byPrefix := domutil.InScopeNamespaces(e, c.nodeSet == nil)


### PR DESCRIPTION
- add an `EntityNode` case to the c14n canonicalizer so an unexpanded entity reference emits its replacement text
- fixes a signature-coverage gap and W3C-C14N interop break for element-content entity references
