### PR TITLE
feat: add xmlenc1 Encryptor.EncryptBytes

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -390,7 +390,7 @@ XML Encryption 1.1 (W3C xmlenc-core1). Encrypt and decrypt XML elements/content.
 
 - **NewEncryptor() → Encryptor** — create fluent builder for encryption (clone-on-write value type)
   - `BlockAlgorithm(uri)`, `AllowLegacyCBC(bool)`, `KeyTransportAlgorithm(uri)`, `RecipientPublicKey(key)`, `SessionKey(key)`, `KeyWrapAlgorithm(uri)`, `KeyEncryptionKey(kek)`, `OAEPDigest(uri)`, `OAEPMGF(uri)`, `OAEPParams(params)` — builder methods
-  - `EncryptElement(ctx, elem)`, `EncryptContent(ctx, elem)` — terminal methods
+  - `EncryptElement(ctx, elem)`, `EncryptContent(ctx, elem)`, `EncryptBytes(ctx, doc, plaintext)` — terminal methods; the last encrypts arbitrary octets, emits no `@Type` (W3C xmlenc-core1 §3.1 leaves it absent for non-element payloads), and returns a **detached** element without touching the tree
 - **NewDecryptor() → Decryptor** — create fluent builder for decryption
   - `PrivateKey(key)`, `ECPrivateKey(key)`, `KeyEncryptionKey(kek)`, `SessionKey(key)`, `AllowUnauthenticatedCBC(bool)`, `MaxEncryptedKeys(n)` — builder methods
   - `Decrypt(ctx, elem)`, `DecryptBytes(ctx, elem)` — terminal methods; the latter returns binary plaintext without XML parsing

--- a/examples/xmlenc1_encrypt_bytes_example_test.go
+++ b/examples/xmlenc1_encrypt_bytes_example_test.go
@@ -1,0 +1,63 @@
+package examples_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"fmt"
+
+	"github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xmlenc1"
+)
+
+func Example_xmlenc1_encrypt_bytes() {
+	// A payload that is not XML at all. XML Encryption allows this: an
+	// EncryptedData whose plaintext is neither an element nor element
+	// content simply carries no Type attribute.
+	payload := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a}
+
+	// EncryptBytes needs a document to own the element it builds, but it
+	// does not attach the element anywhere.
+	doc, err := helium.NewParser().Parse(context.Background(), []byte(`<Envelope/>`))
+	if err != nil {
+		fmt.Printf("failed to parse document: %s\n", err)
+		return
+	}
+
+	// A key-encryption key wraps the randomly generated session key.
+	kek := make([]byte, 32)
+	if _, err := rand.Read(kek); err != nil {
+		fmt.Printf("failed to generate key: %s\n", err)
+		return
+	}
+
+	edElem, err := xmlenc1.NewEncryptor().
+		KeyWrapAlgorithm(xmlenc1.AES256KeyWrap).
+		KeyEncryptionKey(kek).
+		EncryptBytes(context.Background(), doc, payload)
+	if err != nil {
+		fmt.Printf("failed to encrypt: %s\n", err)
+		return
+	}
+
+	// The caller decides where the EncryptedData goes; here it becomes the
+	// sole child of the envelope.
+	if err := doc.DocumentElement().AddChild(edElem); err != nil {
+		fmt.Printf("failed to insert EncryptedData: %s\n", err)
+		return
+	}
+
+	// DecryptBytes is the inverse: it returns the octets without trying to
+	// parse them as XML.
+	got, err := xmlenc1.NewDecryptor().
+		KeyEncryptionKey(kek).
+		DecryptBytes(context.Background(), edElem)
+	if err != nil {
+		fmt.Printf("failed to decrypt: %s\n", err)
+		return
+	}
+
+	fmt.Println(bytes.Equal(payload, got))
+	// Output:
+	// true
+}

--- a/xmlenc1/README.md
+++ b/xmlenc1/README.md
@@ -30,8 +30,12 @@ Import path: `github.com/lestrrat-go/helium/xmlenc1`
   bytes are attacker-controlled, so a relaxed parser would constitute an
   XXE oracle.
 - `Decryptor.ECPrivateKey` enables XML Encryption 1.1 ECDH-ES with P-256,
