### PR TITLE
gate releases on xmldsig suites

### DIFF
--- a/.github/workflows/conformance-run.yml
+++ b/.github/workflows/conformance-run.yml
@@ -21,7 +21,7 @@ on:
         type: boolean
         default: false
       harness_ref:
-        description: helium-w3c-tests (harness) git ref to check out (commit/tag/branch). Defaults to main so a caller that does not pin (the nightly/manual conformance.yml) tracks the harness tip; the release gate passes a pinned harness_ref.
+        description: helium-w3c-tests (harness) git ref to check out (commit/tag/branch). Defaults to main so a caller that does not pin (the nightly/manual conformance.yml) tracks the harness tip; the release gate supplies its pinned harness commit through this input.
         type: string
         default: main
 

--- a/.github/workflows/conformance-run.yml
+++ b/.github/workflows/conformance-run.yml
@@ -6,7 +6,8 @@ name: Conformance run
 # fails when the suite reports any failures.
 #
 # Invoked by conformance.yml (nightly/manual entrypoint) and by release.yml
-# (the release-gating slow xslt30 run). Kept as a single source of truth so the
+# (the release-gating xslt30, xmldsig2ed, xmldsig11, and merlinxmldsig runs;
+# only xslt30 enables slow tests). Kept as a single source of truth so the
 # checkout/fetch/run logic is not duplicated.
 on:
   workflow_call:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -27,7 +27,7 @@ on:
         type: boolean
         default: false
       harness_ref:
-        description: helium-w3c-tests (harness) git ref to pin (commit/tag/branch); use for an audit/release run. Nightly stays on main.
+        description: helium-w3c-tests (harness) git ref to pin (commit/tag/branch) for an audit run. Nightly stays on main.
         type: string
         default: main
   # Nightly full run of the XSLT 3.0 suite with slow tests enabled.

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -4,7 +4,8 @@ name: Conformance
 # These are not run on ordinary pushes/PRs because they clone large upstream
 # fixture sets and, with the performance-gated slow tests enabled, can take many
 # minutes. The actual checkout/fetch/run logic lives in the reusable
-# conformance-run.yml, shared with the release-gating slow xslt30 run.
+# conformance-run.yml, shared with the release-gating xslt30, xmldsig2ed,
+# xmldsig11, and merlinxmldsig runs; only xslt30 enables slow tests.
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,10 @@ name: Release
 
 # Dispatch-driven release. Instead of triggering on a pushed tag (which would
 # leave a public tag behind if the conformance gate then failed), a release is
-# started manually with a version input. The slow XSLT 3.0 conformance suite
-# runs FIRST; only when it is green does the release job create the tag and run
-# goreleaser. A red gate stops the run before any tag exists, so a failing
-# conformance test has zero side effects.
+# started manually with a version input. The required XSLT 3.0 and XMLDSig
+# conformance suites run FIRST; only when they are green does the release job
+# create the tag and run goreleaser. A red gate stops the run before any tag
+# exists, so a failing conformance test has zero side effects.
 #
 # The release job is bound to the `release` GitHub Environment, which requires
 # maintainer approval and is restricted to the `main` branch — so the tag/publish
@@ -72,17 +72,21 @@ jobs:
           )
           PY
 
-  # Release-gating conformance run: the full slow XSLT 3.0 suite must pass with
-  # zero failures before anything is tagged or published. The release job needs:
-  # this, so a red slow run blocks the release BEFORE a tag is ever created.
+  # Release-gating conformance runs: the full slow XSLT 3.0 suite and all three
+  # XMLDSig suites must pass with zero failures before anything is tagged or
+  # published. Every matrix entry is a required job result.
   conformance-gate:
     needs: timeline-presence
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [xslt30, xmldsig2ed, xmldsig11, merlinxmldsig]
     permissions:
       contents: read
     uses: ./.github/workflows/conformance-run.yml
     with:
-      suite: xslt30
-      slow: true
+      suite: ${{ matrix.suite }}
+      slow: ${{ matrix.suite == 'xslt30' }}
       harness_ref: ${{ inputs.harness_ref }}
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ name: Release
 # step pauses for a human even though anyone with write access can dispatch.
 #
 # See RELEASING.md for the full runbook (how to dispatch, how to bump the pinned
-# harness_ref, and recovery if goreleaser fails after tagging).
+# harness commit, and recovery if goreleaser fails after tagging).
 on:
   workflow_dispatch:
     inputs:
@@ -20,16 +20,6 @@ on:
         description: Release version tag to create (e.g. v0.5.2)
         type: string
         required: true
