### PR TITLE
guard VerifyElement nil and non-Signature input

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -348,7 +348,7 @@ XML Digital Signatures 1.1 (W3C xmldsig-core1). Sign and verify XML documents.
   - Signing never mutates the caller's document. For a detached Signature (`SignDetached`/`SignEnveloping`, `sigElem.Parent()==nil`), `computeAndSetSignatureValue` (`sign.go`) canonicalizes `<ds:SignedInfo>` through the SAME throwaway-document proxy (`canonicalizeDetachedSubtree`, `transforms.go`) — the proxy reproduces the caller document element's in-scope namespaces + inherited xml:* per C14N version, so the SignedInfo digest is byte-identical to canonicalizing it while attached under `doc.DocumentElement()`, and the temporary move is undone on normal return, error, or panic. Enveloped signing (`SignEnveloped`) canonicalizes SignedInfo in place under the parent it was inserted into.
 - **NewVerifier(KeySource) → Verifier** — create fluent builder for verification (clone-on-write value type)
   - `AllowSHA1(bool)` — builder method
-  - `Verify(ctx, doc)`, `VerifyElement(ctx, doc, sigElem)` — terminal methods
+  - `Verify(ctx, doc)`, `VerifyElement(ctx, doc, sigElem)` — terminal methods. `VerifyElement` takes the target element straight from the caller (bypassing `findSignatureElements`), so it applies the same gate itself before any work: a nil `sigElem`, or one that is not local-name `Signature` in the core XML-Signature namespace (`isDSigCoreNS`), is rejected with `ErrInvalidSignature` rather than nil-dereferencing or being parsed as a ds:Signature.
 - **NewEnvelopedReference() → ReferenceConfig** — SAML-optimized defaults (enveloped + ExcC14N + SHA-256)
 - Key sources: `StaticKey(key)`, `X509CertKeySource(cert)`, `KeySourceFunc`
 - Key info builders: `X509DataKeyInfo(certs...)`, `RSAKeyValueKeyInfo()`

--- a/xmldsig1/verify_element_test.go
+++ b/xmldsig1/verify_element_test.go
@@ -1,0 +1,68 @@
+package xmldsig1_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/helium/xmldsig1"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerifyElementNilSignature confirms VerifyElement rejects a nil Signature
+// element with a typed error instead of panicking on a nil dereference. Unlike
+// Verify, VerifyElement takes the target element from the caller, so a caller
+// that located nothing (nil) must get an error back, matching the validation
+// findSignatureElements performs for the Verify path.
+func TestVerifyElementNilSignature(t *testing.T) {
+	doc := mustParseXML(t, samlAssertion)
+	key := generateRSAKey(t)
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+
+	_, err := verifier.VerifyElement(t.Context(), doc, nil)
+	require.ErrorIs(t, err, xmldsig1.ErrInvalidSignature)
+}
+
+// TestVerifyElementRejectsNonSignature confirms VerifyElement refuses an element
+// that is not a ds:Signature in the core XML-Signature namespace, matching the
+// local-name + namespace gate findSignatureElements applies for Verify.
+func TestVerifyElementRejectsNonSignature(t *testing.T) {
+	key := generateRSAKey(t)
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+
+	t.Run("plain element", func(t *testing.T) {
+		doc := mustParseXML(t, `<foo><bar/></foo>`)
+		_, err := verifier.VerifyElement(t.Context(), doc, doc.DocumentElement())
+		require.ErrorIs(t, err, xmldsig1.ErrInvalidSignature)
+	})
+
+	t.Run("signature in wrong namespace", func(t *testing.T) {
+		doc := mustParseXML(t, `<Signature xmlns="http://example.com/not-dsig"><SignedInfo/></Signature>`)
+		_, err := verifier.VerifyElement(t.Context(), doc, doc.DocumentElement())
+		require.ErrorIs(t, err, xmldsig1.ErrInvalidSignature)
+	})
+}
+
+// TestVerifyElementValid confirms a genuine ds:Signature element still verifies
+// through VerifyElement once the nil / non-Signature guards are in place.
+func TestVerifyElementValid(t *testing.T) {
+	xml := `<root><data Id="mydata">Hello</data></root>`
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, xml)
+
+	ref := xmldsig1.ReferenceConfig{
+		URI:             "#mydata",
+		DigestAlgorithm: xmldsig1.DigestSHA256,
+		Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+	}
+
+	sigElem, err := xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(ref).
+		SignDetached(t.Context(), doc, key)
+	require.NoError(t, err)
+	require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+	result, err := verifier.VerifyElement(t.Context(), doc, sigElem)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}

--- a/xmldsig1/xmldsig1.go
+++ b/xmldsig1/xmldsig1.go
@@ -2,6 +2,7 @@ package xmldsig1
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	helium "github.com/lestrrat-go/helium"
@@ -237,6 +238,19 @@ func (v Verifier) Verify(ctx context.Context, doc *helium.Document) (*VerifyResu
 // Same-document reference resolution recognizes the same ID attributes as
 // [Verifier.Verify].
 func (v Verifier) VerifyElement(ctx context.Context, doc *helium.Document, sig *helium.Element) (*VerifyResult, error) {
+	// Verify reaches verifySignature only through findSignatureElements, which
+	// already gates on local-name Signature in the core XML-Signature namespace.
+	// VerifyElement takes the target element straight from the caller, so it must
+	// perform the same validation before any work: a nil sig (e.g. a caller's
+	// lookup that matched nothing) would otherwise nil-deref in
+	// parseSignatureElement, and a non-Signature/wrong-namespace element would be
+	// parsed as if it were a ds:Signature.
+	if sig == nil {
+		return nil, fmt.Errorf("%w: nil Signature element", ErrInvalidSignature)
+	}
+	if domutil.LocalName(sig) != "Signature" || !isDSigCoreNS(sig) {
+		return nil, fmt.Errorf("%w: element is not a ds:Signature", ErrInvalidSignature)
+	}
 	return verifySignature(ctx, v.cfg, doc, sig)
 }
 


### PR DESCRIPTION
- reject a nil `sig` in `VerifyElement` with `ErrInvalidSignature` instead of nil-dereferencing
- reject a non-`Signature`/wrong-namespace element in `VerifyElement`, matching the `Verify` gate