-  P-384, or P-521 and ConcatKDF. `Decryptor.DecryptBytes` returns binary
-  plaintext without parsing it as XML.
+  P-384, or P-521 and ConcatKDF.
+- `Encryptor.EncryptBytes` and `Decryptor.DecryptBytes` handle payloads that
+  are neither an element nor element content. `EncryptBytes` returns a
+  detached `EncryptedData` with no `Type` attribute (W3C xmlenc-core1 §3.1)
+  and does not modify the tree; `DecryptBytes` returns the plaintext octets
+  without parsing them as XML.
 
 <!-- INCLUDE(examples/xmlenc1_encrypt_decrypt_example_test.go) -->
 ```go

--- a/xmlenc1/xmlenc1.go
+++ b/xmlenc1/xmlenc1.go
@@ -150,7 +150,64 @@ func (e Encryptor) EncryptContent(ctx context.Context, elem *helium.Element) (*h
 	return encrypt(ctx, e.cfg, elem, TypeContent)
 }
 
-func encrypt(_ context.Context, cfg *encryptConfig, elem *helium.Element, encType string) (*helium.Element, error) {
+// EncryptBytes encrypts arbitrary octets and returns a detached
+// EncryptedData element owned by doc. It is the counterpart of
+// Decryptor.DecryptBytes: together they cover the payloads that are not an
+// XML element or element content, which W3C xmlenc-core1 §3.1 admits by
+// leaving @Type absent. The returned element carries no Type attribute for
+// exactly that reason, and no tree is modified — the caller decides where
+// to insert it.
+func (e Encryptor) EncryptBytes(ctx context.Context, doc *helium.Document, plaintext []byte) (*helium.Element, error) {
+	if doc == nil {
+		return nil, fmt.Errorf("%w: EncryptBytes requires a document to own the EncryptedData element", ErrMissingConfig)
+	}
+	return encryptPlaintext(ctx, e.cfg, doc, plaintext, "")
+}
+
+func encrypt(ctx context.Context, cfg *encryptConfig, elem *helium.Element, encType string) (*helium.Element, error) {
+	// Serialize the plaintext. Element encrypts the element itself;
+	// Content encrypts its children.
+	var plaintext string
+	var err error
+	if encType == TypeElement {
+		plaintext, err = helium.WriteString(elem)
+	} else {
+		plaintext, err = serializeChildren(elem)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrEncryptionFailed, err)
+	}
+
+	edElem, err := encryptPlaintext(ctx, cfg, elem.OwnerDocument(), []byte(plaintext), encType)
+	if err != nil {
+		return nil, err
+	}
+
+	// Replace in tree.
+	if encType == TypeElement {
+		// Replace the element with EncryptedData in place, preserving the
+		// original element's position among its siblings.
+		if err := elem.Replace(edElem); err != nil {
+			return nil, err
+		}
+		return edElem, nil
+	}
+
+	// Replace children with EncryptedData.
+	removeChildren(elem)
+	if err := elem.AddChild(edElem); err != nil {
+		return nil, err
+	}
+	return edElem, nil
+}
+
+// encryptPlaintext performs the whole encryption pipeline over already
+// serialized plaintext: it resolves the block algorithm, enforces the CBC
+// opt-in, obtains and binds the session key, block-encrypts, protects the
+// session key, and marshals the EncryptedData element into doc. It never
+// touches the tree, so both the element/content and the raw-octet entry
+// points share identical crypto and configuration handling.
+func encryptPlaintext(_ context.Context, cfg *encryptConfig, doc *helium.Document, plaintext []byte, encType string) (*helium.Element, error) {
 	// Secure by default: an unset block algorithm uses authenticated
 	// AES-256-GCM rather than refusing or falling back to CBC.
 	blockAlgorithm := cfg.blockAlgorithm
@@ -196,19 +253,8 @@ func encrypt(_ context.Context, cfg *encryptConfig, elem *helium.Element, encTyp
 		return nil, err
 	}
 
-	// Serialize the plaintext.
-	var plaintext string
-	if encType == TypeElement {
-		plaintext, err = helium.WriteString(elem)
-	} else {
-		plaintext, err = serializeChildren(elem)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrEncryptionFailed, err)
-	}
-
 	// Block encrypt.
-	cipherValue, err := blockEncrypt(blockAlgorithm, sessionKey, []byte(plaintext))
+	cipherValue, err := blockEncrypt(blockAlgorithm, sessionKey, plaintext)
 	if err != nil {
 		return nil, err
 	}
@@ -258,28 +304,7 @@ func encrypt(_ context.Context, cfg *encryptConfig, elem *helium.Element, encTyp
 		CipherValue:      cipherValue,
 	}
 
-	doc := elem.OwnerDocument()
-	edElem, err := marshalEncryptedData(doc, ed)
-	if err != nil {
-		return nil, err
-	}
-
-	// Replace in tree.
-	if encType == TypeElement {
-		// Replace the element with EncryptedData in place, preserving the
-		// original element's position among its siblings.
-		if err := elem.Replace(edElem); err != nil {
-			return nil, err
-		}
-	} else {
-		// Replace children with EncryptedData.
-		removeChildren(elem)
-		if err := elem.AddChild(edElem); err != nil {
-			return nil, err
-		}
-	}
-
-	return edElem, nil
+	return marshalEncryptedData(doc, ed)
 }
 
 func serializeChildren(elem *helium.Element) (string, error) {

--- a/xmlenc1/xmlenc1_test.go
+++ b/xmlenc1/xmlenc1_test.go
@@ -475,3 +475,108 @@ func TestEncryptorImmutability(t *testing.T) {
 	_, err = e2.EncryptElement(t.Context(), doc2.DocumentElement())
 	require.NoError(t, err)
 }
+
+// EncryptBytes is the counterpart of DecryptBytes: the package could consume
+// arbitrary-octet EncryptedData but had no way to produce it, so the only
+// bytes-in path was a test-only export.
+func TestEncryptBytes(t *testing.T) {
+	payload := []byte{0x00, 0x01, 0xff, 0xfe, 'n', 'o', 't', ' ', 'x', 'm', 'l'}
+
+	t.Run("round trip under RSA key transport", func(t *testing.T) {
+		key := generateRSAKey(t)
+		doc := mustParseXML(t, `<root/>`)
+
+		edElem, err := xmlenc1.NewEncryptor().
+			KeyTransportAlgorithm(xmlenc1.RSAOAEP).
+			RecipientPublicKey(&key.PublicKey).
+			EncryptBytes(t.Context(), doc, payload)
+		require.NoError(t, err)
+
+		got, err := xmlenc1.NewDecryptor().PrivateKey(key).DecryptBytes(t.Context(), edElem)
+		require.NoError(t, err)
+		require.Equal(t, payload, got)
+	})
+
+	t.Run("round trip under AES key wrap", func(t *testing.T) {
+		kek := randKey(t, 32)
+		doc := mustParseXML(t, `<root/>`)
+
+		edElem, err := xmlenc1.NewEncryptor().
+			KeyWrapAlgorithm(xmlenc1.AES256KeyWrap).
+			KeyEncryptionKey(kek).
+			EncryptBytes(t.Context(), doc, payload)
+		require.NoError(t, err)
+
+		got, err := xmlenc1.NewDecryptor().KeyEncryptionKey(kek).DecryptBytes(t.Context(), edElem)
+		require.NoError(t, err)
+		require.Equal(t, payload, got)
+	})
+
+	t.Run("round trip under a pre-shared session key", func(t *testing.T) {
+		sessionKey := randKey(t, 32)
+		doc := mustParseXML(t, `<root/>`)
+
+		edElem, err := xmlenc1.NewEncryptor().
+			BlockAlgorithm(xmlenc1.AES256GCM11).
+			SessionKey(sessionKey).
+			EncryptBytes(t.Context(), doc, payload)
+		require.NoError(t, err)
+
+		got, err := xmlenc1.NewDecryptor().SessionKey(sessionKey).DecryptBytes(t.Context(), edElem)
+		require.NoError(t, err)
+		require.Equal(t, payload, got)
+	})
+
+	// W3C xmlenc-core1 §3.1: @Type is absent when the plaintext is neither an
+	// element nor element content.
+	t.Run("emits no Type attribute", func(t *testing.T) {
+		doc := mustParseXML(t, `<root/>`)
+		edElem, err := xmlenc1.NewEncryptor().
+			SessionKey(randKey(t, 32)).
+			EncryptBytes(t.Context(), doc, payload)
+		require.NoError(t, err)
+
+		s, err := helium.WriteString(edElem)
+		require.NoError(t, err)
+		require.NotContains(t, s, "Type=")
+	})
+
+	// The returned element is detached: unlike EncryptElement, nothing is
+	// spliced into the document.
+	t.Run("leaves the document untouched", func(t *testing.T) {
+		doc := mustParseXML(t, `<root><keep/></root>`)
+		before, err := helium.WriteString(doc)
+		require.NoError(t, err)
+
+		_, err = xmlenc1.NewEncryptor().
+			SessionKey(randKey(t, 32)).
+			EncryptBytes(t.Context(), doc, payload)
+		require.NoError(t, err)
+
+		after, err := helium.WriteString(doc)
+		require.NoError(t, err)
+		require.Equal(t, before, after)
+	})
+
+	t.Run("reports a missing document", func(t *testing.T) {
+		_, err := xmlenc1.NewEncryptor().
+			SessionKey(randKey(t, 32)).
+			EncryptBytes(t.Context(), nil, payload)
+		require.ErrorIs(t, err, xmlenc1.ErrMissingConfig)
+	})
+
+	t.Run("applies the same key-source checks", func(t *testing.T) {
+		doc := mustParseXML(t, `<root/>`)
+		_, err := xmlenc1.NewEncryptor().EncryptBytes(t.Context(), doc, payload)
+		require.ErrorIs(t, err, xmlenc1.ErrMissingConfig)
+	})
+
+	t.Run("applies the CBC opt-in gate", func(t *testing.T) {
+		doc := mustParseXML(t, `<root/>`)
+		_, err := xmlenc1.NewEncryptor().
+			BlockAlgorithm(xmlenc1.AES256CBC).
+			SessionKey(randKey(t, 32)).
+			EncryptBytes(t.Context(), doc, payload)
+		require.ErrorIs(t, err, xmlenc1.ErrCBCEncryptionRequiresOptIn)
+	})
+}


### PR DESCRIPTION
- add `Encryptor.EncryptBytes(ctx, doc, plaintext)`, the missing counterpart of `Decryptor.DecryptBytes`
- emits no `@Type` per W3C xmlenc-core1 §3.1 and returns a detached element, leaving the tree untouched
- extract `encryptPlaintext` so element, content, and octet paths share one crypto/config path