-      harness_ref:
-        # Pinned to a known-good helium-w3c-tests commit so the release gate is
-        # reproducible and cannot be red-blocked by unrelated harness@main churn.
-        # Bump this to the harness SHA from the latest green nightly conformance
-        # run when certifying a release against newer upstream tests.
-        # See RELEASING.md.
-        description: helium-w3c-tests (harness) commit/tag to gate against
-        type: string
-        default: 6c987d8fe551efb4a9171fdb5657a922cff442d3
-
 permissions:
   contents: read
 
@@ -87,7 +77,9 @@ jobs:
     with:
       suite: ${{ matrix.suite }}
       slow: ${{ matrix.suite == 'xslt30' }}
-      harness_ref: ${{ inputs.harness_ref }}
+      # Pin the release gate to the certified harness commit. Update this SHA
+      # only after a newer harness commit passes the manual Conformance run.
+      harness_ref: 6c987d8fe551efb4a9171fdb5657a922cff442d3
 
   release:
     needs: conformance-gate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ on:
         # See RELEASING.md.
         description: helium-w3c-tests (harness) commit/tag to gate against
         type: string
-        default: b0a79c5b459dd74d0daef6142513f3cab2b5243b
+        default: 594989196668369ed21bac1f8026ef83f5429a1d
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ on:
         # See RELEASING.md.
         description: helium-w3c-tests (harness) commit/tag to gate against
         type: string
-        default: 594989196668369ed21bac1f8026ef83f5429a1d
+        default: 6c987d8fe551efb4a9171fdb5657a922cff442d3
 
 permissions:
   contents: read

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,8 +66,9 @@ candidate and superseded by a real-tag re-measure afterwards. See
 
 ## Conformance gate
 
-A release cannot be tagged/published unless the slow XSLT 3.0 conformance suite
-passes with **0 failures**. The full slow suite is **release-gating, not
+A release cannot be tagged/published unless the XSLT 3.0, XMLDSig2Ed, XMLDSig
+1.1, and Merlin XMLDSig conformance suites pass with **0 failures**. The full
+XSLT suite is **release-gating, not
 PR-gating**: the heavyweight W3C conformance suites are never run on ordinary
 pushes or pull requests (they clone large upstream fixture sets and, with the
 performance-gated slow tests enabled, take many minutes), so they must not block
@@ -75,12 +76,12 @@ day-to-day PR CI.
 
 ### How it is enforced
 
-`.github/workflows/release.yml`'s `conformance-gate` job runs the reusable
-`.github/workflows/conformance-run.yml` with `suite: xslt30` and `slow: true`
-(which sets `HELIUM_SLOW_TESTS=1`). The `release` job declares
-`needs: conformance-gate` and runs *after* the gate, so the tag is created and
-goreleaser runs **only** on a green suite — a red gate stops the workflow before
-any tag exists.
+`.github/workflows/release.yml`'s `conformance-gate` matrix runs the reusable
+`.github/workflows/conformance-run.yml` for `xslt30`, `xmldsig2ed`, `xmldsig11`,
+and `merlinxmldsig`. Only the XSLT entry sets `slow: true`, which enables
+`HELIUM_SLOW_TESTS=1`. The `release` job declares `needs: conformance-gate` and
+runs *after* every matrix entry, so the tag is created and goreleaser runs only
+on a green set of suites.
 
 The reusable run gates on the reported failure **count**: after running the
 suite it reads `<testsuites failures="N">` from the JUnit report and fails the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,8 +32,10 @@ so a failed conformance run never leaves a public tag or partial release behind.
 4. The `timeline-presence` job checks in seconds that `version` has a row in the
    committed timeline (from step 2). If it does not, the run stops here — fix step
    2 and re-dispatch.
-5. The `conformance-gate` job runs the slow XSLT 3.0 suite against the pinned
-   `harness_ref`. If it fails, the run stops here — **no tag, no release.**
+5. The `conformance-gate` job runs the `xslt30`, `xmldsig2ed`, `xmldsig11`, and
+   `merlinxmldsig` suites against the pinned `harness_ref`; only `xslt30`
+   enables slow tests. If any suite fails, the run stops here — **no tag, no
+   release.**
 6. On green, the `release` job waits for **environment approval** (the `release`
    environment: maintainer reviewer, restricted to `main`). Approve it in the run.
 7. After approval it creates and pushes the `version` tag, then runs goreleaser

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,13 +27,13 @@ so a failed conformance run never leaves a public tag or partial release behind.
    re-measures it at the real tag and supersedes the candidate row cleanly.
 3. Run the Release workflow from `main`:
    - GitHub UI: **Actions → Release → Run workflow**, branch `main`, fill in
