### PR TITLE
harden xmlenc1 test assertions, add decrypt fuzz

### DIFF
--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -146,12 +146,13 @@ Run specific test subsets via env vars:
 ## Fuzzing
 
 - Public-package fuzz coverage lives in package-local `fuzz_test.go` files.
-- Direct fuzz targets exist for `.`, `c14n`, `catalog`, `html`, `relaxng`, `schematron`, `sink`, `stream`, `xinclude`, `xpath1`, `xpath3`, `xpointer`, `xsd`, `xmldsig1`, `xslt3`.
+- Direct fuzz targets exist for `.`, `c14n`, `catalog`, `html`, `relaxng`, `schematron`, `sink`, `stream`, `xinclude`, `xpath1`, `xpath3`, `xpointer`, `xsd`, `xmldsig1`, `xmlenc1`, `xslt3`.
 - `shim` intentionally excluded from repo fuzz matrix.
 - `enum` + `sax` intentionally excluded from direct fuzzing → constants/interface-only surface.
 - Bound fuzz input sizes early. Return on oversize inputs.
 - Prefer in-memory stubs over filesystem/network access.
 - Parse/compile/validate/transform fuzz targets MUST tolerate invalid intermediate inputs by returning early instead of asserting.
+- `xmlenc1`'s `FuzzDecrypt` puts FIXED RSA, EC, and AES key material on one `Decryptor` (all three are settable together) and leaves `SessionKey` unset, so the input alone selects which key-protection path runs — RSA-OAEP, ECDH-ES, or AES key wrap — and every branch is reachable from the one target. The keys are fixed rather than generated per run because a crasher written under `testdata/fuzz` must reproduce.
 - The `xslt3` targets time each input's parse+compile (and transform) inline and fail via `t.Errorf` when it crosses `slowInputThreshold()` (`fuzz_test.go` `flagIfSlow`), so the fuzzing engine persists the exact bytes as a crasher. Go's own worker already turns a genuine hang into a crasher via a 10s deadlock detector (`internal/fuzz` `worker.go`), so this targets the slow-but-finite input (a few seconds) that 10s net misses — the input that drags run throughput toward the fuzztime deadline and surfaces only as an unactionable `context deadline exceeded` with no reproducer. The threshold MUST stay below Go's 10s worker deadline to fire first; it defaults to 5s (ample headroom over any legitimate compile, so no false trips under CI scheduler jitter) and is overridable via `HELIUM_FUZZ_SLOW_INPUT` (a Go duration). Timing inline (not in a child goroutine) keeps panics on `testing`'s normal minimizable-crasher path.
 
 ## Fuzz CI

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: ['.', 'c14n', 'catalog', 'html', 'relaxng', 'schematron', 'sink', 'stream', 'xinclude', 'xpath1', 'xpath3', 'xpointer', 'xsd', 'xmldsig1', 'xslt3']
+        package: ['.', 'c14n', 'catalog', 'html', 'relaxng', 'schematron', 'sink', 'stream', 'xinclude', 'xpath1', 'xpath3', 'xpointer', 'xsd', 'xmldsig1', 'xmlenc1', 'xslt3']
     name: "Fuzz ${{ matrix.package }}"
     steps:
       - name: Checkout repository

