### PR TITLE
emit xmlenc1 OAEPparams before wildcards

### DIFF
--- a/xmlenc1/keytransport_test.go
+++ b/xmlenc1/keytransport_test.go
@@ -540,4 +540,49 @@ func TestEncryptorOAEPParamsBound(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, nodes, 1)
 	})
+
+// TestOAEPEncryptionMethodWireOrder pins the child order the serializer writes
+// inside an RSA-OAEP xenc:EncryptionMethod. The xenc-schema EncryptionMethodType
+// content model is a sequence of xenc:KeySize?, then xenc:OAEPparams?, then
+// <any namespace="##other" maxOccurs="unbounded">. ds:DigestMethod and
+// xenc11:MGF are reachable only through that trailing wildcard, so both must
+// follow xenc:OAEPparams or the document is not schema valid. The wildcard does
+// not make the order lax: ##other excludes the xenc target namespace, so it can
+// never match xenc:OAEPparams.
+//
+// The assertions are on byte offsets rather than on a golden document so the
+// test states the ordering rule instead of a snapshot of one serialization.
+func TestOAEPEncryptionMethodWireOrder(t *testing.T) {
+	key := generateRSAKey(t)
+	doc := mustParseXML(t, samlAssertion)
+
+	encryptor := xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+		OAEPDigest(xmlenc1.DigestSHA256).
+		OAEPMGF(xmlenc1.MGFSHA256).
+		OAEPParams([]byte("label-params")).
+		RecipientPublicKey(&key.PublicKey)
+
+	elem, err := encryptor.EncryptElement(t.Context(), doc.DocumentElement())
+	require.NoError(t, err)
+
+	xml, err := helium.WriteString(elem)
+	require.NoError(t, err)
+
+	params := strings.Index(xml, "OAEPparams")
+	require.Positive(t, params, "serialized EncryptionMethod carries xenc:OAEPparams")
+	digest := strings.Index(xml, "DigestMethod")
+	require.Positive(t, digest, "serialized EncryptionMethod carries ds:DigestMethod")
+	mgf := strings.Index(xml, "MGF")
+	require.Positive(t, mgf, "serialized EncryptionMethod carries xenc11:MGF")
+
+	require.Less(t, params, digest, "xenc:OAEPparams precedes ds:DigestMethod")
+	require.Less(t, params, mgf, "xenc:OAEPparams precedes xenc11:MGF")
+
+	// The parse side reads these children by name, not by position, so the
+	// document still round-trips.
+	nodes, err := xmlenc1.NewDecryptor().PrivateKey(key).Decrypt(t.Context(), elem)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
 }

--- a/xmlenc1/keytransport_test.go
+++ b/xmlenc1/keytransport_test.go
@@ -540,15 +540,19 @@ func TestEncryptorOAEPParamsBound(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, nodes, 1)
 	})
+}
 
 // TestOAEPEncryptionMethodWireOrder pins the child order the serializer writes
 // inside an RSA-OAEP xenc:EncryptionMethod. The xenc-schema EncryptionMethodType
 // content model is a sequence of xenc:KeySize?, then xenc:OAEPparams?, then
-// <any namespace="##other" maxOccurs="unbounded">. ds:DigestMethod and
-// xenc11:MGF are reachable only through that trailing wildcard, so both must
-// follow xenc:OAEPparams or the document is not schema valid. The wildcard does
-// not make the order lax: ##other excludes the xenc target namespace, so it can
-// never match xenc:OAEPparams.
+// <any namespace='##other' minOccurs='0' maxOccurs='unbounded'/>.
+// ds:DigestMethod and xenc11:MGF are reachable only through that trailing
+// wildcard, so both must follow xenc:OAEPparams or the document is not schema
+// valid. The wildcard does not make the order lax, for two reasons: ##other
+// excludes the xenc target namespace, so it can never match xenc:OAEPparams;
+// and the laxly schema valid output xmlenc-core1 §3.1 asks for is bounded by
+// its own note to what xsd:ANY admits, so it excuses what those foreign
+// children contain rather than where the declared sequence puts them.
 //
 // The assertions are on byte offsets rather than on a golden document so the
 // test states the ordering rule instead of a snapshot of one serialization.