-     `version` (e.g. `v0.5.2`). Leave `harness_ref` at its pinned default.
+     `version` (e.g. `v0.5.2`).
    - or: `gh workflow run release.yml --ref main -f version=v0.5.2`
 4. The `timeline-presence` job checks in seconds that `version` has a row in the
    committed timeline (from step 2). If it does not, the run stops here — fix step
    2 and re-dispatch.
 5. The `conformance-gate` job runs the `xslt30`, `xmldsig2ed`, `xmldsig11`, and
-   `merlinxmldsig` suites against the pinned `harness_ref`; only `xslt30`
+   `merlinxmldsig` suites against the pinned harness commit; only `xslt30`
    enables slow tests. If any suite fails, the run stops here — **no tag, no
    release.**
 6. On green, the `release` job waits for **environment approval** (the `release`
@@ -106,16 +106,17 @@ release-tag measurements. Release-tag results belong in `CONFORMANCE.md` and
 35/37, while `xmldsig1/summary-xmldsig2ed.md` records 37/37 for its later
 feature-evidence commit because the transform behavior was completed there.
 
-## The pinned harness_ref
+## The pinned release harness
 
-`release.yml` pins `harness_ref` to a known-good `helium-w3c-tests` commit so the
-release gate is **reproducible** and cannot be red-blocked by unrelated churn on
-`helium-w3c-tests@main`. Each release records exactly which harness certified it.
+`release.yml` passes a known-good `helium-w3c-tests` commit to the reusable
+conformance workflow, so the release gate is **reproducible** and cannot be
+red-blocked by unrelated churn on `helium-w3c-tests@main`. Each release records
+exactly which harness certified it.
 
 **Bumping the pin:** the nightly `Conformance` run tracks `helium-w3c-tests@main`
 (unpinned) — a green nightly means that harness commit passes against helium
-`main`. To certify releases against newer upstream tests, set the `harness_ref`
-default in `release.yml` to the harness SHA from the latest green nightly:
+`main`. To certify releases against newer upstream tests, update the pinned
+harness SHA in `release.yml` to the commit from the latest green nightly:
 
 ```
 gh api repos/lestrrat-go/helium-w3c-tests/commits/main --jq .sha

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -97,6 +97,15 @@ Trigger it from the Actions tab (`workflow_dispatch`), choosing the suite and
 whether to enable slow tests; it also runs nightly against `xslt30` with slow
 tests on.
 
+### Generated suite summaries
+
+The committed suite summaries under `xmldsig1/` are generated feature evidence
+for the helium and harness commits recorded in each file. They do not represent
+release-tag measurements. Release-tag results belong in `CONFORMANCE.md` and
+`tools/conformance-timeline/`; for example, the `v0.7.0` XMLDSig2Ed row is
+35/37, while `xmldsig1/summary-xmldsig2ed.md` records 37/37 for its later
+feature-evidence commit because the transform behavior was completed there.
+
 ## The pinned harness_ref
 
 `release.yml` pins `harness_ref` to a known-good `helium-w3c-tests` commit so the

--- a/xmldsig1/summary-xmldsig2ed.md
+++ b/xmldsig1/summary-xmldsig2ed.md
@@ -8,6 +8,13 @@ This is a point-in-time snapshot; regenerate to refresh.
 - helium: `5af7d185`
 - helium-w3c-tests (harness): `6c987d8`
 
+This is current feature evidence for helium commit `5af7d185`, not a
+measurement of the `v0.7.0` release tag. The release tag was measured
+separately in the root [conformance timeline](../CONFORMANCE.md) at 35/37;
+the two expected failures reflect transform behavior that was completed in
+the later feature-evidence commit. The 37/37 result below describes that later
+commit.
+
 | Outcome | Count |
 |---------|------:|
 | Pass | 37 |

--- a/xmldsig1/summary-xmldsig2ed.md
+++ b/xmldsig1/summary-xmldsig2ed.md
@@ -8,13 +8,6 @@ This is a point-in-time snapshot; regenerate to refresh.
 - helium: `5af7d185`
 - helium-w3c-tests (harness): `6c987d8`
 
-This is current feature evidence for helium commit `5af7d185`, not a
-measurement of the `v0.7.0` release tag. The release tag was measured
-separately in the root [conformance timeline](../CONFORMANCE.md) at 35/37;
-the two expected failures reflect transform behavior that was completed in
-the later feature-evidence commit. The 37/37 result below describes that later
-commit.
-
 | Outcome | Count |
 |---------|------:|
 | Pass | 37 |


### PR DESCRIPTION
- Require XSLT 3.0 and all three XMLDSig suites to pass before tagging or publishing.
- Document the release matrix and slow-test behavior in `RELEASING.md`.
- Explain the later 37/37 feature evidence versus the `v0.7.0` tag's 35/37 timeline result.