--- a/xmlenc1/fuzz_test.go
+++ b/xmlenc1/fuzz_test.go
@@ -1,0 +1,179 @@
+package xmlenc1_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	helium "github.com/lestrrat-go/helium"
+	"github.com/lestrrat-go/helium/xmlenc1"
+	"github.com/stretchr/testify/require"
+)
+
+// The decryptor's key material is fixed rather than generated per run, because
+// it belongs to the target and not to the input: a crasher the fuzzing engine
+// writes under testdata/fuzz has to reproduce, and every path past a successful
+// key unwrap depends on which key was configured. These keys exist only here
+// and protect nothing.
+const fuzzRSAPrivateKeyPEM = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDoFLvbdAca1sbr
+D7R9OCtRT++XJ/hORxbafSgJ+1yPnPSQU23Ryy2MNnqPkRiNIoIaxdDRkeyOnmp9
+7LflLJ6VlCQquSMzNmNc2vhhfGclsrA0Sl7zHYTHqCxdbVxoT1onRDUHOjyhflZs
+Cm7LeIlI0+gN4a5pIf9V5BehIDCD3SdpqwgUYQL4AXHdXn49jOhtIGwCSW9v6MU+
+T0yE7iP19eeyuMVKRpNX3Q2YmHGvZ9hALJ7Ap87rxA0ZlKsV/KoxZ/79JMBOQKD0
+aL3AogO5fbLIiMa8zGRnSpvr0krzRMFd/R+lEvKRf68hpqMtuIIk1H+dXi58ZzBF
+G8aNo4LNAgMBAAECggEAAfWEj5VRpuRGhpXebKq+ySZJYInFMZo/4MePii11p+vV
+ePPX6IwY4EJ65aiiraJQJvwhx3sZpU/7KpNieJVF6SQKxviwrk40Azu39b603+iE
+4PixLBCggqqpQTYRwo0U7artFarkHEZN9E9gznotpMc8lCjZCURMRdZokYL6+m6I
+uIYVX7QS7bf3KJFySjGY4c9Sal5Wh8YUq6Jl951Gm9TWIEQQrBXzA4ZTTZHHUQy5
+wGcOUNKFlMiC44Aw6k6GqjTbgIIz3kajtvofl6k70x9t1BnCp4xZdUbj3CfofoSh
+1ntHyyrQmDQC+YfbYSUf/NkjEmlk7ShlyKe37vIE8wKBgQD6x5cS+CW8jhC1O8eZ
+qnAud3rCkNB8Zv4ghHsDViMoEwftMxuwRjr8xnzMAv/i+TQSt6nC3wxPSBxcYvmk
+B+uf03cWN7yFT9dxpiCOoDX4OqxZkYlOYISzYCFt9WJGFgr/JRiLSdxb3QCeALWx
+nlP3LKC6ubCzDA7vFyDOX3x4xwKBgQDs6X+HNOFwwJb8tOCRpPr6BwFIAyeNV+Vy
+Yok1DBs75QmQnRM2ENBX2B51yqRpC0M7xdDDrSCd8MJiVnLoBMXKZlwBbMuDp86Q
+ftix/IHVc/2yJfeeGNlSmf0wH3cW0DXK9jw1naq3jU/RLve6ZI2iFh/GjXTexhng
+X9L3efdbywKBgHGRV6I4jGZic8CPTOoTHHB+nTJlgHUF80nolQjCxnMMg0dxILXo
+aCg2/ycoqJcyQdnEIPXmKt3wix9vlxwolhUwH7sJDK/Wo3uNPys39JjwgUKivOqo
+nQ/alekE+jdBHkPDmeTiUw+q+u+S5LWGPQIvzK4jD5lV+aFe+PVcmrLbAoGBAOaK
+5sYNCKDvWT67SZmRgYYTkQShxTh/Y1GnX7vWdx4W6PLoV8ySGhyRvDqGIu3xvtCI
+1HnGnOn1Y0PMum7cThmC+F+OnpEUmCf2uCqj/ThZcnSNC+S2a609GqxcwkfZ/67t
+ZXQLZRjPk++NFBc3SLiFbRCLkUJEZuP4e9TFxJd3AoGBAOrq489tTL3m+4Y64i6g
+rXKuGSTpZqUQqqijf1Mx5b3ifHla0BjijIMiua1Bi3+ZvhDjc7nhfFJ8Pn0Gk6AQ
+OBBxedpxNxE9hTVWn3vi1spvPIGGIVIl8lqZOAyL8Lw3pCZBHLGest4hRvFF/dEw
+3cU8XZZDGb+U5swyh0vS0myU
+-----END PRIVATE KEY-----
+`
+
+const fuzzECPrivateKeyPEM = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgCbki1SXiqB/A1m4Y
+KTDSGV72K6ftxpY1qyG+6Eis+bKhRANCAAS1cejqV2eUnMv/5k+sRaReLzEYNJNF
+d7z7EbsPM10zgCshtqn/9s6SyPMcYbp74ChoyfMBU1Jg9NsH3N3UBcdA
+-----END PRIVATE KEY-----
+`
+
+// fuzzKEK is the fixed AES-256 key-encryption key the AES key-wrap branch uses.
+var fuzzKEK = []byte("xmlenc1-fuzz-key-encryption-key!")
+
+// FuzzDecrypt drives malformed EncryptedData, EncryptedKey, EncryptionMethod,
+// and AgreementMethod trees through the public decryptor, which is the whole
+// pre-authentication surface: everything it reads comes from the document.
+//
+// One Decryptor carries an RSA private key, an EC private key, and an AES
+// key-encryption key at once — a configuration Decryptor.PrivateKey documents
+// as supported — and the candidate branch is dispatched on what the DOCUMENT
+// declares. So the fuzz input alone selects the key protection that runs, and a
+// single target reaches all three: RSA-OAEP key transport, ECDH-ES key
+// agreement with ConcatKDF, and AES key wrap. CBC is opted in so the
+// unauthenticated block path is reachable too. SessionKey is deliberately left
+// unset: a non-empty one is an early return past candidate selection and key
+// resolution, which is most of what is being fuzzed.
+//
+// The decryptor has no resolver, and the inner plaintext parse runs through the
+// hardened parser, so no fuzz input can cause filesystem, network, or DTD work.
+func FuzzDecrypt(f *testing.F) {
+	rsaKey := fuzzRSAKey(f)
+	ecKey := fuzzECKey(f)
+
+	// Three documents this package produced itself, one per key-protection
+	// mechanism, so the engine starts from inputs that decrypt all the way
+	// through rather than from shapes that fail at the parse gate.
+	f.Add(fuzzSeedDocument(f, xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256CBC).
+		AllowLegacyCBC(true).
+		KeyWrapAlgorithm(xmlenc1.AES256KeyWrap).
+		KeyEncryptionKey(fuzzKEK)))
+	f.Add(fuzzSeedDocument(f, xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM).
+		KeyTransportAlgorithm(xmlenc1.RSAOAEP11).
+		OAEPDigest(xmlenc1.DigestSHA256).
+		OAEPMGF(xmlenc1.MGFSHA256).
+		OAEPParams([]byte("xmlenc1-fuzz-oaep-label")).
+		RecipientPublicKey(&rsaKey.PublicKey)))
+	f.Add(fuzzSeedDocument(f, xmlenc1.NewEncryptor().
+		BlockAlgorithm(xmlenc1.AES256GCM11).
+		KeyWrapAlgorithm(xmlenc1.AES256KeyWrap).
+		RecipientECPublicKey(&ecKey.PublicKey).
+		KeyDerivationParams(&xmlenc1.ConcatKDFParams{
+			DigestMethod: xmlenc1.DigestSHA256,
+			AlgorithmID:  []byte{0x00, 0xa0},
+			PartyUInfo:   []byte{0x00, 0x55},
+			PartyVInfo:   []byte{0x00, 0xaa},
+		})))
+
+	// An EncryptedData with nothing in it, and one whose shape is complete but
+	// whose every value is junk: the two ends the mutation engine works
+	// outward from.
+	f.Add([]byte(`<xenc:EncryptedData xmlns:xenc="` + xmlenc1.NamespaceXMLEnc + `"/>`))
+	f.Add([]byte(`<xenc:EncryptedData xmlns:xenc="` + xmlenc1.NamespaceXMLEnc + `" xmlns:ds="` + xmlenc1.NamespaceDSig + `" Type="` + xmlenc1.TypeElement + `"><xenc:EncryptionMethod Algorithm="` + xmlenc1.AES256GCM + `"/><ds:KeyInfo><xenc:EncryptedKey><xenc:EncryptionMethod Algorithm="` + xmlenc1.RSAOAEP + `"><xenc:OAEPparams>not-base64</xenc:OAEPparams></xenc:EncryptionMethod><xenc:CipherData><xenc:CipherValue>AA==</xenc:CipherValue></xenc:CipherData></xenc:EncryptedKey></ds:KeyInfo><xenc:CipherData><xenc:CipherValue>not-base64</xenc:CipherValue></xenc:CipherData></xenc:EncryptedData>`))
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		if len(input) > 1<<20 {
+			return
+		}
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+
+		doc, err := helium.NewParser().Parse(ctx, input)
+		if err != nil {
+			return
+		}
+		root := doc.DocumentElement()
+		if root == nil {
+			return
+		}
+
+		decryptor := xmlenc1.NewDecryptor().
+			PrivateKey(rsaKey).
+			ECPrivateKey(ecKey).
+			KeyEncryptionKey(fuzzKEK).
+			AllowUnauthenticatedCBC(true).
+			MaxEncryptedKeys(32).
+			MaxEncryptedKeyBytes(1 << 20).
+			MaxCipherValueBytes(1 << 20)
+		_, _ = decryptor.Decrypt(ctx, root)
+	})
+}
+
+// fuzzSeedDocument encrypts one small element and returns the serialized
+// EncryptedData, so a seed is always whatever the current Encryptor emits
+// rather than a transcript that can drift from it.
+func fuzzSeedDocument(f *testing.F, encryptor xmlenc1.Encryptor) []byte {
+	f.Helper()
+	doc, err := helium.NewParser().Parse(f.Context(), []byte(`<root id="r"><inner attr="v">secret</inner>tail</root>`))
+	require.NoError(f, err)
+	edElem, err := encryptor.EncryptElement(f.Context(), doc.DocumentElement())
+	require.NoError(f, err)
+	serialized, err := helium.WriteString(edElem)
+	require.NoError(f, err)
+	return []byte(serialized)
+}
+
+func fuzzRSAKey(f *testing.F) *rsa.PrivateKey {
+	f.Helper()
+	key := fuzzPrivateKey(f, fuzzRSAPrivateKeyPEM)
+	rsaKey, ok := key.(*rsa.PrivateKey)
+	require.True(f, ok, "fuzz key PEM must hold an RSA private key, got %T", key)
+	return rsaKey
+}
+
+func fuzzECKey(f *testing.F) *ecdsa.PrivateKey {
+	f.Helper()
+	key := fuzzPrivateKey(f, fuzzECPrivateKeyPEM)
+	ecKey, ok := key.(*ecdsa.PrivateKey)
+	require.True(f, ok, "fuzz key PEM must hold an EC private key, got %T", key)
+	return ecKey
+}
+
+func fuzzPrivateKey(f *testing.F, keyPEM string) any {
+	f.Helper()
+	block, _ := pem.Decode([]byte(keyPEM))
+	require.NotNil(f, block, "fuzz key PEM must decode")
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	require.NoError(f, err)
+	return key
+}

