### PR TITLE
support XML Encryption 1.1 ECDH-ES

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -392,16 +392,17 @@ XML Encryption 1.1 (W3C xmlenc-core1). Encrypt and decrypt XML elements/content.
   - `BlockAlgorithm(uri)`, `AllowLegacyCBC(bool)`, `KeyTransportAlgorithm(uri)`, `RecipientPublicKey(key)`, `SessionKey(key)`, `KeyWrapAlgorithm(uri)`, `KeyEncryptionKey(kek)`, `OAEPDigest(uri)`, `OAEPMGF(uri)`, `OAEPParams(params)` — builder methods
   - `EncryptElement(ctx, elem)`, `EncryptContent(ctx, elem)` — terminal methods
 - **NewDecryptor() → Decryptor** — create fluent builder for decryption
-  - `PrivateKey(key)`, `KeyEncryptionKey(kek)`, `SessionKey(key)`, `AllowUnauthenticatedCBC(bool)`, `MaxEncryptedKeys(n)` — builder methods
-  - `Decrypt(ctx, elem)` — terminal method
+  - `PrivateKey(key)`, `ECPrivateKey(key)`, `KeyEncryptionKey(kek)`, `SessionKey(key)`, `AllowUnauthenticatedCBC(bool)`, `MaxEncryptedKeys(n)` — builder methods
+  - `Decrypt(ctx, elem)`, `DecryptBytes(ctx, elem)` — terminal methods; the latter returns binary plaintext without XML parsing
 - `Decryptor.MaxEncryptedKeys(n)` caps trial-decrypted `<EncryptedKey>` candidates (DoS guard): zero → `DefaultMaxEncryptedKeys` (100), negative → unlimited; over-cap fails with `ErrTooManyEncryptedKeys` before any RSA op. The candidate loop also polls `ctx.Err()` between candidates
 - Block encryption: AES-128/256-CBC, legacy AES-128/256-GCM, and XML Encryption 1.1 AES-128/192/256-GCM. The 1.1 GCM form uses the standard IV || ciphertext || authentication-tag encoding without additional authenticated data.
 - Secure by default: unset `BlockAlgorithm` → `DefaultBlockAlgorithm` (AES-256-GCM). Selecting a CBC block algorithm for **encryption** requires `Encryptor.AllowLegacyCBC(true)`, else `ErrCBCEncryptionRequiresOptIn`. **Decryption** of CBC requires `Decryptor.AllowUnauthenticatedCBC(true)`, else `ErrCBCRequiresOptIn`
 - Key transport: RSA-OAEP (1.0 + 1.1 with configurable SHA-1/256/384/512 digest and MGF; the OAEP label digest and the MGF1 hash may differ, via `rsa.EncryptOAEPWithOptions`/`OAEPOptions` — requires Go ≥ 1.26)
-- Key wrapping: AES-128/256-KeyWrap (RFC 3394)
+- Key wrapping: AES-128/192/256-KeyWrap (RFC 3394)
+- Key agreement: XML Encryption 1.1 ECDH-ES on P-256, P-384, and P-521 with ConcatKDF using SHA-1/256/384/512
 - Key sizes are bound to the declared algorithm URI on encrypt and decrypt (incl. after unwrap/key transport); mismatch → `KeySizeError`
 - Multi-recipient: `EncryptedData.EncryptedKeys []*EncryptedKey` holds one EncryptedKey per recipient; decrypt tries each candidate through full block decryption + plaintext validation (a bogus prepended key cannot mask the real one). `EncryptedData.EncryptedKey` is the **deprecated** single-key field — `EncryptedKeys` wins when non-empty, else the single field is treated as a one-element list; parse populates both
-- Files: `xmlenc1.go` (API), `constants.go`, `block.go`, `keytransport.go`, `keywrap.go`, `types.go`, `serialize.go`, `parse.go`, `errors.go`
+- Files: `xmlenc1.go` (API), `constants.go`, `block.go`, `keytransport.go`, `keywrap.go`, `key_agreement.go`, `types.go`, `serialize.go`, `parse.go`, `errors.go`
 - Imports: helium
 
 ## shim/

--- a/xmlenc1/README.md
+++ b/xmlenc1/README.md
@@ -11,8 +11,9 @@ Import path: `github.com/lestrrat-go/helium/xmlenc1`
 - Secure by default. `Encryptor` defaults to authenticated AES-256-GCM
   (`DefaultBlockAlgorithm`) when no `BlockAlgorithm` is set. The package
   binds the `EncryptionMethod/@Algorithm` URI into the AEAD
-  additional-authenticated-data so an attacker cannot substitute a
-  different algorithm URI on the wire.
+  additional-authenticated-data for the legacy XML Encryption GCM
+  identifiers. XML Encryption 1.1 GCM uses its standard IV, ciphertext, and
+  authentication-tag encoding without additional authenticated data.
 - AES-CBC is unauthenticated and vulnerable to padding-oracle attacks
   (Jager/Somorovsky 2011).
   - **Encryption:** selecting a CBC `BlockAlgorithm` requires
@@ -28,6 +29,9 @@ Import path: `github.com/lestrrat-go/helium/xmlenc1`
   external entity resolution, and network access all disabled. Decrypted
   bytes are attacker-controlled, so a relaxed parser would constitute an
   XXE oracle.