--- a/xmlenc1/serialize.go
+++ b/xmlenc1/serialize.go
@@ -136,12 +136,16 @@ func marshalEncryptionMethod(doc *helium.Document, em *EncryptionMethod) (*heliu
 
 	// Child order follows the xenc-schema EncryptionMethodType content model:
 	// a sequence of xenc:KeySize?, then xenc:OAEPparams?, then
-	// <any namespace="##other" maxOccurs="unbounded">. ds:DigestMethod and
-	// xenc11:MGF are foreign-namespace children reachable only through that
-	// trailing wildcard, so they come after xenc:OAEPparams; the wildcard does
-	// not make the order lax, since ##other excludes the xenc namespace and can
-	// never match xenc:OAEPparams. This package emits no xenc:KeySize, so the
-	// sequence is OAEPparams first and the two foreign children after it.
+	// <any namespace='##other' minOccurs='0' maxOccurs='unbounded'/>.
+	// ds:DigestMethod and xenc11:MGF are foreign-namespace children reachable
+	// only through that trailing wildcard, so they come after xenc:OAEPparams.
+	// The wildcard does not make the order lax, for two reasons: ##other
+	// excludes the xenc namespace, so it can never match xenc:OAEPparams; and
+	// while xmlenc-core1 §3.1 asks only for laxly schema valid output, its own
+	// note bounds that allowance to what xsd:ANY admits, so it excuses what
+	// those foreign children contain rather than where the declared sequence
+	// puts them. This package emits no xenc:KeySize, so the sequence is
+	// OAEPparams first and the two foreign children after it.
 	if len(em.OAEPParams) > 0 {
 		params, err := doc.CreateElement("OAEPparams")
 		if err != nil {

--- a/xmlenc1/serialize.go
+++ b/xmlenc1/serialize.go
@@ -134,6 +134,31 @@ func marshalEncryptionMethod(doc *helium.Document, em *EncryptionMethod) (*heliu
 		return nil, err
 	}
 
+	// Child order follows the xenc-schema EncryptionMethodType content model:
+	// a sequence of xenc:KeySize?, then xenc:OAEPparams?, then
+	// <any namespace="##other" maxOccurs="unbounded">. ds:DigestMethod and
+	// xenc11:MGF are foreign-namespace children reachable only through that
+	// trailing wildcard, so they come after xenc:OAEPparams; the wildcard does
+	// not make the order lax, since ##other excludes the xenc namespace and can
+	// never match xenc:OAEPparams. This package emits no xenc:KeySize, so the
+	// sequence is OAEPparams first and the two foreign children after it.
+	if len(em.OAEPParams) > 0 {
+		params, err := doc.CreateElement("OAEPparams")
+		if err != nil {
+			return nil, err
+		}
+		if err := params.SetActiveNamespace(nsPrefixEnc, NamespaceXMLEnc); err != nil {
+			return nil, err
+		}
+		encoded := base64.StdEncoding.EncodeToString(em.OAEPParams)
+		if err := params.AddChild(doc.CreateText([]byte(encoded))); err != nil {
+			return nil, err
+		}
+		if err := elem.AddChild(params); err != nil {
+			return nil, err
+		}
+	}
+
 	if em.DigestMethod != "" {
 		dm, err := doc.CreateElement("DigestMethod")
 		if err != nil {
@@ -162,23 +187,6 @@ func marshalEncryptionMethod(doc *helium.Document, em *EncryptionMethod) (*heliu
 			return nil, err
 		}
 		if err := elem.AddChild(mgf); err != nil {
-			return nil, err
-		}
-	}
-
-	if len(em.OAEPParams) > 0 {
-		params, err := doc.CreateElement("OAEPparams")
-		if err != nil {
-			return nil, err
-		}
-		if err := params.SetActiveNamespace(nsPrefixEnc, NamespaceXMLEnc); err != nil {
-			return nil, err
-		}
-		encoded := base64.StdEncoding.EncodeToString(em.OAEPParams)
-		if err := params.AddChild(doc.CreateText([]byte(encoded))); err != nil {
-			return nil, err
-		}
-		if err := elem.AddChild(params); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
- Emit `xenc:OAEPparams` before `ds:DigestMethod`/`xenc11:MGF`, per the xenc-schema `EncryptionMethodType` sequence.
- Add a wire-order test asserting the offsets and that the document still decrypts.