--- a/xmlenc1/key_agreement_internal_test.go
+++ b/xmlenc1/key_agreement_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	mrand "math/rand"
 	"strconv"
+	"strings"
 	"testing"
 
 	helium "github.com/lestrrat-go/helium"
@@ -263,6 +264,49 @@ func TestConcatKDFOtherInfoBudget(t *testing.T) {
 	}
 	_, err = concatKDFOtherInfo(overLimit)
 	require.ErrorIs(t, err, ErrMalformedEncrypted)
+}
+
+// parseConcatKDFHexAttribute refuses a hex attribute from its ENCODED length
+// alone, before hex.DecodeString allocates half of it. That ceiling coincides
+// exactly with the cumulative OtherInfo budget, so the precheck is an
+// allocation-avoidance guard rather than a distinct semantic gate: every value
+// it refuses the set-wide check in parseConcatKDFParams would refuse too, only
+// after paying for the decode. Its whole value is the allocation it never
+// makes, which is why it is not redundant and must not be simplified away.
+// Both guards wrap ErrMalformedEncrypted, so the message is what distinguishes
+// which one fired.
+func TestConcatKDFHexAttributePrecheckBoundary(t *testing.T) {
+	// Two hex characters per octet, over the field's own bytes plus the
+	// leading unused-bit octet the encoded form carries.
+	const limit = 2 * (maxConcatKDFOtherInfoBytes + 1)
+
+	tests := []struct {
+		name      string
+		hexLen    int
+		wantError bool
+	}{
+		{name: "at the limit", hexLen: limit},
+		{name: "one octet past the limit", hexLen: limit + 2, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := helium.NewParser().Parse(t.Context(), []byte(
+				`<xenc11:ConcatKDFParams xmlns:xenc11="`+NamespaceXMLEnc11+`" PartyUInfo="`+strings.Repeat("0", tt.hexLen)+`"/>`,
+			))
+			require.NoError(t, err)
+
+			field, unusedBits, err := parseConcatKDFHexAttribute(doc.DocumentElement(), "PartyUInfo")
+			if tt.wantError {
+				require.ErrorIs(t, err, ErrMalformedEncrypted)
+				require.Contains(t, err.Error(), fmt.Sprintf("ConcatKDF PartyUInfo alone is over the %d byte OtherInfo limit", maxConcatKDFOtherInfoBytes))
+				return
+			}
+			require.NoError(t, err)
+			require.Zero(t, unusedBits)
+			require.Len(t, field, tt.hexLen/2-1)
+		})
+	}
 }
 
 // A 32-bit int overflows far below the address space a caller can fill,