+- `Decryptor.ECPrivateKey` enables XML Encryption 1.1 ECDH-ES with P-256,
+  P-384, or P-521 and ConcatKDF. `Decryptor.DecryptBytes` returns binary
+  plaintext without parsing it as XML.
 
 <!-- INCLUDE(examples/xmlenc1_encrypt_decrypt_example_test.go) -->
 ```go
@@ -112,11 +116,10 @@ source: [examples/xmlenc1_encrypt_decrypt_example_test.go](https://github.com/le
 
 The sibling [`helium-w3c-tests`](https://github.com/lestrrat-go/helium-w3c-tests)
 module runs the XML Encryption 1.1 core vectors with the `xmlenc11` suite. The
-current [conformance summary](summary-xmlenc11.md) records ten vectors: six
-ECDH-ES cases skipped because key agreement is outside the current API, and
-four RSA cases recorded as expected gaps for XML Encryption 1.1 algorithm
-support. The suite is available through the manual Conformance workflow and is
-not part of the release gate until those gaps are removed.
+current [conformance summary](summary-xmlenc11.md) records all ten vectors as
+passing, including the six ECDH-ES cases and four RSA cases. The suite is
+available through the manual Conformance workflow and is not part of the
+release gate.
 
 Run it from `../helium-w3c-tests`:
 

--- a/xmlenc1/block.go
+++ b/xmlenc1/block.go
@@ -13,7 +13,7 @@ func keySizeForAlgorithm(algorithm string) (int, error) {
 	switch algorithm {
 	case AES128CBC, AES128GCM, AES128GCM11, AES128KeyWrap:
 		return 16, nil
-	case AES192GCM11:
+	case AES192GCM11, AES192KeyWrap:
 		return 24, nil
 	case AES256CBC, AES256GCM, AES256GCM11, AES256KeyWrap:
 		return 32, nil

--- a/xmlenc1/constants.go
+++ b/xmlenc1/constants.go
@@ -52,7 +52,9 @@ const (
 	DigestSHA1   = NamespaceDSig + "sha1"
 	DigestSHA256 = NamespaceXMLEnc + "sha256"
 	DigestSHA384 = NamespaceXMLEnc + "sha384"
-	DigestSHA512 = NamespaceXMLEnc + "sha512"
+	// DigestSHA384DSigMore is the XMLDSig-more SHA-384 URI.
+	DigestSHA384DSigMore = NamespaceDSigMore + "sha384"
+	DigestSHA512         = NamespaceXMLEnc + "sha512"
 )
 
 // MGF algorithm URIs.

--- a/xmlenc1/constants.go
+++ b/xmlenc1/constants.go
@@ -14,6 +14,9 @@ const (
 	// NamespaceDSigMore contains the additional XML Digital Signature
 	// algorithm identifiers used by XML Encryption.
 	NamespaceDSigMore = "http://www.w3.org/2001/04/xmldsig-more#"
+
+	// NamespaceDSig11 is the XML Digital Signature 1.1 namespace.
+	NamespaceDSig11 = "http://www.w3.org/2009/xmldsig11#"
 )
 
 // Block encryption algorithm URIs.
@@ -40,6 +43,7 @@ const (
 // Key wrapping algorithm URIs.
 const (
 	AES128KeyWrap = NamespaceXMLEnc + "kw-aes128"
+	AES192KeyWrap = NamespaceXMLEnc + "kw-aes192"
 	AES256KeyWrap = NamespaceXMLEnc + "kw-aes256"
 )
 
@@ -57,6 +61,12 @@ const (
 	MGFSHA256 = NamespaceXMLEnc11 + "mgf1sha256"
 	MGFSHA384 = NamespaceXMLEnc11 + "mgf1sha384"
 	MGFSHA512 = NamespaceXMLEnc11 + "mgf1sha512"
+)
+
+// Key agreement and key derivation algorithm URIs.
+const (
+	ECDHES    = NamespaceXMLEnc11 + "ECDH-ES"
+	ConcatKDF = NamespaceXMLEnc11 + "ConcatKDF"
 )
 
 // Encryption type URIs.

--- a/xmlenc1/key_agreement.go
+++ b/xmlenc1/key_agreement.go
@@ -1,0 +1,110 @@
+package xmlenc1
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/binary"
+	"fmt"
+	"hash"
+)
+
+func decryptECDHSessionKey(priv *ecdsa.PrivateKey, ek *EncryptedKey) ([]byte, error) {
+	agreement := ek.AgreementMethod
+	if agreement == nil || agreement.Algorithm != ECDHES {
+		return nil, fmt.Errorf("%w: %w", ErrDecryptionFailed, &UnsupportedAlgorithmError{Algorithm: agreementAlgorithm(agreement)})
+	}
+	if agreement.OriginatorKey == nil {
+		return nil, fmt.Errorf("%w: ECDH-ES missing OriginatorKeyInfo", ErrMalformedEncrypted)
+	}
+	if agreement.KeyDerivationMethod == nil {
+		return nil, fmt.Errorf("%w: ECDH-ES missing KeyDerivationMethod", ErrMalformedEncrypted)
+	}
+	method := agreement.KeyDerivationMethod
+	if method.Algorithm != ConcatKDF {
+		return nil, fmt.Errorf("%w: %w", ErrDecryptionFailed, &UnsupportedAlgorithmError{Algorithm: method.Algorithm})
+	}
+	if method.ConcatKDF == nil {
+		return nil, fmt.Errorf("%w: ConcatKDF missing parameters", ErrMalformedEncrypted)
+	}
+
+	if ek.EncryptionMethod == nil {
+		return nil, fmt.Errorf("%w: EncryptedKey missing EncryptionMethod", ErrMalformedEncrypted)
+	}
+	kekSize, err := keySizeForAlgorithm(ek.EncryptionMethod.Algorithm)
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey, err := priv.ECDH()
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid ECDH private key: %v", ErrDecryptionFailed, err)
+	}
+	originatorKey, err := agreement.OriginatorKey.Curve.NewPublicKey(agreement.OriginatorKey.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid ECDH public key: %v", ErrDecryptionFailed, err)
+	}
+	sharedSecret, err := privateKey.ECDH(originatorKey)
+	if err != nil {
+		return nil, fmt.Errorf("%w: ECDH exchange failed: %v", ErrDecryptionFailed, err)
+	}
+
+	kek, err := deriveConcatKDF(sharedSecret, method.ConcatKDF, kekSize)
+	if err != nil {
+		return nil, err
+	}
+	return aesKeyUnwrap(kek, ek.CipherValue)
+}
+
+func agreementAlgorithm(agreement *AgreementMethod) string {
+	if agreement == nil {
+		return ""
+	}
+	return agreement.Algorithm
+}
+
+func deriveConcatKDF(sharedSecret []byte, params *ConcatKDFParams, keySize int) ([]byte, error) {
+	newHash, err := concatKDFHash(params.DigestMethod)
+	if err != nil {
+		return nil, err
+	}
+	otherInfo := make([]byte, 0,
+		len(params.AlgorithmID)+len(params.PartyUInfo)+len(params.PartyVInfo)+
+			len(params.SuppPubInfo)+len(params.SuppPrivInfo))
+	otherInfo = append(otherInfo, params.AlgorithmID...)
+	otherInfo = append(otherInfo, params.PartyUInfo...)
+	otherInfo = append(otherInfo, params.PartyVInfo...)
+	otherInfo = append(otherInfo, params.SuppPubInfo...)
+	otherInfo = append(otherInfo, params.SuppPrivInfo...)
+
+	result := make([]byte, 0, keySize)
+	for counter := uint32(1); len(result) < keySize; counter++ {
+		h := newHash()
+		var counterBytes [4]byte
+		binary.BigEndian.PutUint32(counterBytes[:], counter)
+		_, _ = h.Write(counterBytes[:])
+		_, _ = h.Write(sharedSecret)
+		_, _ = h.Write(otherInfo)
+		result = append(result, h.Sum(nil)...)
+		if counter == ^uint32(0) && len(result) < keySize {
+			return nil, fmt.Errorf("%w: ConcatKDF output is too large", ErrDecryptionFailed)
+		}
+	}
+	return result[:keySize], nil
+}
+
+func concatKDFHash(uri string) (func() hash.Hash, error) {
+	switch uri {
+	case DigestSHA1:
+		return sha1.New, nil
+	case DigestSHA256:
+		return sha256.New, nil
+	case DigestSHA384:
+		return sha512.New384, nil
+	case DigestSHA512:
+		return sha512.New, nil
+	default:
+		return nil, fmt.Errorf("%w: %w", ErrDecryptionFailed, &UnsupportedAlgorithmError{Algorithm: uri})
+	}
+}

--- a/xmlenc1/key_agreement.go
+++ b/xmlenc1/key_agreement.go
@@ -114,7 +114,7 @@ func concatKDFOtherInfo(params *ConcatKDFParams) ([]byte, error) {
 	bitOffset := 0
 	for _, field := range fields {
 		bitCount := len(field.value)*8 - int(field.unusedBits)
-		for i := 0; i < bitCount; i++ {
+		for i := range bitCount {
 			if field.value[i/8]&(1<<uint(7-i%8)) != 0 {
 				otherInfo[bitOffset/8] |= 1 << uint(7-bitOffset%8)
 			}

--- a/xmlenc1/key_agreement.go
+++ b/xmlenc1/key_agreement.go
@@ -32,6 +32,11 @@ func decryptECDHSessionKey(priv *ecdsa.PrivateKey, ek *EncryptedKey) ([]byte, er
 	if ek.EncryptionMethod == nil {
 		return nil, fmt.Errorf("%w: EncryptedKey missing EncryptionMethod", ErrMalformedEncrypted)
 	}
+	switch ek.EncryptionMethod.Algorithm {
+	case AES128KeyWrap, AES192KeyWrap, AES256KeyWrap:
+	default:
+		return nil, fmt.Errorf("%w: %w", ErrDecryptionFailed, &UnsupportedAlgorithmError{Algorithm: ek.EncryptionMethod.Algorithm})
+	}
 	kekSize, err := keySizeForAlgorithm(ek.EncryptionMethod.Algorithm)
 	if err != nil {
 		return nil, err
@@ -130,7 +135,7 @@ func concatKDFHash(uri string) (func() hash.Hash, error) {
 		return sha1.New, nil
 	case DigestSHA256:
 		return sha256.New, nil
-	case DigestSHA384:
+	case DigestSHA384, DigestSHA384DSigMore:
 		return sha512.New384, nil
 	case DigestSHA512:
 		return sha512.New, nil

--- a/xmlenc1/key_agreement.go
+++ b/xmlenc1/key_agreement.go
@@ -69,14 +69,10 @@ func deriveConcatKDF(sharedSecret []byte, params *ConcatKDFParams, keySize int) 
 	if err != nil {
 		return nil, err
 	}
-	otherInfo := make([]byte, 0,
-		len(params.AlgorithmID)+len(params.PartyUInfo)+len(params.PartyVInfo)+
-			len(params.SuppPubInfo)+len(params.SuppPrivInfo))
-	otherInfo = append(otherInfo, params.AlgorithmID...)
-	otherInfo = append(otherInfo, params.PartyUInfo...)
-	otherInfo = append(otherInfo, params.PartyVInfo...)
-	otherInfo = append(otherInfo, params.SuppPubInfo...)
-	otherInfo = append(otherInfo, params.SuppPrivInfo...)
+	otherInfo, err := concatKDFOtherInfo(params)
+	if err != nil {
+		return nil, err
+	}
 
 	result := make([]byte, 0, keySize)
 	for counter := uint32(1); len(result) < keySize; counter++ {
@@ -92,6 +88,40 @@ func deriveConcatKDF(sharedSecret []byte, params *ConcatKDFParams, keySize int) 
 		}
 	}
 	return result[:keySize], nil
+}
+
+func concatKDFOtherInfo(params *ConcatKDFParams) ([]byte, error) {
+	fields := []struct {
+		value      []byte
+		unusedBits uint8
+	}{
+		{value: params.AlgorithmID, unusedBits: params.algorithmIDUnusedBits},
+		{value: params.PartyUInfo, unusedBits: params.partyUInfoUnusedBits},
+		{value: params.PartyVInfo, unusedBits: params.partyVInfoUnusedBits},
+		{value: params.SuppPubInfo, unusedBits: params.suppPubInfoUnusedBits},
+		{value: params.SuppPrivInfo, unusedBits: params.suppPrivInfoUnusedBits},
+	}
+
+	totalBits := 0
+	for _, field := range fields {
+		if int(field.unusedBits) > len(field.value)*8 {
+			return nil, fmt.Errorf("%w: invalid ConcatKDF bitstring", ErrMalformedEncrypted)
+		}
+		totalBits += len(field.value)*8 - int(field.unusedBits)
+	}
+
+	otherInfo := make([]byte, (totalBits+7)/8)
+	bitOffset := 0
+	for _, field := range fields {
+		bitCount := len(field.value)*8 - int(field.unusedBits)
+		for i := 0; i < bitCount; i++ {
+			if field.value[i/8]&(1<<uint(7-i%8)) != 0 {
+				otherInfo[bitOffset/8] |= 1 << uint(7-bitOffset%8)
+			}
+			bitOffset++
+		}
+	}
+	return otherInfo, nil
 }
 
 func concatKDFHash(uri string) (func() hash.Hash, error) {

--- a/xmlenc1/key_agreement_internal_test.go
+++ b/xmlenc1/key_agreement_internal_test.go
@@ -1,0 +1,33 @@
+package xmlenc1
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcatKDFNonByteAlignedOtherInfo(t *testing.T) {
+	doc, err := helium.NewParser().Parse(t.Context(), []byte(
+		`<xenc11:ConcatKDFParams xmlns:xenc11="`+NamespaceXMLEnc11+`" xmlns:ds="`+NamespaceDSig+`" PartyUInfo="03D8" PartyVInfo="0780"><ds:DigestMethod Algorithm="`+DigestSHA256+`"/></xenc11:ConcatKDFParams>`,
+	))
+	require.NoError(t, err)
+
+	params, err := parseConcatKDFParams(doc.DocumentElement())
+	require.NoError(t, err)
+	require.Equal(t, []byte{0xd8}, params.PartyUInfo)
+	require.Equal(t, uint8(3), params.partyUInfoUnusedBits)
+	require.Equal(t, []byte{0x80}, params.PartyVInfo)
+	require.Equal(t, uint8(7), params.partyVInfoUnusedBits)
+
+	sharedSecret := []byte{0x01, 0x02, 0x03, 0x04}
+	got, err := deriveConcatKDF(sharedSecret, params, sha256.Size)
+	require.NoError(t, err)
+
+	input := []byte{0, 0, 0, 1}
+	input = append(input, sharedSecret...)
+	input = append(input, 0xdc) // 11011 || 1, repacked with two trailing zero bits.
+	want := sha256.Sum256(input)
+	require.Equal(t, want[:], got)
+}

--- a/xmlenc1/key_agreement_internal_test.go
+++ b/xmlenc1/key_agreement_internal_test.go
@@ -1,6 +1,10 @@
 package xmlenc1
 
 import (
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/sha256"
 	"testing"
 
@@ -30,4 +34,83 @@ func TestConcatKDFNonByteAlignedOtherInfo(t *testing.T) {
 	input = append(input, 0xdc) // 11011 || 1, repacked with two trailing zero bits.
 	want := sha256.Sum256(input)
 	require.Equal(t, want[:], got)
+}
+
+func TestConcatKDFSHA384AcceptsXMLDSigMoreURI(t *testing.T) {
+	sharedSecret := []byte{0x01, 0x02, 0x03, 0x04}
+
+	canonical, err := deriveConcatKDF(sharedSecret, &ConcatKDFParams{DigestMethod: DigestSHA384}, 48)
+	require.NoError(t, err)
+	alias, err := deriveConcatKDF(sharedSecret, &ConcatKDFParams{DigestMethod: DigestSHA384DSigMore}, 48)
+	require.NoError(t, err)
+	require.Equal(t, canonical, alias)
+}
+
+func TestDecryptECDHSessionKeyAllowsOnlyAESKeyWrap(t *testing.T) {
+	tests := []struct {
+		name      string
+		algorithm string
+		wantError bool
+	}{
+		{name: "AES-128 key wrap", algorithm: AES128KeyWrap},
+		{name: "AES-192 key wrap", algorithm: AES192KeyWrap},
+		{name: "AES-256 key wrap", algorithm: AES256KeyWrap},
+		{name: "AES-128 GCM", algorithm: AES128GCM, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			priv, encryptedKey, want := newECDHEncryptedKey(t, tt.algorithm)
+			got, err := decryptECDHSessionKey(priv, encryptedKey)
+			if tt.wantError {
+				require.ErrorIs(t, err, ErrDecryptionFailed)
+				var unsupported *UnsupportedAlgorithmError
+				require.ErrorAs(t, err, &unsupported)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+		})
+	}
+}
+
+func newECDHEncryptedKey(t *testing.T, algorithm string) (*ecdsa.PrivateKey, *EncryptedKey, []byte) {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	originatorKey, err := ecdh.P256().GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	recipientECDH, err := privateKey.ECDH()
+	require.NoError(t, err)
+	sharedSecret, err := recipientECDH.ECDH(originatorKey.PublicKey())
+	require.NoError(t, err)
+
+	kekSize, err := keySizeForAlgorithm(algorithm)
+	require.NoError(t, err)
+	params := &ConcatKDFParams{DigestMethod: DigestSHA256}
+	kek, err := deriveConcatKDF(sharedSecret, params, kekSize)
+	require.NoError(t, err)
+
+	want := make([]byte, 16)
+	_, err = rand.Read(want)
+	require.NoError(t, err)
+	cipherValue, err := aesKeyWrap(kek, want)
+	require.NoError(t, err)
+
+	return privateKey, &EncryptedKey{
+		EncryptionMethod: &EncryptionMethod{Algorithm: algorithm},
+		CipherValue:      cipherValue,
+		AgreementMethod: &AgreementMethod{
+			Algorithm: ECDHES,
+			KeyDerivationMethod: &KeyDerivationMethod{
+				Algorithm: ConcatKDF,
+				ConcatKDF: params,
+			},
+			OriginatorKey: &ECKeyValue{
+				Curve:     ecdh.P256(),
+				PublicKey: originatorKey.PublicKey().Bytes(),
+			},
+		},
+	}, want
 }

--- a/xmlenc1/key_agreement_test.go
+++ b/xmlenc1/key_agreement_test.go
@@ -1,0 +1,48 @@
+package xmlenc1_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/lestrrat-go/helium/xmlenc1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecryptBytes(t *testing.T) {
+	key := randKey(t, 32)
+	plaintext := []byte{0x00, 0x01, 0x02, 0xff, 0xfe}
+	cipherValue, err := xmlenc1.EncryptBytesForTest(xmlenc1.AES256GCM11, key, plaintext)
+	require.NoError(t, err)
+
+	doc := mustParseXML(t, `<root/>`)
+	ed := &xmlenc1.EncryptedData{
+		Type:             xmlenc1.TypeElement,
+		EncryptionMethod: &xmlenc1.EncryptionMethod{Algorithm: xmlenc1.AES256GCM11},
+		CipherValue:      cipherValue,
+	}
+	edElem, err := xmlenc1.MarshalEncryptedDataForTest(doc, ed)
+	require.NoError(t, err)
+
+	got, err := xmlenc1.NewDecryptor().SessionKey(key).DecryptBytes(t.Context(), edElem)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(plaintext, got))
+}
+
+func TestParseECDHAgreement(t *testing.T) {
+	const publicKey = "BGoi18CKzCb0K8RTLj0pEFAj2MWDDilMemPZWlOIxS1WbAiR7UrhIstegXjYfIBEYXmnXZFEx/1Ns+yakYTm/B8="
+	xml := `<xenc:EncryptedData xmlns:xenc="` + xmlenc1.NamespaceXMLEnc + `" xmlns:ds="` + xmlenc1.NamespaceDSig + `" xmlns:dsig11="` + xmlenc1.NamespaceDSig11 + `" xmlns:xenc11="` + xmlenc1.NamespaceXMLEnc11 + `">` +
+		`<xenc:EncryptionMethod Algorithm="` + xmlenc1.AES128GCM11 + `"/>` +
+		`<ds:KeyInfo><xenc:EncryptedKey><xenc:EncryptionMethod Algorithm="` + xmlenc1.AES128KeyWrap + `"/>` +
+		`<ds:KeyInfo><xenc:AgreementMethod Algorithm="` + xmlenc1.ECDHES + `">` +
+		`<xenc11:KeyDerivationMethod Algorithm="` + xmlenc1.ConcatKDF + `"><xenc11:ConcatKDFParams AlgorithmID="" PartyUInfo="00b9e13a70c35edcb3b66fda86b4898942" PartyVInfo=""><ds:DigestMethod Algorithm="` + xmlenc1.DigestSHA256 + `"/></xenc11:ConcatKDFParams></xenc11:KeyDerivationMethod>` +
+		`<xenc:OriginatorKeyInfo><ds:KeyValue><dsig11:ECKeyValue><dsig11:NamedCurve URI="urn:oid:1.2.840.10045.3.1.7"/><dsig11:PublicKey>` + publicKey + `</dsig11:PublicKey></dsig11:ECKeyValue></ds:KeyValue></xenc:OriginatorKeyInfo>` +
+		`</xenc:AgreementMethod></ds:KeyInfo><xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData></xenc:EncryptedKey></ds:KeyInfo>` +
+		`<xenc:CipherData><xenc:CipherValue>AAAA</xenc:CipherValue></xenc:CipherData></xenc:EncryptedData>`
+	doc := mustParseXML(t, xml)
+	ed, err := xmlenc1.ParseEncryptedDataForTest(doc.DocumentElement())
+	require.NoError(t, err)
+	require.Len(t, ed.EncryptedKeys, 1)
+	require.Equal(t, xmlenc1.ECDHES, ed.EncryptedKeys[0].AgreementMethod.Algorithm)
+	require.Equal(t, xmlenc1.ConcatKDF, ed.EncryptedKeys[0].AgreementMethod.KeyDerivationMethod.Algorithm)
+	require.Equal(t, []byte{0xb9, 0xe1, 0x3a, 0x70, 0xc3, 0x5e, 0xdc, 0xb3, 0xb6, 0x6f, 0xda, 0x86, 0xb4, 0x89, 0x89, 0x42}, ed.EncryptedKeys[0].AgreementMethod.KeyDerivationMethod.ConcatKDF.PartyUInfo)
+}

--- a/xmlenc1/keytransport.go
+++ b/xmlenc1/keytransport.go
@@ -86,7 +86,7 @@ func oaepHashes(algorithm, digest, mgf string) (crypto.Hash, crypto.Hash, error)
 		digestHash = crypto.SHA1
 	case DigestSHA256:
 		digestHash = crypto.SHA256
-	case DigestSHA384, NamespaceDSigMore + "sha384":
+	case DigestSHA384, DigestSHA384DSigMore:
 		digestHash = crypto.SHA384
 	case DigestSHA512:
 		digestHash = crypto.SHA512

--- a/xmlenc1/keytransport_test.go
+++ b/xmlenc1/keytransport_test.go
@@ -86,7 +86,7 @@ func TestRSAOAEP(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, xml, xmlenc1.DigestSHA384)
 
-		compatDigest := xmlenc1.NamespaceDSigMore + "sha384"
+		compatDigest := xmlenc1.DigestSHA384DSigMore
 		tampered := strings.Replace(xml, xmlenc1.DigestSHA384, compatDigest, 1)
 		require.NotEqual(t, xml, tampered)
 

--- a/xmlenc1/keywrap_test.go
+++ b/xmlenc1/keywrap_test.go
@@ -41,6 +41,21 @@ func TestAESKeyWrapRFC3394(t *testing.T) {
 }
 
 func TestKeyWrapSize(t *testing.T) {
+	t.Run("AES-192 KEK round-trip", func(t *testing.T) {
+		kek := randKey(t, 24)
+		doc := mustParseXML(t, `<root><a>hi</a></root>`)
+		enc := xmlenc1.NewEncryptor().
+			BlockAlgorithm(xmlenc1.AES128GCM11).
+			KeyWrapAlgorithm(xmlenc1.AES192KeyWrap).
+			KeyEncryptionKey(kek)
+		edElem, err := enc.EncryptElement(t.Context(), doc.DocumentElement())
+		require.NoError(t, err)
+
+		nodes, err := xmlenc1.NewDecryptor().KeyEncryptionKey(kek).Decrypt(t.Context(), edElem)
+		require.NoError(t, err)
+		require.Len(t, nodes, 1)
+	})
+
 	t.Run("correct size round-trip", func(t *testing.T) {
 		kek := randKey(t, 32)
 		doc := mustParseXML(t, samlAssertion)

--- a/xmlenc1/parse.go
+++ b/xmlenc1/parse.go
@@ -227,16 +227,17 @@ func parseConcatKDFParams(elem *helium.Element) (*ConcatKDFParams, error) {
 	params := &ConcatKDFParams{}
 	var err error
 	for _, field := range []struct {
-		name string
-		dest *[]byte
+		name       string
+		dest       *[]byte
+		unusedBits *uint8
 	}{
-		{name: "AlgorithmID", dest: &params.AlgorithmID},
-		{name: "PartyUInfo", dest: &params.PartyUInfo},
-		{name: "PartyVInfo", dest: &params.PartyVInfo},
-		{name: "SuppPubInfo", dest: &params.SuppPubInfo},
-		{name: "SuppPrivInfo", dest: &params.SuppPrivInfo},
+		{name: "AlgorithmID", dest: &params.AlgorithmID, unusedBits: &params.algorithmIDUnusedBits},
+		{name: "PartyUInfo", dest: &params.PartyUInfo, unusedBits: &params.partyUInfoUnusedBits},
+		{name: "PartyVInfo", dest: &params.PartyVInfo, unusedBits: &params.partyVInfoUnusedBits},
+		{name: "SuppPubInfo", dest: &params.SuppPubInfo, unusedBits: &params.suppPubInfoUnusedBits},
+		{name: "SuppPrivInfo", dest: &params.SuppPrivInfo, unusedBits: &params.suppPrivInfoUnusedBits},
 	} {
-		*field.dest, err = parseConcatKDFHexAttribute(elem, field.name)
+		*field.dest, *field.unusedBits, err = parseConcatKDFHexAttribute(elem, field.name)
 		if err != nil {
 			return nil, err
 		}
@@ -260,20 +261,20 @@ func parseConcatKDFParams(elem *helium.Element) (*ConcatKDFParams, error) {
 	return params, nil
 }
 
-func parseConcatKDFHexAttribute(elem *helium.Element, name string) ([]byte, error) {
+func parseConcatKDFHexAttribute(elem *helium.Element, name string) ([]byte, uint8, error) {
 	value, ok := elem.GetAttribute(name)
 	if !ok || strings.TrimSpace(value) == "" {
-		return nil, nil
+		return nil, 0, nil
 	}
 	value = strings.TrimSpace(value)
 	decoded, err := hex.DecodeString(value)
 	if err != nil || len(decoded) == 0 {
-		return nil, fmt.Errorf("%w: invalid ConcatKDF %s", ErrMalformedEncrypted, name)
+		return nil, 0, fmt.Errorf("%w: invalid ConcatKDF %s", ErrMalformedEncrypted, name)
 	}
-	if decoded[0] != 0 {
-		return nil, fmt.Errorf("%w: non-byte-aligned ConcatKDF %s is not supported", ErrMalformedEncrypted, name)
+	if decoded[0] > 7 || (len(decoded) == 1 && decoded[0] != 0) {
+		return nil, 0, fmt.Errorf("%w: invalid ConcatKDF %s", ErrMalformedEncrypted, name)
 	}
-	return decoded[1:], nil
+	return decoded[1:], decoded[0], nil
 }
 
 func parseOriginatorKeyInfo(elem *helium.Element) (*ECKeyValue, error) {

--- a/xmlenc1/parse.go
+++ b/xmlenc1/parse.go
@@ -1,8 +1,11 @@
 package xmlenc1
 
 import (
+	"crypto/ecdh"
+	"encoding/hex"
 	"fmt"
 	"slices"
+	"strings"
 
 	helium "github.com/lestrrat-go/helium"
 	"github.com/lestrrat-go/helium/internal/domutil"
@@ -124,6 +127,12 @@ func parseEncryptedKey(elem *helium.Element) (*EncryptedKey, error) {
 			ek.CipherValue = cv
 		case isXMLEncElem(e, "CarriedKeyName"):
 			ek.CarriedKeyName = domutil.TextContent(e)
+		case isDSigElem(e, "KeyInfo"):
+			agreement, err := parseAgreementMethodForKeyInfo(e)
+			if err != nil {
+				return nil, err
+			}
+			ek.AgreementMethod = agreement
 		}
 	}
 
@@ -132,6 +141,202 @@ func parseEncryptedKey(elem *helium.Element) (*EncryptedKey, error) {
 	}
 
 	return ek, nil
+}
+
+func parseAgreementMethodForKeyInfo(elem *helium.Element) (*AgreementMethod, error) {
+	var agreement *AgreementMethod
+	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
+		e, ok := helium.AsNode[*helium.Element](child)
+		if !ok || !isXMLEncElem(e, "AgreementMethod") {
+			continue
+		}
+		if agreement != nil {
+			return nil, fmt.Errorf("%w: duplicate AgreementMethod", ErrMalformedEncrypted)
+		}
+		var err error
+		agreement, err = parseAgreementMethod(e)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return agreement, nil
+}
+
+func parseAgreementMethod(elem *helium.Element) (*AgreementMethod, error) {
+	algorithm, ok := elem.GetAttribute("Algorithm")
+	if !ok || algorithm == "" {
+		return nil, fmt.Errorf("%w: AgreementMethod missing/empty Algorithm", ErrMalformedEncrypted)
+	}
+	agreement := &AgreementMethod{Algorithm: algorithm}
+	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
+		e, ok := helium.AsNode[*helium.Element](child)
+		if !ok {
+			continue
+		}
+		switch {
+		case isXMLEncElem(e, "OriginatorKeyInfo"):
+			if agreement.OriginatorKey != nil {
+				return nil, fmt.Errorf("%w: duplicate OriginatorKeyInfo", ErrMalformedEncrypted)
+			}
+			key, err := parseOriginatorKeyInfo(e)
+			if err != nil {
+				return nil, err
+			}
+			agreement.OriginatorKey = key
+		case isXMLEnc11Elem(e, "KeyDerivationMethod"):
+			if agreement.KeyDerivationMethod != nil {
+				return nil, fmt.Errorf("%w: duplicate KeyDerivationMethod", ErrMalformedEncrypted)
+			}
+			method, err := parseKeyDerivationMethod(e)
+			if err != nil {
+				return nil, err
+			}
+			agreement.KeyDerivationMethod = method
+		}
+	}
+	return agreement, nil
+}
+
+func parseKeyDerivationMethod(elem *helium.Element) (*KeyDerivationMethod, error) {
+	algorithm, ok := elem.GetAttribute("Algorithm")
+	if !ok || algorithm == "" {
+		return nil, fmt.Errorf("%w: KeyDerivationMethod missing/empty Algorithm", ErrMalformedEncrypted)
+	}
+	method := &KeyDerivationMethod{Algorithm: algorithm}
+	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
+		e, ok := helium.AsNode[*helium.Element](child)
+		if !ok || !isXMLEnc11Elem(e, "ConcatKDFParams") {
+			continue
+		}
+		if method.ConcatKDF != nil {
+			return nil, fmt.Errorf("%w: duplicate ConcatKDFParams", ErrMalformedEncrypted)
+		}
+		params, err := parseConcatKDFParams(e)
+		if err != nil {
+			return nil, err
+		}
+		method.ConcatKDF = params
+	}
+	if method.Algorithm == ConcatKDF && method.ConcatKDF == nil {
+		return nil, fmt.Errorf("%w: ConcatKDF missing ConcatKDFParams", ErrMalformedEncrypted)
+	}
+	return method, nil
+}
+
+func parseConcatKDFParams(elem *helium.Element) (*ConcatKDFParams, error) {
+	params := &ConcatKDFParams{}
+	var err error
+	for _, field := range []struct {
+		name string
+		dest *[]byte
+	}{
+		{name: "AlgorithmID", dest: &params.AlgorithmID},
+		{name: "PartyUInfo", dest: &params.PartyUInfo},
+		{name: "PartyVInfo", dest: &params.PartyVInfo},
+		{name: "SuppPubInfo", dest: &params.SuppPubInfo},
+		{name: "SuppPrivInfo", dest: &params.SuppPrivInfo},
+	} {
+		*field.dest, err = parseConcatKDFHexAttribute(elem, field.name)
+		if err != nil {
+			return nil, err
+		}
+	}
+	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
+		e, ok := helium.AsNode[*helium.Element](child)
+		if !ok || !isDSigElem(e, "DigestMethod") {
+			continue
+		}
+		if params.DigestMethod != "" {
+			return nil, fmt.Errorf("%w: duplicate ConcatKDF DigestMethod", ErrMalformedEncrypted)
+		}
+		params.DigestMethod, _ = e.GetAttribute("Algorithm")
+		if params.DigestMethod == "" {
+			return nil, fmt.Errorf("%w: ConcatKDF DigestMethod missing/empty Algorithm", ErrMalformedEncrypted)
+		}
+	}
+	if params.DigestMethod == "" {
+		return nil, fmt.Errorf("%w: ConcatKDF missing DigestMethod", ErrMalformedEncrypted)
+	}
+	return params, nil
+}
+
+func parseConcatKDFHexAttribute(elem *helium.Element, name string) ([]byte, error) {
+	value, ok := elem.GetAttribute(name)
+	if !ok || strings.TrimSpace(value) == "" {
+		return nil, nil
+	}
+	value = strings.TrimSpace(value)
+	decoded, err := hex.DecodeString(value)
+	if err != nil || len(decoded) == 0 {
+		return nil, fmt.Errorf("%w: invalid ConcatKDF %s", ErrMalformedEncrypted, name)
+	}
+	if decoded[0] != 0 {
+		return nil, fmt.Errorf("%w: non-byte-aligned ConcatKDF %s is not supported", ErrMalformedEncrypted, name)
+	}
+	return decoded[1:], nil
+}
+
+func parseOriginatorKeyInfo(elem *helium.Element) (*ECKeyValue, error) {
+	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
+		keyValue, ok := helium.AsNode[*helium.Element](child)
+		if !ok || !isDSigElem(keyValue, "KeyValue") {
+			continue
+		}
+		for nested := keyValue.FirstChild(); nested != nil; nested = nested.NextSibling() {
+			ecValue, ok := helium.AsNode[*helium.Element](nested)
+			if !ok || !isDSig11Elem(ecValue, "ECKeyValue") {
+				continue
+			}
+			return parseECKeyValue(ecValue)
+		}
+	}
+	return nil, fmt.Errorf("%w: OriginatorKeyInfo missing dsig11:ECKeyValue", ErrMalformedEncrypted)
+}
+
+func parseECKeyValue(elem *helium.Element) (*ECKeyValue, error) {
+	var curve ecdh.Curve
+	var publicKey []byte
+	for child := elem.FirstChild(); child != nil; child = child.NextSibling() {
+		e, ok := helium.AsNode[*helium.Element](child)
+		if !ok || e.URI() != NamespaceDSig11 {
+			continue
+		}
+		switch domutil.LocalName(e) {
+		case "NamedCurve":
+			uri, _ := e.GetAttribute("URI")
+			var err error
+			curve, err = ecdhCurveForURI(uri)
+			if err != nil {
+				return nil, err
+			}
+		case "PublicKey":
+			decoded, err := xmlbase64.DecodeString(domutil.TextContent(e))
+			if err != nil {
+				return nil, fmt.Errorf("%w: invalid ECKeyValue base64: %v", ErrMalformedEncrypted, err)
+			}
+			publicKey = decoded
+		}
+	}
+	if curve == nil || len(publicKey) == 0 {
+		return nil, fmt.Errorf("%w: ECKeyValue requires NamedCurve and PublicKey", ErrMalformedEncrypted)
+	}
+	if _, err := curve.NewPublicKey(publicKey); err != nil {
+		return nil, fmt.Errorf("%w: invalid EC public key: %v", ErrMalformedEncrypted, err)
+	}
+	return &ECKeyValue{Curve: curve, PublicKey: publicKey}, nil
+}
+
+func ecdhCurveForURI(uri string) (ecdh.Curve, error) {
+	switch uri {
+	case "urn:oid:1.2.840.10045.3.1.7":
+		return ecdh.P256(), nil
+	case "urn:oid:1.3.132.0.34":
+		return ecdh.P384(), nil
+	case "urn:oid:1.3.132.0.35":
+		return ecdh.P521(), nil
+	default:
+		return nil, fmt.Errorf("%w: unsupported EC curve %q", ErrMalformedEncrypted, uri)
+	}
 }
 
 func parseEncryptionMethod(elem *helium.Element) (*EncryptionMethod, error) {
@@ -259,11 +464,19 @@ func isXMLEncElem(e *helium.Element, local string) bool {
 	return isElemNS(e, local, NamespaceXMLEnc)
 }
 
+func isXMLEnc11Elem(e *helium.Element, local string) bool {
+	return isElemNS(e, local, NamespaceXMLEnc11)
+}
+
 // isDSigElem reports whether e is an XML Digital Signature element
 // (namespace http://www.w3.org/2000/09/xmldsig#) with the given local name.
 // KeyInfo and DigestMethod are defined in the dsig namespace.
 func isDSigElem(e *helium.Element, local string) bool {
 	return isElemNS(e, local, NamespaceDSig)
+}
+
+func isDSig11Elem(e *helium.Element, local string) bool {
+	return isElemNS(e, local, NamespaceDSig11)
 }
 
 // isMGFElem reports whether e is an MGF element. The element is defined

--- a/xmlenc1/summary-xmlenc11.md
+++ b/xmlenc1/summary-xmlenc11.md
@@ -8,13 +8,7 @@ This is a point-in-time snapshot; regenerate to refresh.
 
 | Outcome | Count |
 |---------|------:|
-| Pass | 4 |
-| Skip | 6 |
+| Pass | 10 |
+| Skip | 0 |
 | Fail | 0 |
 | **Total** | **10** |
-
-## Skipped by reason
-
-| Reason | Count |
-|--------|------:|
-| XML Encryption 1.1 ECDH-ES key agreement is not implemented by xmlenc1 | 6 |

--- a/xmlenc1/types.go
+++ b/xmlenc1/types.go
@@ -1,5 +1,7 @@
 package xmlenc1
 
+import "crypto/ecdh"
+
 // EncryptionMethod represents the <EncryptionMethod> element.
 type EncryptionMethod struct {
 	Algorithm    string
@@ -49,4 +51,38 @@ type EncryptedKey struct {
 	EncryptionMethod *EncryptionMethod
 	CipherValue      []byte // base64-decoded cipher bytes
 	CarriedKeyName   string
+	AgreementMethod  *AgreementMethod
+}
+
+// AgreementMethod describes a key agreement used to derive the key that
+// protects an EncryptedKey. XML Encryption 1.1 places this element inside a
+// ds:KeyInfo child of the EncryptedKey.
+type AgreementMethod struct {
+	Algorithm           string
+	KeyDerivationMethod *KeyDerivationMethod
+	OriginatorKey       *ECKeyValue
+}
+
+// KeyDerivationMethod describes the explicit KDF parameters carried by an
+// AgreementMethod.
+type KeyDerivationMethod struct {
+	Algorithm string
+	ConcatKDF *ConcatKDFParams
+}
+
+// ConcatKDFParams contains the XML Encryption 1.1 ConcatKDF parameters.
+// The parameter attributes are decoded from their hexBinary representation.
+type ConcatKDFParams struct {
+	AlgorithmID  []byte
+	PartyUInfo   []byte
+	PartyVInfo   []byte
+	SuppPubInfo  []byte
+	SuppPrivInfo []byte
+	DigestMethod string
+}
+
+// ECKeyValue contains an XML Signature 1.1 elliptic-curve public key.
+type ECKeyValue struct {
+	Curve     ecdh.Curve
+	PublicKey []byte
 }

--- a/xmlenc1/types.go
+++ b/xmlenc1/types.go
@@ -71,7 +71,8 @@ type KeyDerivationMethod struct {
 }
 
 // ConcatKDFParams contains the XML Encryption 1.1 ConcatKDF parameters.
-// The parameter attributes are decoded from their hexBinary representation.
+// The parameter attributes are decoded from their hexBinary representation;
+// their unused-bit counts are retained internally for KDF bit-string packing.
 type ConcatKDFParams struct {
 	AlgorithmID  []byte
 	PartyUInfo   []byte
@@ -79,6 +80,12 @@ type ConcatKDFParams struct {
 	SuppPubInfo  []byte
 	SuppPrivInfo []byte
 	DigestMethod string
+
+	algorithmIDUnusedBits  uint8
+	partyUInfoUnusedBits   uint8
+	partyVInfoUnusedBits   uint8
+	suppPubInfoUnusedBits  uint8
+	suppPrivInfoUnusedBits uint8
 }
 
 // ECKeyValue contains an XML Signature 1.1 elliptic-curve public key.

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -2,6 +2,7 @@ package xmlenc1
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/rsa"
 	"errors"
@@ -314,6 +315,7 @@ const DefaultMaxEncryptedKeys = 100
 // decryptConfig holds the configuration for a Decryptor.
 type decryptConfig struct {
 	privateKey              *rsa.PrivateKey
+	ecPrivateKey            *ecdsa.PrivateKey
 	keyEncryptionKey        []byte
 	sessionKey              []byte
 	allowUnauthenticatedCBC bool
@@ -343,6 +345,14 @@ func (d Decryptor) clone() Decryptor {
 func (d Decryptor) PrivateKey(key *rsa.PrivateKey) Decryptor {
 	d = d.clone()
 	d.cfg.privateKey = key
+	return d
+}
+
+// ECPrivateKey sets the elliptic-curve private key used for XML Encryption
+// 1.1 ECDH-ES key agreement.
+func (d Decryptor) ECPrivateKey(key *ecdsa.PrivateKey) Decryptor {
+	d = d.clone()
+	d.cfg.ecPrivateKey = key
 	return d
 }
 
@@ -395,6 +405,64 @@ func (d Decryptor) MaxEncryptedKeys(n int) Decryptor {
 // Decrypt decrypts an EncryptedData element and returns the decrypted nodes.
 func (d Decryptor) Decrypt(ctx context.Context, elem *helium.Element) ([]helium.Node, error) {
 	return decryptElement(ctx, d.cfg, elem)
+}
+
+// DecryptBytes decrypts an EncryptedData element and returns its plaintext
+// octets without parsing them as XML. It is used for EncryptedData values whose
+// Type is an application-defined binary payload.
+func (d Decryptor) DecryptBytes(ctx context.Context, elem *helium.Element) ([]byte, error) {
+	return decryptBytes(ctx, d.cfg, elem)
+}
+
+func decryptBytes(ctx context.Context, cfg *decryptConfig, elem *helium.Element) ([]byte, error) {
+	ed, err := parseEncryptedData(elem)
+	if err != nil {
+		return nil, err
+	}
+	if ed.EncryptionMethod == nil {
+		return nil, fmt.Errorf("%w: missing EncryptionMethod", ErrMalformedEncrypted)
+	}
+	alg := ed.EncryptionMethod.Algorithm
+	switch alg {
+	case AES128CBC, AES256CBC:
+		if !cfg.allowUnauthenticatedCBC {
+			return nil, ErrCBCRequiresOptIn
+		}
+	}
+
+	if len(cfg.sessionKey) > 0 {
+		return decryptCipherValue(ed, alg, cfg.sessionKey)
+	}
+	keys := ed.effectiveEncryptedKeys()
+	if len(keys) == 0 {
+		return nil, ErrMissingKey
+	}
+	maxKeys := cfg.maxEncryptedKeys
+	if maxKeys == 0 {
+		maxKeys = DefaultMaxEncryptedKeys
+	}
+	if maxKeys >= 0 && len(keys) > maxKeys {
+		return nil, ErrTooManyEncryptedKeys
+	}
+
+	var lastErr error
+	for _, ek := range keys {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		sessionKey, err := resolveSessionKeyFromEncryptedKey(cfg, ek)
+		if err != nil {
+			lastErr = preferInformativeErr(lastErr, err)
+			continue
+		}
+		plaintext, err := decryptCipherValue(ed, alg, sessionKey)
+		if err != nil {
+			lastErr = preferInformativeErr(lastErr, err)
+			continue
+		}
+		return plaintext, nil
+	}
+	return nil, lastErr
 }
 
 func decryptElement(ctx context.Context, cfg *decryptConfig, elem *helium.Element) ([]helium.Node, error) {
@@ -508,16 +576,8 @@ func preferInformativeErr(existing, candidate error) error {
 // pipeline succeeds, so a caller iterating session-key candidates can
 // safely fall through to the next candidate on any error.
 func finishDecrypt(ctx context.Context, ed *EncryptedData, elem *helium.Element, alg string, isContent bool, sessionKey []byte) ([]helium.Node, error) {
-	plaintext, err := blockDecrypt(alg, sessionKey, ed.CipherValue)
+	plaintext, err := decryptCipherValue(ed, alg, sessionKey)
 	if err != nil {
-		// Squash all decryption errors to the same sentinel — and
-		// crucially, the same string — so callers cannot distinguish
-		// "bad padding" from "bad cipher" from "downstream parse"
-		// when CBC is in use. GCM authenticates so this collapse is
-		// safe there too.
-		if errors.Is(err, ErrDecryptionFailed) || errors.Is(err, ErrInvalidPadding) {
-			return nil, ErrDecryptionFailed
-		}
 		return nil, err
 	}
 
@@ -589,6 +649,21 @@ func finishDecrypt(ctx context.Context, ed *EncryptedData, elem *helium.Element,
 	return nodes, nil
 }
 
+func decryptCipherValue(ed *EncryptedData, alg string, sessionKey []byte) ([]byte, error) {
+	plaintext, err := blockDecrypt(alg, sessionKey, ed.CipherValue)
+	if err == nil {
+		return plaintext, nil
+	}
+	// Squash all decryption errors to the same sentinel — and crucially, the
+	// same string — so callers cannot distinguish "bad padding" from "bad
+	// cipher" from "downstream parse" when CBC is in use. GCM authenticates
+	// so this collapse is safe there too.
+	if errors.Is(err, ErrDecryptionFailed) || errors.Is(err, ErrInvalidPadding) {
+		return nil, ErrDecryptionFailed
+	}
+	return nil, err
+}
+
 // newHardenedInnerParser returns the helium parser used to parse the
 // decrypted plaintext of an EncryptedData element. Decrypted bytes are
 // attacker-controlled (an attacker who can submit ciphertexts to a
@@ -607,6 +682,12 @@ func resolveSessionKeyFromEncryptedKey(cfg *decryptConfig, ek *EncryptedKey) ([]
 	}
 
 	alg := ek.EncryptionMethod.Algorithm
+	if ek.AgreementMethod != nil {
+		if cfg.ecPrivateKey == nil {
+			return nil, ErrMissingKey
+		}
+		return decryptECDHSessionKey(cfg.ecPrivateKey, ek)
+	}
 	switch alg {
 	case RSAOAEP, RSAOAEP11:
 		if cfg.privateKey == nil {

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -695,7 +695,7 @@ func resolveSessionKeyFromEncryptedKey(cfg *decryptConfig, ek *EncryptedKey) ([]
 		}
 		return decryptSessionKey(alg, cfg.privateKey, ek.CipherValue,
 			ek.EncryptionMethod.DigestMethod, ek.EncryptionMethod.MGFAlgorithm, ek.EncryptionMethod.OAEPParams)
-	case AES128KeyWrap, AES256KeyWrap:
+	case AES128KeyWrap, AES192KeyWrap, AES256KeyWrap:
 		if len(cfg.keyEncryptionKey) == 0 {
 			return nil, ErrMissingKey
 		}


### PR DESCRIPTION
- Add ECDH-ES P-256/P-384/P-521 decryption with XML Encryption 1.1 ConcatKDF and AES key wrapping.
- Add DecryptBytes for binary EncryptedData payloads while preserving XML decryption behavior.
- Refresh XML Encryption conformance evidence to ten passing vectors. Stack on #1325.
