### PR TITLE
snapshot xmldsig1 transforms on ingress

### DIFF
--- a/xmldsig1/hardening_internal_test.go
+++ b/xmldsig1/hardening_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	helium "github.com/lestrrat-go/helium"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,4 +66,30 @@ func TestSignerCloneDeepCopiesTransforms(t *testing.T) {
 	exc, ok := stored[1].(excC14NTransform)
 	require.True(t, ok)
 	require.Equal(t, []string{"p1"}, exc.Prefixes())
+}
+
+type mutableTransform struct {
+	uri string
+}
+
+func (t *mutableTransform) URI() string { return t.uri }
+
+// TestSignerReferenceSnapshotsCallerTransform proves a caller-owned Transform
+// cannot change a Signer's transform pipeline after Reference returns.
+func TestSignerReferenceSnapshotsCallerTransform(t *testing.T) {
+	transform := &mutableTransform{uri: ExcC14N10}
+	signer := NewSigner().
+		SignatureAlgorithm(AlgHMACSHA256).
+		Reference(ReferenceConfig{
+			URI:             "#target",
+			DigestAlgorithm: DigestSHA256,
+			Transforms:      []Transform{Enveloped(), transform},
+		})
+
+	transform.uri = "urn:unsupported-after-ingress"
+
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(`<root><target Id="target">payload</target></root>`))
+	require.NoError(t, err)
+	_, err = signer.SignDetached(t.Context(), doc, []byte("signing-key"))
+	require.NoError(t, err)
 }

--- a/xmldsig1/transforms.go
+++ b/xmldsig1/transforms.go
@@ -64,6 +64,16 @@ func ExcC14NTransform(prefixes ...string) Transform {
 	return excC14NTransform{prefixes: slices.Clone(prefixes)}
 }
 
+// transformSnapshot is the immutable representation of a caller-defined
+// transform. Signing observes only the transform URI, so retaining the
+// caller's implementation would let later mutations change a configured
+// Signer.
+type transformSnapshot struct {
+	uri string
+}
+
+func (t transformSnapshot) URI() string { return t.uri }
+
 // cloneReferenceTransforms returns a deep copy of a Reference's transform slice:
 // a fresh backing array plus a copy of each mutable transform's internal state.
 // Signer.clone uses it so a later caller mutation of the original Transforms
@@ -80,15 +90,18 @@ func cloneReferenceTransforms(transforms []Transform) []Transform {
 	return out
 }
 
-// cloneTransform returns a copy of t that shares no mutable state with t. Only
-// excC14NTransform carries mutable state (its prefix slice); every other
-// Transform is an immutable value and is returned unchanged.
+// cloneTransform returns a copy of t that shares no mutable state with t.
 func cloneTransform(t Transform) Transform {
-	exc, ok := t.(excC14NTransform)
-	if !ok {
+	switch t := t.(type) {
+	case nil:
+		return nil
+	case excC14NTransform:
+		return excC14NTransform{prefixes: slices.Clone(t.prefixes)}
+	case envelopedTransform, c14nTransform:
 		return t
+	default:
+		return transformSnapshot{uri: t.URI()}
 	}
-	return excC14NTransform{prefixes: slices.Clone(exc.prefixes)}
 }
 
 // transformStep is the algorithm-agnostic view of a single Reference transform,


### PR DESCRIPTION
- snapshot caller-defined Transform URIs when Reference captures them
- preserve built-in transforms and exclusive C14N prefix state
- cover mutable caller transforms with a detached-signing regression