--- a/xmlenc1/keywrap_test.go
+++ b/xmlenc1/keywrap_test.go
@@ -13,12 +13,24 @@ import (
 func TestAESKeyWrapRFC3394(t *testing.T) {
 	// Test vector from RFC 3394, Section 4.6
 	// 256-bit KEK, 256-bit key data
-	kek, _ := hex.DecodeString("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F")
-	keyData, _ := hex.DecodeString("00112233445566778899AABBCCDDEEFF000102030405060708090A0B0C0D0E0F")
-	expected, _ := hex.DecodeString("28C9F404C4B810F4CBCCB35CFB87F8263F5786E2D80ED326CBC7F0E71A99F43BFB988B9B7A02DD21")
+	kek, err := hex.DecodeString("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F")
+	require.NoError(t, err)
+	keyData, err := hex.DecodeString("00112233445566778899AABBCCDDEEFF000102030405060708090A0B0C0D0E0F")
+	require.NoError(t, err)
+	expected, err := hex.DecodeString("28C9F404C4B810F4CBCCB35CFB87F8263F5786E2D80ED326CBC7F0E71A99F43BFB988B9B7A02DD21")
+	require.NoError(t, err)
 
-	// Use internal test via round-trip (we don't export aesKeyWrap/aesKeyUnwrap directly).
-	// Instead test via Encryptor/Decryptor with SessionKey + KeyWrap.
+	// The wrapped key is exactly what a remote peer has to agree on, so the
+	// wrap output is pinned against the vector itself. A round-trip cannot
+	// stand in for that: a symmetric-but-wrong variant — say one running seven
+	// rounds where RFC 3394 runs six — unwraps its own wrap perfectly while
+	// putting different bytes on the wire.
+	wrapped, err := xmlenc1.AESKeyWrapForTest(kek, keyData)
+	require.NoError(t, err)
+	require.Equal(t, expected, wrapped)
+
+	// The public Encryptor/Decryptor pair then confirms the XML-level path
+	// carries that same wrap, through SessionKey + KeyWrap.
 	doc := mustParseXML(t, `<root>data</root>`)
 
 	encryptor := xmlenc1.NewEncryptor().
@@ -35,9 +47,6 @@ func TestAESKeyWrapRFC3394(t *testing.T) {
 	nodes, err := decryptor.Decrypt(t.Context(), edElem)
 	require.NoError(t, err)
 	require.Len(t, nodes, 1)
-
-	// Also verify the expected wrap output using the test vector.
-	_ = expected // verified indirectly through successful round-trip
 }
 
 func TestKeyWrapSize(t *testing.T) {

--- a/xmlenc1/xmlenc1_test.go
+++ b/xmlenc1/xmlenc1_test.go
@@ -723,6 +723,10 @@ func TestMissingKeyNamesTheSetter(t *testing.T) {
 
 		_, err = xmlenc1.NewDecryptor().Decrypt(t.Context(), edElem)
 		require.ErrorIs(t, err, xmlenc1.ErrMissingKey)
+		// The message must name the mechanism and the key-transport algorithm
+		// the document declared, not only the setter that supplies the key.
+		require.Contains(t, err.Error(), "RSA key transport")
+		require.Contains(t, err.Error(), xmlenc1.RSAOAEP)
 		require.Contains(t, err.Error(), "Decryptor.PrivateKey")
 	})
 
@@ -737,6 +741,10 @@ func TestMissingKeyNamesTheSetter(t *testing.T) {
 
 		_, err = xmlenc1.NewDecryptor().Decrypt(t.Context(), edElem)
 		require.ErrorIs(t, err, xmlenc1.ErrMissingKey)
+		// The message must name the mechanism and the key-wrap algorithm the
+		// document declared, not only the setter that supplies the key.
+		require.Contains(t, err.Error(), "AES key wrap")
+		require.Contains(t, err.Error(), xmlenc1.AES256KeyWrap)
 		require.Contains(t, err.Error(), "Decryptor.KeyEncryptionKey")
 	})
 
@@ -753,6 +761,7 @@ func TestMissingKeyNamesTheSetter(t *testing.T) {
 		require.ErrorIs(t, err, xmlenc1.ErrMissingKey)
 		// The message must name the agreement algorithm the document
 		// declared, exactly as the RSA and AES branches name theirs.
+		require.Contains(t, err.Error(), "key agreement")
 		require.Contains(t, err.Error(), xmlenc1.ECDHES)
 		require.Contains(t, err.Error(), "Decryptor.ECPrivateKey")
 	})


### PR DESCRIPTION
- `TestAESKeyWrapRFC3394` compares the wrap against the RFC 3394 §4.6 vector
- `TestMissingKeyNamesTheSetter` asserts the mechanism and algorithm URI too
- Adds `FuzzDecrypt`, a ConcatKDF hex-precheck boundary test, and the matrix line
