### PR TITLE
honor ctx cancellation in xmldsig1 verify

### DIFF
--- a/xmldsig1/verify.go
+++ b/xmldsig1/verify.go
@@ -54,6 +54,17 @@ type parsedTransform struct {
 }
 
 func verifySignature(ctx context.Context, cfg *verifierConfig, doc *helium.Document, sigElem *helium.Element) (*VerifyResult, error) {
+	// Honor an already-cancelled or already-expired context before any work. All
+	// of the pre-loop steps below — signature-element parse, weak-algorithm
+	// preflight, KeyInfo parse (x509.ParseCertificate per cert), KeySource
+	// resolution, SignedInfo canonicalization, and one SignatureValue crypto
+	// verify — are bounded but non-trivial, so a context the caller cancelled
+	// before calling must short-circuit here rather than run them to completion.
+	// The per-Reference loop below repeats this check each iteration.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	// A zero-value Verifier{} constructed directly (bypassing NewVerifier) has
 	// a nil cfg, and a nil KeySource (e.g. NewVerifier(nil)) cannot resolve a
 	// key. isNilKeySource also catches a typed-nil pointer KeySource, whose

--- a/xmldsig1/verify_element_test.go
+++ b/xmldsig1/verify_element_test.go
@@ -1,6 +1,7 @@
 package xmldsig1_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/lestrrat-go/helium/xmldsig1"
@@ -65,4 +66,53 @@ func TestVerifyElementValid(t *testing.T) {
 	result, err := verifier.VerifyElement(t.Context(), doc, sigElem)
 	require.NoError(t, err)
 	require.NotNil(t, result)
+}
+
+// TestVerifyElementShortCircuitsCancelledContextBeforeValidation confirms an
+// already-cancelled context short-circuits VerifyElement before its nil /
+// local-name / namespace validation guards run, not just before verifySignature.
+// Each case passes a cancelled context and asserts the returned error is the
+// context error rather than a validation error, proving the cancellation check
+// precedes the nil/namespace validation on an attacker-controlled element.
+func TestVerifyElementShortCircuitsCancelledContextBeforeValidation(t *testing.T) {
+	key := generateRSAKey(t)
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(&key.PublicKey))
+
+	newCancelledContext := func(t *testing.T) context.Context {
+		t.Helper()
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		return ctx
+	}
+
+	t.Run("nil signature", func(t *testing.T) {
+		doc := mustParseXML(t, samlAssertion)
+		_, err := verifier.VerifyElement(newCancelledContext(t), doc, nil)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("wrong-namespace element", func(t *testing.T) {
+		doc := mustParseXML(t, `<Signature xmlns="http://example.com/not-dsig"><SignedInfo/></Signature>`)
+		_, err := verifier.VerifyElement(newCancelledContext(t), doc, doc.DocumentElement())
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("valid signature", func(t *testing.T) {
+		xml := `<root><data Id="signed">Hello</data></root>`
+		doc := mustParseXML(t, xml)
+		ref := xmldsig1.ReferenceConfig{
+			URI:             "#signed",
+			DigestAlgorithm: xmldsig1.DigestSHA256,
+			Transforms:      []xmldsig1.Transform{xmldsig1.ExcC14NTransform()},
+		}
+		sigElem, err := xmldsig1.NewSigner().
+			SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+			Reference(ref).
+			SignDetached(t.Context(), doc, key)
+		require.NoError(t, err)
+		require.NoError(t, doc.DocumentElement().AddChild(sigElem))
+
+		_, err = verifier.VerifyElement(newCancelledContext(t), doc, sigElem)
+		require.ErrorIs(t, err, context.Canceled)
+	})
 }

--- a/xmldsig1/verify_test.go
+++ b/xmldsig1/verify_test.go
@@ -687,3 +687,20 @@ func TestVerifyShortCircuitsCancelledContext(t *testing.T) {
 		require.False(t, ks.called, "cancelled context must short-circuit before key resolution")
 	})
 }
+
+// TestVerifyShortCircuitsBeforeSignatureDiscovery ensures an already-cancelled
+// context aborts Verify before the signature-discovery walk. Verify walks the
+// whole document to locate ds:Signature elements before delegating to the
+// per-signature verify path, so the cancellation check must sit ahead of that
+// walk: on a large or attacker-supplied document with no Signature, a cancelled
+// context must return the context error immediately rather than pay for the
+// unbounded discovery walk and then report ErrSignatureNotFound.
+func TestVerifyShortCircuitsBeforeSignatureDiscovery(t *testing.T) {
+	doc := mustParseXML(t, `<root/>`)
+	verifier := xmldsig1.NewVerifier(xmldsig1.StaticKey(nil))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := verifier.Verify(ctx, doc)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/xmldsig1/verify_test.go
+++ b/xmldsig1/verify_test.go
@@ -621,3 +621,69 @@ func TestVerifyHonorsContextCancellation(t *testing.T) {
 	_, err = verifier.Verify(ctx, doc)
 	require.ErrorIs(t, err, context.Canceled)
 }
+
+// recordingKeySource wraps a fixed key and records whether ResolveKey was ever
+// invoked, so a test can prove that verification short-circuited before reaching
+// key resolution.
+type recordingKeySource struct {
+	key    any
+	called bool
+}
+
+func (r *recordingKeySource) ResolveKey(_ context.Context, _ *xmldsig1.KeyInfoData, _ string) (any, error) {
+	r.called = true
+	return r.key, nil
+}
+
+// TestVerifyShortCircuitsCancelledContext ensures an already-cancelled context
+// aborts verification before any pre-loop work — signature parse, KeyInfo parse,
+// key resolution, SignedInfo canonicalization, and the SignatureValue crypto
+// verify. The recording KeySource proves ResolveKey is never reached, and the
+// returned error is the context error. This complements
+// TestVerifyHonorsContextCancellation, which covers the per-Reference loop.
+func TestVerifyShortCircuitsCancelledContext(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	require.NoError(t, xmldsig1.NewSigner().
+		SignatureAlgorithm(xmldsig1.AlgRSASHA256).
+		Reference(xmldsig1.NewEnvelopedReference()).
+		SignEnveloped(t.Context(), doc, doc.DocumentElement(), key))
+
+	t.Run("verify", func(t *testing.T) {
+		ks := &recordingKeySource{key: &key.PublicKey}
+		verifier := xmldsig1.NewVerifier(ks)
+
+		// Sanity: under a live context verification reaches key resolution and
+		// succeeds.
+		_, err := verifier.Verify(t.Context(), doc)
+		require.NoError(t, err)
+		require.True(t, ks.called, "live verify must reach key resolution")
+
+		ks.called = false
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err = verifier.Verify(ctx, doc)
+		require.ErrorIs(t, err, context.Canceled)
+		require.False(t, ks.called, "cancelled context must short-circuit before key resolution")
+	})
+
+	t.Run("verify element", func(t *testing.T) {
+		sig := findSignatureElement(doc.DocumentElement())
+		require.NotNil(t, sig)
+
+		ks := &recordingKeySource{key: &key.PublicKey}
+		verifier := xmldsig1.NewVerifier(ks)
+
+		_, err := verifier.VerifyElement(t.Context(), doc, sig)
+		require.NoError(t, err)
+		require.True(t, ks.called, "live verify must reach key resolution")
+
+		ks.called = false
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err = verifier.VerifyElement(ctx, doc, sig)
+		require.ErrorIs(t, err, context.Canceled)
+		require.False(t, ks.called, "cancelled context must short-circuit before key resolution")
+	})
+}

--- a/xmldsig1/xmldsig1.go
+++ b/xmldsig1/xmldsig1.go
@@ -283,6 +283,14 @@ func (v Verifier) Verify(ctx context.Context, doc *helium.Document) (*VerifyResu
 // rechecked between References, and a ctx deadline is the lever for bounding the
 // per-Reference work of a SignedInfo that carries many References.
 func (v Verifier) VerifyElement(ctx context.Context, doc *helium.Document, sig *helium.Element) (*VerifyResult, error) {
+	// Honor an already-cancelled or already-expired context before any work,
+	// including the nil / local-name / namespace validation guards below. The
+	// caller supplies sig directly, so on an attacker-controlled element a
+	// cancelled context must short-circuit here rather than pay for the
+	// validation before verifySignature's own ctx check would catch it.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	// Verify reaches verifySignature only through findSignatureElements, which
 	// already gates on local-name Signature in the core XML-Signature namespace.
 	// VerifyElement takes the target element straight from the caller, so it must

--- a/xmldsig1/xmldsig1.go
+++ b/xmldsig1/xmldsig1.go
@@ -252,6 +252,14 @@ func (v Verifier) AllowSHA1(allow bool) Verifier {
 // per-Reference work scales with the number of References; bound it by passing a
 // ctx with a deadline. On cancellation the context error (ctx.Err()) is returned.
 func (v Verifier) Verify(ctx context.Context, doc *helium.Document) (*VerifyResult, error) {
+	// Honor an already-cancelled or already-expired context before the
+	// signature-discovery walk. findSignatureElements below traverses the whole
+	// document, which is unbounded on a large or attacker-supplied input, so a
+	// context the caller cancelled before calling must short-circuit here rather
+	// than pay for the full walk only to return ErrSignatureNotFound.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	sigs := findSignatureElements(doc.DocumentElement())
 	switch len(sigs) {
 	case 0:

--- a/xmldsig1/xmldsig1.go
+++ b/xmldsig1/xmldsig1.go
@@ -244,6 +244,13 @@ func (v Verifier) AllowSHA1(allow bool) Verifier {
 // DTD/schema, or by marking the attribute's type as an ID before verifying —
 // rather than have it inferred from the name. If more than one element matches
 // the referenced ID the reference is refused (ErrAmbiguousReference).
+//
+// Verification honors ctx: an already-cancelled or already-expired context
+// short-circuits before any work, and cancellation is rechecked between
+// References. Because a SignedInfo may carry arbitrarily many References and each
+// empty-URI enveloped Reference canonicalizes a copy of the whole document, the
+// per-Reference work scales with the number of References; bound it by passing a
+// ctx with a deadline. On cancellation the context error (ctx.Err()) is returned.
 func (v Verifier) Verify(ctx context.Context, doc *helium.Document) (*VerifyResult, error) {
 	sigs := findSignatureElements(doc.DocumentElement())
 	switch len(sigs) {
@@ -262,6 +269,11 @@ func (v Verifier) Verify(ctx context.Context, doc *helium.Document) (*VerifyResu
 //
 // Same-document reference resolution recognizes the same ID attributes as
 // [Verifier.Verify].
+//
+// Verification honors ctx the same way as [Verifier.Verify]: an already-cancelled
+// or already-expired context short-circuits before any work, cancellation is
+// rechecked between References, and a ctx deadline is the lever for bounding the
+// per-Reference work of a SignedInfo that carries many References.
 func (v Verifier) VerifyElement(ctx context.Context, doc *helium.Document, sig *helium.Element) (*VerifyResult, error) {
 	// Verify reaches verifySignature only through findSignatureElements, which
 	// already gates on local-name Signature in the core XML-Signature namespace.


### PR DESCRIPTION
- check `ctx.Err()` at `verifySignature` entry so a cancelled context short-circuits before key resolution and crypto
- document that a `ctx` deadline bounds a many-Reference SignedInfo on `Verify`/`VerifyElement`
